### PR TITLE
Include cwd in compiler cache key

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -105,7 +105,7 @@ defmodule Mix.Tasks.Compile.Elixir do
 
     manifest = manifest()
     base = xref_exclude_opts(project[:elixirc_options] || [], project)
-    cache_key = {base, srcs, "--no-optional-deps" in args}
+    cache_key = {base, srcs, File.cwd!(), "--no-optional-deps" in args}
 
     opts =
       base

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -82,32 +82,6 @@ defmodule Mix.Tasks.Compile.ElixirTest do
     end)
   end
 
-  test "recompiles project if working directory changed" do
-    in_fixture("no_mixfile", fn ->
-      Mix.Project.push(MixTest.Case.Sample)
-
-      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
-      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
-      assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
-
-      tmp = tmp_path("copied")
-      File.cp_r!(File.cwd!(), tmp)
-      File.cd!(tmp)
-
-      File.touch!("_build/dev/lib/sample/.mix/compile.elixir", @old_time)
-
-      Code.put_compiler_option(:ignore_module_conflict, true)
-
-      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
-      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
-      assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
-      assert File.stat!("_build/dev/lib/sample/.mix/compile.elixir").mtime > @old_time
-    end)
-  after
-    Code.put_compiler_option(:ignore_module_conflict, false)
-    File.rm_rf!(tmp_path("copied"))
-  end
-
   test "recompiles files using Mix.Project if mix.exs changes" do
     in_fixture("no_mixfile", fn ->
       Mix.Project.push(MixTest.Case.Sample, __ENV__.file)

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -82,6 +82,32 @@ defmodule Mix.Tasks.Compile.ElixirTest do
     end)
   end
 
+  test "recompiles project if working directory changed" do
+    in_fixture("no_mixfile", fn ->
+      Mix.Project.push(MixTest.Case.Sample)
+
+      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
+      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+
+      tmp = tmp_path("copied")
+      File.cp_r!(File.cwd!(), tmp)
+      File.cd!(tmp)
+
+      File.touch!("_build/dev/lib/sample/.mix/compile.elixir", @old_time)
+
+      Code.put_compiler_option(:ignore_module_conflict, true)
+
+      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
+      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+      assert File.stat!("_build/dev/lib/sample/.mix/compile.elixir").mtime > @old_time
+    end)
+  after
+    Code.put_compiler_option(:ignore_module_conflict, false)
+    File.rm_rf!(tmp_path("copied"))
+  end
+
   test "recompiles files using Mix.Project if mix.exs changes" do
     in_fixture("no_mixfile", fn ->
       Mix.Project.push(MixTest.Case.Sample, __ENV__.file)


### PR DESCRIPTION
Without this, moving or copying a directory would not recompile beam files despite the fact their `:source` absolute path is obsolete. This could create issues with `ex_doc` when generating links.
