### PR TITLE
writing-documentation: removed redundant link

### DIFF
--- a/lib/elixir/pages/writing-documentation.md
+++ b/lib/elixir/pages/writing-documentation.md
@@ -4,7 +4,7 @@ Elixir treats documentation as a first-class citizen. This means documentation s
 
 ## Markdown
 
-Elixir documentation is written using Markdown. There are plenty of guides on Markdown online, we recommend the ones available at GitHub as a getting started point:
+Elixir documentation is written using Markdown. There are plenty of guides on Markdown online, we recommend the one from GitHub as a getting started point:
 
   * [Basic writing and formatting syntax](https://help.github.com/articles/basic-writing-and-formatting-syntax/)
 

--- a/lib/elixir/pages/writing-documentation.md
+++ b/lib/elixir/pages/writing-documentation.md
@@ -7,7 +7,6 @@ Elixir treats documentation as a first-class citizen. This means documentation s
 Elixir documentation is written using Markdown. There are plenty of guides on Markdown online, we recommend the ones available at GitHub as a getting started point:
 
   * [Basic writing and formatting syntax](https://help.github.com/articles/basic-writing-and-formatting-syntax/)
-  * [Mastering Markdown](https://guides.github.com/features/mastering-markdown/)
 
 ## Module Attributes
 


### PR DESCRIPTION
Hi 

I've stumbled upon that those two links — 

1. https://help.github.com/articles/basic-writing-and-formatting-syntax/
2. https://guides.github.com/features/mastering-markdown/

Results to one resource — 

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

(1) and (2) are basically point to the same resource, so I removed one and made this PR, because it did confuse me, and I think it is confusing in general that two (kinda of) different links point to the same resource at the end.


