### PR TITLE
Add details about waiting modules in `--profile time` compiler output

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -312,9 +312,9 @@ defmodule Kernel.ParallelCompiler do
   defp spawn_workers([{pid, found} | t], spawned, waiting, files, result, warnings, errors, state) do
     {files, waiting} =
       case Map.pop(waiting, pid) do
-        {{_kind, ref, file_pid, _on, _defining, _deadlock}, waiting} ->
+        {{_kind, ref, file_pid, on, _defining, _deadlock}, waiting} ->
           send(pid, {ref, found})
-          {update_timing(files, file_pid, :waiting), waiting}
+          {update_timing(files, file_pid, {:waiting, on}), waiting}
 
         {nil, waiting} ->
           # In case the waiting process died (for example, it was an async process),
@@ -356,7 +356,7 @@ defmodule Kernel.ParallelCompiler do
       file: file,
       timestamp: System.monotonic_time(),
       compiling: 0,
-      waiting: 0,
+      waiting: [],
       warned: false
     }
 
@@ -663,18 +663,18 @@ defmodule Kernel.ParallelCompiler do
 
   defp update_timing(files, pid, key) do
     Enum.map(files, fn data ->
-      if data.pid == pid do
-        time = System.monotonic_time()
-        %{data | key => data[key] + time - data.timestamp, timestamp: time}
-      else
-        data
-      end
+      if data.pid == pid, do: update_timing(data, key), else: data
     end)
   end
 
-  defp update_timing(data, key) do
+  defp update_timing(data, :compiling) do
     time = System.monotonic_time()
-    %{data | key => data[key] + time - data.timestamp, timestamp: time}
+    %{data | compiling: data.compiling + time - data.timestamp, timestamp: time}
+  end
+
+  defp update_timing(data, {:waiting, on}) do
+    time = System.monotonic_time()
+    %{data | waiting: [{on, time - data.timestamp} | data.waiting], timestamp: time}
   end
 
   defp maybe_warn_long_compilation(data, state) do
@@ -705,13 +705,26 @@ defmodule Kernel.ParallelCompiler do
 
     if state.profile != :none do
       compiling = to_padded_ms(data.compiling)
-      waiting = to_padded_ms(data.waiting)
       relative = Path.relative_to_cwd(data.file)
 
-      IO.puts(
-        :stderr,
-        "[profile] #{compiling}ms compiling + #{waiting}ms waiting for #{relative}"
-      )
+      waiting_total =
+        data.waiting
+        |> Enum.reduce(0, fn {_on, time}, acc -> acc + time end)
+        |> to_padded_ms()
+
+      waiting_details =
+        Enum.map(data.waiting, fn {on, time} ->
+          "\n[profile]                    | #{to_padded_ms(time)}ms waiting for #{inspect(on)}"
+        end)
+
+      message =
+        "[profile] #{compiling}ms compiling + #{waiting_total}ms total waiting for #{relative}"
+
+      if waiting_details == [] do
+        IO.puts(:stderr, message)
+      else
+        IO.puts(:stderr, [message | waiting_details])
+      end
     end
   end
 

--- a/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
+++ b/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
@@ -33,6 +33,17 @@ defmodule Kernel.ParallelCompilerTest do
           bar: """
           defmodule HelloWorld do
           end
+          """,
+          has_compile_dep: """
+          defmodule HasCompileDep do
+            @foo IsCompileDep.run()
+            def foo, do: @foo
+          end
+          """,
+          is_compile_dep: """
+          defmodule IsCompileDep do
+           def run, do: :ok
+          end
           """
         )
 
@@ -44,10 +55,19 @@ defmodule Kernel.ParallelCompilerTest do
         end)
 
       assert profile =~
-               ~r"\[profile\] [\s\d]{6}ms compiling \+      0ms waiting for .*tmp/profile_time/bar.ex"
+               ~r"\[profile\] [\s\d]{6}ms compiling \+      0ms total waiting for .*tmp/profile_time/bar.ex"
 
-      assert profile =~ ~r"\[profile\] Finished compilation cycle of 1 modules in \d+ms"
-      assert profile =~ ~r"\[profile\] Finished group pass check of 1 modules in \d+ms"
+      assert profile =~
+               ~r"\[profile\] [\s\d]{6}ms compiling \+      0ms total waiting for .*tmp/profile_time/is_compile_dep.ex"
+
+      assert profile =~
+               ~r"\[profile\] [\s\d]{6}ms compiling \+ [\s\d]{6}ms total waiting for .*tmp/profile_time/has_compile_dep.ex"
+
+      assert profile =~
+               ~r"\[profile\]                    | [\s\d]{6}ms waiting for IsCompileDep"
+
+      assert profile =~ ~r"\[profile\] Finished compilation cycle of 3 modules in \d+ms"
+      assert profile =~ ~r"\[profile\] Finished group pass check of 3 modules in \d+ms"
     after
       purge([HelloWorld])
     end

--- a/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
+++ b/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
@@ -33,17 +33,6 @@ defmodule Kernel.ParallelCompilerTest do
           bar: """
           defmodule HelloWorld do
           end
-          """,
-          has_compile_dep: """
-          defmodule HasCompileDep do
-            @foo IsCompileDep.run()
-            def foo, do: @foo
-          end
-          """,
-          is_compile_dep: """
-          defmodule IsCompileDep do
-           def run, do: :ok
-          end
           """
         )
 
@@ -55,19 +44,10 @@ defmodule Kernel.ParallelCompilerTest do
         end)
 
       assert profile =~
-               ~r"\[profile\] [\s\d]{6}ms compiling \+      0ms total waiting for .*tmp/profile_time/bar.ex"
+               ~r"\[profile\] [\s\d]{6}ms compiling \+      0ms waiting while compiling .*tmp/profile_time/bar.ex"
 
-      assert profile =~
-               ~r"\[profile\] [\s\d]{6}ms compiling \+      0ms total waiting for .*tmp/profile_time/is_compile_dep.ex"
-
-      assert profile =~
-               ~r"\[profile\] [\s\d]{6}ms compiling \+ [\s\d]{6}ms total waiting for .*tmp/profile_time/has_compile_dep.ex"
-
-      assert profile =~
-               ~r"\[profile\]                    | [\s\d]{6}ms waiting for IsCompileDep"
-
-      assert profile =~ ~r"\[profile\] Finished compilation cycle of 3 modules in \d+ms"
-      assert profile =~ ~r"\[profile\] Finished group pass check of 3 modules in \d+ms"
+      assert profile =~ ~r"\[profile\] Finished compilation cycle of 1 modules in \d+ms"
+      assert profile =~ ~r"\[profile\] Finished group pass check of 1 modules in \d+ms"
     after
       purge([HelloWorld])
     end


### PR DESCRIPTION
# Context
When running `mix compile --profile time`, we currently get output about how long each file took to compile, and how long it spent waiting for other compile-time dependencies to be available, but it doesn't say what those module are.

# Existing Solutions
We can, for example, use `mix xref trace` and `mix xref graph` to determine what those dependencies are, but it isn't easy to analyze which ones will actually have an impact in practice on the compile times of the dependent modules.

# New Feature
This PR adds more detail to the `--profile time` option of the Elixir compiler, so that it also lists how long each module spent waiting for each dependency to become available.

# Alternatives Considered
I also looked into leaving the output the same unless the user also passes the `--verbose` option, but the problem is that it then outputs the file name twice (once for the `--verbose` option and once for the `--profile` option) and I felt like that was messy. Let me know if you'd prefer to split this into a separate `--profile` option value like `time-details`, to preserve the existing behavior, instead.

# Future Work
I was also looking into how I can add this to the Compiler Tracing feature, but it was trivial to add to the existing profiling code this way, and I have not figured out the right place to inject the appropriate tracing events yet, but I will continue to work on that and open a separate PR.

# Example
As an example, I ran it against the Phoenix codebase:

## Before
```
...
[profile]    147ms compiling +      0ms waiting for lib/phoenix/router/scope.ex
[profile]     58ms compiling +      0ms waiting for lib/phoenix/socket/pool_supervisor.ex
[profile]    318ms compiling +      0ms waiting for lib/phoenix/router.ex
[profile]     47ms compiling +      0ms waiting for lib/phoenix/socket/serializer.ex
[profile]     68ms compiling +      0ms waiting for lib/phoenix/token.ex
[profile]    188ms compiling +      0ms waiting for lib/phoenix/socket/message.ex
[profile]    428ms compiling +      0ms waiting for lib/phoenix/param.ex
[profile]    114ms compiling +    526ms waiting for lib/phoenix/channel.ex
[profile]     83ms compiling +     81ms waiting for lib/phoenix/socket/serializers/v1_json_serializer.ex
[profile]    115ms compiling +      0ms waiting for lib/phoenix/transports/long_poll.ex
[profile]    157ms compiling +      0ms waiting for lib/phoenix/socket/transport.ex
[profile]    119ms compiling +     75ms waiting for lib/phoenix/socket/serializers/v2_json_serializer.ex
[profile]     42ms compiling +      0ms waiting for lib/phoenix/transports/websocket.ex
[profile]    198ms compiling +      0ms waiting for lib/phoenix/test/conn_test.ex
[profile]    286ms compiling +     42ms waiting for lib/phoenix/socket.ex
[profile]     96ms compiling +      0ms waiting for lib/phoenix/transports/long_poll_server.ex
[profile]    210ms compiling +    576ms waiting for lib/phoenix/channel/server.ex
[profile]    273ms compiling +      0ms waiting for lib/phoenix/test/channel_test.ex
[profile]    167ms compiling +      0ms waiting for lib/phoenix/verified_routes.ex
[profile] Finished compilation cycle of 87 modules in 1244ms
[profile] Finished group pass check of 87 modules in 106ms
Generated phoenix app
```

## After
```
...
[profile]    149ms compiling +      0ms total waiting for lib/phoenix/router/scope.ex
[profile]    332ms compiling +      0ms total waiting for lib/phoenix/router.ex
[profile]     50ms compiling +      0ms total waiting for lib/phoenix/socket/serializer.ex
[profile]    147ms compiling +      0ms total waiting for lib/phoenix/socket/message.ex
[profile]    391ms compiling +      0ms total waiting for lib/phoenix/param.ex
[profile]     77ms compiling +     11ms total waiting for lib/phoenix/socket/serializers/v1_json_serializer.ex
[profile]                    |     11ms waiting for Phoenix.Socket.Serializer
[profile]    132ms compiling +    490ms total waiting for lib/phoenix/channel.ex
[profile]                    |    490ms waiting for Phoenix.Socket
[profile]    119ms compiling +      0ms total waiting for lib/phoenix/socket/serializers/v2_json_serializer.ex
[profile]     70ms compiling +      0ms total waiting for lib/phoenix/token.ex
[profile]    151ms compiling +      0ms total waiting for lib/phoenix/socket/transport.ex
[profile]     90ms compiling +      0ms total waiting for lib/phoenix/transports/long_poll.ex
[profile]    287ms compiling +     12ms total waiting for lib/phoenix/socket.ex
[profile]                    |     12ms waiting for Phoenix.Socket.Broadcast
[profile]     42ms compiling +      0ms total waiting for lib/phoenix/transports/websocket.ex
[profile]    226ms compiling +    508ms total waiting for lib/phoenix/channel/server.ex
[profile]                    |    334ms waiting for Phoenix.Socket.Broadcast
[profile]                    |    174ms waiting for Phoenix.Endpoint
[profile]     94ms compiling +      0ms total waiting for lib/phoenix/transports/long_poll_server.ex
[profile]    197ms compiling +      0ms total waiting for lib/phoenix/test/channel_test.ex
[profile]    197ms compiling +      0ms total waiting for lib/phoenix/test/conn_test.ex
[profile]    152ms compiling +      0ms total waiting for lib/phoenix/verified_routes.ex
[profile] Finished compilation cycle of 87 modules in 1260ms
[profile] Finished group pass check of 87 modules in 104ms
Generated phoenix app
```