### PR TITLE
Add failing test for #12416 (Enum.chunk_every/4)

### DIFF
--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -112,6 +112,7 @@ defmodule EnumTest do
     assert Enum.chunk_every([1, 2, 3, 4, 5, 6], 3, 2, :discard) == [[1, 2, 3], [3, 4, 5]]
     assert Enum.chunk_every([1, 2, 3, 4, 5, 6], 2, 3, :discard) == [[1, 2], [4, 5]]
     assert Enum.chunk_every([1, 2, 3, 4, 5, 6], 3, 2, []) == [[1, 2, 3], [3, 4, 5], [5, 6]]
+    assert Enum.chunk_every([1, 2, 3], 3, 1, 4..5) == [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
     assert Enum.chunk_every([1, 2, 3, 4, 5, 6], 3, 3, []) == [[1, 2, 3], [4, 5, 6]]
     assert Enum.chunk_every([1, 2, 3, 4, 5], 4, 4, 6..10) == [[1, 2, 3, 4], [5, 6, 7, 8]]
     assert Enum.chunk_every([1, 2, 3, 4, 5], 2, 3, []) == [[1, 2], [4, 5]]


### PR DESCRIPTION
### Elixir and Erlang/OTP versions

Erlang/OTP 25 [erts-13.1.2] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1] [jit:ns]

Elixir 1.14.3 (compiled with Erlang/OTP 23)

### Operating system

macOS Ventura 13.0.1

### Current behavior

```elixir
# Expected:
Enum.chunk_every([1, 2, 3], 2, 1, [4])
# [[1, 2], [2, 3], [3, 4]]

# Unexpected:
Enum.chunk_every([1, 2, 3], 3, 1, 4..5)
# Actual:   [[1, 2, 3], [2, 3, 4]]
# Expected: [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
```

The docs for `Enum.chunk_every/4` state:
> Returns list of lists containing count elements each, where each new chunk starts step elements into the enumerable.

### Expected behavior

When using `step = 1`, I expect a chunk to be emitted for every element of the enumerable.