### PR TITLE
Warn about name conflicts in nested modules

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4991,7 +4991,6 @@ defmodule Kernel do
       {^alias, other_parent} ->
         defmod_name = Enum.join(parts, ".")
         nested_mod_name = :elixir_aliases.concat([env.module | parts])
-        actual_mod_name = :elixir_aliases.concat([other_parent | parts])
 
         IO.warn(
           """

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1967,7 +1967,13 @@ defmodule Kernel.WarningTest do
         """)
       end)
 
-    assert output =~ ~s(the nested call to "defmodule Child" will not implicitly alias)
+    assert output =~ """
+           you are defining a module named Child inside module Parent, which will result in the \
+           full module name Parent.Child. However, the implicit alias to Child will not be set \
+           up because there is already an existing "alias OtherParent.Child, as: Child". You \
+           must address this ambiguity either by removing the alias or by defining the nested \
+           module outside of the parent\
+           """
   after
     purge([Parent, Child])
   end
@@ -1988,8 +1994,13 @@ defmodule Kernel.WarningTest do
         """)
       end)
 
-    assert output =~
-             ~s(the nested call to "defmodule Child.One" will not implicitly alias Child)
+    assert output =~ """
+           you are defining a module named Child.One inside module Parent, which will result in \
+           the full module name Parent.Child.One. However, the implicit alias to Child will not \
+           be set up because there is already an existing \"alias OtherParent.Child, as: Child\". \
+           You must address this ambiguity either by removing the alias or by defining the \
+           nested module outside of the parent\
+           """
   after
     purge([Parent, Child])
   end

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -943,48 +943,6 @@ defmodule KernelTest do
         defmodule :"foo\\bar", do: :ok
       end
     end
-
-    test "warns when nested and there is an alias with the same name" do
-      output =
-        ExUnit.CaptureIO.capture_io(:stderr, fn ->
-          Code.eval_string("""
-          defmodule Parent do
-            alias OtherParent.Child
-
-            defmodule Child do
-            end
-          end
-          """)
-        end)
-
-      assert output =~ ~s(the nested call to "defmodule Child" will not implicitly alias)
-    after
-      purge(Parent)
-      purge(Child)
-    end
-
-    test "warns when nested with multiple name components and there is an alias with the same name" do
-      output =
-        ExUnit.CaptureIO.capture_io(:stderr, fn ->
-          Code.eval_string("""
-          defmodule Parent do
-            alias OtherParent.Child
-
-            defmodule Child.One do
-            end
-
-            defmodule Child.Two do
-            end
-          end
-          """)
-        end)
-
-      assert output =~
-               ~s(the nested call to "defmodule Child.One" will not implicitly alias Child)
-    after
-      purge(Parent)
-      purge(Child)
-    end
   end
 
   describe "access" do

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -3,7 +3,6 @@ Code.require_file("test_helper.exs", __DIR__)
 # Holds tests for both Kernel.Typespec and Code.Typespec
 defmodule TypespecTest do
   use ExUnit.Case, async: true
-  alias TypespecTest.TypespecSample
 
   defstruct [:hello]
 
@@ -120,7 +119,7 @@ defmodule TypespecTest do
 
     test "redefined type" do
       assert_raise Kernel.TypespecError,
-                   ~r"type foo/0 is already defined in .*test/elixir/typespec_test.exs:126",
+                   ~r"type foo/0 is already defined in .*test/elixir/typespec_test.exs:125",
                    fn ->
                      test_module do
                        @type foo :: atom
@@ -129,7 +128,7 @@ defmodule TypespecTest do
                    end
 
       assert_raise Kernel.TypespecError,
-                   ~r"type foo/2 is already defined in .*test/elixir/typespec_test.exs:136",
+                   ~r"type foo/2 is already defined in .*test/elixir/typespec_test.exs:135",
                    fn ->
                      test_module do
                        @type foo :: atom
@@ -139,7 +138,7 @@ defmodule TypespecTest do
                    end
 
       assert_raise Kernel.TypespecError,
-                   ~r"type foo/0 is already defined in .*test/elixir/typespec_test.exs:145",
+                   ~r"type foo/0 is already defined in .*test/elixir/typespec_test.exs:144",
                    fn ->
                      test_module do
                        @type foo :: atom


### PR DESCRIPTION
Closes #11130.

I’m not sure what to do for this particular warning in this particular test, since we're testing exactly the behaviour that warns here 😕 

```
warning: the nested call to "defmodule First" will not implicitly alias First here because there is already an alias Some.First that resolves to the same alias. To fix this, either remove the Some.First alias, or define the nested module outside of the parent
  test/elixir/kernel/alias_test.exs:132: Macro.AliasTest.User (module)
```