### PR TITLE
Add iex tests for OTP26

### DIFF
--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -31,9 +31,9 @@ defmodule IEx.AutocompleteTest do
   end
 
   test "Erlang module multiple values completion" do
-    {:yes, ~c"", list} = expand(~c":user")
-    assert ~c"user" in list
-    assert ~c"user_drv" in list
+    {:yes, ~c"", list} = expand(~c":logger")
+    assert ~c"logger" in list
+    assert ~c"logger_proxy" in list
   end
 
   test "Erlang root completion" do

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -124,7 +124,15 @@ defmodule IEx.InteractionTest do
   end
 
   test "inspect opts" do
-    opts = [inspect: [binaries: :as_binaries, charlists: :as_lists, structs: false, limit: 4]]
+    opts = [
+      inspect: [
+        binaries: :as_binaries,
+        charlists: :as_lists,
+        structs: false,
+        limit: 4,
+        custom_options: [sort_maps: true]
+      ]
+    ]
 
     assert capture_iex("<<45, 46, 47>>\n[45, 46, 47]\n%IO.Stream{}", opts) ==
              "<<45, 46, 47>>\n[45, 46, 47]\n%{__struct__: IO.Stream, device: nil, line_or_bytes: :line, raw: true}"


### PR DESCRIPTION
The `:user` module seems to be removed, so I changed the test to use `:logger`.
Also added `sort_maps` for "inspect opts" test to make it pass again.

This fixes the last failing tests for OTP26-rc2 for me.