### PR TITLE
Add ability for System.cmd/3 to return lines

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -1071,10 +1071,10 @@ defmodule System do
   defp do_port(port, acc, fun) do
     receive do
       {^port, {:data, {:noeol, data}}} ->
-        do_port(port, fun.(acc, {:cont, data}), fun)
+        do_port(port, fun.(acc, {:cont, {:noeol, data}}), fun)
 
       {^port, {:data, {:eol, data}}} ->
-        do_port(port, fun.(acc, {:cont, data}), fun)
+        do_port(port, fun.(acc, {:cont, {:eol, data}}), fun)
 
       {^port, {:data, data}} ->
         do_port(port, fun.(acc, {:cont, data}), fun)
@@ -1107,14 +1107,14 @@ defmodule System do
 
   defp cmd_opts([{:lines, max_line_length} | t], opts, "")
        when is_integer(max_line_length) and max_line_length > 0,
-       do: cmd_opts(t, [{:line, max_line_length} | opts], [])
+       do: cmd_opts(t, [{:line, max_line_length} | opts], System.LineBuffer.new())
 
   defp cmd_opts([{:lines, max_line_length} | t], opts, into)
        when is_integer(max_line_length) and max_line_length > 0,
        do: cmd_opts(t, [{:line, max_line_length} | opts], into)
 
   defp cmd_opts([:lines | t], opts, ""),
-    do: cmd_opts(t, [{:line, 1024} | opts], [])
+    do: cmd_opts(t, [{:line, 1024} | opts], System.LineBuffer.new())
 
   defp cmd_opts([:lines | t], opts, into),
     do: cmd_opts(t, [{:line, 1024} | opts], into)

--- a/lib/elixir/lib/system/line_buffer.ex
+++ b/lib/elixir/lib/system/line_buffer.ex
@@ -7,7 +7,7 @@ defmodule System.LineBuffer do
   end
 end
 
-defimpl Elixir.Collectable, for: System.LineBuffer do
+defimpl Collectable, for: System.LineBuffer do
   def into(line_buffer) do
     collector_fun = fn
       acc, {:cont, {:noeol, elem}} ->

--- a/lib/elixir/lib/system/line_buffer.ex
+++ b/lib/elixir/lib/system/line_buffer.ex
@@ -1,0 +1,31 @@
+defmodule System.LineBuffer do
+  @moduledoc false
+  defstruct current_line: "", lines: []
+
+  def new() do
+    %__MODULE__{}
+  end
+end
+
+defimpl Elixir.Collectable, for: System.LineBuffer do
+  def into(line_buffer) do
+    collector_fun = fn
+      acc, {:cont, {:noeol, elem}} ->
+        %{acc | current_line: acc.current_line <> elem}
+
+      acc, {:cont, {:eol, elem}} ->
+        current_line = acc.current_line <> elem
+        %{acc | current_line: "", lines: [current_line | acc.lines]}
+
+      acc, :done ->
+        Enum.reverse(acc.lines)
+
+      _acc, :halt ->
+        :ok
+    end
+
+    initial_acc = line_buffer
+
+    {initial_acc, collector_fun}
+  end
+end


### PR DESCRIPTION
Hi! First of all, thank you for any consideration of this PR. Forgive me if there is already a way to do this with the standard library, I wasn't able to find anything, but it's possible I missed it!

### What this PR does

1. Adds an option to `System.cmd/3` to allow for collecting the results of the command as a list of lines, like:

```elixir
iex(1)> {out, 0} = System.cmd("cat", ["/etc/hosts"], [:lines])
{["##", "# Host Database", "#",
  "# localhost is used to configure the loopback interface",
  "# when the system is booting.  Do not change this entry.", "##",
  "127.0.0.1\tlocalhost", "255.255.255.255\tbroadcasthost",
  "::1             localhost", "# Added by Docker Desktop",
  "# To allow the same kube context to work on the host and the container:",
  "127.0.0.1 kubernetes.docker.internal", "# End of section"], 0}
```

2. Allow passing your own `Collectable` instance to `System.cmd/3`, such that it can work on a single line at a time, without holding the entire output in memory, like this:

```elixir
# with the following setup:
require Logger

# a very simple custom Collectable that simply
# echos lines with their line number
defmodule LineStream do
  defstruct line_number: 1

  def new() do
    %__MODULE__{}
  end
end

defimpl Collectable, for: LineStream do
  def into(line_stream) do
    Logger.debug(initial: line_stream)

    collector_fun = fn
      acc, {:cont, {:eol, elem}} ->
        Logger.debug(line_number: acc.line_number, line: elem)
        %{acc | line_number: acc.line_number + 1}

      _acc, :done ->
        :ok

      _acc, :halt ->
        :ok
    end

    initial_acc = line_stream

    {initial_acc, collector_fun}
  end
end

{s4, 0} = System.cmd("cat", ["/etc/hosts"], [:lines, into: LineStream.new()])

# which outputs:

# 22:04:22.326 [debug] [initial: %LineStream{line_number: 1}]
# 22:04:22.334 [debug] [line_number: 1, line: "##"]
# 22:04:22.335 [debug] [line_number: 2, line: "# Host Database"]
# 22:04:22.335 [debug] [line_number: 3, line: "#"]
# 22:04:22.335 [debug] [line_number: 4, line: "# localhost is used to configure the loopback interface"]
# 22:04:22.335 [debug] [line_number: 5, line: "# when the system is booting.  Do not change this entry."]
# 22:04:22.335 [debug] [line_number: 6, line: "##"]
# 22:04:22.335 [debug] [line_number: 7, line: "127.0.0.1\tlocalhost"]
# 22:04:22.335 [debug] [line_number: 8, line: "255.255.255.255\tbroadcasthost"]
# 22:04:22.335 [debug] [line_number: 9, line: "::1             localhost"]
# 22:04:22.335 [debug] [line_number: 10, line: "# Added by Docker Desktop"]
# 22:04:22.335 [debug] [line_number: 11, line: "# To allow the same kube context to work on the host and the container:"]
# 22:04:22.335 [debug] [line_number: 12, line: "127.0.0.1 kubernetes.docker.internal"]
# 22:04:22.335 [debug] [line_number: 13, line: "# End of section"]
```

### Rationale

A ton of command line utilities are line-oriented, and I wanted to be able to use them with `System.cmd/3` in a few ways that didn't seem to currently exist in the standard library, reflective of the examples above: with their results as as a list of lines, and with their results in a streaming "one line at a time" way.

### Implementation notes

The magic `1024` in the `{:line, 1024}` passed to the `Port.open` call is the size in bytes of the buffer Erlang uses internally to buffer the results of whatever command you had the `port` execute. Erlang breaks lines that are longer than this boundary into their own separate messages, so I added `System.LineBuffer` to reconstruct the buffer-sized chunks into their original lines. Though I haven't benchmarked it, I imagine there is a tradeoff here between the size of the buffer in memory and the number of times Erlang has to flush this buffer back to the port (a larger buffer requires fewer flushes per line but larger memory use vs. a smaller buffer requires more frequent flushing but takes less memory), so this `:line` option is overridable in the same way that Erlang's [erlang:open_port/2](https://www.erlang.org/doc/man/erlang.html#open_port-2) is, like `# {s3, 0} = System.cmd("cat", ["/etc/hosts"], lines: 5000)`. `1024` seemed to me like a reasonable default.

As far as I can tell, this PR doesn't alter any of the existing functionality of `System.cmd/3`.

Thanks again for the consideration!