### PR TITLE
system_test - link instead of copy to bypass macos 13 codesign

### DIFF
--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -121,7 +121,7 @@ defmodule SystemTest do
     test "cmd/3 with absolute and relative paths", config do
       echo = Path.join(config.tmp_dir, @echo)
       File.mkdir_p!(Path.dirname(echo))
-      File.cp!(System.find_executable("cmd"), echo)
+      File.ln_s!(System.find_executable("cmd"), echo)
 
       File.cd!(Path.dirname(echo), fn ->
         # There is a bug in OTP where find_executable is finding
@@ -186,7 +186,7 @@ defmodule SystemTest do
     test "cmd/3 with absolute and relative paths", config do
       echo = Path.join(config.tmp_dir, @echo)
       File.mkdir_p!(Path.dirname(echo))
-      File.cp!(System.find_executable("echo"), echo)
+      File.ln_s!(System.find_executable("echo"), echo)
 
       File.cd!(Path.dirname(echo), fn ->
         # There is a bug in OTP where find_executable is finding


### PR DESCRIPTION
That's a proposal to fix #12290

Not signed binaries are just killed by codesign:

```
$ ./echo-elixir-test foo
zsh: killed     ./echo-elixir-test foo
```

But copying or linking works fine and there's no need to install `coreutils`. Makes sense?

/edit I'm getting the very same error as reported on the issue :)