### PR TITLE
Disable parallel build in Make 4.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SOURCE_DATE_EPOCH_PATH = lib/elixir/tmp/ebin_reproducible
 SOURCE_DATE_EPOCH_FILE = $(SOURCE_DATE_EPOCH_PATH)/SOURCE_DATE_EPOCH
 
 .PHONY: install compile erlang elixir unicode app build_plt clean_plt dialyze test check_reproducible clean clean_residual_files format install_man clean_man docs Docs.zip Precompiled.zip zips
-.NOTPARALLEL: compile
+.NOTPARALLEL:
 
 #==> Functions
 


### PR DESCRIPTION
In versions of GNU Make prior to 4.4, ".NOTPARALLEL: compile" made the whole build run serially. In 4.4 and later, ".NOTPARALLEL: compile" makes only the compile target run serially.

This breaks the build and can lead to e.g. EEx being built before Mix.

Ref: https://bugs.gentoo.org/870016