### PR TITLE
Fix Calendar.strftime/2 format negative year incorrectly

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -795,9 +795,9 @@ defmodule Calendar do
   defp format_modifiers("Y" <> rest, width, pad, datetime, format_options, acc) do
     {sign, year} =
       if datetime.year < 0 do
-        {"-", datetime.year * -1}
+        {?-, -datetime.year}
       else
-        {"", datetime.year}
+        {[], datetime.year}
       end
 
     result = [sign | year |> Integer.to_string() |> pad_leading(width, pad)]

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -793,7 +793,14 @@ defmodule Calendar do
 
   # Year
   defp format_modifiers("Y" <> rest, width, pad, datetime, format_options, acc) do
-    result = datetime.year |> Integer.to_string() |> pad_leading(width, pad)
+    {sign, year} =
+      if datetime.year < 0 do
+        {"-", datetime.year * -1}
+      else
+        {"", datetime.year}
+      end
+
+    result = [sign | year |> Integer.to_string() |> pad_leading(width, pad)]
     parse(rest, datetime, format_options, [result | acc])
   end
 

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -382,5 +382,12 @@ defmodule CalendarTest do
         Calendar.strftime(~D[2019-08-15], "%D", unknown: "option")
       end
     end
+
+    test "zero padding for negative year" do
+      assert Calendar.strftime(Date.new!(-1, 1, 1), "%Y") == "-0001"
+      assert Calendar.strftime(Date.new!(-11, 1, 1), "%Y") == "-0011"
+      assert Calendar.strftime(Date.new!(-111, 1, 1), "%Y") == "-0111"
+      assert Calendar.strftime(Date.new!(-1111, 1, 1), "%Y") == "-1111"
+    end
   end
 end


### PR DESCRIPTION
Closes #12266