### PR TITLE
Compile `String.valid_utf8?/1` inline

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1805,6 +1805,7 @@ defmodule String do
 
   def valid?(<<string::binary>>), do: valid_utf8?(string)
 
+  @compile {:inline, valid_utf8?: 1}
   defp valid_utf8?(<<_::utf8, rest::bits>>), do: valid_utf8?(rest)
   defp valid_utf8?(<<>>), do: true
   defp valid_utf8?(_), do: false


### PR DESCRIPTION
A quick win to get about a 15% performance boost on UTF-8 validation. This function is consistently at the top of Bandit's WebSocket profile traces, so any wins we can get here would be great.

```elixir
Mix.install([:benchee])

defmodule New do
  def valid?(<<string::binary>>), do: valid_utf8?(string)
  def valid?(_), do: false

  @compile {:inline, valid_utf8?: 1}
  defp valid_utf8?(<<_::utf8, rest::bits>>), do: valid_utf8?(rest)
  defp valid_utf8?(<<>>), do: true
  defp valid_utf8?(_), do: false
end

Benchee.run(
  %{
    "old" => fn input -> String.valid?(input) end,
    "new" => fn input -> New.valid?(input) end
  },
  time: 10,
  memory_time: 2,
  inputs: %{
    "micro" => String.duplicate("a", 10),
    "medium" => String.duplicate("a", 10_002)
  }
)
```

yields

```
Operating System: macOS
CPU Information: Apple M1
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.14.1
Erlang 25.1

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: medium, micro
Estimated total run time: 56 s

Benchmarking new with input medium ...
Benchmarking new with input micro ...
Benchmarking old with input medium ...
Benchmarking old with input micro ...

##### With input medium #####
Name           ips        average  deviation         median         99th %
new        38.39 K       26.05 μs    ±21.92%       25.83 μs       29.92 μs
old        34.39 K       29.08 μs    ±19.84%       28.79 μs       29.92 μs

Comparison:
new        38.39 K
old        34.39 K - 1.12x slower +3.03 μs

Memory usage statistics:

Name    Memory usage
new            656 B
old            656 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input micro #####
Name           ips        average  deviation         median         99th %
new         2.94 M      340.37 ns ±11621.35%         250 ns         375 ns
old         2.89 M      345.75 ns ±11544.85%         250 ns         416 ns

Comparison:
new         2.94 M
old         2.89 M - 1.02x slower +5.38 ns

Memory usage statistics:

Name    Memory usage
new            656 B
old            656 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**
```

(FWIW @moogle19 and I have spent a fair bit of time trying to improve this implementation (longer strides, clever `Bitwise` tricks, [Cowboy's implementation](https://ninenines.eu/articles/erlang-validate-utf8/), and others) and haven't been able to get anything better that doesn't have awful memory characteristics. See notes at https://github.com/mtrudel/bandit/pull/73)