### PR TITLE
Fix formatter error on nested do without parenthesis

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -1236,7 +1236,7 @@ warn_nested_no_parens_keyword(Key, Value) when is_atom(Key) ->
 
 % Key might not be an atom when using literal_encoder, we just skip the warning
 warn_nested_no_parens_keyword(_Key, _Value) ->
-  nil.
+  ok.
 
 warn_empty_paren({_, {Line, Column, _}}) ->
   warn(

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -1215,15 +1215,11 @@ warn_pipe(_Token, _) ->
   ok.
 
 %% TODO: Make this an error on v2.0
-warn_nested_no_parens_keyword(Key, Value) ->
+warn_nested_no_parens_keyword(Key, Value) when is_atom(Key) ->
   {line, Line} = lists:keyfind(line, 1, ?meta(Value)),
-  MaybeKeyword = case Key of
-    Atom when is_atom(Atom) ->  "\"" ++ atom_to_list(Key) ++ ":\" ";
-    _ -> ""
-  end,
   warn(
     Line,
-    "missing parentheses for expression following " ++ MaybeKeyword ++ "keyword. "
+    "missing parentheses for expression following \"" ++ atom_to_list(Key) ++ ":\" keyword. "
     "Parentheses are required to solve ambiguity inside keywords.\n\n"
     "This error happens when you have function calls without parentheses inside keywords. "
     "For example:\n\n"
@@ -1236,7 +1232,11 @@ warn_nested_no_parens_keyword(Key, Value) ->
     "    function(arg, one: if(expr, do: :this, else: :that))\n"
     "    function(arg, one: nested_call(a, b, c))\n\n"
     "Ambiguity found at:"
-  ).
+  );
+
+% Key might not be an atom when using literal_encoder, we just skip the warning
+warn_nested_no_parens_keyword(_Key, _Value) ->
+  nil.
 
 warn_empty_paren({_, {Line, Column, _}}) ->
   warn(

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -1217,9 +1217,13 @@ warn_pipe(_Token, _) ->
 %% TODO: Make this an error on v2.0
 warn_nested_no_parens_keyword(Key, Value) ->
   {line, Line} = lists:keyfind(line, 1, ?meta(Value)),
+  MaybeKeyword = case Key of
+    Atom when is_atom(Atom) ->  "\"" ++ atom_to_list(Key) ++ ":\" ";
+    _ -> ""
+  end,
   warn(
     Line,
-    "missing parentheses for expression following \"" ++ atom_to_list(Key) ++ ":\" keyword. "
+    "missing parentheses for expression following " ++ MaybeKeyword ++ "keyword. "
     "Parentheses are required to solve ambiguity inside keywords.\n\n"
     "This error happens when you have function calls without parentheses inside keywords. "
     "For example:\n\n"

--- a/lib/elixir/test/elixir/code_formatter/integration_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/integration_test.exs
@@ -698,4 +698,9 @@ defmodule Code.Formatter.IntegrationTest do
                 """,
                 line_length: :infinity
   end
+
+  test "functions without parentheses within do: keyword" do
+    assert_format ~S"defmodule Foo, do: foo bar, baz",
+                  ~S"defmodule Foo, do: foo(bar, baz)"
+  end
 end


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/12273

This was caused by `Code.format_string` calling `Code.string_to_quoted_with_comments` with the option `literal_encoder: &{:ok, {:__block__, &2, [&1]}})`

Minimal example:
```elixir
iex(9)> Code.string_to_quoted_with_comments(~c"if 1, do: max 1, 2", literal_encoder: &{:ok, {:__block__, &2, [&1]}})
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not an atom

    :erlang.atom_to_list({:__block__, [format: :keyword, line: 1], [:do]})
    (elixir 1.15.0-dev) lib/elixir/src/elixir_parser.yrl:1222: :elixir_parser.warn_nested_no_parens_keyword/2
    (elixir 1.15.0-dev) lib/elixir/src/elixir_parser.yrl:577: :elixir_parser.yeccpars2_463/7
    (elixir 1.15.0-dev) /Users/sabiwara/.asdf/installs/erlang/25.0/lib/parsetools-2.4/include/yeccpre.hrl:57: :elixir_parser.yeccpars0/5
```