### PR TITLE
Implement IEx.Info for Regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ TODO: Mention :console vs Logger.Backends.Console
   * [IEx] Make pry opt-in on dbg with `--dbg pry`
   * [IEX] Support `IEX_HOME`
   * [IEx.Helpers] Add `runtime_info(:allocators)`
-  * [IEx.Info] Implement protocol for `Range` and `DateTime`
+  * [IEx.Info] Implement protocol for `Range`, `DateTime` and `Regex`
 
 #### Logger
 

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -398,13 +398,16 @@ defimpl IEx.Info, for: Reference do
   end
 end
 
-defimpl IEx.Info, for: [Date, Time, DateTime, NaiveDateTime] do
-  {sigil, repr} =
+defimpl IEx.Info, for: [Date, Time, DateTime, NaiveDateTime, Regex] do
+  naive_datetime_repr = ~S{"naive" datetime (that is, a datetime without a time zone)}
+
+  {sigil, repr, modules} =
     case @for do
-      Date -> {"D", "date"}
-      Time -> {"T", "time"}
-      DateTime -> {"U", "datetime"}
-      NaiveDateTime -> {"N", ~S{"naive" datetime (that is, a datetime without a time zone)}}
+      Date -> {"D", "date", [Calendar, Map]}
+      Time -> {"T", "time", [Calendar, Map]}
+      DateTime -> {"U", "datetime", [Calendar, Map]}
+      NaiveDateTime -> {"N", naive_datetime_repr, [Calendar, Map]}
+      Regex -> {"r", "regular expression", [:re]}
     end
 
   def info(value) do
@@ -418,7 +421,7 @@ defimpl IEx.Info, for: [Date, Time, DateTime, NaiveDateTime] do
       {"Data type", inspect(@for)},
       {"Description", description},
       {"Raw representation", raw_inspect(value)},
-      {"Reference modules", inspect(@for) <> ", Calendar, Map"}
+      {"Reference modules", unquote(Enum.map_join([@for | modules], ", ", &inspect/1))}
     ]
   end
 

--- a/lib/iex/test/iex/info_test.exs
+++ b/lib/iex/test/iex/info_test.exs
@@ -222,6 +222,14 @@ defmodule IEx.InfoTest do
     end
   end
 
+  test "Regex" do
+    info = Info.info(~r/(ab)+c/)
+    assert get_key(info, "Data type") == "Regex"
+    assert get_key(info, "Description")
+    assert get_key(info, "Raw representation") =~ "%Regex{re_pattern: {:re_pattern, "
+    assert get_key(info, "Reference modules") == "Regex, :re"
+  end
+
   test "Range" do
     info = Info.info(1..10//2)
     assert get_key(info, "Data type") == "Range"


### PR DESCRIPTION
Since regexes are also represented with a sigil, I thought it might be a good idea for them to implement `IEx.Info` too.

Feel free to close if you prefer to avoid it.

<img width="590" alt="Screenshot 2023-03-14 at 9 32 45" src="https://user-images.githubusercontent.com/11598866/224862337-c81f4776-da6f-48aa-bf66-89fba2cf6ba1.png">
