### PR TITLE
Fix shell snippet in mix do doc

### DIFF
--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.Do do
   Elixir versions prior to v1.14 used the comma exclusively
   to separate commands:
 
-      $ mix do compile --list + deps
+      $ mix do compile --list, deps
 
   Since then, the `+` operator has been introduced as a
   separator for better support on Windows terminals.


### PR DESCRIPTION
Fixes a shell snippet that is supposed to illustrate the use of the comma separator.