### PR TITLE
Fix elixir_erl:debug_info/4 returning core_v1

### DIFF
--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -24,7 +24,7 @@ debug_info(core_v1, _Module, {elixir_v1, Map, Specs}, Opts) ->
   %% warnings nor the other functionality provided there.
   case elixir_erl_compiler:erl_to_core(Prefix ++ Specs ++ Forms, AllOpts) of
     {ok, CoreForms, _} ->
-      try compile:noenv_forms(CoreForms, [no_spawn_compiler_process, from_core, core, return | AllOpts]) of
+      try compile:noenv_forms(CoreForms, [no_spawn_compiler_process, from_core, to_core, return | AllOpts]) of
         {ok, _, Core, _} -> {ok, Core};
         _What -> {error, failed_conversion}
       catch


### PR DESCRIPTION
I am not entirely sure why the pass `from_core` -> `to_core` is even necessary, but I suppose it might invoke some compiler optimizations that operate on Core Erlang. Anyway, unless I am very much mistaken, `core` is not a valid option for the `compile` module: it is ignored and this function was actually returning BEAM byte code instead.