### PR TITLE
Update tests to new OTP start behaviour

### DIFF
--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -769,8 +769,10 @@ defmodule Logger.TranslatorTest do
     assert capture_log(:info, fn ->
              trap = Process.flag(:trap_exit, true)
              children = [worker(__MODULE__, [], function: :error)]
-             Supervisor.start_link(children, strategy: :one_for_one)
-             receive do: ({:EXIT, _, {:shutdown, {:failed_to_start_child, _, _}}} -> :ok)
+
+             assert {:error, {:shutdown, {:failed_to_start_child, __MODULE__, :stop}}} =
+                      Supervisor.start_link(children, strategy: :one_for_one)
+
              Process.flag(:trap_exit, trap)
            end) =~ ~r"""
            \[error\] Child Logger.TranslatorTest of Supervisor #PID<\d+\.\d+\.\d+> \(Supervisor\.Default\) failed to start
@@ -783,8 +785,10 @@ defmodule Logger.TranslatorTest do
     assert capture_log(:info, fn ->
              trap = Process.flag(:trap_exit, true)
              children = [worker(__MODULE__, [], function: :undef)]
-             Supervisor.start_link(children, strategy: :one_for_one)
-             receive do: ({:EXIT, _, {:shutdown, {:failed_to_start_child, _, _}}} -> :ok)
+
+             assert {:error, {:shutdown, {:failed_to_start_child, __MODULE__, {:EXIT, _}}}} =
+                      Supervisor.start_link(children, strategy: :one_for_one)
+
              Process.flag(:trap_exit, trap)
            end) =~ ~r"""
            \[error\] Child Logger.TranslatorTest of Supervisor #PID<\d+\.\d+\.\d+> \(Supervisor\.Default\) failed to start


### PR DESCRIPTION
It looks like OTP changed the [behaviour during startup](https://www.erlang.org/news/162#stdlib) of supervisor children in OTP26-rc2.

This results in them not sending messages to the starting process anymore, but rather only return errors synchronously (if I understand the changes correctly). 
But since there isn't that much documentation about this I am not quite sure if this is the intended behaviour or a bug.