### PR TITLE
Add `:fast_ascii` mode to `String.valid?/2`

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1781,7 +1781,7 @@ defmodule String do
 
   `algorithm` may be `:default` or `:fast_ascii`. Both algorithms are equivalent
   from a validation perspective (they will always produce the same output), but
-  `:fast_ascii` can yield signifcant performance benefits in specific scenarios.
+  `:fast_ascii` can yield significant performance benefits in specific scenarios.
 
   If all of the following conditions are true, you may want to experiment with
   the `:fast_ascii` algorithm to see if it yields performance benefits in your

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1779,21 +1779,21 @@ defmodule String do
   @doc ~S"""
   Checks whether `string` contains only valid characters.
 
-  `mode` may be `:default` or `:fast_ascii`. Both modes are equivalent from a validation
+  `algorithm` may be `:default` or `:fast_ascii`. Both algorithms are equivalent from a validation
   perspective (they will always produce the same output), but `:fast_ascii` can yield signifcant 
   performance benefits in specific scenarios.
 
   If all of the following conditions are true, you may want to experiment with the `:fast_ascii`
-  mode to see if it yields performance benefits in your specific scenario:
+  algorithm to see if it yields performance benefits in your specific scenario:
 
   * You are running Erlang/OTP 26 or newer on a 64 bit platform
   * You expect most of your strings to be longer than ~64 bytes
   * You expect most of your strings to contain mostly ASCII codepoints
 
-  Note that the `:fast_ascii` mode does not affect correctness, you can expect the output of
-  `String.valid?/2` to be the same in all modes. The only difference to be expected is one of
-  performance, which can be expected to improve roughly quadratically in string length compared
-  to the `:default` mode.
+  Note that the `:fast_ascii` algorithm does not affect correctness, you can expect the output of
+  `String.valid?/2` to be the same regardless of algorithm. The only difference to be expected is
+  one of performance, which can be expected to improve roughly quadratically in string length
+  compared to the `:default` algorithm.
 
   ## Examples
 
@@ -1820,7 +1820,7 @@ defmodule String do
 
   """
   @spec valid?(t) :: boolean
-  def valid?(string, mode \\ :default)
+  def valid?(string, algorithm \\ :default)
 
   def valid?(<<string::binary>>, :default), do: valid_utf8?(string)
   def valid?(<<string::binary>>, :fast_ascii), do: valid_utf8_fast_ascii?(string)

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1786,11 +1786,11 @@ defmodule String do
   If all of the following conditions are true, you may want to experiment with the `:fast_ascii`
   mode to see if it yields performance benefits in your specific scenario:
 
-  * You are running OTP 26 or newer on a 64 bit platform
+  * You are running Erlang/OTP 26 or newer on a 64 bit platform
   * You expect most of your strings to be longer than ~64 bytes
   * You expect most of your strings to contain mostly ASCII codepoints
 
-  Note that the `:fast_ascii` mode does not affect correctness; you can expect the output of
+  Note that the `:fast_ascii` mode does not affect correctness, you can expect the output of
   `String.valid?/2` to be the same in all modes. The only difference to be expected is one of
   performance, which can be expected to improve roughly quadratically in string length compared
   to the `:default` mode.

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1779,21 +1779,23 @@ defmodule String do
   @doc ~S"""
   Checks whether `string` contains only valid characters.
 
-  `algorithm` may be `:default` or `:fast_ascii`. Both algorithms are equivalent from a validation
-  perspective (they will always produce the same output), but `:fast_ascii` can yield signifcant 
-  performance benefits in specific scenarios.
+  `algorithm` may be `:default` or `:fast_ascii`. Both algorithms are equivalent
+  from a validation perspective (they will always produce the same output), but
+  `:fast_ascii` can yield signifcant performance benefits in specific scenarios.
 
-  If all of the following conditions are true, you may want to experiment with the `:fast_ascii`
-  algorithm to see if it yields performance benefits in your specific scenario:
+  If all of the following conditions are true, you may want to experiment with
+  the `:fast_ascii` algorithm to see if it yields performance benefits in your
+  specific scenario:
 
   * You are running Erlang/OTP 26 or newer on a 64 bit platform
   * You expect most of your strings to be longer than ~64 bytes
   * You expect most of your strings to contain mostly ASCII codepoints
 
-  Note that the `:fast_ascii` algorithm does not affect correctness, you can expect the output of
-  `String.valid?/2` to be the same regardless of algorithm. The only difference to be expected is
-  one of performance, which can be expected to improve roughly quadratically in string length
-  compared to the `:default` algorithm.
+  Note that the `:fast_ascii` algorithm does not affect correctness, you can
+  expect the output of `String.valid?/2` to be the same regardless of algorithm.
+  The only difference to be expected is one of performance, which can be
+  expected to improve roughly linearly in string length compared to the
+  `:default` algorithm.
 
   ## Examples
 

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -812,6 +812,14 @@ defmodule StringTest do
 
     refute String.valid?(<<0xFFFF::16>>)
     refute String.valid?("asd" <> <<0xFFFF::16>>)
+
+    assert String.valid?("afdsafdsafds", :fast_ascii)
+    assert String.valid?("øsdfhøsdfh", :fast_ascii)
+    assert String.valid?("dskfjあskadskfjあska", :fast_ascii)
+    assert String.valid?(<<0xEF, 0xB7, 0x90, 0xEF, 0xB7, 0x90, 0xEF, 0xB7, 0x90>>, :fast_ascii)
+
+    refute String.valid?(<<0xFFFF::16>>, :fast_ascii)
+    refute String.valid?("asdasdasd" <> <<0xFFFF::16>>, :fast_ascii)
   end
 
   test "chunk/2 with :valid trait" do


### PR DESCRIPTION
Based on the discussion on #12354, this PR adds an optional `:fast_ascii` option to `String.valid?/2` (based on the `bit56` algorithm discussed there). I've confirmed that this implementation yields the same benefits as observed previously:

<details>
<summary>Benchmark (OTP26, ARM)</summary>

```
iex(3)> Benchee.run(
...(3)>   %{
...(3)>     "stock" => fn {valid, input} -> ^valid = String.valid?(input) end,
...(3)>     "fast_ascii" => fn {valid, input} -> ^valid = String.valid?(input, :fast_ascii) end,
...(3)>   },
...(3)>   time: 10,
...(3)>   memory_time: 2,
...(3)>   inputs: %{
...(3)>     1 => {false, String.duplicate("a", 0) <> <<128::8>>},
...(3)>     4 => {false, String.duplicate("a", 3) <> <<128::8>>},
...(3)>     8 => {false, String.duplicate("a", 7) <> <<128::8>>},
...(3)>     16 => {false, String.duplicate("a", 15) <> <<128::8>>},
...(3)>     32 => {false, String.duplicate("a", 31) <> <<128::8>>},
...(3)>     64 => {false, String.duplicate("a", 63) <> <<128::8>>},
...(3)>     128 => {false, String.duplicate("a", 127) <> <<128::8>>},
...(3)>     256 => {false, String.duplicate("a", 255) <> <<128::8>>},
...(3)>     512 => {false, String.duplicate("a", 511) <> <<128::8>>},
...(3)>     1024 => {false, String.duplicate("a", 1023) <> <<128::8>>},
...(3)>     2048 => {false, String.duplicate("a", 2047) <> <<128::8>>},
...(3)>     4096 => {false, String.duplicate("a", 4095) <> <<128::8>>}
...(3)>   }
...(3)> )
Operating System: macOS
CPU Information: Apple M1
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.15.0-dev
Erlang 26.0-rc0

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: 1, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096
Estimated total run time: 5.60 min

Benchmarking fast_ascii with input 1 ...
Benchmarking fast_ascii with input 4 ...
Benchmarking fast_ascii with input 8 ...
Benchmarking fast_ascii with input 16 ...
Benchmarking fast_ascii with input 32 ...
Benchmarking fast_ascii with input 64 ...
Benchmarking fast_ascii with input 128 ...
Benchmarking fast_ascii with input 256 ...
Benchmarking fast_ascii with input 512 ...
Benchmarking fast_ascii with input 1024 ...
Benchmarking fast_ascii with input 2048 ...
Benchmarking fast_ascii with input 4096 ...
Benchmarking stock with input 1 ...
Benchmarking stock with input 4 ...
Benchmarking stock with input 8 ...
Benchmarking stock with input 16 ...
Benchmarking stock with input 32 ...
Benchmarking stock with input 64 ...
Benchmarking stock with input 128 ...
Benchmarking stock with input 256 ...
Benchmarking stock with input 512 ...
Benchmarking stock with input 1024 ...
Benchmarking stock with input 2048 ...
Benchmarking stock with input 4096 ...

##### With input 1 #####
Name                 ips        average  deviation         median         99th %
stock             2.33 M      429.50 ns  ±8326.31%         333 ns         500 ns
fast_ascii        1.75 M      571.29 ns  ±7050.58%         417 ns        1375 ns

Comparison:
stock             2.33 M
fast_ascii        1.75 M - 1.33x slower +141.79 ns

Memory usage statistics:

Name          Memory usage
stock              0.95 KB
fast_ascii         1.21 KB - 1.28x memory usage +0.27 KB

**All measurements for memory usage were the same**

##### With input 4 #####
Name                 ips        average  deviation         median         99th %
stock             2.27 M      440.72 ns  ±8391.93%         333 ns         500 ns
fast_ascii        1.70 M      588.49 ns  ±5044.09%         458 ns        1375 ns

Comparison:
stock             2.27 M
fast_ascii        1.70 M - 1.34x slower +147.77 ns

Memory usage statistics:

Name          Memory usage
stock              0.95 KB
fast_ascii         1.21 KB - 1.28x memory usage +0.27 KB

**All measurements for memory usage were the same**

##### With input 8 #####
Name                 ips        average  deviation         median         99th %
stock             2.22 M      449.63 ns  ±8262.54%         333 ns         500 ns
fast_ascii        1.75 M      571.52 ns  ±6966.38%         417 ns        1417 ns

Comparison:
stock             2.22 M
fast_ascii        1.75 M - 1.27x slower +121.89 ns

Memory usage statistics:

Name          Memory usage
stock              0.95 KB
fast_ascii         1.21 KB - 1.28x memory usage +0.27 KB

**All measurements for memory usage were the same**

##### With input 16 #####
Name                 ips        average  deviation         median         99th %
stock             2.12 M      472.24 ns  ±8088.62%         375 ns         542 ns
fast_ascii        1.74 M      575.32 ns  ±6022.48%         417 ns        1375 ns

Comparison:
stock             2.12 M
fast_ascii        1.74 M - 1.22x slower +103.08 ns

Memory usage statistics:

Name          Memory usage
stock              0.95 KB
fast_ascii         1.21 KB - 1.28x memory usage +0.27 KB

**All measurements for memory usage were the same**

##### With input 32 #####
Name                 ips        average  deviation         median         99th %
stock             1.91 M      523.51 ns  ±7420.64%         417 ns         583 ns
fast_ascii        1.69 M      591.28 ns  ±4932.73%         458 ns        1416 ns

Comparison:
stock             1.91 M
fast_ascii        1.69 M - 1.13x slower +67.78 ns

Memory usage statistics:

Name          Memory usage
stock              0.95 KB
fast_ascii         1.21 KB - 1.28x memory usage +0.27 KB

**All measurements for memory usage were the same**

##### With input 64 #####
Name                 ips        average  deviation         median         99th %
fast_ascii        1.74 M      575.27 ns  ±5064.74%         417 ns        1416 ns
stock             1.69 M      591.09 ns  ±4528.66%         500 ns         667 ns

Comparison:
fast_ascii        1.74 M
stock             1.69 M - 1.03x slower +15.82 ns

Memory usage statistics:

Name          Memory usage
fast_ascii         1.21 KB
stock              0.95 KB - 0.78x memory usage -0.26563 KB

**All measurements for memory usage were the same**

##### With input 128 #####
Name                 ips        average  deviation         median         99th %
fast_ascii        1.63 M      612.55 ns  ±4946.12%         459 ns        1333 ns
stock             1.33 M      751.79 ns  ±3756.57%         666 ns         833 ns

Comparison:
fast_ascii        1.63 M
stock             1.33 M - 1.23x slower +139.23 ns

Memory usage statistics:

Name          Memory usage
fast_ascii         1.21 KB
stock              0.95 KB - 0.78x memory usage -0.26563 KB

**All measurements for memory usage were the same**

##### With input 256 #####
Name                 ips        average  deviation         median         99th %
fast_ascii        1.56 M        0.64 μs  ±4380.88%        0.50 μs        0.79 μs
stock             0.93 M        1.07 μs  ±2111.72%        0.96 μs        1.17 μs

Comparison:
fast_ascii        1.56 M
stock             0.93 M - 1.67x slower +0.43 μs

Memory usage statistics:

Name          Memory usage
fast_ascii         1.21 KB
stock              0.95 KB - 0.78x memory usage -0.26563 KB

**All measurements for memory usage were the same**

##### With input 512 #####
Name                 ips        average  deviation         median         99th %
fast_ascii        1.45 M        0.69 μs  ±4132.72%        0.54 μs        0.79 μs
stock             0.57 M        1.76 μs  ±1141.26%        1.63 μs        1.83 μs

Comparison:
fast_ascii        1.45 M
stock             0.57 M - 2.54x slower +1.07 μs

Memory usage statistics:

Name          Memory usage
fast_ascii         1.21 KB
stock              0.95 KB - 0.78x memory usage -0.26563 KB

**All measurements for memory usage were the same**

##### With input 1024 #####
Name                 ips        average  deviation         median         99th %
fast_ascii        1.18 M        0.85 μs  ±3472.48%        0.71 μs        0.88 μs
stock            0.194 M        5.15 μs  ±2568.66%        3.04 μs           5 μs

Comparison:
fast_ascii        1.18 M
stock            0.194 M - 6.09x slower +4.30 μs

Memory usage statistics:

Name          Memory usage
fast_ascii         1.21 KB
stock              0.95 KB - 0.78x memory usage -0.26563 KB

**All measurements for memory usage were the same**

##### With input 2048 #####
Name                 ips        average  deviation         median         99th %
fast_ascii        1.01 M        0.99 μs  ±2266.22%        0.88 μs        1.17 μs
stock            0.169 M        5.93 μs   ±239.39%        5.54 μs       17.62 μs

Comparison:
fast_ascii        1.01 M
stock            0.169 M - 5.96x slower +4.94 μs

Memory usage statistics:

Name          Memory usage
fast_ascii         1.21 KB
stock              0.95 KB - 0.78x memory usage -0.26563 KB

**All measurements for memory usage were the same**

##### With input 4096 #####
Name                 ips        average  deviation         median         99th %
fast_ascii      699.67 K        1.43 μs  ±1280.99%        1.33 μs        1.54 μs
stock            92.49 K       10.81 μs    ±75.20%       10.62 μs       12.16 μs

Comparison:
fast_ascii      699.67 K
stock            92.49 K - 7.56x slower +9.38 μs

Memory usage statistics:

Name          Memory usage
fast_ascii         1.21 KB
stock              0.95 KB - 0.78x memory usage -0.26563 KB

**All measurements for memory usage were the same**
```

</details>