### PR TITLE
Raise undefined variable compile error, not undefined function

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -367,7 +367,7 @@ expand({Name, Meta, Kind}, S, E) when is_atom(Name), is_atom(Kind) ->
 
         %% TODO: Remove this clause on v2.0
         _ when Error == warn ->
-          expand({Name, [{var_as_call, Kind} | Meta], []}, S, E);
+          expand({Name, [{if_undefined, warn}, {var_as_call, Kind} | Meta], []}, S, E);
 
         _ when Error == pin ->
           form_error(Meta, E, ?MODULE, {undefined_var_pin, Name, Kind});

--- a/lib/elixir/src/elixir_locals.erl
+++ b/lib/elixir/src/elixir_locals.erl
@@ -148,5 +148,8 @@ format_error({undefined_function, {F, A}, Module}) ->
   io_lib:format("undefined function ~ts/~B (expected ~ts to define such a function or "
                 "for it to be imported, but none are available)", [F, A, elixir_aliases:inspect(Module)]);
 
+format_error({undefined_variable, {F, 0}, _Module}) ->
+  io_lib:format("undefined variable \"~ts\"", [F]);
+
 format_error({incorrect_dispatch, {F, A}, _Module}) ->
   io_lib:format("cannot invoke macro ~ts/~B before its definition", [F, A]).

--- a/lib/elixir/test/elixir/kernel/defaults_test.exs
+++ b/lib/elixir/test/elixir/kernel/defaults_test.exs
@@ -44,7 +44,7 @@ defmodule Kernel.DefaultsTest do
     message = "variable \"default\" does not exist"
 
     assert capture_io(:stderr, fn ->
-             assert_raise CompileError, ~r/undefined function default\/0/, fn ->
+             assert_raise CompileError, ~r/undefined variable \"default\"/, fn ->
                defmodule VarDefaultScope do
                  def test(_ \\ default = 1),
                    do: default
@@ -85,7 +85,7 @@ defmodule Kernel.DefaultsTest do
     end
 
     assert capture_io(:stderr, fn ->
-             assert_raise CompileError, ~r"undefined function foo/0", fn ->
+             assert_raise CompileError, ~r"undefined variable \"foo\"", fn ->
                defmodule Kernel.ErrorsTest.ClauseWithDefaults5 do
                  def hello(foo, bar \\ foo)
                  def hello(foo, bar), do: foo + bar

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -102,6 +102,25 @@ defmodule Kernel.ErrorsTest do
                       ~c"call foo, do: :foo"
   end
 
+  test "undefined variable" do
+    stderr =
+      capture_io(:stderr, fn ->
+        assert_eval_raise CompileError,
+                          "nofile:3: undefined variable \"bar\"",
+                          ~c"""
+                          defmodule Sample do
+                            def foo do
+                              bar
+                              baz
+                            end
+                          end
+                          """
+      end)
+
+    assert stderr =~ "variable \"bar\" does not exist and is being expanded to \"bar()\""
+    assert stderr =~ "variable \"baz\" does not exist and is being expanded to \"baz()\""
+  end
+
   test "function without definition" do
     assert_eval_raise CompileError,
                       "nofile:2: implementation not provided for predefined def foo/0",

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -260,7 +260,7 @@ defmodule Kernel.ExpansionTest do
   describe "vars" do
     test "expands vars to local call" do
       {output, env} = expand_env({:a, [], nil}, __ENV__, [])
-      assert output == {:a, [var_as_call: nil], []}
+      assert output == {:a, [if_undefined: :warn, var_as_call: nil], []}
       assert Macro.Env.vars(env) == []
     end
 

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -260,7 +260,7 @@ defmodule Kernel.ExpansionTest do
   describe "vars" do
     test "expands vars to local call" do
       {output, env} = expand_env({:a, [], nil}, __ENV__, [])
-      assert output == {:a, [if_undefined: :warn], []}
+      assert output == {:a, [var_as_call: nil], []}
       assert Macro.Env.vars(env) == []
     end
 
@@ -2934,7 +2934,11 @@ defmodule Kernel.ExpansionTest do
     expand_env(expr, __ENV__) |> elem(0)
   end
 
-  defp expand_env(expr, env, to_clean \\ [:version, :inferred_bitstring_spec, :if_undefined]) do
+  defp expand_env(
+         expr,
+         env,
+         to_clean \\ [:version, :inferred_bitstring_spec, :if_undefined, :var_as_call]
+       ) do
     {{expr, scope, env}, _capture} =
       ExUnit.CaptureIO.with_io(:stderr, fn ->
         :elixir_expand.expand(expr, :elixir_env.env_to_ex(env), env)

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -229,7 +229,7 @@ defmodule Kernel.WarningTest do
     message = "variable \"x\" is unused"
 
     assert capture_err(fn ->
-             assert_raise CompileError, ~r/undefined function x/, fn ->
+             assert_raise CompileError, ~r/undefined variable \"x\"/, fn ->
                Code.eval_string("""
                case false do
                  true -> x = 1
@@ -241,7 +241,7 @@ defmodule Kernel.WarningTest do
            end) =~ message
 
     assert capture_err(fn ->
-             assert_raise CompileError, ~r/undefined function x/, fn ->
+             assert_raise CompileError, ~r/undefined variable \"x\"/, fn ->
                Code.eval_string("""
                false and (x = 1)
                x
@@ -250,7 +250,7 @@ defmodule Kernel.WarningTest do
            end) =~ message
 
     assert capture_err(fn ->
-             assert_raise CompileError, ~r/undefined function x/, fn ->
+             assert_raise CompileError, ~r/undefined variable \"x\"/, fn ->
                Code.eval_string("""
                true or (x = 1)
                x
@@ -259,7 +259,7 @@ defmodule Kernel.WarningTest do
            end) =~ message
 
     assert capture_err(fn ->
-             assert_raise CompileError, ~r/undefined function x/, fn ->
+             assert_raise CompileError, ~r/undefined variable \"x\"/, fn ->
                Code.eval_string("""
                if false do
                  x = 1
@@ -270,7 +270,7 @@ defmodule Kernel.WarningTest do
            end) =~ message
 
     assert capture_err(fn ->
-             assert_raise CompileError, ~r/undefined function x/, fn ->
+             assert_raise CompileError, ~r/undefined variable \"x\"/, fn ->
                Code.eval_string("""
                cond do
                  false -> x = 1
@@ -282,7 +282,7 @@ defmodule Kernel.WarningTest do
            end) =~ message
 
     assert capture_err(fn ->
-             assert_raise CompileError, ~r/undefined function x/, fn ->
+             assert_raise CompileError, ~r/undefined variable \"x\"/, fn ->
                Code.eval_string("""
                receive do
                  :foo -> x = 1
@@ -295,7 +295,7 @@ defmodule Kernel.WarningTest do
            end) =~ message
 
     assert capture_err(fn ->
-             assert_raise CompileError, ~r/undefined function x/, fn ->
+             assert_raise CompileError, ~r/undefined variable \"x\"/, fn ->
                Code.eval_string("""
                false && (x = 1)
                x
@@ -304,7 +304,7 @@ defmodule Kernel.WarningTest do
            end) =~ message
 
     assert capture_err(fn ->
-             assert_raise CompileError, ~r/undefined function x/, fn ->
+             assert_raise CompileError, ~r/undefined variable \"x\"/, fn ->
                Code.eval_string("""
                true || (x = 1)
                x
@@ -313,7 +313,7 @@ defmodule Kernel.WarningTest do
            end) =~ message
 
     assert capture_err(fn ->
-             assert_raise CompileError, ~r/undefined function x/, fn ->
+             assert_raise CompileError, ~r/undefined variable \"x\"/, fn ->
                Code.eval_string("""
                with true <- true do
                  x = false
@@ -324,7 +324,7 @@ defmodule Kernel.WarningTest do
            end) =~ message
 
     assert capture_err(fn ->
-             assert_raise CompileError, ~r/undefined function x/, fn ->
+             assert_raise CompileError, ~r/undefined variable \"x\"/, fn ->
                Code.eval_string("""
                fn ->
                  x = true

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1057,7 +1057,7 @@ defmodule IEx.HelpersTest do
       with_file("dot-iex", "variable = :hello\nimport IO", fn ->
         capture_io(:stderr, fn ->
           assert capture_iex("variable") =~
-                   "** (CompileError) iex:1: undefined function variable/0"
+                   "** (CompileError) iex:1: undefined variable \"variable\""
         end)
 
         assert capture_iex("puts \"hi\"") =~ "** (CompileError) iex:1: undefined function puts/1"
@@ -1073,7 +1073,7 @@ defmodule IEx.HelpersTest do
 
       with_file(["dot-iex", "dot-iex-1"], [dot, dot_1], fn ->
         capture_io(:stderr, fn ->
-          assert capture_iex("parent") =~ "** (CompileError) iex:1: undefined function parent/0"
+          assert capture_iex("parent") =~ "** (CompileError) iex:1: undefined variable \"parent\""
         end)
 
         assert capture_iex("puts \"hi\"") =~ "** (CompileError) iex:1: undefined function puts/1"

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -201,7 +201,7 @@ defmodule IEx.InteractionTest do
     test "no .iex" do
       capture_io(:stderr, fn ->
         assert capture_iex("my_variable") =~
-                 "** (CompileError) iex:1: undefined function my_variable/0"
+                 "** (CompileError) iex:1: undefined variable \"my_variable\""
       end)
     end
 

--- a/lib/iex/test/iex/server_test.exs
+++ b/lib/iex/test/iex/server_test.exs
@@ -48,7 +48,7 @@ defmodule IEx.ServerTest do
         send(evaluator, :run)
 
         assert Task.await(client) == {:error, :refused}
-        assert Task.await(server) =~ "undefined function iex_context"
+        assert Task.await(server) =~ "undefined variable \"iex_context\""
       end)
     end
 
@@ -81,7 +81,7 @@ defmodule IEx.ServerTest do
         assert accepted =~ ":inside_pry"
         refute refused =~ "pry(1)>"
         assert refused =~ "** session was already accepted elsewhere"
-        assert refused =~ "undefined function iex_context"
+        assert refused =~ "undefined variable \"iex_context\""
 
         assert Task.await(client) == {:ok, false}
       end)
@@ -100,8 +100,8 @@ defmodule IEx.ServerTest do
         reply1 = Task.await(server1)
         reply2 = Task.await(server2)
 
-        assert reply1 =~ "undefined function iex_context"
-        assert reply2 =~ "undefined function iex_context"
+        assert reply1 =~ "undefined variable \"iex_context\""
+        assert reply2 =~ "undefined variable \"iex_context\""
 
         assert Task.await(client) == {:error, :refused}
       end)
@@ -118,7 +118,7 @@ defmodule IEx.ServerTest do
         send(evaluator1, :run)
         send(evaluator2, :run)
         assert Task.await(server1) =~ ":inside_pry"
-        assert Task.await(server2) =~ "undefined function iex_context"
+        assert Task.await(server2) =~ "undefined variable \"iex_context\""
 
         assert Task.await(client) == {:ok, false}
       end)
@@ -134,7 +134,7 @@ defmodule IEx.ServerTest do
 
         send(evaluator1, :run)
         send(evaluator2, :run)
-        assert Task.await(server1) =~ "undefined function iex_context"
+        assert Task.await(server1) =~ "undefined variable \"iex_context\""
         assert Task.await(server2) =~ ":inside_pry"
 
         assert Task.await(client) == {:ok, false}


### PR DESCRIPTION
This is a proposal of improvement for compile errors on undefined variables, for discussion purpose.

Currently, an undefined variable would emit a warning + a compile error:

```elixir
warning: variable "bar" does not exist and is being expanded to "bar()", please use parentheses to remove the ambiguity or change the variable name
  lib/foo.ex:3: Foo.foo/0


== Compilation error in file lib/foo.ex ==
** (CompileError) lib/foo.ex:3: undefined function bar/0 (expected Foo to define such a function or for it to be imported, but none are available)
```

I think this can be confusing and directly returning a variable error in this case seems more natural.

The `"does not exist and is being expanded"` warning is helpful if the variable wasn't found but a zero-arity function could actually be resolved.