### PR TITLE
Add Map.intersect/2 and Map.intersect/3

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1182,7 +1182,7 @@ defmodule Map do
       %{b: 4}
   """
   @doc since: "1.15.0"
-  @spec merge(map, map, (key, value, value -> value)) :: map
+  @spec intersect(map, map, (key, value, value -> value)) :: map
   def intersect(map1, map2, fun) when is_function(fun, 3) do
     :maps.intersect_with(fun, map1, map2)
   end

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1174,8 +1174,6 @@ defmodule Map do
   `map1`), and `value2` (the value of `key` in `map2`). The value returned by
   `fun` is used as the value under `key` in the resulting map.
 
-  Inlined by the compiler.
-
   ## Examples
 
       iex> Map.intersect(%{a: 1, b: 2}, %{b: 2, c: 3}, fn _k, v1, v2 ->

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1149,6 +1149,46 @@ defmodule Map do
     end
   end
 
+  @doc """
+  Intersects two maps into one.
+
+  If a key exists in both maps, the value in `map2` will be used.
+
+  Inlined by the compiler.
+
+  ## Examples
+
+      iex> Map.intersect(%{a: 1, b: 2}, %{b: "b", c: "c"})
+      %{b: "b"}
+
+  """
+  @doc since: "1.15.0"
+  @spec intersect(map, map) :: map
+  defdelegate intersect(map1, map2), to: :maps
+
+  @doc """
+  Intersects two maps into one, resolving conflicts through the given `fun`.
+
+  The given function will be invoked when there are duplicate keys; its
+  arguments are `key` (the duplicate key), `value1` (the value of `key` in
+  `map1`), and `value2` (the value of `key` in `map2`). The value returned by
+  `fun` is used as the value under `key` in the resulting map.
+
+  Inlined by the compiler.
+
+  ## Examples
+
+      iex> Map.intersect(%{a: 1, b: 2}, %{b: 2, c: 3}, fn _k, v1, v2 ->
+      ...>   v1 + v2
+      ...> end)
+      %{b: 4}
+  """
+  @doc since: "1.15.0"
+  @spec merge(map, map, (key, value, value -> value)) :: map
+  def intersect(map1, map2, fun) when is_function(fun, 3) do
+    :maps.intersect_with(fun, map1, map2)
+  end
+
   @doc false
   @deprecated "Use Map.new/2 instead (invoke Map.from_struct/1 before if you have a struct)"
   def map(map, fun) when is_map(map) do

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1150,9 +1150,9 @@ defmodule Map do
   end
 
   @doc """
-  Intersects two maps into one.
+  Intersects two maps, returning a map with the common keys.
 
-  If a key exists in both maps, the value in `map2` will be used.
+  The values in the returned map are the values of the intersected keys in `map2`.
 
   Inlined by the compiler.
 
@@ -1167,7 +1167,7 @@ defmodule Map do
   defdelegate intersect(map1, map2), to: :maps
 
   @doc """
-  Intersects two maps into one, resolving conflicts through the given `fun`.
+  Intersects two maps, returning a map with the common keys and resolving conflicts through a function.
 
   The given function will be invoked when there are duplicate keys; its
   arguments are `key` (the duplicate key), `value1` (the value of `key` in

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -21,7 +21,11 @@ defmodule KeywordTest do
   end
 
   test "implements (almost) all functions in Map" do
-    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [from_struct: 1]
+    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [
+             from_struct: 1,
+             intersect: 2,
+             intersect: 3
+           ]
   end
 
   test "get_and_update/3 raises on bad return value from the argument function" do

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -231,18 +231,13 @@ defmodule MapTest do
     end
   end
 
-  test "intersect/2 with map literals optimized by the compiler" do
+  test "intersect/2" do
     map = %{a: 1, b: 2}
 
     assert Map.intersect(map, %{a: 2}) == %{a: 2}
     assert Map.intersect(map, %{c: 3}) == %{}
     assert Map.intersect(%{a: 2}, map) == %{a: 1}
     assert Map.intersect(%{c: 3}, map) == %{}
-
-    assert Map.intersect(%{map | a: 2}, %{a: 3}) == %{a: 3}
-    assert Map.intersect(%{map | a: 2}, %{b: 3}) == %{b: 3}
-    assert Map.intersect(%{a: 2}, %{map | a: 3}) == %{a: 3}
-    assert Map.intersect(%{a: 2}, %{map | b: 3}) == %{a: 1}
 
     assert Map.intersect(map, %{a: 2}) |> Map.intersect(%{a: 3, c: 3}) == %{a: 3}
     assert Map.intersect(map, %{c: 3}) |> Map.intersect(%{c: 4}) == %{}

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -231,6 +231,34 @@ defmodule MapTest do
     end
   end
 
+  test "intersect/2 with map literals optimized by the compiler" do
+    map = %{a: 1, b: 2}
+
+    assert Map.intersect(map, %{a: 2}) == %{a: 2}
+    assert Map.intersect(map, %{c: 3}) == %{}
+    assert Map.intersect(%{a: 2}, map) == %{a: 1}
+    assert Map.intersect(%{c: 3}, map) == %{}
+
+    assert Map.intersect(%{map | a: 2}, %{a: 3}) == %{a: 3}
+    assert Map.intersect(%{map | a: 2}, %{b: 3}) == %{b: 3}
+    assert Map.intersect(%{a: 2}, %{map | a: 3}) == %{a: 3}
+    assert Map.intersect(%{a: 2}, %{map | b: 3}) == %{a: 1}
+
+    assert Map.intersect(map, %{a: 2}) |> Map.intersect(%{a: 3, c: 3}) == %{a: 3}
+    assert Map.intersect(map, %{c: 3}) |> Map.intersect(%{c: 4}) == %{}
+    assert Map.intersect(map, %{a: 3, c: 3}) |> Map.intersect(%{a: 2}) == %{a: 2}
+  end
+
+  test "intersect/3" do
+    # When first map is bigger
+    assert Map.intersect(%{a: 1, b: 2, c: 3}, %{c: 4, d: 5}, fn :c, 3, 4 -> :x end) ==
+             %{c: :x}
+
+    # When second map is bigger
+    assert Map.intersect(%{b: 2, c: 3}, %{a: 1, c: 4, d: 5}, fn :c, 3, 4 -> :x end) ==
+             %{c: :x}
+  end
+
   test "implements (almost) all functions in Keyword" do
     assert Keyword.__info__(:functions) -- Map.__info__(:functions) == [
              delete: 3,


### PR DESCRIPTION
Following up from https://elixirforum.com/t/map-intersection-2/53121/12. I didn't see any duplicates, hopefully it's okay I pushed up.

My first PR, so tried to follow https://github.com/elixir-lang/elixir#contributing & https://github.com/elixir-lang/elixir/blob/main/CODE_OF_CONDUCT.md as best as I could.

---

* Add corresponding functions for Erlang's [`:maps.intersect/2`](https://www.erlang.org/doc/man/maps.html#intersect-2) & [`:maps.intersect_with/3`](https://www.erlang.org/doc/man/maps.html#intersect_with-3).
* Largely cargo-culted from `Map.merge/3`, including the tests & docs. More than happy to extend these.
* I extended the diff list in `KeywordTest` since I wasn't sure if extending `Keyword` would be out-of-scope. Happy to add a `Keyword.intersect` function as well, if desired.
* `make test_stdlib` resulted in `1948 doctests, 4187 tests, 0 failures, 13 excluded`
* Test from running `./bin/iex`
  ```
  ❯ ./bin/iex
  Erlang/OTP 25 [erts-13.1.3] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit] [dtrace]
  
  Interactive Elixir (1.15.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
  iex(1)> Map.intersect(%{a: 1, b: 2}, %{b: 2, c: 3})
  %{b: 2}
  iex(2)> Map.intersect(%{a: 1, b: 2}, %{b: 2, c: 3}, fn _k, v1, v2 -> v1 + v2 end)
  %{b: 4}
  ```
