### PR TITLE
Add `Access.key` and `Access.key!` support for keyword lists

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -504,6 +504,8 @@ defmodule Access do
       {"john", %{user: %{name: "JOHN"}}}
       iex> pop_in(map, [Access.key!(:user), Access.key!(:name)])
       {"john", %{user: %{}}}
+      iex> pop_in([user: [name: "john"]], [Access.key!(:user), Access.key!(:name)])
+      {"john", [user: []]}
       iex> get_in(map, [Access.key!(:user), Access.key!(:unknown)])
       ** (KeyError) key :unknown not found in: %{name: \"john\"}
 

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -496,15 +496,20 @@ defmodule Access do
   ## Examples
 
       iex> map = %{user: %{name: "john"}}
+      iex> keyword_list = [user: [name: "john"]]
       iex> get_in(map, [Access.key!(:user), Access.key!(:name)])
       "john"
       iex> get_and_update_in(map, [Access.key!(:user), Access.key!(:name)], fn prev ->
       ...>   {prev, String.upcase(prev)}
       ...> end)
       {"john", %{user: %{name: "JOHN"}}}
+      iex> get_and_update_in(keyword_list, [Access.key!(:user), Access.key!(:name)], fn prev ->
+      ...>   {prev, String.upcase(prev)}
+      ...> end)
+      {"john", [user: [name: "JOHN"]]}
       iex> pop_in(map, [Access.key!(:user), Access.key!(:name)])
       {"john", %{user: %{}}}
-      iex> pop_in([user: [name: "john"]], [Access.key!(:user), Access.key!(:name)])
+      iex> pop_in(keyword_list, [Access.key!(:user), Access.key!(:name)])
       {"john", [user: []]}
       iex> get_in(map, [Access.key!(:user), Access.key!(:unknown)])
       ** (KeyError) key :unknown not found in: %{name: \"john\"}

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -525,6 +525,14 @@ defmodule Access do
       :get, %{} = data, next ->
         next.(Map.fetch!(data, key))
 
+      :get_and_update, data, next when is_list(data) ->
+        value = Keyword.fetch!(data, key)
+
+        case next.(value) do
+          {get, update} -> {get, Keyword.put(data, key, update)}
+          :pop -> {value, Keyword.delete(data, key)}
+        end
+
       :get_and_update, %{} = data, next ->
         value = Map.fetch!(data, key)
 

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -318,6 +318,12 @@ defmodule AccessTest do
       assert [1, 2, 3] = [one, two, three]
     end
 
+    test "succeeds with get_in/2 on a nested keyword list" do
+      input = [one: [two: [three: 3]]]
+      three = get_in(input, [Access.key(:one), Access.key(:two), Access.key(:three)])
+      assert 3 = three
+    end
+
     test "succeeds with put_in/2 on a map" do
       input = %{one: 1, two: 2, three: 3}
       one = put_in(input, [Access.key(:one)], "one")

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -288,4 +288,127 @@ defmodule AccessTest do
       assert get_in(input, [:list, Access.at!(0), :greeting]) == "hi"
     end
   end
+
+  describe "key/2" do
+    test "succeeds with get_in/2 on a map" do
+      input = %{one: 1, two: 2, three: 3}
+      one = get_in(input, [Access.key(:one)])
+      two = get_in(input, [Access.key(:two)])
+      three = get_in(input, [Access.key(:three)])
+      assert [1, 2, 3] = [one, two, three]
+    end
+
+    defmodule KeyStruct do
+      defstruct one: nil, two: nil, three: nil
+    end
+
+    test "succeeds with get_in/2 on a struct" do
+      input = %AccessTest.KeyStruct{one: 1, two: 2, three: 3}
+      one = get_in(input, [Access.key(:one)])
+      two = get_in(input, [Access.key(:two)])
+      three = get_in(input, [Access.key(:three)])
+      assert [1, 2, 3] = [one, two, three]
+    end
+
+    test "succeeds with get_in/2 on a keyword list" do
+      input = [one: 1, two: 2, three: 3]
+      one = get_in(input, [Access.key(:one)])
+      two = get_in(input, [Access.key(:two)])
+      three = get_in(input, [Access.key(:three)])
+      assert [1, 2, 3] = [one, two, three]
+    end
+
+    test "succeeds with put_in/2 on a map" do
+      input = %{one: 1, two: 2, three: 3}
+      one = put_in(input, [Access.key(:one)], "one")
+      two = put_in(input, [Access.key(:two)], "two")
+      three = put_in(input, [Access.key(:three)], "three")
+      assert %{one: "one"} = one
+      assert %{two: "two"} = two
+      assert %{three: "three"} = three
+    end
+
+    test "succeeds with put_in/2 on a struct" do
+      input = %AccessTest.KeyStruct{one: 1, two: 2, three: 3}
+      one = put_in(input, [Access.key(:one)], "one")
+      two = put_in(input, [Access.key(:two)], "two")
+      three = put_in(input, [Access.key(:three)], "three")
+      assert %AccessTest.KeyStruct{one: "one"} = one
+      assert %AccessTest.KeyStruct{two: "two"} = two
+      assert %AccessTest.KeyStruct{three: "three"} = three
+    end
+
+    test "succeeds with put_in/2 on a keyword list" do
+      input = [one: 1, two: 2, three: 3]
+      one = put_in(input, [Access.key(:one)], "one")
+      two = put_in(input, [Access.key(:two)], "two")
+      three = put_in(input, [Access.key(:three)], "three")
+      assert "one" = Keyword.get(one, :one)
+      assert "two" = Keyword.get(two, :two)
+      assert "three" = Keyword.get(three, :three)
+    end
+
+    test "succeeds with pop_in/2 on a map" do
+      input = %{one: 1, two: 2, three: 3}
+      {1, one} = pop_in(input, [Access.key(:one)])
+      {2, two} = pop_in(input, [Access.key(:two)])
+      {3, three} = pop_in(input, [Access.key(:three)])
+      assert !Map.has_key?(one, :one)
+      assert !Map.has_key?(two, :two)
+      assert !Map.has_key?(three, :three)
+    end
+
+    test "succeeds with pop_in/2 on a struct" do
+      input = %AccessTest.KeyStruct{one: 1, two: 2, three: 3}
+      {1, one} = pop_in(input, [Access.key(:one)])
+      {2, two} = pop_in(input, [Access.key(:two)])
+      {3, three} = pop_in(input, [Access.key(:three)])
+      assert !Map.has_key?(one, :one)
+      assert !Map.has_key?(two, :two)
+      assert !Map.has_key?(three, :three)
+    end
+
+    test "succeeds with pop_in/2 on a keyword list" do
+      input = [one: 1, two: 2, three: 3]
+      {1, one} = pop_in(input, [Access.key(:one)])
+      {2, two} = pop_in(input, [Access.key(:two)])
+      {3, three} = pop_in(input, [Access.key(:three)])
+      assert !Keyword.has_key?(one, :one)
+      assert !Keyword.has_key?(two, :two)
+      assert !Keyword.has_key?(three, :three)
+    end
+
+    test "succeeds with get_and_update_in/2 on a map" do
+      input = %{one: 1, two: 2, three: 3}
+      mult = &{&1, &1 * 2}
+      {1, one} = get_and_update_in(input, [Access.key(:one)], mult)
+      {2, two} = get_and_update_in(input, [Access.key(:two)], mult)
+      {3, three} = get_and_update_in(input, [Access.key(:three)], mult)
+      assert %{one: 2} = one
+      assert %{two: 4} = two
+      assert %{three: 6} = three
+    end
+
+    test "succeeds with get_and_update_in/2 on a struct" do
+      input = %AccessTest.KeyStruct{one: 1, two: 2, three: 3}
+      mult = &{&1, &1 * 2}
+      {1, one} = get_and_update_in(input, [Access.key(:one)], mult)
+      {2, two} = get_and_update_in(input, [Access.key(:two)], mult)
+      {3, three} = get_and_update_in(input, [Access.key(:three)], mult)
+      assert %AccessTest.KeyStruct{one: 2} = one
+      assert %AccessTest.KeyStruct{two: 4} = two
+      assert %AccessTest.KeyStruct{three: 6} = three
+    end
+
+    test "succeeds with get_and_update_in/2 on a keyword list" do
+      input = [one: 1, two: 2, three: 3]
+      mult = &{&1, &1 * 2}
+      {1, one} = get_and_update_in(input, [Access.key(:one)], mult)
+      {2, two} = get_and_update_in(input, [Access.key(:two)], mult)
+      {3, three} = get_and_update_in(input, [Access.key(:three)], mult)
+      assert 2 = Keyword.get(one, :one)
+      assert 4 = Keyword.get(two, :two)
+      assert 6 = Keyword.get(three, :three)
+    end
+  end
 end


### PR DESCRIPTION
Currently the `Access.key` function supports maps and structs, this PR adds the same functionality to keyword lists. 

Added tests for the `Access.key` behavior of maps and structs too to make sure everything is `:ok`

Motivated per the first few lines of [`Access.key`](https://hexdocs.pm/elixir/1.14.2/Access.html#get/3) docs: 

> [Access](https://hexdocs.pm/elixir/1.14.2/Access.html#content) supports keyword lists ([Keyword](https://hexdocs.pm/elixir/1.14.2/Keyword.html)) and maps ([Map](https://hexdocs.pm/elixir/1.14.2/Map.html)) out of the box.

# Before this PR:
```elixir
# keyword lists
get_in([one: 1, two: 2], [:one]) # :ok
get_in([one: 1, two: 2], [Access.key(:one)]) # error

# map
get_in(%{one: 1, two: 2}, [:one]) # :ok
get_in(%{one: 1, two: 2}, [Access.key(:one)]) # :ok
```

# After this PR:
```elixir
# keyword lists
get_in([one: 1, two: 2], [:one]) # :ok
get_in([one: 1, two: 2], [Access.key(:one)]) # :ok

# map
get_in(%{one: 1, two: 2}, [:one]) # :ok
get_in(%{one: 1, two: 2}, [Access.key(:one)]) # :ok
```