### PR TITLE
Fix logger formatting in OTP26

### DIFF
--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -134,7 +134,8 @@ defmodule Logger.Utils do
     pad_char: ?\s,
     precision: :none,
     strings: true,
-    width: :none
+    width: :none,
+    maps_order: :undefined
   }
 
   defp handle_format_spec(%{control_char: char} = spec, opts) when char in ~c"wWpP" do


### PR DESCRIPTION
There is a regression in the logger for OTP26 due to this [change in :io_lib.unscan_format](https://github.com/erlang/otp/commit/553d40aaeebab959fcd3942742c3e67ce16e569d#diff-97fd60be48b979b2b52a427b1de551783e16faa6fd1851a41088a76578ca6e0cR120).

Following this, the pattern wouldn't match without the `maps_order` key and just return the plain map:
<img width="1115" alt="Screenshot 2023-02-28 at 20 45 24" src="https://user-images.githubusercontent.com/11598866/221845321-1e2ee505-7643-46cc-a438-015c02cc21ef.png">

I'm not sure if there is a way to avoid this issue in the future:
- could we generate the [`format_spec`](https://www.erlang.org/doc/man/io_lib.html#type-format_spec) using only public functions to make this more robust?
- should we send a PR upstream to erlang to accept a map without the new key? (`maps.get/3` instead of pattern-matching)