### PR TITLE
Another clarification for terminate/2

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -652,6 +652,12 @@ defmodule GenServer do
   exits by default and an exit signal is sent when a linked process exits or its
   node is disconnected.
 
+  `c:terminate/2` is only called after the `GenServer` finishes processing all
+  messages which arrived in its mailbox prior to the exit signal; if it
+  receives a `:kill` signal before it finishes processing those,
+  `c:terminate/2` will not be called. If `c:terminate/2` is called, any
+  messages received after the exit signal will still be in the mailbox.
+
   There is no cleanup needed when the `GenServer` controls a `port` (for example,
   `:gen_tcp.socket`) or `t:File.io_device/0`, because these will be closed on
   receiving a `GenServer`'s exit signal and do not need to be closed manually

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -653,7 +653,7 @@ defmodule GenServer do
   node is disconnected.
 
   `c:terminate/2` is only called after the `GenServer` finishes processing all
-  messages which arrived in its mailbox prior to the exit signal; if it
+  messages which arrived in its mailbox prior to the exit signal. If it
   receives a `:kill` signal before it finishes processing those,
   `c:terminate/2` will not be called. If `c:terminate/2` is called, any
   messages received after the exit signal will still be in the mailbox.


### PR DESCRIPTION
Determined by experimentation:

```elixir
defmodule Experiment do
  use GenServer, shutdown: 15_000

  def start_link(_args) do
    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
  end

  @impl GenServer
  def init(_args) do
    Process.flag(:trap_exit, true)
    {:ok, %{}}
  end

  def handle_call({:hi, int}, _from, state) do
    IO.inspect "got hi #{int}..."
    Process.sleep(1_000)
    {:reply, :ok, state}
  end

  def terminate(reason, state) do
    IO.inspect inspect(:erlang.process_info(self(), :messages)), label: "terminating"
  end
end

```

Place that in a supervision tree, `iex -S mix`, and call

```elixir
# to see messages handled until process death; `terminate/1` does not run
iex> for i <- 1..20, do: spawn(fn -> GenServer.call(Experiment, {:hi, i}) end)
iex> System.stop()
```

or

```elixir
# to see pre-signal messages handled, then `terminate/1` with post-signal messages in the mailbox
iex> for i <- 1..5, do: spawn(fn -> GenServer.call(Experiment, {:hi, i}) end)
iex> System.stop()
iex> for i <- 1..5, do: spawn(fn -> GenServer.call(Experiment, {:hi, i}) end)
```