### PR TITLE
Add examples to Enum.group_by/3

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1366,6 +1366,9 @@ defmodule Enum do
       iex> Enum.group_by(~w{ant buffalo cat dingo}, &String.length/1, &String.first/1)
       %{3 => ["a", "c"], 5 => ["d"], 7 => ["b"]}
 
+  The key can be any Elixir value. For example, you may use a tuple
+  to group by multiple keys:
+
       iex> collection = [
       ...>   %{id: 1, lang: "Elixir", seq: 1},
       ...>   %{id: 1, lang: "Java", seq: 1},

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1366,6 +1366,31 @@ defmodule Enum do
       iex> Enum.group_by(~w{ant buffalo cat dingo}, &String.length/1, &String.first/1)
       %{3 => ["a", "c"], 5 => ["d"], 7 => ["b"]}
 
+      iex> collection = [
+      ...>   %{id: 1, lang: "Elixir", seq: 1},
+      ...>   %{id: 1, lang: "Java", seq: 1},
+      ...>   %{id: 1, lang: "Ruby", seq: 2},
+      ...>   %{id: 2, lang: "Python", seq: 1},
+      ...>   %{id: 2, lang: "C#", seq: 2},
+      ...>   %{id: 2, lang: "Haskell", seq: 2},
+      ...> ]
+
+      iex> Enum.group_by(collection, &{&1.id, &1.seq})
+      %{
+        {1, 1} => [%{id: 1, lang: "Elixir", seq: 1}, %{id: 1, lang: "Java", seq: 1}],
+        {1, 2} => [%{id: 1, lang: "Ruby", seq: 2}],
+        {2, 1} => [%{id: 2, lang: "Python", seq: 1}],
+        {2, 2} => [%{id: 2, lang: "C#", seq: 2}, %{id: 2, lang: "Haskell", seq: 2}]
+      }
+
+      iex> Enum.group_by(collection, &{&1.id, &1.seq}, &{&1.id, &1.lang})
+      %{
+        {1, 1} => [{1, "Elixir"}, {1, "Java"}],
+        {1, 2} => [{1, "Ruby"}],
+        {2, 1} => [{2, "Python"}],
+        {2, 2} => [{2, "C#"}, {2, "Haskell"}]
+      }
+
   """
   @spec group_by(t, (element -> any), (element -> any)) :: map
   def group_by(enumerable, key_fun, value_fun \\ fn x -> x end)

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1374,7 +1374,6 @@ defmodule Enum do
       ...>   %{id: 2, lang: "C#", seq: 2},
       ...>   %{id: 2, lang: "Haskell", seq: 2},
       ...> ]
-
       iex> Enum.group_by(collection, &{&1.id, &1.seq})
       %{
         {1, 1} => [%{id: 1, lang: "Elixir", seq: 1}, %{id: 1, lang: "Java", seq: 1}],
@@ -1382,7 +1381,6 @@ defmodule Enum do
         {2, 1} => [%{id: 2, lang: "Python", seq: 1}],
         {2, 2} => [%{id: 2, lang: "C#", seq: 2}, %{id: 2, lang: "Haskell", seq: 2}]
       }
-
       iex> Enum.group_by(collection, &{&1.id, &1.seq}, &{&1.id, &1.lang})
       %{
         {1, 1} => [{1, "Elixir"}, {1, "Java"}],


### PR DESCRIPTION
Add examples to use Enum.group_by/3 on multiple keys.

Based on [this comment](https://elixirforum.com/t/how-to-use-enum-group-by-with-multi-columns/22122/3).