### PR TITLE
Fix circular reference in Enum.count_until/3 docstring

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -769,7 +769,7 @@ defmodule Enum do
   @doc """
   Counts the elements in the enumerable for which `fun` returns a truthy value, stopping at `limit`.
 
-  See `count/2` and `count_until/3` for more information.
+  See `count/2` and `count_until/2` for more information.
 
   ## Examples
 


### PR DESCRIPTION
The docstring for `Enum.count_until/3` references itself:
> See [count/2](https://hexdocs.pm/elixir/Enum.html#count/2) and [count_until/3](https://hexdocs.pm/elixir/Enum.html#count_until/3) for more information.

This PR changes that to reference `Enum.count_until/2` instead.