### PR TITLE
Fix wildcard edge case

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -602,6 +602,10 @@ defmodule Path do
       :file.read_link_info(file)
     end
 
+    def read_file_info(file) do
+      :file.read_file_info(file)
+    end
+
     def list_dir(dir) do
       case :file.list_dir(dir) do
         {:ok, files} -> {:ok, for(file <- files, hd(file) != ?., do: file)}

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -38,6 +38,21 @@ defmodule PathTest do
     File.rm_rf(Path.join(config.tmp_dir, "wildcard"))
   end
 
+  @tag :tmp_dir
+  test "wildcard/2 follows ..", config do
+    hello = Path.join(config.tmp_dir, "wildcard/hello")
+    world = Path.join(config.tmp_dir, "wildcard/world")
+    File.mkdir_p(hello)
+    File.touch(world)
+
+    assert Path.wildcard(Path.join(config.tmp_dir, "wildcard/w*/../h*")) == []
+
+    assert Path.wildcard(Path.join(config.tmp_dir, "wildcard/h*/../w*")) ==
+             [Path.join(config.tmp_dir, "wildcard/hello/../world")]
+  after
+    File.rm_rf(Path.join(config.tmp_dir, "wildcard"))
+  end
+
   test "wildcard/2 raises on null byte" do
     assert_raise ArgumentError, ~r/null byte/, fn -> Path.wildcard("foo\0bar") end
   end


### PR DESCRIPTION
A fix for `Path.wildcard/2` when the wildcard contains a `..` like `Path.wilcard("h*/../w*")`.