### PR TITLE
Ensure all runtime_modules loaded before mapping their paths

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -271,6 +271,8 @@ defmodule Kernel.ParallelCompiler do
       for {{:module, module}, binary} when is_binary(binary) <- result,
           do: module
 
+    :code.ensure_modules_loaded(runtime_modules)
+
     runtime_modules =
       for module <- runtime_modules,
           path = :code.which(module),


### PR DESCRIPTION
During a typical recompilation in our codebase, we identified a long wait unaccounted for during logs emitted by `mix compile --profile time`. You can see the discrepancy here:

```bash
$ time mix compile --profile time
Compiling 53 files (.ex)
[profile]    152ms compiling +      0ms waiting for # super/secret/file.ex
# 52 more lines of compiling logs
[profile] Finished compilation cycle of 61 modules in 13129ms
# very long wait!
[profile] Finished group pass check of 4749 modules in 3693ms
mix compile --profile time  105.24s user 49.85s system 135% cpu 1:54.71 total
```

We tracked this down to https://github.com/elixir-lang/elixir/blob/c02ea5406d8a4fa7ee6dc5ad8d26c78de35e761e/lib/elixir/lib/kernel/parallel_compiler.ex#L275-L278, where we eventually learned that most of the `:code.which/1` calls were taking ~25ms each because the module was not already loaded.

By using the already-optimized `:code.ensure_modules_loaded/1`, this change cut a huge amount of time during this pre-group-pass-check stage of the compilation process.

```bash
$ time mix compile --profile time
Compiling 53 files (.ex)
[profile]    142ms compiling +      0ms waiting for # super/secret/file.ex
# 52 more lines of compiling logs
[profile] Finished compilation cycle of 61 modules in 13466ms
[profile] Finished group pass check of 4749 modules in 2354ms
mix compile --profile time  37.48s user 9.48s system 210% cpu 22.291 total
```

Implementation notes:
* Considering the current `:code.which/1` gracefully filters out non-path return values, I opted to similarly not check (or log) any non-`:ok` return value from `:code.ensure_modules_loaded/1`
* Don't think this requires any new tests, but could be wrong!

Miscellanea:
* Yes, ~4700 runtime modules checked after compilation of 61 modules is surprising and something we're working on fixing though I think this fix is useful even with a much smaller number.