### PR TITLE
Make mix test reports deterministic in OTP26

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -337,7 +337,9 @@ defmodule ExUnit.CLIFormatter do
   end
 
   defp format_test_type_counts(%{test_counter: test_counter} = _config) do
-    Enum.map(test_counter, fn {test_type, count} ->
+    test_counter
+    |> Enum.sort()
+    |> Enum.map(fn {test_type, count} ->
       type_pluralized = pluralize(count, test_type, ExUnit.plural_rule(test_type |> to_string()))
       "#{count} #{type_pluralized}, "
     end)

--- a/lib/mix/lib/mix/tasks/test.coverage.ex
+++ b/lib/mix/lib/mix/tasks/test.coverage.ex
@@ -173,6 +173,7 @@ defmodule Mix.Tasks.Test.Coverage do
 
     if apps_paths = Mix.Project.apps_paths(config) do
       build_path = Mix.Project.build_path(config)
+      apps_paths = Enum.sort(apps_paths)
 
       compile_paths =
         Enum.map(apps_paths, fn {app, _} ->

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -488,6 +488,10 @@ defmodule Mix.DepTest do
     Mix.RemoteConverger.register(nil)
   end
 
+  defp sorted_keys(map) do
+    map |> Map.keys() |> Enum.sort()
+  end
+
   test "deps_paths" do
     deps = [
       {:abc_repo, "0.1.0", path: "custom/abc_repo"},
@@ -502,33 +506,42 @@ defmodule Mix.DepTest do
                  [:abc_repo, :git_repo, :deps_repo]
                ]
 
-        assert Map.keys(Mix.Project.deps_paths()) == [:abc_repo, :deps_repo, :git_repo]
+        assert sorted_keys(Mix.Project.deps_paths()) == [:abc_repo, :deps_repo, :git_repo]
 
-        assert Map.keys(Mix.Project.deps_paths(depth: 1)) == [:abc_repo, :deps_repo]
-        assert Map.keys(Mix.Project.deps_paths(depth: 2)) == [:abc_repo, :deps_repo, :git_repo]
-        assert Map.keys(Mix.Project.deps_paths(depth: 3)) == [:abc_repo, :deps_repo, :git_repo]
+        assert sorted_keys(Mix.Project.deps_paths(depth: 1)) == [:abc_repo, :deps_repo]
+        assert sorted_keys(Mix.Project.deps_paths(depth: 2)) == [:abc_repo, :deps_repo, :git_repo]
+        assert sorted_keys(Mix.Project.deps_paths(depth: 3)) == [:abc_repo, :deps_repo, :git_repo]
 
-        assert Map.keys(Mix.Project.deps_paths(parents: [:abc_repo])) == [:abc_repo]
-        assert Map.keys(Mix.Project.deps_paths(parents: [:deps_repo])) == [:deps_repo, :git_repo]
-        assert Map.keys(Mix.Project.deps_paths(parents: [:git_repo])) == [:git_repo]
+        assert sorted_keys(Mix.Project.deps_paths(parents: [:abc_repo])) == [:abc_repo]
 
-        assert Map.keys(Mix.Project.deps_paths(parents: [:abc_repo], depth: 1)) == [:abc_repo]
-        assert Map.keys(Mix.Project.deps_paths(parents: [:deps_repo], depth: 1)) == [:deps_repo]
-        assert Map.keys(Mix.Project.deps_paths(parents: [:git_repo], depth: 1)) == [:git_repo]
+        assert sorted_keys(Mix.Project.deps_paths(parents: [:deps_repo])) == [
+                 :deps_repo,
+                 :git_repo
+               ]
 
-        assert Map.keys(Mix.Project.deps_paths(parents: [:abc_repo], depth: 2)) == [:abc_repo]
-        assert Map.keys(Mix.Project.deps_paths(parents: [:git_repo], depth: 2)) == [:git_repo]
+        assert sorted_keys(Mix.Project.deps_paths(parents: [:git_repo])) == [:git_repo]
 
-        assert Map.keys(Mix.Project.deps_paths(parents: [:deps_repo], depth: 2)) ==
+        assert sorted_keys(Mix.Project.deps_paths(parents: [:abc_repo], depth: 1)) == [:abc_repo]
+
+        assert sorted_keys(Mix.Project.deps_paths(parents: [:deps_repo], depth: 1)) == [
+                 :deps_repo
+               ]
+
+        assert sorted_keys(Mix.Project.deps_paths(parents: [:git_repo], depth: 1)) == [:git_repo]
+
+        assert sorted_keys(Mix.Project.deps_paths(parents: [:abc_repo], depth: 2)) == [:abc_repo]
+        assert sorted_keys(Mix.Project.deps_paths(parents: [:git_repo], depth: 2)) == [:git_repo]
+
+        assert sorted_keys(Mix.Project.deps_paths(parents: [:deps_repo], depth: 2)) ==
                  [:deps_repo, :git_repo]
 
-        assert Map.keys(Mix.Project.deps_paths(parents: [:abc_repo, :deps_repo])) ==
+        assert sorted_keys(Mix.Project.deps_paths(parents: [:abc_repo, :deps_repo])) ==
                  [:abc_repo, :deps_repo, :git_repo]
 
-        assert Map.keys(Mix.Project.deps_paths(parents: [:abc_repo, :deps_repo], depth: 1)) ==
+        assert sorted_keys(Mix.Project.deps_paths(parents: [:abc_repo, :deps_repo], depth: 1)) ==
                  [:abc_repo, :deps_repo]
 
-        assert Map.keys(Mix.Project.deps_paths(parents: [:abc_repo, :deps_repo], depth: 2)) ==
+        assert sorted_keys(Mix.Project.deps_paths(parents: [:abc_repo, :deps_repo], depth: 2)) ==
                  [:abc_repo, :deps_repo, :git_repo]
       end)
     end)


### PR DESCRIPTION
Fixes `make test_mix` on OTP 26:

1. Make mix test reports deterministic 91c258f78dc505e4cbd5ffce4d8e0f657eb43111
  The reports for the following were both relying on map keys ordering:
  - mix test
  - mix test.cover

2. Fix non-deterministic test 534b48237d0e919604d7bd8119d9350fc36c7e15

<img width="1145" alt="Screenshot 2023-03-02 at 9 55 09" src="https://user-images.githubusercontent.com/11598866/222302937-28220d5f-4421-4f4c-870e-adf677d5970b.png">
