### PR TITLE
Fix out-of-order arguments in IEx.Server.shell_loop

### DIFF
--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -57,7 +57,7 @@ defmodule IEx.Server do
   defp shell_loop(opts, pid, ref) do
     receive do
       {:take_over, take_pid, take_ref, take_location, take_whereami, take_opts} ->
-        if take_over?(take_pid, take_ref, take_location, take_whereami, 1, take_opts) do
+        if take_over?(take_pid, take_ref, take_location, take_whereami, take_opts, 1) do
           run_without_registration(init_state(opts), take_opts, nil)
         else
           shell_loop(opts, pid, ref)


### PR DESCRIPTION
In 7132a115296e86038cb495f6d07d2e38180cd71b, an additional argument was added to `IEx.Server.take_over?/5`, `counter`.

old:
```
defp take_over?(take_pid, take_ref, take_location, take_whereami, take_opts)
```

new:
```
defp take_over?(take_pid, take_ref, take_location, take_whereami, take_opts, counter)
```

`take_over?/6` is called at two places in IEx.Server, lines 60 and 201.

In one of those locations (line 60), the new `counter` argument was placed in the second-to-last position rather than the last position.
```
if take_over?(take_pid, take_ref, take_location, take_whereami, 1, take_opts)
```

I'm still working through a test for the test suite, but the following set of steps reproduces the issue when using elixir compiled from `main` as of time of writing:
```
% mix new testapp
% cd testapp
```

Add the following to `application` in `mix.exs`
```
      mod: {Testapp, []},
```

Add the following inside `Testapp` module in `lib/testapp.ex`. Note the `dbg()` call at the top of the function:
```
  def start(_, _) do
    dbg()
    children = []
    Supervisor.start_link(children, strategy: :one_for_one)
  end
```

Attempt to start an iex session with pry dbg backend, get error:
```
% iex --dbg pry -S mix run
Erlang/OTP 25 [erts-13.0.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

*** ERROR: Shell process terminated! (^G to start new job) ***
binding() #=> []

13:47:23.472 [error] Process #PID<0.77.0> raised an exception
** (FunctionClauseError) no function clause matching in Access.get/3
    (elixir 1.15.0-dev) lib/access.ex:286: Access.get(1, :evaluator, nil)
    (iex 1.15.0-dev) lib/iex/server.ex:292: IEx.Server.take_over?/6
    (iex 1.15.0-dev) lib/iex/server.ex:60: IEx.Server.shell_loop/3
```

Note the error in `Access.get(1, :evaluator, nil)`. The first argument, is [supposed to be a
container](https://hexdocs.pm/elixir/Access.html#get/2), but is actually `1` (the new value added to the second-to-last position in the `take_over?` call).

Swapping the argument order and recompiling iex results in the following output (as expected):
```
% iex --dbg pry -S mix run
Erlang/OTP 25 [erts-13.0.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Request to pry #PID<0.150.0> at Testapp.start/2 (lib/testapp.ex:20)

   17:   end
   18:
   19:   def start(_, _) do
   20:     dbg()
   21:     children = []
   22:     Supervisor.start_link(children, strategy: :one_for_one)
   23:   end

Allow? [Yn]
```

I'm still figuring out how to trigger the issue programmatically in an ExUnit test. I think this code might only be triggered by `IEx.Server.run_from_shell`, which, if I understand correctly, doesn't have a convenient test_helper like `capture_iex`.