### PR TITLE
Edianness binding not needed

### DIFF
--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -124,7 +124,7 @@ check_endianness() ->
     {module, ?system} ->
       Endianness = ?system:endianness(),
       case ?system:compiled_endianness() of
-        Endianness ->
+        _Endianness ->
           ok;
         _ ->
           io:format(standard_error,


### PR DESCRIPTION
Edianness is not being returned so it does not need to be bound. 