### PR TITLE
Let `pid/1` parse a pid's inspection string

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -1240,11 +1240,24 @@ defmodule IEx.Helpers do
 
       iex> pid("0.21.32")
       #PID<0.21.32>
+      
+      iex> pid("#PID<0.21.32>")
+      #PID<0.21.32>
 
       iex> pid(:init)
       #PID<0.0.0>
 
   """
+  def pid("#PID<" <> _rest = string) do
+    case Regex.named_captures(~r/#PID<(?<triplet>\d+.\d+.\d+)>/, string) do
+      %{"triplet" => triplet} ->
+        pid(triplet)
+
+      _ ->
+        raise ArgumentError, "invalid pid format: #{inspect(string)}"
+    end
+  end
+
   def pid(string) when is_binary(string) do
     :erlang.list_to_pid(~c"<#{string}>")
   end


### PR DESCRIPTION
This is convenient because it lets you copy and paste a pid value shown in the shell and turn it into a real pid.