### PR TITLE
Fix more map inspection tests

### DIFF
--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -18,13 +18,20 @@ defmodule ExceptionTest do
       end
     end
 
-    assert Exception.message(%{__struct__: BadException, __exception__: true, raise: true}) =~
-             "got RuntimeError with message \"oops\" while retrieving Exception.message/1 " <>
-               "for %{__exception__: true, __struct__: ExceptionTest.BadException, raise: true}"
+    assert "got RuntimeError with message \"oops\" while retrieving Exception.message/1 for %{" <>
+             inspected =
+             Exception.message(%{__struct__: BadException, __exception__: true, raise: true})
 
-    assert Exception.message(%{__struct__: BadException, __exception__: true, raise: false}) =~
-             "got nil while retrieving Exception.message/1 " <>
-               "for %{__exception__: true, __struct__: ExceptionTest.BadException, raise: false}"
+    assert inspected =~ "raise: true"
+    assert inspected =~ "__exception__: true"
+    assert inspected =~ "__struct__: ExceptionTest.BadException"
+
+    assert "got nil while retrieving Exception.message/1 for %{" <> inspected =
+             Exception.message(%{__struct__: BadException, __exception__: true, raise: false})
+
+    assert inspected =~ "raise: false"
+    assert inspected =~ "__exception__: true"
+    assert inspected =~ "__struct__: ExceptionTest.BadException"
   end
 
   test "normalize/2" do


### PR DESCRIPTION
I noticed one more failing test on OTP26 due to non-deterministic map inspection (see also https://github.com/elixir-lang/elixir/pull/12418):

<img width="1419" alt="Screenshot 2023-02-28 at 19 14 30" src="https://user-images.githubusercontent.com/11598866/221824333-b3685684-649a-468e-be5a-5c196c777b88.png">
