### PR TITLE
Proposal: dbg gives more info for :case

### DIFF
--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -443,6 +443,62 @@ defmodule MacroTest do
              """
     end
 
+    test "with case" do
+      list = [1, 2, 3]
+
+      {result, formatted} =
+        dbg_format(
+          case list do
+            [] -> nil
+            _ -> Enum.sum(list)
+          end
+        )
+
+      assert result == 6
+
+      assert formatted =~ "macro_test.exs"
+
+      assert formatted =~ """
+             list #=> [1, 2, 3]
+             _ #=> clause #2 matched
+             case list do
+               [] -> nil
+               _ -> Enum.sum(list)
+             end #=> 6
+             """
+    end
+
+    test "with case - guard" do
+      {result, formatted} =
+        dbg_format(
+          case 0..100//5 do
+            %{first: first, last: last, step: step} when last > first ->
+              count = div(last - first, step)
+              {:ok, count}
+
+            _ ->
+              :error
+          end
+        )
+
+      assert result == {:ok, 20}
+
+      assert formatted =~ "macro_test.exs"
+
+      assert formatted =~ """
+             0..100//5 #=> 0..100//5
+             %{first: first, last: last, step: step} when last > first #=> clause #1 matched
+             case 0..100//5 do
+               %{first: first, last: last, step: step} when last > first ->
+                 count = div(last - first, step)
+                 {:ok, count}
+
+               _ ->
+                 :error
+             end #=> {:ok, 20}
+             """
+    end
+
     test "with \"syntax_colors: []\" it doesn't print any color sequences" do
       {_result, formatted} = dbg_format("hello")
       refute formatted =~ "\e["


### PR DESCRIPTION
Hi! Here is a prototype for discussion about how we could add information about what is happening inside a `case` expression:

<img width="578" alt="Screenshot 2023-03-15 at 20 54 17" src="https://user-images.githubusercontent.com/11598866/225301933-1ec0a6af-f9c5-46f8-b727-bb3a11c8ce59.png">
