### PR TITLE
Add Range.subset?/2

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -464,8 +464,17 @@ defmodule Range do
   @doc """
   Checks if all points of range2 are inside range1.
 
+  It returns true if all of the following conditions are met:
+
+   * the bounds of range2 are fully within range1
+   * the step size of range2 is a multiple of range1's step size
+   * The start of range2 is a member of range1
+
       iex> Range.contains?(1..10, 2..5)
       true
+
+      # the next 2 examples return false because the second range is not within
+      # the bounds of the first one
       iex> Range.contains?(1..10, 11..12)
       false
       iex> Range.contains?(8..20, 1..12)
@@ -478,17 +487,19 @@ defmodule Range do
       true
       iex> Range.contains?(2..8//2, 4..8//4)
       true
+      # false returned because the second range doesn't start (3) at a point
+      # contained by the first (2, 4, 6 and 8)
       iex> Range.contains?(2..8//2, 3..7//4)
       false
       iex> Range.contains?(2..11//3, 5..11//6)
       true
       iex> Range.contains?(11..2//-3, 5..11//6)
       true
+      # false returned because the step sizes are not multiples
       iex> Range.contains?(1..10//2, 2..8//3)
       false
-      iex> Range.contains?(0..10//5, 0..4//2)
+      iex> Range.contains?(0..10//4, 0..4//2)
       false
-      iex> Range.contains?(0..10, 1..3//10)
   """
   @spec contains?(t, t) :: boolean
   def contains?(first1..last1//step1 = range1, first2..last2//step2 = range2) do

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -505,11 +505,9 @@ defmodule Range do
   def contains?(first1..last1//step1 = range1, first2..last2//step2 = range2) do
     {first1, last1, step1} = normalize(first1, last1, step1)
     {first2, last2, step2} = normalize(first2, last2, step2)
-    size1 = size(range1)
-    size2 = size(range2)
 
     cond do
-      size2 == 1 ->
+      size(range2) == 1 ->
         # this should work even when step1 and step2 are completely different
         # that's why it's a special case
         Enum.member?(range1, first2)

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -462,7 +462,7 @@ defmodule Range do
   end
 
   @doc """
-  Checks if all elements of range2 are members of range1.
+  Checks if all points of range2 are inside range1.
 
       iex> Range.contains?(1..10, 2..5)
       true
@@ -471,7 +471,8 @@ defmodule Range do
       iex> Range.contains?(8..20, 1..12)
       false
 
-  Steps are also considered when checking if the second range is a subset of the first:
+  Steps are also considered when checking if the second range is contained by the
+  first:
 
       iex> Range.contains?(1..10, 2..4//2)
       true

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -502,8 +502,8 @@ defmodule Range do
   """
   @spec contains_members?(t, t) :: boolean
   def contains_members?(first1..last1//step1 = range1, first2..last2//step2 = range2) do
-    {first1, last1, step1} = normalize(first1, last1, step1)
-    {first2, last2, step2} = normalize(first2, last2, step2)
+    {first1, _last1, step1} = normalize(first1, last1, step1)
+    {first2, _last2, step2} = normalize(first2, last2, step2)
 
     cond do
       size(range2) == 0 ->
@@ -542,7 +542,7 @@ defmodule Range do
       false
   """
   @spec contains_bounds?(t, t) :: boolean()
-  def contains_bounds?(first1..last1//step1 = range1, first2..last2//step2 = range2) do
+  def contains_bounds?(first1..last1//step1, first2..last2//step2) do
     {first1, last1, _step1} = normalize(first1, last1, step1)
     {first2, last2, _step2} = normalize(first2, last2, step2)
     first2 >= first1 and first2 <= last1 and

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -515,8 +515,7 @@ defmodule Range do
         Enum.member?(range1, first2)
 
       true ->
-        first2 >= first1 and first2 <= last1 and
-          last2 >= first1 and last2 <= last1 and
+        contains_bounds?(range1, range2) and
           multiple?(step2, step1) and
           multiple?(first1 - first2, step1)
     end

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -464,42 +464,39 @@ defmodule Range do
   @doc """
   Checks if all elements of range2 are members of range1.
 
-      iex> Range.subset?(1..10, 2..5)
+      iex> Range.contains?(1..10, 2..5)
       true
-      iex> Range.subset?(1..10, 11..12)
+      iex> Range.contains?(1..10, 11..12)
       false
-      iex> Range.subset?(8..20, 1..12)
+      iex> Range.contains?(8..20, 1..12)
       false
 
   Steps are also considered when checking if the second range is a subset of the first:
 
-      iex> Range.subset?(1..10, 2..4//2)
+      iex> Range.contains?(1..10, 2..4//2)
       true
-      iex> Range.subset?(2..8//2, 4..8//4)
+      iex> Range.contains?(2..8//2, 4..8//4)
       true
-      iex> Range.subset?(2..8//2, 3..7//4)
+      iex> Range.contains?(2..8//2, 3..7//4)
       false
-      iex> Range.subset?(2..11//3, 5..11//6)
+      iex> Range.contains?(2..11//3, 5..11//6)
       true
-      iex> Range.subset?(11..2//-3, 5..11//6)
+      iex> Range.contains?(11..2//-3, 5..11//6)
       true
-      iex> Range.subset?(1..10//2, 2..8//3)
+      iex> Range.contains?(1..10//2, 2..8//3)
       false
-      iex> Range.subset?(0..10//5, 0..4//2)
+      iex> Range.contains?(0..10//5, 0..4//2)
       false
-      iex> Range.subset?(0..10, 1..3//10)
+      iex> Range.contains?(0..10, 1..3//10)
   """
-  @spec subset?(t, t) :: boolean
-  def subset?(first1..last1//step1 = range1, first2..last2//step2 = range2) do
+  @spec contains?(t, t) :: boolean
+  def contains?(first1..last1//step1 = range1, first2..last2//step2 = range2) do
     {first1, last1, step1} = normalize(first1, last1, step1)
     {first2, last2, step2} = normalize(first2, last2, step2)
     size1 = size(range1)
     size2 = size(range2)
 
     cond do
-      size1 == 0 and size2 == 0 ->
-        true
-
       size2 == 1 ->
         # this should work even when step1 and step2 are completely different
         # that's why it's a special case

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -545,8 +545,9 @@ defmodule Range do
   def contains_bounds?(first1..last1//step1, first2..last2//step2) do
     {first1, last1, _step1} = normalize(first1, last1, step1)
     {first2, last2, _step2} = normalize(first2, last2, step2)
+
     first2 >= first1 and first2 <= last1 and
-    last2 >= first1 and last2 <= last1
+      last2 >= first1 and last2 <= last1
   end
 
   @compile inline: [multiple?: 2]

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -461,6 +461,62 @@ defmodule Range do
     end
   end
 
+  @doc """
+  Checks if all elements of range2 are members of range1.
+
+      iex> Range.subset?(1..10, 2..5)
+      true
+      iex> Range.subset?(1..10, 11..12)
+      false
+      iex> Range.subset?(8..20, 1..12)
+      false
+
+  Steps are also considered when checking if the second range is a subset of the first:
+
+      iex> Range.subset?(1..10, 2..4//2)
+      true
+      iex> Range.subset?(2..8//2, 4..8//4)
+      true
+      iex> Range.subset?(2..8//2, 3..7//4)
+      false
+      iex> Range.subset?(2..11//3, 5..11//6)
+      true
+      iex> Range.subset?(11..2//-3, 5..11//6)
+      true
+      iex> Range.subset?(1..10//2, 2..8//3)
+      false
+      iex> Range.subset?(0..10//5, 0..4//2)
+      false
+      iex> Range.subset?(0..10, 1..3//10)
+  """
+  @spec subset?(t, t) :: boolean
+  def subset?(first1..last1//step1 = range1, first2..last2//step2 = range2) do
+    {first1, last1, step1} = normalize(first1, last1, step1)
+    {first2, last2, step2} = normalize(first2, last2, step2)
+    size1 = size(range1)
+    size2 = size(range2)
+
+    cond do
+      size1 == 0 and size2 == 0 ->
+        true
+
+      size2 == 1 ->
+        # this should work even when step1 and step2 are completely different
+        # that's why it's a special case
+        Enum.member?(range1, first2)
+
+      true ->
+        first2 >= first1 and first2 <= last1 and
+          last2 >= first1 and last2 <= last1 and
+          is_multiple?(step2, step1) and
+          is_multiple?(first1 - first2, step1)
+    end
+  end
+
+  @compile inline: [is_multiple?: 2]
+  # checks if a is a multiple of b
+  defp is_multiple?(a, b), do: rem(a, b) == 0
+
   @compile inline: [normalize: 3]
   defp normalize(first, last, step) when first > last, do: {last, first, -step}
   defp normalize(first, last, step), do: {first, last, step}


### PR DESCRIPTION
Since we have `disjoint?/2` in the Range module, we should also be able to check for subsets.

This PR adds to functions to the range module:

 * `contains_bounds?/2` which checks if the bounds of the second range is fully within the first range, while disregarding steps or sizes
 * `contains_members?/2` which does the same, and also checks if the points/members of `range2` are all contained in `range1`. 