### PR TITLE
Clarify that `Task.Supervisor.async_nolink/3` must also have a :temporary restart strategy

### DIFF
--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -201,7 +201,8 @@ defmodule Task.Supervisor do
   children.
 
   Note this function requires the task supervisor to have `:temporary`
-  as the `:restart` option (the default). See `async_nolink/5` for more details.
+  as the `:restart` option (the default), as `async_nolink/3` keeps a
+  direct reference to the task which is lost if the task is restarted.
 
   ## Options
 

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -200,6 +200,9 @@ defmodule Task.Supervisor do
   Raises an error if `supervisor` has reached the maximum number of
   children.
 
+  Note this function requires the task supervisor to have `:temporary`
+  as the `:restart` option (the default). See `async_nolink/5` for more details.
+
   ## Options
 
     * `:shutdown` - `:brutal_kill` if the tasks must be killed directly on shutdown


### PR DESCRIPTION
Both `async_nolink/3` and `async_nolink/5` require that you use a `temporary` restart strategy (the former simply calls the latter) but the docs do not make this sufficiently clear. This bit me while messing with them, as I thought the caveat only applied to the latter, but alas, it is not so.