### PR TITLE
Readability improvements for Calendar.strftime/3

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -402,6 +402,14 @@ defmodule Calendar do
   or a map without the `:year` field to a format that expects `%Y`,
   an error will be raised.
 
+  Examples of common usage:
+
+      iex> Calendar.strftime(~U[2019-08-26 13:52:06.0Z], "%Y-%m-%d %I:%M:%S %p")
+      "19-08-26 01:52:06 PM"
+
+      iex> Calendar.strftime(~U[2019-08-26 13:52:06.0Z], "%a, %B %d %Y")
+      "Mon, August 26 2019"
+
   ## User Options
 
     * `:preferred_datetime` - a string for the preferred format to show datetimes,

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -404,7 +404,7 @@ defmodule Calendar do
 
   Examples of common usage:
 
-      iex> Calendar.strftime(~U[2019-08-26 13:52:06.0Z], "%Y-%m-%d %I:%M:%S %p")
+      iex> Calendar.strftime(~U[2019-08-26 13:52:06.0Z], "%y-%m-%d %I:%M:%S %p")
       "19-08-26 01:52:06 PM"
 
       iex> Calendar.strftime(~U[2019-08-26 13:52:06.0Z], "%a, %B %d %Y")

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -402,7 +402,7 @@ defmodule Calendar do
   or a map without the `:year` field to a format that expects `%Y`,
   an error will be raised.
 
-  ## Options
+  ## User Options
 
     * `:preferred_datetime` - a string for the preferred format to show datetimes,
       it can't contain the `%c` format and defaults to `"%Y-%m-%d %H:%M:%S"`
@@ -438,7 +438,8 @@ defmodule Calendar do
 
   ## Formatting syntax
 
-  The formatting syntax for strftime is a sequence of characters in the following format:
+  The formatting syntax for the `string_format` argument is a sequence of characters in
+  the following format:
 
       %<padding><width><format>
 
@@ -455,9 +456,9 @@ defmodule Calendar do
     * `_`: pad with spaces
     * `0`: pad with zeroes
 
-  ### Accepted formats
+  ### Accepted string formats
 
-  The accepted formats are:
+  The accepted formats for `string_format` are:
 
   Format | Description                                                             | Examples (in ISO)
   :----- | :-----------------------------------------------------------------------| :------------------------
@@ -491,7 +492,7 @@ defmodule Calendar do
 
   ## Examples
 
-  Without options:
+  Without user options:
 
       iex> Calendar.strftime(~U[2019-08-26 13:52:06.0Z], "%y-%m-%d %I:%M:%S %p")
       "19-08-26 01:52:06 PM"
@@ -505,7 +506,7 @@ defmodule Calendar do
       iex> Calendar.strftime(~U[2019-08-26 13:52:06.0Z], "%c")
       "2019-08-26 13:52:06"
 
-  With options:
+  With user options:
 
       iex> Calendar.strftime(~U[2019-08-26 13:52:06.0Z], "%c", preferred_datetime: "%H:%M:%S %d-%m-%y")
       "13:52:06 26-08-19"


### PR DESCRIPTION
There was a report on the ElixirForum about the docs for [`Calendar.strftime/3`](https://hexdocs.pm/elixir/1.14.3/Calendar.html#strftime/3) being difficult to read/understand: https://elixirforum.com/t/converting-time-to-remedial-human-form/54511/3

This PR attempts to improve the docs by making it more clear that the "User Options" section corresponds to the `user_options` argument and that the "Accpeted string formats" section applies to the `string_format` argument.

I also thought about moving one of the examples higher up in the docs since the docs for this function are quite lengthy but I wasn't sure if that was against the documentation guidelines for Elixir since I'm not aware of any other function that has examples up front instead of at the bottom.

Another alternative to consider is changing the names of the arguments from
- `user_options` to `options`
- `string_format` to `format` (although maybe it should be called `formats` since depending on how you read the docs there may be multiple formats)