### PR TITLE
Fix badfunc test on OTP26

### DIFF
--- a/lib/elixir/test/elixir/kernel/raise_test.exs
+++ b/lib/elixir/test/elixir/kernel/raise_test.exs
@@ -424,6 +424,7 @@ defmodule Kernel.RaiseTest do
       fun = BadFunction.Missing.fun()
 
       :code.delete(BadFunction.Missing)
+      :code.purge(BadFunction.Missing)
 
       defmodule BadFunction.Missing do
         def fun, do: fn -> :another end


### PR DESCRIPTION
Without this extra purge, tests are failing on OTP26 RC1 (`fun.()` still returning `:ok`).

But maybe we can just remove this test since `BadFunctionError` is already tested.