### PR TITLE
Improve docs for Kernel.pow

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4231,9 +4231,9 @@ defmodule Kernel do
   @doc """
   Power operator.
 
-  It expects two numbers are input. If the left-hand side is an integer
-  and the right-hand side is more than or equal to 0, then the result is
-  integer. Otherwise it returns a float.
+  It takes two numbers for input. If both are integers and the right-hand
+  side (the `exponent`) is also greater than or equal to 0, then the result
+  will also be an integer. Otherwise it returns a float.
 
   ## Examples
 
@@ -4252,6 +4252,8 @@ defmodule Kernel do
   @spec integer ** non_neg_integer :: integer
   @spec integer ** neg_integer :: float
   @spec float ** float :: float
+  @spec integer ** float :: float
+  @spec float ** integer :: float
   def base ** exponent when is_integer(base) and is_integer(exponent) and exponent >= 0 do
     integer_pow(base, 1, exponent)
   end


### PR DESCRIPTION
This change:
- Explicitly mention that both numbers need to be integers for the result to be an integer to make that condition clearer. Before this change, the docs explicitly mentions base had to be an integer, but there is no mention of this condition for the exponent.
- Adds `@spec` for the float-integer and integer-float input combinations.