### PR TITLE
Accept label option in Macro.dbg/2

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5868,6 +5868,24 @@ defmodule Kernel do
       |> String.split() #=> ["Elixir", "is", "cool"]
       |> List.first() #=> "Elixir"
 
+  `dbg()` can be can be decorated with a label, similarly to `IO.inspect/2`, by providing the `:label` option to easily distinguish it from other `dbg/2` calls. The label will be printed before the inspected `code`
+
+  With a label option:
+
+      "Elixir is cool!"
+      |> String.trim_trailing("!")
+      |> String.split()
+      |> List.first()
+      |> dbg(label: "Trim Output")
+
+  The above code prints:
+
+      Trim Output: [dbg.exs:8: (file)]
+      "Elixir is cool!" #=> "Elixir is cool!"
+      |> String.trim_trailing("!") #=> "Elixir is cool"
+      |> String.split() #=> ["Elixir", "is", "cool"]
+      |> List.first() #=> "Elixir"
+
   With no arguments, `dbg()` debugs information about the current binding. See `binding/1`.
 
   ## `dbg` inside IEx

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2598,8 +2598,9 @@ defmodule Macro do
         [formatted, "\n"]
       end
 
+    label = if label = options[:label], do: [label, ": "], else: []
     ansi_enabled? = options[:syntax_colors] != []
-    :ok = IO.write(IO.ANSI.format(formatted, ansi_enabled?))
+    :ok = IO.write([label, IO.ANSI.format(formatted, ansi_enabled?)])
 
     result
   end


### PR DESCRIPTION
This should make it easier to search backward in terminal output to find the output of a `dbg/2` call, especially if:
* You have a lot of output from logging (Ecto Stacktrace, application logs, etc.)
* You have configured the default `dbg/2` callback to be `{Macro, :dbg_callback, []}` 