### PR TITLE
Clarify partition supervisor

### DIFF
--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -183,6 +183,8 @@ defmodule PartitionSupervisor do
     * `:name` - an atom or via tuple representing the name of the partition
       supervisor (see `t:name/0`).
 
+    * `:child_spec` - the child spec to be used when starting the partitions.
+
     * `:partitions` - a positive integer with the number of partitions.
       Defaults to `System.schedulers_online()` (typically the number of cores).
 
@@ -203,9 +205,9 @@ defmodule PartitionSupervisor do
 
   Sometimes you want each partition to know their partition assigned number.
   This can be done with the `:with_arguments` option. This function receives
-  the list of arguments of the child specification and the partition. It
-  must return a new list of arguments that will be passed to the child specification
-  of children.
+  the the value of the `:child_spec` option and an integer for the partition
+  number. It must return a new list of arguments that will be used to start the
+  partition process.
 
   For example, most processes are started by calling `start_link(opts)`,
   where `opts` is a keyword list. You could inject the partition into the

--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -14,13 +14,13 @@ defmodule PartitionSupervisor do
   for routing.
 
   ## Simple Example
-  
+
   Let's start with an example which is not useful per se, but shows how the
   partitions are started and how messages are routed to them.
-  
+
   Here's a toy GenServer that simply collects the messages it's given.
   It prints them for easy illustration.
-  
+
       defmodule Collector do
         use GenServer
 
@@ -51,7 +51,7 @@ defmodule PartitionSupervisor do
         child_spec: Collector.child_spec([some: :arg]),
         name: MyApp.PartitionSupervisor
       }
-  
+
   We can send messages to them using a "via tuple":
 
       # The key is used to route our message to a particular instance.


### PR DESCRIPTION
The existing example for `ParititionSupervisor` used `DynamicSupervisor`. Having to consider the two together made it a bit harder (IMO) to understand the part that was unique to `PartitionSupervisor`.

This PR adds a simpler example and also shows the `{:via` tuple needed to send a message to a partition.