### PR TITLE
Fix IEx.Broker.take_over/3 spec

### DIFF
--- a/lib/iex/lib/iex/broker.ex
+++ b/lib/iex/lib/iex/broker.ex
@@ -79,7 +79,8 @@ defmodule IEx.Broker do
   Client requests a takeover.
   """
   @spec take_over(binary, iodata, keyword) ::
-          {:ok, server :: pid, group_leader :: pid} | {:error, :no_iex | :refused}
+          {:ok, server :: pid, group_leader :: pid, counter :: integer}
+          | {:error, :no_iex | :refused}
   def take_over(location, whereami, opts) do
     case GenServer.whereis(@name) do
       nil ->


### PR DESCRIPTION
The return type changed in
https://github.com/elixir-lang/elixir/commit/7132a115296e86038cb495f6d07d2e38180cd71b#diff-3e0ede30fd7f00793f4a685a30d4dfc03dfd3c881e1f648d9299b03470ad5a42R134