### PR TITLE
Fix unused for optimization

### DIFF
--- a/lib/elixir/src/elixir_erl_for.erl
+++ b/lib/elixir/src/elixir_erl_for.erl
@@ -29,7 +29,7 @@ translate_into(Meta, Cases, Expr, Opts, S) ->
   {TInto, SI} =
     case lists:keyfind(into, 1, Opts) of
       {into, Into} -> elixir_erl_pass:translate(Into, Ann, S);
-      false -> {{nil, Ann}, S}
+      false -> {false, S}
     end,
 
   TUniq = lists:keyfind(uniq, 1, Opts) == {uniq, true},


### PR DESCRIPTION
I'm sorry, I just realized that I made a mistake in a [previous PR](https://github.com/elixir-lang/elixir/pull/12116/files#diff-1a2516ae4428444dcbaa8145d7ddc3392734519d455a18a2e6072a3de87f8d75L33-R32) and accidentally broke the optimization when a `for` comprehension result isn't used. This has been broken since 1.14.1.

I could confirm it works again after the fix:

```elixir
iex(1)> quote do
...(1)> for x <- [], do: x
...(1)> 1
...(1)> end
{:__block__, [],
 [{:for, [], [{:<-, [], [{:x, [], Elixir}, []]}, [do: {:x, [], Elixir}]]}, 1]}
iex(2)> |> :elixir.quoted_to_erl(__ENV__) |> elem(0)
{:block, 0,
 [
   {:call, 0, {:remote, 0, {:atom, 0, Enum}, {:atom, 0, :reduce}},
    [
      {nil, 0},
      {nil, 0},
      {:fun, 0,
       {:clauses,
        [
          {:clause, 0, [{:var, 0, :_@3}, {:var, 0, :_@4}], [],
           [{:block, 0, [{:var, 0, :_@3}, {:atom, 0, nil}]}]}
        ]}}
    ]},
   {:integer, 0, 1}
 ]}
```

On Elixir 1.14.1 (`cons` + final `:lists.reverse`):

```elixir
{:block, 0,
 [
   {:call, 0, {:remote, 0, {:atom, 0, :lists}, {:atom, 0, :reverse}},
    [
      {:call, 0, {:remote, 0, {:atom, 0, Enum}, {:atom, 0, :reduce}},
       [
         {nil, 0},
         {nil, 0},
         {:fun, 0,
          {:clauses,
           [
             {:clause, 0, [{:var, 0, :_@3}, {:var, 0, :_@4}], [],
              [{:cons, 0, {:var, 0, :_@3}, {:var, 0, :_@4}}]}
           ]}}
       ]}
    ]},
   {:integer, 0, 1}
 ]}
```

I'm not sure if I should try to add a regression test for this, the only way I can think of would be to check the Erlang AST as above.