### PR TITLE
Precompile runtime module paths

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -271,12 +271,6 @@ defmodule Kernel.ParallelCompiler do
       for {{:module, module}, _} <- result,
           do: module
 
-    runtime_modules =
-      for module <- runtime_modules,
-          path = :code.which(module),
-          is_list(path) and path != [],
-          do: {module, path}
-
     profile_checker(profile, compiled_modules, runtime_modules, fn ->
       Module.ParallelChecker.verify(checker, runtime_modules)
     end)

--- a/lib/elixir/lib/module/parallel_checker.ex
+++ b/lib/elixir/lib/module/parallel_checker.ex
@@ -62,7 +62,10 @@ defmodule Module.ParallelChecker do
               if is_map(info) do
                 info
               else
-                info |> File.read!() |> maybe_module_map(module)
+                case File.read(info) do
+                  {:ok, binary} -> maybe_module_map(binary, module)
+                  {:error, _} -> nil
+                end
               end
 
             module_map && cache_from_module_map(ets, module_map)
@@ -136,7 +139,7 @@ defmodule Module.ParallelChecker do
   the modules and adds the ExCk chunk to the binaries. Returns the updated
   list of warnings from the verification.
   """
-  @spec verify(pid(), [{module(), binary()}]) :: [warning()]
+  @spec verify(pid(), [{module(), Path.t()}]) :: [warning()]
   def verify(checker, runtime_files) do
     for {module, file} <- runtime_files do
       spawn({self(), checker}, module, file)

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -465,7 +465,11 @@ defmodule Mix.Compilers.Elixir do
 
       modules_set = Map.from_keys(modules, true)
       {_, runtime_modules} = fixpoint_runtime_modules(sources, modules_set)
-      {:runtime, runtime_modules, warnings}
+
+      runtime_paths =
+        Enum.map(runtime_modules, &{&1, Path.join(compile_path, Atom.to_string(&1) <> ".beam")})
+
+      {:runtime, runtime_paths, warnings}
     else
       Mix.Utils.compiling_n(length(changed), :ex)
 


### PR DESCRIPTION
Backport of https://github.com/elixir-lang/elixir/commit/8f867100bb9d3bff1155907d9b355f64e85fc96d to `v1.14`