### PR TITLE
Fixtypo

### DIFF
--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -361,8 +361,7 @@ defmodule NaiveDateTime do
   `t:System.time_unit/0`. It defaults to `:second`. Negative values
   will move backwards in time.
 
-  This function always consider the unit to be computed according
-  to the `Calendar.ISO`.
+  This function always considers the unit to be computed according to the `Calendar.ISO`.
 
   ## Examples
 


### PR DESCRIPTION
Fixes a typo in the naive_datetime documentation