### PR TITLE
Document supported version for __info__(:struct)

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -579,7 +579,7 @@ defmodule Module do
 
     * `:module` - the module atom name
 
-    * `:struct` - if the module defines a struct and if so each field in order
+    * `:struct` - (since v1.14.0) if the module defines a struct and if so each field in order
 
   """
   @callback __info__(:attributes) :: keyword()


### PR DESCRIPTION
The ability to call `module.__info__(:struct)` has been added since 1.14 but the doc wasn't mentioning since when