### PR TITLE
Add optional callback quoted_to_algebra/2 to Mix.Tasks.Format

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -211,6 +211,19 @@ defmodule Mix.Tasks.Format do
   """
   @callback format(String.t(), Keyword.t()) :: String.t()
 
+  @doc """
+  Converts a quoted expression to an algebra document using the plugin formatter
+  rules.
+
+  This callback is optional for plugins that are able to format Elixir's quoted
+  expressions.
+
+  See `Code.quoted_to_algebra/2` for more information.
+  """
+  @callback quoted_to_algebra(Macro.t(), keyword) :: Inspect.Algebra.t()
+
+  @optional_callbacks quoted_to_algebra: 2
+
   @impl true
   def run(args) do
     {opts, args} = OptionParser.parse!(args, strict: @switches)


### PR DESCRIPTION
The optional callback offers the possibility for formatter plugins handling Elixir code to run with quoted expressions.
The benefit would be that developers can format a changed AST with formatter plugins.

A specific example is the project `recode`/`rewrite` that uses `sourceror` to manipulate the AST to realise an linter with autocorrection. This project the also respects the `FreedomFormatter`. For now that is realized with a workaround in `rewrite`: 
```elixir
  defp format(ast, file \\ "source.ex") do
    ext = Path.extname(file)
    {_formatter, formatter_opts} = Format.formatter_for_file(file)
    plugins = plugins_for_ext(formatter_opts, ext)

    {quoted_to_algebra, plugins} =
      case plugins do
        [FreedomFormatter | plugins] ->
          # For now just a workaround to support the FreedomFormatter.
          {&FreedomFormatter.Formatter.to_algebra/2, plugins}

        plugins ->
          {&Code.quoted_to_algebra/2, plugins}
      end

    formatter_opts =
      formatter_opts ++
        [
          quoted_to_algebra: quoted_to_algebra,
          extension: ext,
          file: file
        ]

    code = Sourceror.to_string(ast, formatter_opts)

    Enum.reduce(plugins, code, fn plugin, code ->
      plugin.format(code, formatter_opts)
    end)
  end
```