### PR TITLE
More function clauses for Range's Enumerable.member? implementation

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -501,6 +501,17 @@ defimpl Enumerable, for: Range do
     {:done, acc}
   end
 
+  def member?(first..last//1, value) when first <= last and is_integer(value) do
+    {:ok, first <= value and value <= last}
+  end
+
+  def member?(first..last//-1, value) when last <= first and is_integer(value) do
+    {:ok, last <= value and value <= first}
+  end
+
+  def member?(first..last//1, _) when first > last, do: {:ok, false}
+  def member?(first..last//-1, _) when first < last, do: {:ok, false}
+
   def member?(first..last//step = range, value) when is_integer(value) do
     cond do
       Range.size(range) == 0 ->


### PR DESCRIPTION
Doing [Advent of Code 2022, Day 4](https://adventofcode.com/2022/day/4), I was using a `value in range` condition in my solution and then [ran this benchmark](https://github.com/ryanwinchester/advent-of-code-elixir/blob/master/bench/day04.exs) for comparing the value against `range.first` and `range.last` instead, and the `value in range` version was around `4.6x` slower for my usage (which has multiple range comparisons in a reduce).

I think if we make a special case for when `step` is `+/-1` (which is probably the most common case), then we could see some improved performance.

These extra function matches should allow us to avoid
 * the `Range.size/1` call (which does `abs(div(last - first, step)) + 1`), and
 * the `rem(value - first, step)` calls for our our `+/-1` step ranges.

Thoughts?