### PR TITLE
Supporting IEX_HOME like MIX_HOME

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -327,6 +327,7 @@ defmodule IEx do
   working directory), then for a global `.iex.exs` file located inside the
   directory pointed by the `IEX_HOME` environment variable (which defaults
   to `~`) and loads the first one it finds (if any).
+
   The code in the chosen `.iex.exs` file is evaluated line by line in the shell's
   context, as if each line were being typed in the shell. For instance, any modules
   that are loaded or variables that are bound in the `.iex.exs` file will be available

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -326,7 +326,6 @@ defmodule IEx do
   When starting, IEx looks for a local `.iex.exs` file (located in the current
   working directory), then a global one defined by an environment variable `IEX_HOME` (defaults to `~/.iex.exs`) and loads the
   first one it finds (if any).
-  
   The code in the chosen `.iex.exs` file is evaluated line by line in the shell's
   context, as if each line were being typed in the shell. For instance, any modules
   that are loaded or variables that are bound in the `.iex.exs` file will be available

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -324,8 +324,9 @@ defmodule IEx do
   ## The .iex.exs file
 
   When starting, IEx looks for a local `.iex.exs` file (located in the current
-  working directory), then a global one defined by an environment variable `IEX_HOME` (defaults to `~/.iex.exs`) and loads the
-  first one it finds (if any).
+  working directory), then for a global `.iex.exs` file located inside the
+  directory pointed by the `IEX_HOME` environment variable (which defaults
+  to `~`) and loads the first one it finds (if any).
   The code in the chosen `.iex.exs` file is evaluated line by line in the shell's
   context, as if each line were being typed in the shell. For instance, any modules
   that are loaded or variables that are bound in the `.iex.exs` file will be available

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -324,9 +324,9 @@ defmodule IEx do
   ## The .iex.exs file
 
   When starting, IEx looks for a local `.iex.exs` file (located in the current
-  working directory), then a global one (located at `~/.iex.exs`) and loads the
+  working directory), then a global one defined by an environment variable `IEX_HOME` (defaults to `~/.iex.exs`) and loads the
   first one it finds (if any).
-
+  
   The code in the chosen `.iex.exs` file is evaluated line by line in the shell's
   context, as if each line were being typed in the shell. For instance, any modules
   that are loaded or variables that are bound in the `.iex.exs` file will be available

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -253,7 +253,9 @@ defmodule IEx.Evaluator do
       if path do
         [path]
       else
-        Enum.map([".iex.exs", System.get_env("IEX_HOME", "~/.iex.exs")], &Path.expand/1)
+        Enum.map([".", System.get_env("IEX_HOME", "~")], fn dir ->
+          dir |> Path.join(".iex.exs") |> Path.expand()
+        end)
       end
 
     path = Enum.find(candidates, &File.regular?/1)

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -253,7 +253,7 @@ defmodule IEx.Evaluator do
       if path do
         [path]
       else
-        Enum.map([".iex.exs", "~/.iex.exs"], &Path.expand/1)
+        Enum.map([".iex.exs", System.get_env("IEX_HOME", "~/.iex.exs")], &Path.expand/1)
       end
 
     path = Enum.find(candidates, &File.regular?/1)


### PR DESCRIPTION
On a mission to purge clutter, moving elixir related stuff into its own folder.  Besides, this lets you override "default" `iex.exs` by setting an env variable instead of loading the default one at `~/`.