### PR TITLE
Add error message when piping into an expression ending in bracket-based access

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -315,9 +315,11 @@ defmodule Macro do
             "Kernel.#{op}(#{to_string(arg)}), instead of #{op}#{to_string(arg)}"
   end
 
+  # Piping to an Access.get/2,3 call in the form of brackets
+  # (foo |> bar[]) raises a nice error.
   def pipe(
         expr,
-        {{_, meta, [Access, :get] = op}, _line, args} = _op_args,
+        {{_, meta, [Access, :get] = op}, _meta, args} = _op_args,
         integer
       )
       when is_list(args) do

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -319,16 +319,23 @@ defmodule Macro do
   # (foo |> bar[]) raises a nice error.
   def pipe(
         expr,
-        {{_, meta, [Access, :get] = op}, _meta, args} = _op_args,
+        {{_, meta, [Access, :get] = op}, _meta, [first, second]} = _op_args,
         integer
-      )
-      when is_list(args) do
+      ) do
     if {:from_brackets, true} in meta do
-      raise ArgumentError,
-            "cannot pipe into expression ending in a bracket-based Access.get/3. It is likely you intended to pipe " <>
-              "#{to_string(expr)} into #{to_string(List.first(args))}. Please call Access.get/3 directly rather than using brackets."
+      raise ArgumentError, """
+      wrong operator precedence when piping into bracket-based access
+
+       Instead of:
+
+           #{to_string(expr)} |> #{to_string(first)}[#{to_string(second)}]
+
+       You should write:
+
+           (#{to_string(expr)} |> #{to_string(first)})[#{to_string(second)}]
+      """
     else
-      {op, meta, List.insert_at(args, integer, expr)}
+      {op, meta, List.insert_at([first, second], integer, expr)}
     end
   end
 

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -299,7 +299,7 @@ bracket_arg -> open_bracket container_expr ',' close_bracket : build_access_arg(
 bracket_arg -> open_bracket container_expr ',' container_args close_bracket : error_too_many_access_syntax('$3').
 
 bracket_expr -> dot_bracket_identifier bracket_arg : build_access(build_no_parens('$1', nil), '$2').
-bracket_expr -> access_expr bracket_arg : build_access('$1', '$2').
+bracket_expr -> access_expr bracket_arg : build_access('$1', meta_with_from_brackets('$2')).
 
 bracket_at_expr -> at_op_eol dot_bracket_identifier bracket_arg :
                      build_access(build_unary_op('$1', build_no_parens('$2', nil)), '$3').
@@ -957,6 +957,9 @@ meta_with_indentation(Meta, nil) ->
   Meta;
 meta_with_indentation(Meta, Indentation) ->
   [{indentation, Indentation} | Meta].
+
+meta_with_from_brackets({List ,Meta}) ->
+  {List, [{from_brackets, true} | Meta]}.
 
 build_bin_heredoc({bin_heredoc, Location, Indentation, Args}) ->
   ExtraMeta =

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -958,7 +958,7 @@ meta_with_indentation(Meta, nil) ->
 meta_with_indentation(Meta, Indentation) ->
   [{indentation, Indentation} | Meta].
 
-meta_with_from_brackets({List ,Meta}) ->
+meta_with_from_brackets({List, Meta}) ->
   {List, [{from_brackets, true} | Meta]}.
 
 build_bin_heredoc({bin_heredoc, Location, Indentation, Args}) ->

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -1029,6 +1029,9 @@ defmodule MacroTest do
     assert Macro.pipe(1, quote(do: foo), -1) == quote(do: foo(1))
     assert Macro.pipe(2, quote(do: foo(1)), -1) == quote(do: foo(1, 2))
 
+    assert Macro.pipe(quote(do: %{foo: "bar"}), quote(do: Access.get(:foo)), 0) ==
+             quote(do: Access.get(%{foo: "bar"}, :foo))
+
     assert_raise ArgumentError, ~r"cannot pipe 1 into 2", fn ->
       Macro.pipe(1, 2, 0)
     end
@@ -1067,7 +1070,7 @@ defmodule MacroTest do
       Macro.pipe(:foo, quote(do: fn x -> x end), 0)
     end
 
-    message = ~r"cannot pipe into expression ending in a bracket-based Access.get/3"
+    message = ~r"wrong operator precedence when piping into bracket-based access"
 
     assert_raise ArgumentError, message, fn ->
       Macro.pipe(:foo, quote(do: %{foo: bar}[:foo]), 0)

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -1066,6 +1066,12 @@ defmodule MacroTest do
     assert_raise ArgumentError, message, fn ->
       Macro.pipe(:foo, quote(do: fn x -> x end), 0)
     end
+
+    message = ~r"cannot pipe into expression ending in a bracket-based Access.get/3"
+
+    assert_raise ArgumentError, message, fn ->
+      Macro.pipe(:foo, quote(do: %{foo: bar}[:foo]), 0)
+    end
   end
 
   test "unpipe/1" do


### PR DESCRIPTION
Addresses the issue discussed in https://github.com/elixir-lang/elixir/issues/12351.

This adds a piece of `from_brackets` metadata to `Access.get/3` calls that is used to determine when raising this error is necessary. I was not sure how much context/suggestion to offer in the error message, so I tried to strike a balance between being helpful and overly prescriptive to the user.

Please let me know if I've broken any conventions, need to add more tests, or could improve the error message here as this is my first time contributing! Thanks.