### PR TITLE
Pretty print KeyError exception message

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1409,7 +1409,7 @@ defmodule KeyError do
     message = "key #{inspect(key)} not found"
 
     if term != nil do
-      message <> " in: #{inspect(term)}"
+      message <> " in: #{inspect(term, pretty: true)}"
     else
       message
     end


### PR DESCRIPTION
Companion of https://github.com/elixir-plug/plug/pull/1126

Should `limit: :infinity` be added too?