### PR TITLE
Add explicit `:verify_none` for httpc

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -649,6 +649,7 @@ defmodule Mix.Utils do
   end
 
   defp read_httpc(path) do
+    Mix.ensure_application!(:public_key)
     Mix.ensure_application!(:ssl)
     Mix.ensure_application!(:inets)
 
@@ -665,7 +666,7 @@ defmodule Mix.Utils do
     # Use the system certificates if available, otherwise skip peer verification
     # TODO: Always use system certificates when OTP >= 25 is required
     ssl_options =
-      if function_exported?(:public_key, :cacerts_get, 0) do
+      if Code.ensure_loaded?(:public_key) and function_exported?(:public_key, :cacerts_get, 0) do
         [cacerts: apply(:public_key, :cacerts_get, [])]
       else
         [verify: :verify_none]

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -668,7 +668,7 @@ defmodule Mix.Utils do
     # is given.
     #
     # If a proxy environment variable was supplied add a proxy to httpc.
-    http_options = [relaxed: true] ++ proxy_config(path)
+    http_options = [relaxed: true, ssl: [verify: :verify_none]] ++ proxy_config(path)
 
     # Silence the warning from OTP as we verify the contents
     level = Logger.level()

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -667,7 +667,16 @@ defmodule Mix.Utils do
     # TODO: Always use system certificates when OTP >= 25 is required
     ssl_options =
       if Code.ensure_loaded?(:public_key) and function_exported?(:public_key, :cacerts_get, 0) do
-        [cacerts: apply(:public_key, :cacerts_get, [])]
+        try do
+          [cacerts: apply(:public_key, :cacerts_get, [])]
+        rescue
+          _ ->
+            msg =
+              "warning: Failed to load system certificates. Falling back to skip SSL peer verification."
+
+            Mix.shell().error(msg)
+            [verify: :verify_none]
+        end
       else
         [verify: :verify_none]
       end


### PR DESCRIPTION
OTP26-rc2 changed the default behaviour of the http client from `:verify_none` to `:verify_peer` which results in following error when trying to install hex: 

```
Mix requires the Hex package manager to fetch dependencies
Shall I install Hex? (if running non-interactively, use "mix local.hex --force") [Yn] 
** (Mix) httpc request failed with: {:failed_connect, [{:to_address, {~c"repo.hex.pm", 443}}, {:inet, [:inet], {:options, {:verify, {:missing_dep_cacertfile_or_cacerts}}}}]}
```

This PR fixes this, by explicitly defining `:verify_none`.