### PR TITLE
Fix dialyzer tests in OTP26

### DIFF
--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -22,7 +22,26 @@ defmodule Kernel.DialyzerTest do
     end
 
     # Add a few key Elixir modules for types and macro functions
-    mods = [:elixir, :elixir_env, Atom, Enum, Exception, Kernel, Macro, Macro.Env, String]
+    mods = [
+      :elixir,
+      :elixir_env,
+      ArgumentError,
+      Atom,
+      Enum,
+      Exception,
+      ExUnit.AssertionError,
+      ExUnit.Assertions,
+      IO,
+      Kernel,
+      Kernel.Utils,
+      List,
+      Macro,
+      Macro.Env,
+      Module,
+      String,
+      String.Chars
+    ]
+
     files = Enum.map(mods, &:code.which/1)
     dialyzer_run(analysis_type: :plt_build, output_plt: plt, apps: [:erts], files: files)
 
@@ -102,6 +121,7 @@ defmodule Kernel.DialyzerTest do
 
     copy_beam!(context, ProtocolOpaque)
     copy_beam!(context, ProtocolOpaque.Entity)
+    copy_beam!(context, ProtocolOpaque.Entity.Any)
     copy_beam!(context, ProtocolOpaque.Duck)
     assert_dialyze_no_warnings!(context)
 


### PR DESCRIPTION
I'm a bit out of my depth trying to investigate why, but dialyzer tests break on OTP26 with errors like
<img width="742" alt="Screenshot 2023-03-23 at 9 56 07" src="https://user-images.githubusercontent.com/11598866/227071923-4db385a2-07dd-44c2-aeae-04501d7cde88.png">

I couldn't pinpoint which change is causing this. Adding all the "unknown" modules to the PLT manually fixed the tests, but I'm not sure if there is a regression in dialyzer itself to be fixed instead?