### PR TITLE
Fix Stream.zip/1 with empty list inducing memory spike

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1316,6 +1316,8 @@ defmodule Stream do
     {:suspended, acc, &zip_list(enumerables, &1, fun, zip_fun)}
   end
 
+  defp zip_list([], {:cont, acc}, _fun, _zip_fun), do: {:done, acc}
+
   defp zip_list(enumerables, {:cont, acc}, fun, zip_fun) do
     case zip_list_heads_tails(enumerables, [], []) do
       {heads, tails} -> zip_list(tails, fun.(zip_fun.(heads), acc), fun, zip_fun)

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -1340,6 +1340,8 @@ defmodule StreamTest do
     assert Stream.chunk_every([0, 1, 2, 3], 2) |> Stream.zip() |> Enum.to_list() ==
              [{0, 2}, {1, 3}]
 
+    assert Stream.zip([]) |> Enum.to_list() == []
+
     stream = %HaltAcc{acc: 1..3}
     assert Stream.zip([1..3, stream]) |> Enum.to_list() == [{1, 1}, {2, 2}, {3, 3}]
 


### PR DESCRIPTION
closes #12459 