### PR TITLE
CI should ignore changes to markdown files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [pull_request, push]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 env:
   ELIXIR_ASSERT_TIMEOUT: 2000


### PR DESCRIPTION
I'm not sure that this change is the correct syntax, but it seems wasteful for CI to run on changes to markdown files, as it did on https://github.com/elixir-lang/elixir/pull/12482