### PR TITLE
Add `URI.append_path/2`

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -982,7 +982,8 @@ defmodule URI do
   Appends `path` to the given `uri`.
 
   Path must start with `/` and cannot contain additional URL components like
-  fragments or query strings.
+  fragments or query strings. This function further assumes the path is valid and
+  it does not contain a query string or fragment parts.
 
   ## Examples
 
@@ -1000,10 +1001,6 @@ defmodule URI do
   end
 
   def append_path(%URI{} = uri, "/" <> _ = path) do
-    if String.contains?(path, ["?", "#"]) do
-      raise ArgumentError, "path cannot contain a query or fragment, got: #{inspect(path)}"
-    end
-
     %{uri | path: String.trim_trailing(uri.path || "", "/") <> path}
   end
 

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -979,29 +979,36 @@ defmodule URI do
   end
 
   @doc """
-  Joins `path` to the given `uri`.
+  Appends `path` to the given `uri`.
 
   Any additional url components in `path` (like query strings) will be removed.
 
   ## Examples
 
-      iex> URI.join_path(URI.parse("http://example.com"), "my-path") |> URI.to_string()
+      iex> URI.append_path(URI.parse("http://example.com"), "my-path") |> URI.to_string()
       "http://example.com/my-path"
 
-      iex> URI.join_path(URI.parse("http://example.com/foo/?x=1"), "/my-path") |> URI.to_string()
+      iex> URI.append_path(URI.parse("http://example.com/foo/?x=1"), "/my-path") |> URI.to_string()
       "http://example.com/foo/my-path?x=1"
 
-      iex> URI.join_path(URI.parse("http://example.com"), "/my-path?x=1") |> URI.to_string()
+      iex> URI.append_path(URI.parse("http://example.com"), "/my-path?x=1") |> URI.to_string()
       "http://example.com/my-path"
   """
   @doc since: "1.15.0"
-  @spec join_path(t(), binary()) :: t()
-  def join_path(%URI{} = uri, path) when is_binary(path) do
+  @spec append_path(t(), binary()) :: t()
+  def append_path(%URI{} = uri, path) when is_binary(path) do
     current_path = uri.path || ""
-    to_join = URI.parse(path).path
+    to_append = parse(path).path
 
-    if to_join do
-      %{uri | path: Path.join(["/", current_path, to_join])}
+    if to_append do
+      updated_path =
+        IO.chardata_to_string([
+          String.trim_trailing(current_path, "/"),
+          "/",
+          String.trim_leading(to_append, "/")
+        ])
+
+      %{uri | path: updated_path}
     else
       uri
     end

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -1000,32 +1000,12 @@ defmodule URI do
   end
 
   def append_path(%URI{} = uri, "/" <> _ = path) do
-    current_path = String.trim_trailing(uri.path || "", "/")
-
-    case new(path) do
-      {:ok, %URI{fragment: nil, path: parsed_path, query: nil}}
-      when is_binary(parsed_path) ->
-        %{uri | path: current_path <> path}
-
-      {:ok, uri} ->
-        non_path_segment_message =
-          uri
-          |> Map.take([:query, :fragment])
-          |> Enum.reject(&match?({_, nil}, &1))
-          |> Enum.map_join("\n", fn {k, v} -> "    #{k}: #{inspect(v)}" end)
-
-        raise ArgumentError, """
-        path cannot contain non-path segments, got: #{inspect(path)}
-
-          Non-path segments:
-
-        #{non_path_segment_message}
-        """
-
-      {:error, invalid_character} ->
-        raise ArgumentError,
-              "path cannot contain invalid characters, got: #{inspect(invalid_character)}"
+    if String.contains?(path, ["?", "#"]) do
+      raise ArgumentError,
+            "path cannot contain a query or fragment, got: #{inspect(path)}"
     end
+
+    %{uri | path: String.trim_trailing(uri.path || "", "/") <> path}
   end
 
   def append_path(%URI{}, path) when is_binary(path) do

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -1000,8 +1000,12 @@ defmodule URI do
     raise ArgumentError, ~s|path cannot start with "//", got: #{inspect(path)}|
   end
 
-  def append_path(%URI{} = uri, "/" <> _ = path) do
-    %{uri | path: String.trim_trailing(uri.path || "", "/") <> path}
+  def append_path(%URI{path: path} = uri, "/" <> rest = all) do
+    cond do
+      path == nil -> %{uri | path: all}
+      path != "" and :binary.last(path) == ?/ -> %{uri | path: path <> rest}
+      true -> %{uri | path: path <> all}
+    end
   end
 
   def append_path(%URI{}, path) when is_binary(path) do

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -977,6 +977,35 @@ defmodule URI do
       %{uri | query: uri.query <> "&" <> query}
     end
   end
+
+  @doc """
+  Joins `path` to the given `uri`.
+
+  Any additional url components in `path` (like query strings) will be removed.
+
+  ## Examples
+
+      iex> URI.join_path(URI.parse("http://example.com"), "my-path") |> URI.to_string()
+      "http://example.com/my-path"
+
+      iex> URI.join_path(URI.parse("http://example.com/foo/?x=1"), "/my-path") |> URI.to_string()
+      "http://example.com/foo/my-path?x=1"
+
+      iex> URI.join_path(URI.parse("http://example.com"), "/my-path?x=1") |> URI.to_string()
+      "http://example.com/my-path"
+  """
+  @doc since: "1.15.0"
+  @spec join_path(t(), binary()) :: t()
+  def join_path(%URI{} = uri, path) when is_binary(path) do
+    current_path = uri.path || ""
+    to_join = URI.parse(path).path
+
+    if to_join do
+      %{uri | path: Path.join(["/", current_path, to_join])}
+    else
+      uri
+    end
+  end
 end
 
 defimpl String.Chars, for: URI do

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -1001,8 +1001,7 @@ defmodule URI do
 
   def append_path(%URI{} = uri, "/" <> _ = path) do
     if String.contains?(path, ["?", "#"]) do
-      raise ArgumentError,
-            "path cannot contain a query or fragment, got: #{inspect(path)}"
+      raise ArgumentError, "path cannot contain a query or fragment, got: #{inspect(path)}"
     end
 
     %{uri | path: String.trim_trailing(uri.path || "", "/") <> path}

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -981,7 +981,7 @@ defmodule URI do
   @doc """
   Appends `path` to the given `uri`.
 
-  Path must start with "/" and cannot contain additional url components like
+  Path must start with `/` and cannot contain additional URL components like
   fragments or query strings.
 
   ## Examples
@@ -991,9 +991,10 @@ defmodule URI do
 
       iex> URI.append_path(URI.parse("http://example.com"), "my-path")
       ** (ArgumentError) path must start with "/", got: "my-path"
+
   """
   @doc since: "1.15.0"
-  @spec append_path(t(), binary()) :: t()
+  @spec append_path(t(), String.t()) :: t()
   def append_path(%URI{}, "//" <> _ = path) do
     raise ArgumentError, ~s|path cannot start with "//", got: #{inspect(path)}|
   end
@@ -1011,8 +1012,7 @@ defmodule URI do
           uri
           |> Map.take([:query, :fragment])
           |> Enum.reject(&match?({_, nil}, &1))
-          |> Enum.map(fn {k, v} -> "    #{k}: #{inspect(v)}" end)
-          |> Enum.join("\n")
+          |> Enum.map_join("\n", fn {k, v} -> "    #{k}: #{inspect(v)}" end)
 
         raise ArgumentError, """
         path cannot contain non-path segments, got: #{inspect(path)}

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -536,12 +536,6 @@ defmodule URITest do
                    fn ->
                      URI.append_path(base_uri, "//foo")
                    end
-
-      assert_raise ArgumentError,
-                   ~S|path cannot contain a query or fragment, got: "/foo?var=1#tag"|,
-                   fn ->
-                     URI.append_path(base_uri, "/foo?var=1#tag")
-                   end
     end
   end
 

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -538,22 +538,9 @@ defmodule URITest do
                    end
 
       assert_raise ArgumentError,
-                   """
-                   path cannot contain non-path segments, got: "/foo?var=1#tag"
-
-                     Non-path segments:
-
-                       fragment: "tag"
-                       query: "var=1"
-                   """,
+                   ~S|path cannot contain a query or fragment, got: "/foo?var=1#tag"|,
                    fn ->
                      URI.append_path(base_uri, "/foo?var=1#tag")
-                   end
-
-      assert_raise ArgumentError,
-                   ~S|path cannot contain invalid characters, got: ">"|,
-                   fn ->
-                     URI.append_path(base_uri, "/>")
                    end
     end
   end

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -490,21 +490,21 @@ defmodule URITest do
     assert URI.append_query(URI.parse("http://example.com/?x=1&"), "x=2").query == "x=1&x=2"
   end
 
-  test "join_path/2" do
+  test "append_path/2" do
     examples = [
       {"http://example.com", "", "http://example.com"},
       {"http://example.com", "/", "http://example.com/"},
       {"http://example.com/", "", "http://example.com/"},
       {"http://example.com", "foo", "http://example.com/foo"},
       {"http://example.com/", "foo", "http://example.com/foo"},
-      {"http://example.com/", "foo/", "http://example.com/foo"},
+      {"http://example.com/", "foo/", "http://example.com/foo/"},
       {"http://example.com/", "/foo", "http://example.com/foo"},
       {"http://example.com/foo", "bar", "http://example.com/foo/bar"},
       {"http://example.com/foo", "/bar", "http://example.com/foo/bar"},
-      {"http://example.com/foo", "/bar/", "http://example.com/foo/bar"},
+      {"http://example.com/foo", "/bar/", "http://example.com/foo/bar/"},
       {"http://example.com/foo", "/bar/baz", "http://example.com/foo/bar/baz"},
       {"http://example.com/foo/bar", "baz", "http://example.com/foo/bar/baz"},
-      {"http://example.com/foo?var=1", "/bar/", "http://example.com/foo/bar?var=1"},
+      {"http://example.com/foo?var=1", "/bar/", "http://example.com/foo/bar/?var=1"},
       {"http://example.com/foo", "/bar?foo", "http://example.com/foo/bar"},
       {"http://example.com", "?foo", "http://example.com"}
     ]
@@ -513,11 +513,11 @@ defmodule URITest do
       result =
         base_url
         |> URI.parse()
-        |> URI.join_path(path)
+        |> URI.append_path(path)
         |> URI.to_string()
 
       assert result == expected_result, """
-      Path did not join as expected
+      Path did not append as expected
 
         base_url: #{inspect(base_url)}
         path: #{inspect(path)}

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -490,6 +490,44 @@ defmodule URITest do
     assert URI.append_query(URI.parse("http://example.com/?x=1&"), "x=2").query == "x=1&x=2"
   end
 
+  test "join_path/2" do
+    examples = [
+      {"http://example.com", "", "http://example.com"},
+      {"http://example.com", "/", "http://example.com/"},
+      {"http://example.com/", "", "http://example.com/"},
+      {"http://example.com", "foo", "http://example.com/foo"},
+      {"http://example.com/", "foo", "http://example.com/foo"},
+      {"http://example.com/", "foo/", "http://example.com/foo"},
+      {"http://example.com/", "/foo", "http://example.com/foo"},
+      {"http://example.com/foo", "bar", "http://example.com/foo/bar"},
+      {"http://example.com/foo", "/bar", "http://example.com/foo/bar"},
+      {"http://example.com/foo", "/bar/", "http://example.com/foo/bar"},
+      {"http://example.com/foo", "/bar/baz", "http://example.com/foo/bar/baz"},
+      {"http://example.com/foo/bar", "baz", "http://example.com/foo/bar/baz"},
+      {"http://example.com/foo?var=1", "/bar/", "http://example.com/foo/bar?var=1"},
+      {"http://example.com/foo", "/bar?foo", "http://example.com/foo/bar"},
+      {"http://example.com", "?foo", "http://example.com"}
+    ]
+
+    for {base_url, path, expected_result} <- examples do
+      result =
+        base_url
+        |> URI.parse()
+        |> URI.join_path(path)
+        |> URI.to_string()
+
+      assert result == expected_result, """
+      Path did not join as expected
+
+        base_url: #{inspect(base_url)}
+        path: #{inspect(path)}
+
+        result:          #{inspect(result)}
+        expected_result: #{inspect(expected_result)}
+      """
+    end
+  end
+
   ## Deprecate API
 
   describe "authority" do


### PR DESCRIPTION
This adds `URI.join_path/2` which was [proposed on the Elixir mailing list](https://groups.google.com/g/elixir-lang-core/c/KstQ_7ty6W4/m/CJxEBCCoDQAJ). This can be really useful when joining path segments on to a base url that already has a path.

```
iex> URI.join_path(URI.parse("http://example.com/foo"), "/my-path") |> URI.to_string()
"http://example.com/foo/my-path"
```

## Open questions

### Function name
Do we like this function name? I chose it because it's similar to `Path.join/2`. However, there's also `URI.append_query/2`, so this could also be named `URI.append_path`.

### Path parameter

Do we want to support providing `path` as a list so it would work similar to `Path.join/1`? I'm thinking it's simpler to just accept a string, but I figured I should double-check.

Also, this function strips any non-path URL segments like query strings or fragments. I figured this would provide less possibility of errors if bad data was passed in on `path`.