### PR TITLE
Convert Logger translator into a logger filter

### DIFF
--- a/lib/logger/lib/logger/config.ex
+++ b/lib/logger/lib/logger/config.ex
@@ -9,14 +9,6 @@ defmodule Logger.Config do
     :gen_event.call(Logger, @name, {:configure, options})
   end
 
-  def add_translator(translator) do
-    :gen_event.call(Logger, @name, {:add_translator, translator})
-  end
-
-  def remove_translator(translator) do
-    :gen_event.call(Logger, @name, {:remove_translator, translator})
-  end
-
   ## Callbacks
 
   def init(counter) do
@@ -45,16 +37,6 @@ defmodule Logger.Config do
     end)
 
     {:ok, :ok, load_state(counter)}
-  end
-
-  def handle_call({:add_translator, translator}, state) do
-    update_translators(fn t -> [translator | List.delete(t, translator)] end)
-    {:ok, :ok, state}
-  end
-
-  def handle_call({:remove_translator, translator}, state) do
-    update_translators(&List.delete(&1, translator))
-    {:ok, :ok, state}
   end
 
   def handle_info(@update_counter_message, state) do
@@ -121,13 +103,5 @@ defmodule Logger.Config do
 
   defp schedule_update_counter({_, _, _, discard_period}) do
     Process.send_after(self(), @update_counter_message, discard_period)
-  end
-
-  ## Data helpers
-
-  defp update_translators(fun) do
-    {:ok, %{config: data}} = :logger.get_handler_config(Logger)
-    translators = fun.(data.translators)
-    :ok = :logger.update_handler_config(Logger, :config, {:translators, translators})
   end
 end

--- a/lib/logger/test/logger/handler_test.exs
+++ b/lib/logger/test/logger/handler_test.exs
@@ -3,11 +3,11 @@ defmodule Logger.HandlerTest do
   @moduletag :logger
 
   defmodule CustomTranslator do
-    def t(:debug, :info, :format, {~c"hello: ~p", [:ok]}) do
+    def t(:debug, _level, :format, {~c"hello: ~p", [:ok]}) do
       :skip
     end
 
-    def t(:debug, :info, :format, {~c"world: ~p", [:ok]}) do
+    def t(:debug, _level, :format, {~c"world: ~p", [:ok]}) do
       {:ok, "rewritten"}
     end
 


### PR DESCRIPTION
The separation will help us extract the Logger
formatter into its own entity in future commits.