### PR TITLE
Allow passing extra arguments to eval release command

### DIFF
--- a/lib/mix/lib/mix/tasks/eval.ex
+++ b/lib/mix/lib/mix/tasks/eval.ex
@@ -65,7 +65,7 @@ defmodule Mix.Tasks.Eval do
       )
 
     case head do
-      [to_eval] ->
+      [to_eval | argv] ->
         cond do
           Mix.Project.get() ->
             Mix.Task.run("app.config", ["--no-app-loading" | args])
@@ -81,8 +81,16 @@ defmodule Mix.Tasks.Eval do
             )
         end
 
-        Code.eval_string(to_eval)
-        Mix.Task.reenable("eval")
+        old_argv = System.argv()
+
+        try do
+          System.argv(argv)
+
+          Code.eval_string(to_eval)
+          Mix.Task.reenable("eval")
+        after
+          System.argv(old_argv)
+        end
 
       _ ->
         Mix.raise("\"mix eval\" expects a single string to evaluate as argument")

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -201,14 +201,15 @@ defmodule Mix.Tasks.Release.Init do
           echo "ERROR: EVAL expects an expression as argument" >&2
           exit 1
         fi
-
+        script="$2"
+        shift 2
         export_release_sys_config
         exec "$REL_VSN_DIR/elixir" \
            --cookie "$RELEASE_COOKIE" \
            --erl-config "$RELEASE_SYS_CONFIG" \
            --boot "$REL_VSN_DIR/$RELEASE_BOOT_SCRIPT_CLEAN" \
            --boot-var RELEASE_LIB "$RELEASE_ROOT/lib" \
-           --vm-args "$RELEASE_VM_ARGS" --eval "$2"
+           --vm-args "$RELEASE_VM_ARGS" --eval "$script" -- "$@"
         ;;
 
       remote)
@@ -385,13 +386,21 @@ defmodule Mix.Tasks.Release.Init do
     goto end
 
     :eval
+    set EVAL=%~2
+    shift
+    :loop
+    shift
+    if not "%1"=="" (
+      set args=%args% %1
+      goto :loop
+    )
     "!REL_VSN_DIR!\elixir.bat" ^
-      --eval "%~2" ^
+      --eval "!EVAL!" ^
       --cookie "!RELEASE_COOKIE!" ^
       --erl-config "!RELEASE_SYS_CONFIG!" ^
       --boot "!REL_VSN_DIR!\!RELEASE_BOOT_SCRIPT_CLEAN!" ^
       --boot-var RELEASE_LIB "!RELEASE_ROOT!\lib" ^
-      --vm-args "!RELEASE_VM_ARGS!"
+      --vm-args "!RELEASE_VM_ARGS!" -- %args%
     goto end
 
     :remote

--- a/lib/mix/test/mix/tasks/eval_test.exs
+++ b/lib/mix/test/mix/tasks/eval_test.exs
@@ -26,6 +26,30 @@ defmodule Mix.Tasks.EvalTest do
     end)
   end
 
+  test "can accept arguments", context do
+    in_tmp(context.test, fn ->
+      Mix.Tasks.Eval.run(["send self(), {:argv, System.argv()}", "bar", "baz"])
+      assert_received {:argv, ~w[bar baz]}
+    end)
+  end
+
+  test "reset argv to previous value", context do
+    argv = System.argv()
+
+    try do
+      in_tmp(context.test, fn ->
+        System.argv(["foo"])
+
+        Mix.Tasks.Eval.run(["send self(), {:argv, System.argv()}", "bar", "baz"])
+        assert_received {:argv, ~w[bar baz]}
+
+        assert ["foo"] == System.argv()
+      end)
+    after
+      System.argv(argv)
+    end
+  end
+
   test "runs without mix.exs" do
     Mix.Project.pop()
 

--- a/lib/mix/test/mix/tasks/eval_test.exs
+++ b/lib/mix/test/mix/tasks/eval_test.exs
@@ -26,14 +26,14 @@ defmodule Mix.Tasks.EvalTest do
     end)
   end
 
-  test "can accept arguments", context do
+  test "accepts arguments", context do
     in_tmp(context.test, fn ->
       Mix.Tasks.Eval.run(["send self(), {:argv, System.argv()}", "bar", "baz"])
       assert_received {:argv, ~w[bar baz]}
     end)
   end
 
-  test "reset argv to previous value", context do
+  test "resets argv to previous value", context do
     argv = System.argv()
 
     try do

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -659,7 +659,7 @@ defmodule Mix.Tasks.ReleaseTest do
         refute File.exists?(Path.join(root, "RELEASE_BOOTED"))
 
         {hello_world, 0} =
-          System.cmd(script, ["eval", "IO.inspect(System.argv())", "a", "b", "c"])
+          System.cmd(script, ["eval", "IO.inspect(System.argv( ))", "a", "b", "c"])
 
         assert String.trim_trailing(hello_world) == ~S(["a", "b", "c"])
         refute File.exists?(Path.join(root, "RELEASE_BOOTED"))

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -658,6 +658,12 @@ defmodule Mix.Tasks.ReleaseTest do
         assert String.trim_trailing(hello_world) == "hello_world"
         refute File.exists?(Path.join(root, "RELEASE_BOOTED"))
 
+        {hello_world, 0} =
+          System.cmd(script, ["eval", "IO.inspect(System.argv())", "a", "b", "c"])
+
+        assert String.trim_trailing(hello_world) == ~S(["a", "b", "c"])
+        refute File.exists?(Path.join(root, "RELEASE_BOOTED"))
+
         open_port(script, [~c"eval", ~c"Application.ensure_all_started(:release_test)"])
 
         assert %{


### PR DESCRIPTION
It is handy for writing custom actions to communicate and operate with the release. 
