### PR TITLE
Fix arity of __after_verify__ in Compile callbacks documentation

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -504,7 +504,7 @@ defmodule Module do
 
   Accepts a module or a `{module, function_name}` tuple. The function
   must take one argument: the module name. When just a module is provided,
-  the function is assumed to be `__after_verify__/2`.
+  the function is assumed to be `__after_verify__/1`.
 
   Callbacks will run in the order they are registered.
 


### PR DESCRIPTION
Fixing a small typo I run into while reading the docs.