### PR TITLE
Clarify docs on terminate/2

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -615,7 +615,8 @@ defmodule GenServer do
   `c:terminate/2` is useful for cleanup that requires access to the
   `GenServer`'s state. However, it is **not guaranteed** that `c:terminate/2`
   is called when a `GenServer` exits. Therefore, important clean-up should be
-  done using process links and/or monitors.
+  done using process links and/or monitors. A monitoring process will receive the
+  same exit `reason` that would be passed to `c:terminate/2`.
 
   `c:terminate/2` is called if:
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -614,7 +614,7 @@ defmodule GenServer do
 
   `c:terminate/2` is useful for cleanup that requires access to the
   `GenServer`'s state. However, it is **not guaranteed** that `c:terminate/2`
-  is called when a `GenServer` exits. Therefore, important clean-up should be
+  is called when a `GenServer` exits. Therefore, important cleanup should be
   done using process links and/or monitors. A monitoring process will receive the
   same exit `reason` that would be passed to `c:terminate/2`.
 


### PR DESCRIPTION
- Explain what 'parent process' means in this context
- Explain when `c:terminate/2` is useful vs a monitor
- Move the "not guaranteed" warning higher up in the description