### PR TITLE
Add more info for :with expressions in dbg/1

### DIFF
--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -532,6 +532,99 @@ defmodule MacroTest do
              """
     end
 
+    test "with with/1 (all clauses match)" do
+      opts = %{width: 10, height: 15}
+
+      {result, formatted} =
+        dbg_format(
+          with {:ok, width} <- Map.fetch(opts, :width),
+               double_width = width * 2,
+               IO.puts("just a side effect"),
+               {:ok, height} <- Map.fetch(opts, :height) do
+            {:ok, double_width * height}
+          end
+        )
+
+      assert result == {:ok, 300}
+
+      assert formatted =~ "macro_test.exs"
+
+      assert formatted =~ """
+             With clauses:
+             Map.fetch(opts, :width) #=> {:ok, 10}
+             width * 2 #=> 20
+             Map.fetch(opts, :height) #=> {:ok, 15}
+
+             With expression:
+             with {:ok, width} <- Map.fetch(opts, :width),
+                  double_width = width * 2,
+                  IO.puts("just a side effect"),
+                  {:ok, height} <- Map.fetch(opts, :height) do
+               {:ok, double_width * height}
+             end #=> {:ok, 300}
+             """
+    end
+
+    test "with with/1 (no else)" do
+      opts = %{width: 10}
+
+      {result, formatted} =
+        dbg_format(
+          with {:ok, width} <- Map.fetch(opts, :width),
+               {:ok, height} <- Map.fetch(opts, :height) do
+            {:ok, width * height}
+          end
+        )
+
+      assert result == :error
+
+      assert formatted =~ "macro_test.exs"
+
+      assert formatted =~ """
+             With clauses:
+             Map.fetch(opts, :width) #=> {:ok, 10}
+             Map.fetch(opts, :height) #=> :error
+
+             With expression:
+             with {:ok, width} <- Map.fetch(opts, :width),
+                  {:ok, height} <- Map.fetch(opts, :height) do
+               {:ok, width * height}
+             end #=> :error
+             """
+    end
+
+    test "with with/1 (else clause)" do
+      opts = %{width: 10}
+
+      {result, formatted} =
+        dbg_format(
+          with {:ok, width} <- Map.fetch(opts, :width),
+               {:ok, height} <- Map.fetch(opts, :height) do
+            width * height
+          else
+            :error -> 0
+          end
+        )
+
+      assert result == 0
+
+      assert formatted =~ "macro_test.exs"
+
+      assert formatted =~ """
+             With clauses:
+             Map.fetch(opts, :width) #=> {:ok, 10}
+             Map.fetch(opts, :height) #=> :error
+
+             With expression:
+             with {:ok, width} <- Map.fetch(opts, :width),
+                  {:ok, height} <- Map.fetch(opts, :height) do
+               width * height
+             else
+               :error -> 0
+             end #=> 0
+             """
+    end
+
     test "with \"syntax_colors: []\" it doesn't print any color sequences" do
       {_result, formatted} = dbg_format("hello")
       refute formatted =~ "\e["


### PR DESCRIPTION
Smilar as https://github.com/elixir-lang/elixir/pull/12472 and https://github.com/elixir-lang/elixir/pull/12475.

<img width="386" alt="Screenshot 2023-03-18 at 11 26 12" src="https://user-images.githubusercontent.com/11598866/226088314-0f1d69dd-1e05-4d2f-8ef3-72ff1d4a9b66.png">

Explanation of some choices I made here for further discussion:
1. Used the process dict because we want to a) keep matching clauses even if we only match partially b) keep a `with` ast close to the original one (vs creating a tree of `case`s). This seemed to be the simplest way?
2. Show AST and value for the right-hand side of `<-` and `=`, because they are the important ones to understand the flow (esp. `<-`, maybe `=` isn't actually necessary?)
3. Don't show non-assigning clauses like `IO.puts(...),`, these would typically be used for side effects and shouldn't provide any interesting return value explaining the final result
4. Don't show which `else` clause gets picked: it feels a bit overkill and having complex clauses for `else` is discouraged in [the doc](https://hexdocs.pm/elixir/Kernel.SpecialForms.html#with/1-beware) anyway. And it is probably straightforward from the last non-matching value to understand which was picked.