### PR TITLE
Make symlink_or_copy a no-op if source is same as target

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -466,6 +466,10 @@ defmodule Mix.Utils do
   Expects source and target to be absolute paths as it generates
   a relative symlink.
   """
+  def symlink_or_copy(path, path) do
+    :ok
+  end
+
   def symlink_or_copy(source, target) do
     if File.exists?(source) do
       # Relative symbolic links on Windows are broken


### PR DESCRIPTION
I am trying to implement a `mix` builder for `rebar3` to improve compatibility. `rebar3` has a slightly different model for compiling its dependencies in that it (usually) compiles in-place, having the code checked out to `_build/default/lib`. This is effectively `MIX_DEPS_PATH=./_build/default/lib` and `MIX_BUILD_PATH=./_build/default`. Setting these values breaks due to `symlink_or_copy` getting the same path as source and target from `Mix.Project`.