### PR TITLE
fix: start service using erlsrv.exe in path with spaces

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -454,8 +454,8 @@ defmodule Mix.Tasks.Release.Init do
     "!ERLSRV!" add "!RELEASE_NAME!_!RELEASE_NAME!" ^
       -!RELEASE_DISTRIBUTION! "!RELEASE_NODE!" ^
       -env RELEASE_ROOT="!RELEASE_ROOT!" -env RELEASE_NAME="!RELEASE_NAME!" -env RELEASE_VSN="!RELEASE_VSN!" -env RELEASE_MODE="!RELEASE_MODE!" -env RELEASE_COOKIE="!RELEASE_COOKIE!" -env RELEASE_NODE="!RELEASE_NODE!" -env RELEASE_VM_ARGS="!RELEASE_VM_ARGS!" -env RELEASE_TMP="!RELEASE_TMP!" -env RELEASE_SYS_CONFIG="!RELEASE_SYS_CONFIG!" ^
-      -args "-setcookie !RELEASE_COOKIE! -config !RELEASE_SYS_CONFIG! <%= release_mode(@release, "!RELEASE_MODE!") %> -boot !REL_VSN_DIR!\start -boot_var RELEASE_LIB !RELEASE_ROOT!\lib -args_file !REL_VSN_DIR!\vm.args"
-
+      -args "-setcookie !RELEASE_COOKIE! -config ""!RELEASE_SYS_CONFIG!"" <%= release_mode(@release, "!RELEASE_MODE!") %> -boot ""!REL_VSN_DIR!\start"" -boot_var RELEASE_LIB ""!RELEASE_ROOT!\lib"" -args_file ""!REL_VSN_DIR!\vm.args"""
+      
     if %ERRORLEVEL% EQU 0 (
       echo Service installed but not started. From now on, it must be started and stopped by erlsrv:
       echo.


### PR DESCRIPTION
This is related to https://github.com/elixir-lang/elixir/pull/12335 - we found one more place where a couple of quotes need to be added to actually be able to run the service after installation on windows