### PR TITLE
Optimize for into map as Enum.map/2

### DIFF
--- a/lib/elixir/src/elixir_erl_for.erl
+++ b/lib/elixir/src/elixir_erl_for.erl
@@ -119,6 +119,11 @@ build_inline_each(Ann, [{enum, _, Left = {var, _, _}, Right, [] = _Filters}], Ex
   Clauses = [{clause, Ann, [Left], [], [Expr]}],
   Args = [Right, {'fun', Ann, {clauses, Clauses}}],
   {?remote(Ann, 'Elixir.Enum', map, Args), S};
+build_inline_each(Ann, [{enum, _, Left = {var, _, _}, Right, [] = _Filters}], Expr, {map, _, []} = _Into, false, S) ->
+  Clauses = [{clause, Ann, [Left], [], [Expr]}],
+  Args = [Right, {'fun', Ann, {clauses, Clauses}}],
+  List = ?remote(Ann, 'Elixir.Enum', map, Args),
+  {?remote(Ann, maps, from_list, [List]), S};
 build_inline_each(Ann, Clauses, Expr, {nil, _} = Into, Uniq, S) ->
   InnerFun = fun(InnerExpr, InnerAcc) -> {cons, Ann, InnerExpr, InnerAcc} end,
   {ReduceExpr, SR} = build_reduce(Ann, Clauses, InnerFun, Expr, Into, Uniq, S),


### PR DESCRIPTION
In the same spirit as https://github.com/elixir-lang/elixir/pull/12352, `for x <- ..., into: %{}, do: ...` can use `Enum.map |> :maps.from_list` instead of `Enum.reduce |> :lists.reverse |> :maps.from_list`:

<img width="743" alt="Screenshot 2023-01-19 at 22 45 32" src="https://user-images.githubusercontent.com/11598866/213458910-e17e1a2a-8acb-46be-a814-cbdbf89b40c1.png">
