### PR TITLE
Backport test fixes from #12491

### DIFF
--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -31,9 +31,9 @@ defmodule IEx.AutocompleteTest do
   end
 
   test "Erlang module multiple values completion" do
-    {:yes, '', list} = expand(':user')
-    assert 'user' in list
-    assert 'user_drv' in list
+    {:yes, '', list} = expand(':logger')
+    assert 'logger' in list
+    assert 'logger_proxy' in list
   end
 
   test "Erlang root completion" do

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -126,8 +126,13 @@ defmodule IEx.InteractionTest do
   test "inspect opts" do
     opts = [inspect: [binaries: :as_binaries, charlists: :as_lists, structs: false, limit: 4]]
 
-    assert capture_iex("<<45, 46, 47>>\n[45, 46, 47]\n%IO.Stream{}", opts) ==
-             "<<45, 46, 47>>\n[45, 46, 47]\n%{__struct__: IO.Stream, device: nil, line_or_bytes: :line, raw: true}"
+    assert "<<45, 46, 47>>\n[45, 46, 47]\n%{" <> map =
+             capture_iex("<<45, 46, 47>>\n[45, 46, 47]\n%IO.Stream{}", opts)
+
+    assert map =~ "__struct__: IO.Stream"
+    assert map =~ "device: nil"
+    assert map =~ "line_or_bytes: :line"
+    assert map =~ "raw: true"
   end
 
   test "exception" do


### PR DESCRIPTION
Couldn't think of a more elegant solution than string matching the fields of the resulting map output. 
Hope that's good enough.