### PR TITLE
Make `to_atom` vs `to_exsting_atom` usage more explicit

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2586,7 +2586,7 @@ defmodule String do
   end
 
   @doc """
-  Converts a string to an atom.
+  Converts a string to an existing atom or creates a new one.
 
   Warning: this function creates atoms dynamically and atoms are
   not garbage-collected. Therefore, `string` should not be an
@@ -2612,10 +2612,10 @@ defmodule String do
   end
 
   @doc """
-  Converts a string to an existing atom.
+  Converts a string to an existing atom or raises an `ArgumentError` if
+  the atom does not exist.
 
   The maximum atom size is of 255 Unicode code points.
-  Raises an `ArgumentError` if the atom does not exist.
 
   Inlined by the compiler.
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2616,7 +2616,7 @@ defmodule String do
   the atom does not exist.
 
   The maximum atom size is of 255 Unicode code points.
-  Raises `ArgumentError` if the atom does not exist.
+  Raises an `ArgumentError` if the atom does not exist.
 
   Inlined by the compiler.
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2612,10 +2612,11 @@ defmodule String do
   end
 
   @doc """
-  Converts a string to an existing atom or raises an `ArgumentError` if
+  Converts a string to an existing atom or raises if
   the atom does not exist.
 
   The maximum atom size is of 255 Unicode code points.
+  Raises `ArgumentError` if the atom does not exist.
 
   Inlined by the compiler.
 


### PR DESCRIPTION
Like [this person here](https://elixirforum.com/t/is-this-a-correct-way-to-avoid-wasting-or-reaching-the-atom-limit/23137), I misunderstood what was happening when one calls `String.to_atom`. This commit makes a minor documentation change to make the difference more explicit. 

-----------

In the link, the person asked:

> As I have to generate several atoms from strings and as atoms are not garbage collected and there’s a limit for each process, does this function is correct to “save” them atoms ? :
> 
> ```
> def string_to_atom(str) do
>     try do
>       String.to_existing_atom(str)
>     rescue
>       ArgumentError -> String.to_atom(str)
>     end
>   end
> ```
> Or do you know any smarter (or “elixier”) way to achieve this (perhaps without this ugly “try rescue”) ?

