### PR TITLE
Follow-up for Erlang `maybe`

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1662,7 +1662,8 @@ defmodule ErlangError do
     %CaseClauseError{term: term}
   end
 
-  def normalize({:with_clause, term}, _stacktrace) do
+  # :else_clause is aligned on what Erlang returns for `maybe`
+  def normalize({:else_clause, term}, _stacktrace) do
     %WithClauseError{term: term}
   end
 

--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -188,7 +188,7 @@ expand_with_do(Meta, Opts, S, Acc, E) ->
   end.
 
 expand_with_else(Meta, Opts, S, E, HasMatch) ->
-  case lists:keytake(else, 1, Opts) of
+  case lists:keytake('else', 1, Opts) of
     {value, Pair, RestOpts} ->
       if
         HasMatch -> ok;
@@ -212,7 +212,7 @@ expand_with_else(Meta, Opts, S, E, HasMatch) ->
 'try'(Meta, Opts, S, E) ->
   % TODO: Make this an error on v2.0
   case Opts of
-    [{do, _}, {else, _}] ->
+    [{do, _}, {'else', _}] ->
       file_warn(Meta, ?key(E, file), ?MODULE, {try_with_only_else_clause, origin(Meta, 'try')});
     _ ->
       ok

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -417,7 +417,7 @@ translate_with_else(Meta, [{'else', Else}], S) ->
   {ElseVarEx, ElseVarErl, SE} = elixir_erl_var:assign(Generated, S),
   {RaiseVar, _, SV} = elixir_erl_var:assign(Generated, SE),
 
-  RaiseExpr = {{'.', Generated, [erlang, error]}, Generated, [{with_clause, RaiseVar}]},
+  RaiseExpr = {{'.', Generated, [erlang, error]}, Generated, [{else_clause, RaiseVar}]},
   RaiseClause = {'->', Generated, [[RaiseVar], RaiseExpr]},
   GeneratedElse = [build_generated_clause(Generated, ElseClause) || ElseClause <- Else],
 

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -158,7 +158,7 @@ translate({'try', Meta, [Opts]}, _Ann, S) ->
       {[], SC}
   end,
 
-  Else = elixir_erl_clauses:get_clauses(else, Opts, match),
+  Else = elixir_erl_clauses:get_clauses('else', Opts, match),
   {TElse, SE} = elixir_erl_clauses:clauses(Else, SA),
   {{'try', ?ann(Meta), unblock(TDo), TElse, TCatch, TAfter}, SE};
 
@@ -406,13 +406,13 @@ translate_with_else(Meta, [], S) ->
   {VarName, SC} = elixir_erl_var:build('_', S),
   Var = {var, Generated, VarName},
   {{clause, Generated, [Var], [], [Var]}, SC};
-translate_with_else(Meta, [{else, [{'->', _, [[{Var, VarMeta, Kind}], Clause]}]}], S) when is_atom(Var), is_atom(Kind) ->
+translate_with_else(Meta, [{'else', [{'->', _, [[{Var, VarMeta, Kind}], Clause]}]}], S) when is_atom(Var), is_atom(Kind) ->
   Ann = ?ann(Meta),
   Generated = erl_anno:set_generated(true, Ann),
   {ElseVarErl, SV} = elixir_erl_var:translate(VarMeta, Var, Kind, S#elixir_erl{context=match}),
   {TranslatedClause, SC} = translate(Clause, Ann, SV#elixir_erl{context=nil}),
   {{clause, Generated, [ElseVarErl], [], [TranslatedClause]}, SC};
-translate_with_else(Meta, [{else, Else}], S) ->
+translate_with_else(Meta, [{'else', Else}], S) ->
   Generated = ?generated(Meta),
   {ElseVarEx, ElseVarErl, SE} = elixir_erl_var:assign(Generated, S),
   {RaiseVar, _, SV} = elixir_erl_var:assign(Generated, SE),

--- a/lib/elixir/src/elixir_erl_try.erl
+++ b/lib/elixir/src/elixir_erl_try.erl
@@ -171,7 +171,7 @@ erl_rescue_guard_for(Meta, Var, 'Elixir.CaseClauseError') ->
 erl_rescue_guard_for(Meta, Var, 'Elixir.WithClauseError') ->
   erl_and(Meta,
           erl_tuple_size(Meta, Var, 2),
-          erl_record_compare(Meta, Var, with_clause));
+          erl_record_compare(Meta, Var, else_clause));
 
 erl_rescue_guard_for(Meta, Var, 'Elixir.TryClauseError') ->
   erl_and(Meta,

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -16,7 +16,7 @@ cond_line_test() ->
 
 optimized_if_test() ->
   {'case', _, _,
-    [{clause, _, [{atom, _, false}], [], [{atom, _, else}]},
+    [{clause, _, [{atom, _, false}], [], [{atom, _, 'else'}]},
      {clause, _, [{atom, _, true}], [], [{atom, _, do}]}]
   } = to_erl("if is_list([]), do: :do, else: :else").
 

--- a/lib/elixir/test/erlang/function_test.erl
+++ b/lib/elixir/test/erlang/function_test.erl
@@ -67,7 +67,7 @@ function_call_without_arg_test() ->
   {3, _} = eval("x = fn -> 2 + 1 end\nx.()").
 
 function_call_do_end_test() ->
-  {[1, [{do, 2}, {else, 3}]], _} = eval("x = fn a, b -> [a, b] end\nx.(1) do\n2\nelse 3\nend").
+  {[1, [{do, 2}, {'else', 3}]], _} = eval("x = fn a, b -> [a, b] end\nx.(1) do\n2\nelse 3\nend").
 
 function_call_with_assignment_test() ->
   {3, [{a, _}, {c, 3}]} = eval("a = fn x -> x + 2 end; c = a.(1)").


### PR DESCRIPTION
Since the [`maybe`](https://www.erlang.org/doc/reference_manual/expressions.html#maybe) expression has been added to erlang:
- `else` has became a keyword, so it is better to quote its atom
- when `else` doesn't match, it throws an `{:else_clause, value}`, since our `with` is quite similar we might as well use the same for consistency