### PR TITLE
Fix escaping of positional args in bin/elixir (#12345)

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -236,7 +236,7 @@ set -- "$ERTS_BIN$ERL_EXEC" -pa "$SCRIPT_PATH"/../lib/*/ebin $ELIXIR_ERL_OPTIONS
 if [ -n "$RUN_ERL_PIPE" ]; then
   ESCAPED=""
   for PART in "$@"; do
-    ESCAPED="$ESCAPED $(echo "$PART" | sed 's/[^a-zA-Z0-9_\-\/]/\\&/g')"
+    ESCAPED="$ESCAPED $(echo "$PART" | sed 's@[^a-zA-Z0-9_/-]@\\&@g')"
   done
   mkdir -p "$RUN_ERL_PIPE"
   mkdir -p "$RUN_ERL_LOG"


### PR DESCRIPTION
This fixes #1234 where previous escaping pattern accidentally used invalid character range in the regexp.

By using `@` as a pattern delimiter and pushing the `-` to the end of the bracket we avoid both problems (wrong escaping, and accidental character range).