### PR TITLE
Use erlang `:maps.merge_with` instead of custom implementation

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -642,19 +642,7 @@ defmodule Map do
   """
   @spec merge(map, map, (key, value, value -> value)) :: map
   def merge(map1, map2, fun) when is_function(fun, 3) do
-    if map_size(map1) > map_size(map2) do
-      folder = fn key, val2, acc ->
-        update(acc, key, val2, fn val1 -> fun.(key, val1, val2) end)
-      end
-
-      :maps.fold(folder, map1, map2)
-    else
-      folder = fn key, val2, acc ->
-        update(acc, key, val2, fn val1 -> fun.(key, val2, val1) end)
-      end
-
-      :maps.fold(folder, map2, map1)
-    end
+    :maps.merge_with(fun, map1, map2)
   end
 
   @doc """


### PR DESCRIPTION
Following the discussion about `intersection/2` I noticed that `merge/3` uses a custom implementation, but OTP 24 introduced `:maps.merge_with/3`. Since 1.15 will need OTP >= 24 we can use that function directly.