### PR TITLE
Add more info for :cond expressions in dbg/1

### DIFF
--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -520,8 +520,7 @@ defmodule MacroTest do
       assert formatted =~ "macro_test.exs"
 
       assert formatted =~ """
-             Cond clauses (clause #2 matched):
-             a = map[:a] #=> nil
+             Cond clause (clause #2 matched):
              b = map[:b] #=> 5
 
              Cond expression:

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -532,6 +532,33 @@ defmodule MacroTest do
              """
     end
 
+    test "with cond - last matching" do
+      {result, formatted} =
+        dbg_format(
+          cond do
+            1 > 2 -> :not_happening
+            is_number(:NaN) -> :nope
+            true -> :default
+          end
+        )
+
+      assert result == :default
+
+      assert formatted =~ "macro_test.exs"
+
+      assert formatted =~ """
+             Cond clause (clause #3 matched):
+             true #=> true
+
+             Cond expression:
+             cond do
+               1 > 2 -> :not_happening
+               is_number(:NaN) -> :nope
+               true -> :default
+             end #=> :default
+             """
+    end
+
     test "with \"syntax_colors: []\" it doesn't print any color sequences" do
       {_result, formatted} = dbg_format("hello")
       refute formatted =~ "\e["

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -503,6 +503,36 @@ defmodule MacroTest do
              """
     end
 
+    test "with cond" do
+      map = %{b: 5}
+
+      {result, formatted} =
+        dbg_format(
+          cond do
+            a = map[:a] -> a + 1
+            b = map[:b] -> b * 2
+            true -> nil
+          end
+        )
+
+      assert result == 10
+
+      assert formatted =~ "macro_test.exs"
+
+      assert formatted =~ """
+             Cond clauses (clause #2 matched):
+             a = map[:a] #=> nil
+             b = map[:b] #=> 5
+
+             Cond expression:
+             cond do
+               a = map[:a] -> a + 1
+               b = map[:b] -> b * 2
+               true -> nil
+             end #=> 10
+             """
+    end
+
     test "with \"syntax_colors: []\" it doesn't print any color sequences" do
       {_result, formatted} = dbg_format("hello")
       refute formatted =~ "\e["

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -532,33 +532,6 @@ defmodule MacroTest do
              """
     end
 
-    test "with cond - last matching" do
-      {result, formatted} =
-        dbg_format(
-          cond do
-            1 > 2 -> :not_happening
-            is_number(:NaN) -> :nope
-            true -> :default
-          end
-        )
-
-      assert result == :default
-
-      assert formatted =~ "macro_test.exs"
-
-      assert formatted =~ """
-             Cond clause (clause #3 matched):
-             true #=> true
-
-             Cond expression:
-             cond do
-               1 > 2 -> :not_happening
-               is_number(:NaN) -> :nope
-               true -> :default
-             end #=> :default
-             """
-    end
-
     test "with \"syntax_colors: []\" it doesn't print any color sequences" do
       {_result, formatted} = dbg_format("hello")
       refute formatted =~ "\e["


### PR DESCRIPTION
Hi, I made a follow-up similar to https://github.com/elixir-lang/elixir/pull/12472 for `cond` expressions:

<img width="250" alt="Screenshot 2023-03-16 at 22 34 06" src="https://user-images.githubusercontent.com/11598866/225633890-ad221a51-ec60-46a8-a70b-feff6df6ae12.png">

Unlike `case`, I figured it might be nice to give the result of each clause's left-expression, since it is truthiness based and the result might even be used on the right-hand side.