### PR TITLE
Optimize Enum.to_list for ranges, closes #12383

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3675,6 +3675,7 @@ defmodule Enum do
   """
   @spec to_list(t) :: [element]
   def to_list(enumerable) when is_list(enumerable), do: enumerable
+  def to_list(%{__struct__: Range} = range), do: Range.to_list(range)
   def to_list(%_{} = enumerable), do: reverse(enumerable) |> :lists.reverse()
   def to_list(%{} = enumerable), do: Map.to_list(enumerable)
   def to_list(enumerable), do: reverse(enumerable) |> :lists.reverse()

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -390,6 +390,26 @@ defmodule Range do
   end
 
   @doc """
+  Converts a range to a list.
+  """
+  @doc since: "1.15.0"
+  def to_list(first..last//step)
+      when step > 0 and first <= last
+      when step < 0 and first >= last do
+    :lists.seq(first, last, step)
+  end
+
+  def to_list(_first.._last//_step) do
+    []
+  end
+
+  # TODO: Remove me on v2.0
+  def to_list(%{__struct__: Range, first: first, last: last}) do
+    step = if first <= last, do: 1, else: -1
+    :lists.seq(first, last, step)
+  end
+
+  @doc """
   Checks if two ranges are disjoint.
 
   ## Examples


### PR DESCRIPTION
<details>
  <summary>Banchee report</summary>

```
Operating System: Linux
CPU Information: AMD Ryzen 7 PRO 6850U with Radeon Graphics
Number of Available Cores: 16
Available memory: 30.13 GB
Elixir 1.15.0-dev
Erlang 25.2

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: 100, 1000, 100_000, 10_000
Estimated total run time: 1.87 min

Benchmarking :list.seq with input 100 ...
Benchmarking :list.seq with input 1000 ...
Benchmarking :list.seq with input 100_000 ...
Benchmarking :list.seq with input 10_000 ...
Benchmarking Range + Enum.to_list with input 100 ...
Benchmarking Range + Enum.to_list with input 1000 ...
Benchmarking Range + Enum.to_list with input 100_000 ...
Benchmarking Range + Enum.to_list with input 10_000 ...

##### With input 100 #####
Name                           ips        average  deviation         median         99th %
:list.seq                 695.70 K        1.44 μs   ±931.48%        1.40 μs        2.38 μs
Range + Enum.to_list      676.80 K        1.48 μs   ±992.20%        1.40 μs        2.44 μs

Comparison: 
:list.seq                 695.70 K
Range + Enum.to_list      676.80 K - 1.03x slower +0.0401 μs

Memory usage statistics:

Name                    Memory usage
:list.seq                    1.56 KB
Range + Enum.to_list         1.66 KB - 1.06x memory usage +0.0938 KB

**All measurements for memory usage were the same**

##### With input 1000 #####
Name                           ips        average  deviation         median         99th %
Range + Enum.to_list      378.06 K        2.65 μs   ±771.47%        2.38 μs        5.59 μs
:list.seq                 341.17 K        2.93 μs   ±794.98%        2.44 μs        6.29 μs

Comparison: 
Range + Enum.to_list      378.06 K
:list.seq                 341.17 K - 1.11x slower +0.29 μs

Memory usage statistics:

Name                    Memory usage
Range + Enum.to_list        15.72 KB
:list.seq                   15.63 KB - 0.99x memory usage -0.09375 KB

**All measurements for memory usage were the same**

##### With input 100_000 #####
Name                           ips        average  deviation         median         99th %
:list.seq                   3.92 K      255.41 μs    ±43.94%      347.81 μs      423.93 μs
Range + Enum.to_list        3.08 K      324.34 μs     ±6.98%      318.76 μs      403.85 μs

Comparison: 
:list.seq                   3.92 K
Range + Enum.to_list        3.08 K - 1.27x slower +68.93 μs

Memory usage statistics:

Name                    Memory usage
:list.seq                    1.53 MB
Range + Enum.to_list         1.53 MB - 1.00x memory usage +0.00009 MB

**All measurements for memory usage were the same**

##### With input 10_000 #####
Name                           ips        average  deviation         median         99th %
Range + Enum.to_list       62.95 K       15.89 μs    ±89.96%       12.43 μs       44.35 μs
:list.seq                  50.59 K       19.77 μs    ±78.15%       16.20 μs       39.60 μs

Comparison: 
Range + Enum.to_list       62.95 K
:list.seq                  50.59 K - 1.24x slower +3.88 μs

Memory usage statistics:

Name                    Memory usage
Range + Enum.to_list       156.34 KB
:list.seq                  156.25 KB - 1.00x memory usage -0.09375 KB

**All measurements for memory usage were the same**

```
</details>