### PR TITLE
Improve errors for ExUnit callbacks

### DIFF
--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -380,10 +380,15 @@ defmodule ExUnit.CallbacksTest do
     end
 
     output = capture_io(fn -> ExUnit.run() end)
-    assert output =~ "** (RuntimeError)"
-    assert output =~ "expected setup callback in ExUnit.CallbacksTest.SetupErrorTest"
-    assert output =~ ~r/at .*callbacks_test\.exs:\d+/
-    assert output =~ "to return :ok | keyword | map, got {:ok, \"foo\"} instead"
+
+    assert output =~
+             "** (RuntimeError) expected ExUnit setup or setup_all callback in " <>
+               "ExUnit.CallbacksTest.SetupErrorTest to return :ok | keyword | map, " <>
+               "got {:ok, \"foo\"} instead"
+
+    # Make sure that at least the right file where the setup/setup_all call is defined is included
+    # in the stacktrace.
+    assert output =~ ~r/.*callbacks_test\.exs:\d+/
   end
 
   test "raises an error when overriding a reserved callback key in setup" do

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -334,6 +334,38 @@ defmodule ExUnit.CallbacksTest do
            """
   end
 
+  test "raises an error when using setup/2 with something other than a block" do
+    message =
+      "setup/2 requires a block as the second argument after the context, got: :start_counter"
+
+    assert_raise ArgumentError, message, fn ->
+      Code.eval_quoted(
+        quote do
+          defmodule SetupWithoutBlockTest do
+            use ExUnit.Case
+            setup context, :start_counter
+          end
+        end
+      )
+    end
+  end
+
+  test "raises an error when using setup_all/2 with something other than a block" do
+    message =
+      "setup_all/2 requires a block as the second argument after the context, got: :start_counter"
+
+    assert_raise ArgumentError, message, fn ->
+      Code.eval_quoted(
+        quote do
+          defmodule SetupWithoutBlockTest do
+            use ExUnit.Case
+            setup_all context, :start_counter
+          end
+        end
+      )
+    end
+  end
+
   test "raises an error when setting an invalid callback in setup" do
     defmodule SetupErrorTest do
       use ExUnit.Case
@@ -347,10 +379,11 @@ defmodule ExUnit.CallbacksTest do
       end
     end
 
-    assert capture_io(fn -> ExUnit.run() end) =~
-             "** (RuntimeError) expected ExUnit callback in " <>
-               "ExUnit.CallbacksTest.SetupErrorTest to return " <>
-               ":ok | keyword | map, got {:ok, \"foo\"} instead"
+    output = capture_io(fn -> ExUnit.run() end)
+    assert output =~ "** (RuntimeError)"
+    assert output =~ "expected setup callback in ExUnit.CallbacksTest.SetupErrorTest"
+    assert output =~ ~r/at .*callbacks_test\.exs:\d+/
+    assert output =~ "to return :ok | keyword | map, got {:ok, \"foo\"} instead"
   end
 
   test "raises an error when overriding a reserved callback key in setup" do


### PR DESCRIPTION
Attempt to improve the error in https://github.com/elixir-lang/elixir/issues/12381.

@josevalim if we carry around the caller's file/line, we can make a nice error right? Are there downsides here that I'm missing?

(Also, we could use `:erlang.raise/3` and make it seem like the error is actually coming from the setup call?)