### PR TITLE
add +JPperf map to releases

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -50,6 +50,9 @@ defmodule Mix.Tasks.Release.Init do
 
     ## Tweak GC to run more often
     ##-env ERL_FULLSWEEP_AFTER 10
+    
+    ## Make sure that debug symbol are logged to /tmp to use with perf
+    +JPperf map
     """
 
   @doc false


### PR DESCRIPTION
This has nearly no cost (as long as /tmp gets cleaned semi-regularly on a machine that would restart the beam all the time) but is indispensable if you want to run `perf` on a running BEAM, which is really useful for production debugging and profiling.

I was talking with @jhogberg about this, and he mentioned that the cost was basically none but that we should probably always run it. I agree.

The only thing I am not sure of is if an older version than OTP 25 will crash on unknown flags. I think not, but I may be wrong. I will check tomorrow if no one knows, but I wanted to open this before, to not forget.