### PR TITLE
Optimize for as Enum.map/2 when sensible

### DIFF
--- a/lib/elixir/src/elixir_erl_for.erl
+++ b/lib/elixir/src/elixir_erl_for.erl
@@ -115,6 +115,10 @@ build_inline(Ann, Clauses, Expr, Into, Uniq, S) ->
 build_inline_each(Ann, Clauses, Expr, false, Uniq, S) ->
   InnerFun = fun(InnerExpr, _InnerAcc) -> InnerExpr end,
   build_reduce(Ann, Clauses, InnerFun, Expr, {nil, Ann}, Uniq, S);
+build_inline_each(Ann, [{enum, _, Left = {var, _, _}, Right, [] = _Filters}], Expr, {nil, _} = _Into, false, S) ->
+  Clauses = [{clause, Ann, [Left], [], [Expr]}],
+  Args = [Right, {'fun', Ann, {clauses, Clauses}}],
+  {?remote(Ann, 'Elixir.Enum', map, Args), S};
 build_inline_each(Ann, Clauses, Expr, {nil, _} = Into, Uniq, S) ->
   InnerFun = fun(InnerExpr, InnerAcc) -> {cons, Ann, InnerExpr, InnerAcc} end,
   {ReduceExpr, SR} = build_reduce(Ann, Clauses, InnerFun, Expr, Into, Uniq, S),


### PR DESCRIPTION
Optimizing simple `for` comprehensions as `Enum.map/2` when possible, e.g. just looping on a variable (instead of `Enum.reduce |> :lists.reverse`).

<img width="664" alt="Screenshot 2023-01-19 at 20 46 42" src="https://user-images.githubusercontent.com/11598866/213434487-233e6300-6b9e-4ec1-b933-8fb3983077a9.png">
