### PR TITLE
Deterministic struct expansion

### DIFF
--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -254,7 +254,7 @@ defmodule Module.Types do
         "undefined field \"#{atom}\" ",
         format_expr(expr, location),
         "expected one of the following fields: ",
-        Enum.map_join(Enum.sort(known_atoms), ", ", & &1),
+        Enum.join(Enum.sort(known_atoms), ", "),
         "\n\n",
         traces,
         format_message_hints(hints),

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -128,7 +128,7 @@ defmodule Module.Types.Of do
     context = remote(struct, :__struct__, 0, meta, context)
 
     entries =
-      for key <- Map.keys(struct.__struct__()), key != :__struct__ do
+      for key <- Map.keys(struct.__struct__()) |> :lists.sort(), key != :__struct__ do
         {:required, {:atom, key}, :dynamic}
       end
 

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -128,7 +128,7 @@ defmodule Module.Types.Of do
     context = remote(struct, :__struct__, 0, meta, context)
 
     entries =
-      for key <- Map.keys(struct.__struct__()) |> :lists.sort(), key != :__struct__ do
+      for key <- Map.keys(struct.__struct__()), key != :__struct__ do
         {:required, {:atom, key}, :dynamic}
       end
 

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -25,7 +25,7 @@ expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, S, #{context := Context} = 
           AssocKeys = [K || {K, _} <- Assocs],
           Struct = load_struct(Meta, ELeft, [Assocs], AssocKeys, EE),
           Keys = ['__struct__'] ++ AssocKeys,
-          WithoutKeys = maps:to_list(maps:without(Keys, Struct)),
+          WithoutKeys = lists:sort(maps:to_list(maps:without(Keys, Struct))),
           StructAssocs = elixir_quote:escape(WithoutKeys, none, false),
           {{'%', Meta, [ELeft, {'%{}', MapMeta, StructAssocs ++ Assocs}]}, SE, EE};
 

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -140,25 +140,25 @@ defmodule Module.Types.PatternTest do
     end
 
     test "struct" do
-      assert quoted_pattern(%:"Elixir.Module.Types.PatternTest.Struct"{}) ==
-               {:ok,
-                {:map,
-                 [
-                   {:required, {:atom, :__struct__}, {:atom, Module.Types.PatternTest.Struct}},
-                   {:required, {:atom, :bar}, :dynamic},
-                   {:required, {:atom, :baz}, :dynamic},
-                   {:required, {:atom, :foo}, :dynamic}
-                 ]}}
+      assert {:ok, {:map, fields}} = quoted_pattern(%:"Elixir.Module.Types.PatternTest.Struct"{})
 
-      assert quoted_pattern(%:"Elixir.Module.Types.PatternTest.Struct"{foo: 123, bar: :atom}) ==
-               {:ok,
-                {:map,
-                 [
-                   {:required, {:atom, :foo}, :integer},
-                   {:required, {:atom, :bar}, {:atom, :atom}},
-                   {:required, {:atom, :__struct__}, {:atom, Module.Types.PatternTest.Struct}},
-                   {:required, {:atom, :baz}, :dynamic}
-                 ]}}
+      assert Enum.sort(fields) == [
+               {:required, {:atom, :__struct__}, {:atom, Module.Types.PatternTest.Struct}},
+               {:required, {:atom, :bar}, :dynamic},
+               {:required, {:atom, :baz}, :dynamic},
+               {:required, {:atom, :foo}, :dynamic}
+             ]
+
+      assert {:ok, {:map, fields}} =
+               quoted_pattern(%:"Elixir.Module.Types.PatternTest.Struct"{foo: 123, bar: :atom})
+
+      assert Enum.sort(fields) ==
+               [
+                 {:required, {:atom, :__struct__}, {:atom, Module.Types.PatternTest.Struct}},
+                 {:required, {:atom, :bar}, {:atom, :atom}},
+                 {:required, {:atom, :baz}, :dynamic},
+                 {:required, {:atom, :foo}, :integer}
+               ]
     end
 
     test "struct var" do


### PR DESCRIPTION
This should be the last fix regarding non-deterministic key order in OTP26 maps.
- One fix to make struct expansion deterministic
- One fix to make pattern typing deterministic

<img width="644" alt="Screenshot 2023-02-18 at 23 07 37" src="https://user-images.githubusercontent.com/11598866/219870284-0e5ed3f6-a2f7-45d1-969e-c3424bc5b5fc.png">
<img width="681" alt="Screenshot 2023-02-18 at 23 08 02" src="https://user-images.githubusercontent.com/11598866/219870287-0b8ce26a-b001-4a2b-8611-b417f12c8ba1.png">
