### PR TITLE
Refactor: use :elixir_bitstring to avoid duplication

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -143,24 +143,6 @@ defmodule Code.Formatter do
 
   @do_end_keywords [:rescue, :catch, :else, :after]
 
-  @bitstring_modifiers [
-    :integer,
-    :float,
-    :bits,
-    :bitstring,
-    :binary,
-    :bytes,
-    :utf8,
-    :utf16,
-    :utf32,
-    :signed,
-    :unsigned,
-    :little,
-    :big,
-    :native,
-    :_
-  ]
-
   @doc """
   Converts the quoted expression into an algebra document.
   """
@@ -1482,8 +1464,14 @@ defmodule Code.Formatter do
     quoted_to_algebra_with_parens_if_operator(spec_element, :parens_arg, state)
   end
 
-  defp bitstring_spec_normalize_empty_args(atom) when atom in @bitstring_modifiers, do: nil
-  defp bitstring_spec_normalize_empty_args(_atom), do: []
+  defp bitstring_spec_normalize_empty_args(:_), do: nil
+
+  defp bitstring_spec_normalize_empty_args(atom) do
+    case :elixir_bitstring.validate_spec(atom, nil) do
+      :none -> []
+      _ -> nil
+    end
+  end
 
   defp bitstring_wrap_parens(doc, i, last) when i == 0 or i == last do
     string = format_to_string(doc)

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1992,26 +1992,9 @@ defmodule Macro do
        do: true
 
   defp quoted_bitstring_modifier?({modifier, _, ctx}) when is_atom(ctx) or ctx == [],
-    do: bitstring_literal_type?(modifier)
+    do: :elixir_bitstring.validate_spec(modifier, nil) != :none
 
   defp quoted_bitstring_modifier?(_other), do: false
-
-  # cannot use in/2 guard in Macro module for bootstrapping issues
-  defp bitstring_literal_type?(:integer), do: true
-  defp bitstring_literal_type?(:float), do: true
-  defp bitstring_literal_type?(:bits), do: true
-  defp bitstring_literal_type?(:bitstring), do: true
-  defp bitstring_literal_type?(:binary), do: true
-  defp bitstring_literal_type?(:bytes), do: true
-  defp bitstring_literal_type?(:utf8), do: true
-  defp bitstring_literal_type?(:utf16), do: true
-  defp bitstring_literal_type?(:utf32), do: true
-  defp bitstring_literal_type?(:signed), do: true
-  defp bitstring_literal_type?(:unsigned), do: true
-  defp bitstring_literal_type?(:big), do: true
-  defp bitstring_literal_type?(:little), do: true
-  defp bitstring_literal_type?(:native), do: true
-  defp bitstring_literal_type?(_other), do: false
 
   @doc false
   @deprecated "Use Macro.expand_literals/2 instead"

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -1,5 +1,5 @@
 -module(elixir_bitstring).
--export([expand/5, format_error/1]).
+-export([expand/5, format_error/1, validate_spec/2]).
 -import(elixir_errors, [form_error/4]).
 -include("elixir.hrl").
 


### PR DESCRIPTION
Apply refactor suggested in https://github.com/elixir-lang/elixir/pull/12270#issuecomment-1327482191 and remove duplicated definitions of bitstring modifiers.