### PR TITLE
fprof mix task: trace to file

### DIFF
--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -177,7 +177,7 @@ defmodule Mix.Tasks.Profile.Fprof do
     * `:details` - includes profile data for each profiled process
     * `:sort` - sorts the output by given key: `:acc` (default) or `:own`
     * `:trace_to_file` - uses a file to trace. Can improve performance and memory
-    usage for larger workloads.
+      usage for larger workloads.
 
   """
   @spec profile((-> any()), keyword()) :: any()

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Profile.Fprof do
     * `--details` - includes profile data for each profiled process
     * `--sort key` - sorts the output by given key: `acc` (default) or `own`
     * `--trace-to-file` - uses a file to trace. Can improve performance and memory
-    usage for larger workloads
+      usage for larger workloads
     * `--eval`, `-e` - evaluates the given code
     * `--require`, `-r` - requires pattern before running the command
     * `--parallel`, `-p` - makes all requires parallel

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -197,7 +197,7 @@ defmodule Mix.Tasks.Profile.Fprof do
 
     {return_value, file_to_remove} =
       if Keyword.get(opts, :trace_to_file, false) do
-        trace_file = Path.join([System.tmp_dir!(), "fprof_trace_#{System.unique_integer()}"])
+        trace_file = Path.join(System.tmp_dir!(), "fprof_trace_#{System.os_time()}")
 
         filename =
           trace_file

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -190,9 +190,17 @@ defmodule Mix.Tasks.Profile.Fprof do
       fun.()
     end
 
-    {:ok, tracer} = :fprof.profile(:start)
-    return_value = :fprof.apply(fun, [], tracer: tracer)
+    trace_file_path =
+      [System.tmp_dir!(), "fprof_trace_#{System.unique_integer()}"]
+      |> Path.join()
 
+    trace_file_path_charlist =
+      trace_file_path
+      |> Path.expand()
+      |> String.to_charlist()
+
+    return_value = :fprof.apply(fun, [], file: trace_file_path_charlist)
+    :fprof.profile(file: trace_file_path_charlist)
     {:ok, analyse_dest} = StringIO.open("")
 
     try do
@@ -209,6 +217,7 @@ defmodule Mix.Tasks.Profile.Fprof do
         {return_value, String.to_charlist(analysis_output)}
     after
       StringIO.close(analyse_dest)
+      File.rm(trace_file_path)
     end
   end
 

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -27,6 +27,8 @@ defmodule Mix.Tasks.Profile.Fprof do
     * `--callers` - prints detailed information about immediate callers and called functions
     * `--details` - includes profile data for each profiled process
     * `--sort key` - sorts the output by given key: `acc` (default) or `own`
+    * `--trace-to-file` - uses a file to trace. Can improve performance and memory
+    usage for larger workloads
     * `--eval`, `-e` - evaluates the given code
     * `--require`, `-r` - requires pattern before running the command
     * `--parallel`, `-p` - makes all requires parallel
@@ -111,6 +113,7 @@ defmodule Mix.Tasks.Profile.Fprof do
   @switches [
     parallel: :boolean,
     require: :keep,
+    trace_to_file: :boolean,
     eval: :keep,
     config: :keep,
     compile: :boolean,
@@ -173,6 +176,8 @@ defmodule Mix.Tasks.Profile.Fprof do
     * `:callers` - prints detailed information about immediate callers and called functions
     * `:details` - includes profile data for each profiled process
     * `:sort` - sorts the output by given key: `:acc` (default) or `:own`
+    * `:trace_to_file` - uses a file to trace. Can improve performance and memory
+    usage for larger workloads.
 
   """
   @spec profile((-> any()), keyword()) :: any()
@@ -190,17 +195,23 @@ defmodule Mix.Tasks.Profile.Fprof do
       fun.()
     end
 
-    trace_file_path =
-      [System.tmp_dir!(), "fprof_trace_#{System.unique_integer()}"]
-      |> Path.join()
+    {return_value, file_to_remove} =
+      if Keyword.get(opts, :trace_to_file, false) do
+        trace_file = Path.join([System.tmp_dir!(), "fprof_trace_#{System.unique_integer()}"])
 
-    trace_file_path_charlist =
-      trace_file_path
-      |> Path.expand()
-      |> String.to_charlist()
+        filename =
+          trace_file
+          |> Path.expand()
+          |> String.to_charlist()
 
-    return_value = :fprof.apply(fun, [], file: trace_file_path_charlist)
-    :fprof.profile(file: trace_file_path_charlist)
+        result = :fprof.apply(fun, [], file: filename)
+        :fprof.profile(file: filename)
+        {result, trace_file}
+      else
+        {:ok, tracer} = :fprof.profile([:start])
+        {:fprof.apply(fun, [], tracer: tracer), nil}
+      end
+
     {:ok, analyse_dest} = StringIO.open("")
 
     try do
@@ -217,7 +228,7 @@ defmodule Mix.Tasks.Profile.Fprof do
         {return_value, String.to_charlist(analysis_output)}
     after
       StringIO.close(analyse_dest)
-      File.rm(trace_file_path)
+      if file_to_remove, do: File.rm(file_to_remove)
     end
   end
 

--- a/lib/mix/test/mix/tasks/profile.fprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.fprof_test.exs
@@ -36,6 +36,15 @@ defmodule Mix.Tasks.Profile.FprofTest do
     end)
   end
 
+  test "writes traces to file", context do
+    in_tmp(context.test, fn ->
+      assert capture_io(fn ->
+               expr = "Enum.each(1..5, fn(_) -> MapSet.new() end)"
+               Fprof.run(["-e", expr, "--trace-to-file"])
+             end) =~ ~r(MapSet\.new/0 *5 *\d+\.\d{3} *\d+\.\d{3})
+    end)
+  end
+
   test "expands processes", context do
     in_tmp(context.test, fn ->
       expr =


### PR DESCRIPTION
The fprof mix task was using a tracer process. When tracing larger workloads, this tracer would get overloaded and cause issues (such as consuming too much memory, possibly crashing the VM). 

This is recommended in fprof docs: https://www.erlang.org/docs/23/man/fprof.html

I'm not sure this should be the default, maybe it should be behind an option.