### PR TITLE
`Code.Normalizer`: Use correct meta fields in `normalize_call/2`

### DIFF
--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -362,7 +362,7 @@ defmodule Code.Normalizer do
         normalize_kw_blocks(form, meta, args, state)
 
       allow_keyword?(form, arity) ->
-        args = normalize_args(args, %{state | parent_meta: state.parent_meta})
+        args = normalize_args(args, %{state | parent_meta: meta})
         {last_arg, leading_args} = List.pop_at(args, -1, [])
 
         last_args =
@@ -384,7 +384,7 @@ defmodule Code.Normalizer do
         {form, meta, leading_args ++ last_args}
 
       true ->
-        args = normalize_args(args, %{state | parent_meta: state.parent_meta})
+        args = normalize_args(args, %{state | parent_meta: meta})
         {form, meta, args}
     end
   end

--- a/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
@@ -507,6 +507,28 @@ defmodule Code.Normalizer.FormatterASTTest do
                   # after
                   """,
                   literal_encoder: fn literal, _ -> {:ok, literal} end
+
+      assert_same """
+                  block do
+                    # before 1
+                    1 + 1
+
+                    # before 2
+                    2 + 2
+                  end
+                  """,
+                  literal_encoder: fn literal, _ -> {:ok, literal} end
+
+      assert_same """
+                  block do
+                    # before 1
+                    Mix.install([1 + 1])
+
+                    # before 2
+                    Mix.install([2 + 2])
+                  end
+                  """,
+                  literal_encoder: fn literal, _ -> {:ok, literal} end
     end
 
     test "before and after expressions with newlines" do


### PR DESCRIPTION
`normalize_call/2` was passing the old `state.parent_meta` when normalizing call arguments, which prevented `:line` meta from being correctly applied to unwrapped literals. This had the effect of causing comment collapses in certain cases:

```elixir
# This would fail
assert_same """
            block do
              # before 1
              1 + 1

              # before 2
              2 + 2
            end
            """,
            literal_encoder: fn literal, _ -> {:ok, literal} end

# The newline would collapse, resulting in
"""
block do
  # before 1
  1 + 1
  # before 2
  2 + 2
end
"""
```