### PR TITLE
Clarification to convert a string to module name by `to_existing_atom`

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2630,7 +2630,8 @@ defmodule String do
   > generally recommended to call `String.to_existing_atom/1` only to
   > convert atoms defined within the module making the function call
   > to `to_existing_atom/1`.
-  > It should be noted that to create a module name based on a string,
+  >
+  > To create a module name itself from a string safely,
   > it is recommended to use `Module.safe_concat/1`.
 
   ## Examples

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2630,19 +2630,14 @@ defmodule String do
   > generally recommended to call `String.to_existing_atom/1` only to
   > convert atoms defined within the module making the function call
   > to `to_existing_atom/1`.
+  > It should be noted that to create a module name based on a string,
+  > it is recommended to use `Module.safe_concat/1`.
 
   ## Examples
 
       iex> _ = :my_atom
       iex> String.to_existing_atom("my_atom")
       :my_atom
-
-  This function can help you in converting a string to a module name, however it is necessary that you add the string `Elixir` first.
-  
-  ## Examples
-  
-      iex> module_name = String.to_existing_atom("Elixir.Enum")
-      Enum
 
   """
   @spec to_existing_atom(String.t()) :: atom

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2637,6 +2637,13 @@ defmodule String do
       iex> String.to_existing_atom("my_atom")
       :my_atom
 
+  This function can help you in converting a string to a module name, however it is necessary that you add the string `Elixir` first.
+  
+  ## Examples
+  
+      iex> module_name = String.to_existing_atom("Elixir.Enum")
+      Enum
+
   """
   @spec to_existing_atom(String.t()) :: atom
   def to_existing_atom(string) when is_binary(string) do


### PR DESCRIPTION
Every time I try to convert a string to a module name, I receive an error, which I find to be very confusing. I believe the example in the document can help to address this issue. Therefore, I am aware that the document needs to be very simple and basic. 

You get to decide. 🙏🏻 
Hopefully I didn't squander your time.
Thanks