### PR TITLE
Add archive_forbidden option to mix projects

### DIFF
--- a/lib/mix/lib/mix/tasks/archive.build.ex
+++ b/lib/mix/lib/mix/tasks/archive.build.ex
@@ -42,6 +42,15 @@ defmodule Mix.Tasks.Archive.Build do
 
     * `--include-dot-files` - adds dot files from priv directory to the archive.
 
+  ## Configuration
+
+  The following option may be specified in your `mix.exs` under the
+  `:project` key:
+
+    * `:archive_forbidden` - if set, mix returns an error if the user runs
+      `mix archive.build`.  The value is a reason to let the user know why
+      or what to do instead.
+
   """
   @switches [
     force: :boolean,
@@ -64,6 +73,12 @@ defmodule Mix.Tasks.Archive.Build do
       Mix.Task.run(:compile, args)
     end
 
+    project_config = Mix.Project.config()
+
+    if project_config[:archive_forbidden] do
+      Mix.raise("Cannot create archive: #{project_config[:archive_forbidden]}")
+    end
+
     source =
       cond do
         input = opts[:input] ->
@@ -83,8 +98,6 @@ defmodule Mix.Tasks.Archive.Build do
         true ->
           Mix.raise("Cannot create archive without input directory, please pass -i as an option")
       end
-
-    project_config = Mix.Project.config()
 
     target =
       cond do

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -15,6 +15,12 @@ defmodule Mix.Tasks.ArchiveTest do
     end
   end
 
+  defmodule ForbiddenArchiveProject do
+    def project do
+      [app: :archive, version: "0.1.0", archive_forbidden: "Install xyz instead"]
+    end
+  end
+
   setup do
     File.rm_rf!(tmp_path("userhome"))
     System.put_env("MIX_ARCHIVES", tmp_path("userhome/.mix/archives/"))
@@ -61,6 +67,17 @@ defmodule Mix.Tasks.ArchiveTest do
            )
 
     assert has_in_zip_file?(~c"archive-0.1.0.ez", ~c"archive-0.1.0/ebin/archive.app")
+  end
+
+  test "archive build fails when archive_forbidden" do
+    in_fixture("archive", fn ->
+      Mix.Project.pop()
+      Mix.Project.push(ForbiddenArchiveProject)
+
+      assert_raise Mix.Error, "Cannot create archive: Install xyz instead", fn ->
+        Mix.Tasks.Archive.Build.run(["--no-elixir-version-check"])
+      end
+    end)
   end
 
   test "archive install" do


### PR DESCRIPTION
For the Nerves project, we had someone read the directions too quickly and run `mix archive.install hex nerves` instead of `mix archive.install hex nerves_bootstrap`. The `archive.install` step worked, but they got errors later on that were not helpful in debugging the issue. We were hoping to figure out a way to make the `mix archive.install` step fail so that the problem could be fixed more easily.

We first tried poisoning the `:nerves` library to see if we could break `archive.install`, but couldn't find a way to do that. This PR proposes adding a project configuration option. If there's another way of doing there, please close and we'll do that instead.

--- 

Specifying `:archive_forbidden` in project configuration prevents the project from being built and installed as an archive. The option takes a message to show to the user.

For example, in the project config adding this:

```
  def project do
    [
      app: :not_an_archive
      ...,
      archive_forbidden: "Run 'mix archive.install hex abcd' instead"
    ]
  end
```

Will produce this error if someone tries to build or install it:

```
** (Mix) Cannot create archive: Run 'mix archive.install hex abcd' instead
```