### PR TITLE
Deterministically calculate exports_md5

### DIFF
--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -277,7 +277,8 @@ get_module_info(Module) ->
 exports_md5_info(Struct, Def, Defmacro) ->
   %% Deprecations do not need to be part of exports_md5 because it is always
   %% checked by the runtime pass, so it is not really part of compilation.
-  Md5 = erlang:md5(erlang:term_to_binary({Def, Defmacro, Struct})),
+  Options = lists:filter(fun(Opt) -> Opt == deterministic end, compile:env_compiler_options()),
+  Md5 = erlang:md5(erlang:term_to_binary({Def, Defmacro, Struct}, Options)),
   {clause, 0, [{atom, 0, exports_md5}], [], [elixir_to_erl(Md5)]}.
 
 functions_info(Def) ->

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -641,7 +641,10 @@ defmodule Mix.Compilers.Elixir do
             _ -> nil
           end
 
-        {defs, defmacros, struct} |> :erlang.term_to_binary() |> :erlang.md5()
+        term_to_binary_opts =
+          :compile.env_compiler_options() |> Enum.filter(&(&1 == :deterministic))
+
+        {defs, defmacros, struct} |> :erlang.term_to_binary(term_to_binary_opts) |> :erlang.md5()
 
       true ->
         nil


### PR DESCRIPTION
The exports_md5 calculation is performed by encoding the function,
macro, and struct definitions for a module using
`:erlang.term_to_binary/1` and outputting this into the Erlang AST that
is then passed on to the Erlang compiler.

Maps with more than 32 keys use a non-sorted data structure, and the
result of `term_to_binary` is non-deterministic unless you pass the
`:deterministic` option, which was introduced in OTP 24.1.

When the Erlang compiler is encoding the beam asm code into the final
.beam file, if the `deterministic` compiler option is set, it will use
the `:deterministic` option with `term_to_binary`, which is calls on map
literals.

The Elixir compiler was not honoring this compiler option (which
initially makes sense, since it is an Erlang compiler option, not an
Elixir compiler option), so even when attempting to achieve reproducible
builds using the `deterministic` compiler option, the md5 checksum of
the module (I believe it is technically of the Erlang AST) would be
different everytime you compiled.

This patch passes the `:deterministic` option to `term_to_binary` the
two places that Elixir compiler calls it to calculate the exports_md5
checksum based on whether the user has passed the `deterministic`
compiler option, which is achievable with
`ERL_COMPILER_OPTIONS=deterministic`.

This should be backwards compatible with releases prior to OTP 24.1 as
far as I can tell.

Notes:

I discovered this by force compiling an example project with the
aforementioned compiler option, then decompiling to asm with
https://github.com/michalmuskala/decompile, saving the output, then
force recompiling again and then diffing to two generated asm files.

As far as I know, the two .beam files should be identical, but they
still result in different checksums (of the actual files, not the module
checksums embedded in the file). I assume this to be an issue with OTP
and not Elixir.
