### PR TITLE
Fix {Keyword, Map}.get_and_update!/3 specs

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -526,7 +526,7 @@ defmodule Keyword do
       {1, []}
 
   """
-  @spec get_and_update!(t, key, (value | nil -> {current_value, new_value :: value} | :pop)) ::
+  @spec get_and_update!(t, key, (value -> {current_value, new_value :: value} | :pop)) ::
           {current_value, new_keywords :: t}
         when current_value: value
   def get_and_update!(keywords, key, fun) do

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -995,7 +995,7 @@ defmodule Map do
       {1, %{}}
 
   """
-  @spec get_and_update!(map, key, (value | nil -> {current_value, new_value :: value} | :pop)) ::
+  @spec get_and_update!(map, key, (value -> {current_value, new_value :: value} | :pop)) ::
           {current_value, map}
         when current_value: value
   def get_and_update!(map, key, fun) when is_function(fun, 1) do


### PR DESCRIPTION
This removes `nil` from the spec, as `nil` is not returned
as it happens with get_and_update/3.