### PR TITLE
Fix Enum tests for maps in OTP26

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2302,13 +2302,13 @@ defmodule Enum do
       iex> Enum.split_with([5, 4, 3, 2, 1, 0], fn x -> rem(x, 2) == 0 end)
       {[4, 2, 0], [5, 3, 1]}
 
-      iex> Enum.split_with(%{a: 1, b: -2, c: 1, d: -3}, fn {_k, v} -> v < 0 end)
+      iex> Enum.split_with([a: 1, b: -2, c: 1, d: -3], fn {_k, v} -> v < 0 end)
       {[b: -2, d: -3], [a: 1, c: 1]}
 
-      iex> Enum.split_with(%{a: 1, b: -2, c: 1, d: -3}, fn {_k, v} -> v > 50 end)
+      iex> Enum.split_with([a: 1, b: -2, c: 1, d: -3], fn {_k, v} -> v > 50 end)
       {[], [a: 1, b: -2, c: 1, d: -3]}
 
-      iex> Enum.split_with(%{}, fn {_k, v} -> v > 50 end)
+      iex> Enum.split_with([], fn {_k, v} -> v > 50 end)
       {[], []}
 
   """


### PR DESCRIPTION
Make `Enum` tests for maps independent of Map ordering, in order to fix tests for [OTP26](https://github.com/erlang/otp/releases/tag/OTP-26.0-rc1). (see also: https://github.com/elixir-lang/elixir/pull/12404)