### PR TITLE
Include direct example of calling protocol function

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -45,10 +45,10 @@ defmodule Protocol do
 
   Finally, we can use the `Size` protocol to call the correct implementation:
 
-    Size.size({1, 2})
-    # => 2
-    Size.size(%{key: :value})
-    # => 1
+      Size.size({1, 2})
+      # => 2
+      Size.size(%{key: :value})
+      # => 1
 
   Note that we didn't implement it for lists as we don't have the
   `size` information on lists, rather its value needs to be

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -43,6 +43,13 @@ defmodule Protocol do
         def size(tuple), do: tuple_size(tuple)
       end
 
+  Finally, we can use the `Size` protocol to call the correct implementation:
+
+    Size.size({1,2})
+    # => 2
+    Size.size(%{key: :value})
+    # => 1
+
   Note that we didn't implement it for lists as we don't have the
   `size` information on lists, rather its value needs to be
   computed with `length`.

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -45,7 +45,7 @@ defmodule Protocol do
 
   Finally, we can use the `Size` protocol to call the correct implementation:
 
-    Size.size({1,2})
+    Size.size({1, 2})
     # => 2
     Size.size(%{key: :value})
     # => 1


### PR DESCRIPTION
The protocols documentation doesn't include an obvious "how to use the protocol" after you've defined it. It does have an example in the "Types" section but it felt a bit tucked away. Hopefully this makes it pretty obvious to new readers.