### PR TITLE
Use the cd option in Mix.Shell

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -304,16 +304,14 @@ defmodule Mix.Tasks.Deps.Compile do
   defp do_command(dep, config, command, print_app?, env \\ []) do
     %Mix.Dep{app: app, system_env: system_env, opts: opts} = dep
 
-    File.cd!(opts[:dest], fn ->
-      env = [{"ERL_LIBS", Path.join(config[:env_path], "lib")} | system_env] ++ env
+    env = [{"ERL_LIBS", Path.join(config[:env_path], "lib")} | system_env] ++ env
 
-      if Mix.shell().cmd(command, env: env, print_app: print_app?) != 0 do
-        Mix.raise(
-          "Could not compile dependency #{inspect(app)}, \"#{command}\" command failed. " <>
-            deps_compile_feedback(app)
-        )
-      end
-    end)
+    if Mix.shell().cmd(command, env: env, print_app: print_app?, cd: opts[:dest]) != 0 do
+      Mix.raise(
+        "Could not compile dependency #{inspect(app)}, \"#{command}\" command failed. " <>
+          deps_compile_feedback(app)
+      )
+    end
 
     true
   end


### PR DESCRIPTION
While writing an experimental language server, I was firing up a separate VM to host the project. From this VM, i would get consistent crashes when trying to invoke `Mix.Task.run("deps.compile")` when it tried to compile `telemetry`, which is a rebar3 project. The reason was that the language server vm sets the current directory away from the project after the project is bootstrapped, and again during the compilation process. The global nature of `File.cd!` meant the command was being run from the incorrect directory, which led compilation to fail. 

This is a far edge case, but it seems to me that using the `cd:` option to `Mix.Shell` should be much safer than relying on the race-prone `File.cd!`.

This change drops the use of File.cd! when invoking Mix.shell in favor of passing the cd option to the shell invocation.
File.cd! is known to have race conditions, unlike the cd option in Mix.shell.