### PR TITLE
Support nested expressions in `cursor_context/1`

### DIFF
--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -141,7 +141,8 @@ defmodule Code.Fragment do
                | {:dot, inside_dot, charlist}
                | {:module_attribute, charlist}
                | {:unquoted_atom, charlist}
-               | {:var, charlist},
+               | {:var, charlist}
+               | :expr,
              inside_alias:
                {:local_or_var, charlist}
                | {:module_attribute, charlist},
@@ -278,7 +279,7 @@ defmodule Code.Fragment do
 
       {:identifier, [?%], acc, count} ->
         case identifier_to_cursor_context(acc |> Enum.reverse(), count, true) do
-          {{:local_or_var, _} = idenifier, _} -> {{:struct, idenifier}, count + 1}
+          {{:local_or_var, _} = identifier, _} -> {{:struct, identifier}, count + 1}
           _ -> {:none, 0}
         end
 
@@ -416,6 +417,9 @@ defmodule Code.Fragment do
       {{:module_attribute, _} = prev, count} ->
         {{:dot, prev, acc}, count}
 
+      {:expr, count} ->
+        {{:dot, :expr, acc}, count}
+
       {_, _} ->
         {:none, 0}
     end
@@ -440,6 +444,10 @@ defmodule Code.Fragment do
     else
       {{:sigil, ~c""}, count}
     end
+  end
+
+  defp operator([?) | rest], _, [], true) when hd(rest) != ?? do
+    {:expr, 0}
   end
 
   defp operator(rest, count, acc, _call_op?) do

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -200,6 +200,19 @@ defmodule CodeFragmentTest do
                {:dot_call, {:alias, {:module_attribute, ~c"foo"}, ~c"Foo"}, ~c"hello"}
     end
 
+    test "nested expressions" do
+      assert CF.cursor_context("Hello.world()") == :none
+      assert CF.cursor_context("hello().") == {:dot, :expr, ~c""}
+      assert CF.cursor_context("Foo.hello ('(').") == {:dot, :expr, ~c""}
+      assert CF.cursor_context("Foo.hello('(', ?), ?().bar") == {:dot, :expr, ~c"bar"}
+      assert CF.cursor_context("Hello.bar(World.call(42), ?), ?().foo") == {:dot, :expr, ~c"foo"}
+      assert CF.cursor_context("Foo.hello( ).world") == {:dot, :expr, ~c"world"}
+      assert CF.cursor_context("hello.dyn_impl().call(42).bar") == {:dot, :expr, ~c"bar"}
+
+      assert CF.cursor_context("Foo.dyn_impl().call(") == {:dot_call, :expr, ~c"call"}
+      assert CF.cursor_context("hello().call(") == {:dot_call, :expr, ~c"call"}
+    end
+
     test "alias" do
       assert CF.cursor_context("HelloWor") == {:alias, ~c"HelloWor"}
       assert CF.cursor_context("Hello.Wor") == {:alias, ~c"Hello.Wor"}


### PR DESCRIPTION
Hey 👋

Addressing this issue https://github.com/elixir-lang/elixir/issues/11876.
This is probably not the correct or optimal way to achieve this but I just gave it a shot while trying to understand the `Code.Fragment` module better. So I'm happy to completely retry it with a different suggested approach.

The return types are as suggested in the issue:
```elixir
iex(1)> Code.Fragment.cursor_context("DateTime.utc_now()")
:none
iex(2)> Code.Fragment.cursor_context("DateTime.utc_now().")
{:dot, {:dot_call, {:alias, ~c"DateTime"}, ~c"utc_now"}, []}
iex(3)> Code.Fragment.cursor_context("DateTime.utc_now().ho")
{:dot, {:dot_call, {:alias, ~c"DateTime"}, ~c"utc_now"}, ~c"ho"}
iex(4)>
```