### PR TITLE
Updates Strictly Pretty paper link

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -232,7 +232,7 @@ defmodule Inspect.Algebra do
   This implementation also adds `force_unfit/1` and `next_break_fits/2` which
   give more control over the document fitting.
 
-    [0]: http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.34.2200
+    [0]: https://citeseerx.ist.psu.edu/doc_view/pid/c73ca9cc74351fe7f8f3dddc69d2e82326af82c0
 
   """
 


### PR DESCRIPTION
The paper link in `Inspect.Algebra` is not working.

This PR updates it.