### PR TITLE
Optimize Enum.sort(list, :asc | :desc)

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3156,7 +3156,11 @@ defmodule Enum do
           (element, element -> boolean) | :asc | :desc | module() | {:asc | :desc, module()}
         ) :: list
   def sort(enumerable, sorter) when is_list(enumerable) do
-    :lists.sort(to_sort_fun(sorter), enumerable)
+    case sorter do
+      :asc -> :lists.sort(enumerable)
+      :desc -> :lists.sort(enumerable) |> :lists.reverse()
+      _ -> :lists.sort(to_sort_fun(sorter), enumerable)
+    end
   end
 
   def sort(enumerable, sorter) do


### PR DESCRIPTION
While doing a small [benchmark](https://github.com/sabiwara/elixir_benches/commit/533fa8f35fd7b5e43939e49700139f5bec80bbba), I noticed that `:lists.sort/1` followed by `:lists.reverse` is still 2~4x faster and uses ~1.4x less memory than using `:lists.sort/2`.