### PR TITLE
Add `map_get/2` guard

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -866,6 +866,29 @@ defmodule Kernel do
   end
 
   @doc """
+  Returns the value of the given key of a map.
+
+  It raises `BadMapError` if the first element is not a map.
+
+  It raises `KeyError` if the given key is not present in the map.
+
+  Allowed in guard tests. Inlined by the compiler.
+
+  ## Examples
+
+      iex> map_get(%{a: "foo", b: "bar"}, :b)
+      "bar"
+
+  """
+  @doc guard: true, since: "1.14.3"
+  @spec map_get(map, term) :: term
+  defmacro map_get(map, key) do
+    quote do
+      :erlang.map_get(unquote(key), unquote(map))
+    end
+  end
+
+  @doc """
   Returns the size of a map.
 
   The size of a map is the number of key-value pairs that the map contains.

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1505,4 +1505,21 @@ defmodule KernelTest do
       """)
     end
   end
+
+  test "map_get/2" do
+    assert map_get(Map.new(a: 1, b: 2, c: 3), :b) == 2
+
+    assert_raise BadMapError, fn ->
+      map_get(empty_list(), :a)
+    end
+
+    assert_raise KeyError, fn ->
+      map_get(Map.new(a: 1), :b)
+    end
+
+    case Map.new(a: 1) do
+      map when map_get(map, :a) == 1 -> map
+      _ -> flunk("invalid guard")
+    end
+  end
 end


### PR DESCRIPTION
Hello!

Erlang/OTP 21 added both `is_map_key/2` and `map_get/2`, but currently only `is_map_key/2` is exposed via Elixir guards.

As most users will likely look through [Elixir documentation](https://hexdocs.pm/elixir/1.14.2/Kernel.html#guards) to discover which guards are available, exposing `map_get/2` seems appropriate.

This PR adds a `map_get/2` guard, exposing `:erlang.map_get/2` to aid in discoverability.
The argument order has been changed to `(map, key)` for consistency with `is_map_key/2` and the `Map` module.

I've defined `map_get/2` as a macro, as if I simply def and immediately delegate to `:erlang.map_get/2` tests fail with:
```
error: cannot invoke remote function Kernel.map_get/2 inside guards
  lib/elixir/test/elixir/kernel_test.exs:1521: KernelTest."test map_get/2"/1
```

Thanks for everything!