### PR TITLE
Don't call formatter on directories

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -586,7 +586,9 @@ defmodule Mix.Tasks.Format do
   end
 
   defp stdin_or_wildcard("-"), do: [:stdin]
-  defp stdin_or_wildcard(path), do: path |> Path.expand() |> Path.wildcard(match_dot: true)
+
+  defp stdin_or_wildcard(path),
+    do: path |> Path.expand() |> Path.wildcard(match_dot: true) |> Enum.filter(&File.regular?/1)
 
   defp elixir_format(content, formatter_opts) do
     case Code.format_string!(content, formatter_opts) do

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -81,6 +81,16 @@ defmodule Mix.Tasks.FormatTest do
     end)
   end
 
+  test "does not try to format a directory that matches a given pattern", context do
+    in_tmp(context.test, fn ->
+      File.mkdir_p!("a.ex")
+
+      assert_raise Mix.Error, ~r"Could not find a file to format", fn ->
+        Mix.Tasks.Format.run(["*.ex"])
+      end
+    end)
+  end
+
   test "reads file from stdin and prints to stdout", context do
     in_tmp(context.test, fn ->
       File.write!("a.ex", """


### PR DESCRIPTION
This came up today with a custom formatter that we have for json files. Vscode's ElixirLS created a directory called "apps/our_app/.elixir_ls/build/test/lib/phoenix/priv/templates/phx.gen.json" and running `mix format` resulted in the following error:
```
** (File.Error) could not read file "/Users/edennis/sandbox/...": illegal operation on a directory
    (elixir 1.13.4) lib/file.ex:355: File.read!/1
    (mix 1.13.4) lib/mix/tasks/format.ex:563: Mix.Tasks.Format.format_file/2
    (elixir 1.13.4) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (elixir 1.13.4) lib/task/supervised.ex:34: Task.Supervised.reply/4
    (stdlib 3.17.2.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```
The fact that we're accidentally formatting files from ElixirLS is of course an issue of ours, but with the exception of `:stdin`, I'd say we'd only want to ever try to format regular files.