### PR TITLE
Add `:return_separator` to `OptionParser`

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -234,9 +234,9 @@ defmodule OptionParser do
 
   ## Return separator
 
-  The separator `--` can be parsed and returned as part of the arguments. Defaults to `false`.
-
-  ## Examples
+  The separator `--` implies options should no longer be processed.
+  By default, the separator is not returned as parts of the arguments,
+  but that can be changed via the `:return_separator` option:
 
       iex> OptionParser.parse(["--", "lib"], return_separator: true, strict: [])
       {[], ["--", "lib"], []}

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -84,7 +84,7 @@ defmodule OptionParser do
     * `:switches` or `:strict` - see the "Switch definitions" section below
     * `:allow_nonexistent_atoms` - see the "Parsing unknown switches" section below
     * `:aliases` - see the "Aliases" section below
-    * `:return_separator` - see the "Return Separator" section below
+    * `:return_separator` - see the "Return separator" section below
 
   ## Switch definitions
 
@@ -232,7 +232,7 @@ defmodule OptionParser do
       ...> )
       {[unlock: "path/to/file", unlock: "path/to/another/file"], [], []}
 
-  ## Return Separator
+  ## Return separator
 
   The separator `--` can be parsed and returned as part of the arguments. Defaults to `false`.
 

--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -148,6 +148,23 @@ defmodule OptionParserTest do
              ) == {[source: "foo"], ["bar", "--", "-x"], []}
     end
 
+    test "return separators" do
+      assert OptionParser.parse_head(["--", "foo"],
+               switches: [],
+               return_separator: true
+             ) == {[], ["--", "foo"], []}
+
+      assert OptionParser.parse_head(["--no-halt", "--", "foo"],
+               switches: [halt: :boolean],
+               return_separator: true
+             ) == {[halt: false], ["--", "foo"], []}
+
+      assert OptionParser.parse_head(["foo.exs", "--no-halt", "--", "foo"],
+               switches: [halt: :boolean],
+               return_separator: true
+             ) == {[], ["foo.exs", "--no-halt", "--", "foo"], []}
+    end
+
     test "parses - as argument" do
       argv = ["--foo", "-", "-b", "-"]
       opts = [strict: [foo: :boolean, boo: :string], aliases: [b: :boo]]

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -111,11 +111,11 @@ defmodule Mix.Tasks.Run do
       end)
 
     {file, argv} =
-      case {Keyword.has_key?(opts, :eval), args, head} do
-        {true, _, _} -> {nil, head}
-        {_, ["--" | _], head} -> {nil, head}
+      case {args, opts, head} do
+        {_, [_opt | _], head} -> {nil, head}
+        {["--" | _], _, head} -> {nil, head}
         {_, _, [head | tail]} -> {head, tail}
-        {_, _, []} -> {nil, []}
+        {_, _, _} -> {nil, []}
       end
 
     System.argv(argv)

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -78,7 +78,8 @@ defmodule Mix.Tasks.Run do
           elixir_version_check: :boolean,
           parallel_require: :keep,
           preload_modules: :boolean
-        ]
+        ],
+        return_separator: true
       )
 
     run(args, opts, head, &Code.eval_string/1, &Code.require_file/1)
@@ -111,11 +112,11 @@ defmodule Mix.Tasks.Run do
       end)
 
     {file, argv} =
-      case {args, opts, head} do
-        {_, [_opt | _], head} -> {nil, head}
-        {["--" | _], _, head} -> {nil, head}
-        {_, _, [head | tail]} -> {head, tail}
-        {_, _, _} -> {nil, []}
+      case {Keyword.has_key?(opts, :eval), head} do
+        {_, ["--" | rest]} -> {nil, rest}
+        {true, _} -> {nil, head}
+        {_, [head | tail]} -> {head, tail}
+        {_, []} -> {nil, []}
       end
 
     System.argv(argv)

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -111,10 +111,11 @@ defmodule Mix.Tasks.Run do
       end)
 
     {file, argv} =
-      case {Keyword.has_key?(opts, :eval), head} do
-        {true, _} -> {nil, head}
-        {_, [head | tail]} -> {head, tail}
-        {_, []} -> {nil, []}
+      case {Keyword.has_key?(opts, :eval), args, head} do
+        {true, _, _} -> {nil, head}
+        {_, ["--" | _], head} -> {nil, head}
+        {_, _, [head | tail]} -> {head, tail}
+        {_, _, []} -> {nil, []}
       end
 
     System.argv(argv)

--- a/lib/mix/test/mix/tasks/run_test.exs
+++ b/lib/mix/test/mix/tasks/run_test.exs
@@ -85,6 +85,10 @@ defmodule Mix.Tasks.RunTest do
       assert_received {:argv, ["foo", "--", "bar"]}
 
       unload_file.()
+      Mix.Tasks.Run.run([file, "--no-start", "foo", "--", "bar"])
+      assert_received {:argv, ["--no-start", "foo", "--", "bar"]}
+
+      unload_file.()
       Mix.Tasks.Run.run(["-e", expr, file, "foo", "-x", "bar"])
       assert_received {:argv, [^file, "foo", "-x", "bar"]}
 
@@ -132,7 +136,7 @@ defmodule Mix.Tasks.RunTest do
 
     test "with opts" do
       in_fixture("no_mixfile", fn ->
-        Mix.Tasks.Run.run(["--no-halt", "--", "foo", "bar"])
+        Mix.Tasks.Run.run(["--no-start", "--", "foo", "bar"])
         assert_received {:argv, ["foo", "bar"]}
       end)
     end

--- a/lib/mix/test/mix/tasks/run_test.exs
+++ b/lib/mix/test/mix/tasks/run_test.exs
@@ -85,8 +85,8 @@ defmodule Mix.Tasks.RunTest do
       assert_received {:argv, ["foo", "--", "bar"]}
 
       unload_file.()
-      Mix.Tasks.Run.run([file, "--no-start", "foo", "--", "bar"])
-      assert_received {:argv, ["--no-start", "foo", "--", "bar"]}
+      Mix.Tasks.Run.run([file, "--custom-opt", "foo", "--", "bar"])
+      assert_received {:argv, ["--custom-opt", "foo", "--", "bar"]}
 
       unload_file.()
       Mix.Tasks.Run.run(["-e", expr, file, "foo", "-x", "bar"])

--- a/lib/mix/test/mix/tasks/run_test.exs
+++ b/lib/mix/test/mix/tasks/run_test.exs
@@ -81,6 +81,10 @@ defmodule Mix.Tasks.RunTest do
       assert_received {:argv, ["foo", "-e", "bar"]}
 
       unload_file.()
+      Mix.Tasks.Run.run([file, "foo", "--", "bar"])
+      assert_received {:argv, ["foo", "--", "bar"]}
+
+      unload_file.()
       Mix.Tasks.Run.run(["-e", expr, file, "foo", "-x", "bar"])
       assert_received {:argv, [^file, "foo", "-x", "bar"]}
 
@@ -122,6 +126,13 @@ defmodule Mix.Tasks.RunTest do
     test "multiple args" do
       in_fixture("no_mixfile", fn ->
         Mix.Tasks.Run.run(["--", "foo", "bar"])
+        assert_received {:argv, ["foo", "bar"]}
+      end)
+    end
+
+    test "with opts" do
+      in_fixture("no_mixfile", fn ->
+        Mix.Tasks.Run.run(["--no-halt", "--", "foo", "bar"])
         assert_received {:argv, ["foo", "bar"]}
       end)
     end


### PR DESCRIPTION
Attempt to fix #12460

What about `mix run file -- arg1 arg2`? It will return argv as `["--", "arg1", "arg2"]`, I'd like to confirm that's the expected value.