### PR TITLE
Fix column count when tokenizing escaped interpolations

### DIFF
--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -39,7 +39,7 @@ extract([$\\, Last, Last, Last | Rest], Buffer, Output, Line, Column, Scope, Int
   extract(Rest, [Last, Last, Last | Buffer], Output, Line, Column+4, Scope, Interpol, All);
 
 extract([$\\, $#, ${ | Rest], Buffer, Output, Line, Column, Scope, true, Last) ->
-  extract(Rest, [${, $#, $\\ | Buffer], Output, Line, Column+1, Scope, true, Last);
+  extract(Rest, [${, $#, $\\ | Buffer], Output, Line, Column+3, Scope, true, Last);
 
 extract([$#, ${ | Rest], Buffer, Output, Line, Column, Scope, true, Last) ->
   Output1 = build_string(Buffer, Output),

--- a/lib/elixir/test/erlang/string_test.erl
+++ b/lib/elixir/test/erlang/string_test.erl
@@ -22,7 +22,7 @@ extract_interpolations_without_interpolation_test() ->
 
 extract_interpolations_with_escaped_interpolation_test() ->
   ["f\\#{o}o"] = extract_interpolations("f\\#{o}o"),
-  {1, 8, ["f\\#{o}o"], [], _} =
+  {1, 10, ["f\\#{o}o"], [], _} =
     elixir_interpolation:extract(1, 2, #elixir_tokenizer{}, true, "f\\#{o}o\"", $").
 
 extract_interpolations_with_interpolation_test() ->

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -199,6 +199,11 @@ interpolation_test() ->
    {concat_op, {1, 10, nil}, '<>'},
    {bin_string, {1, 13, nil}, [<<>>]}] = tokenize("\"f#{oo}\" <> \"\"").
 
+escaped_interpolation_test() ->
+  [{bin_string, {1, 1, nil}, [<<"f#{oo}">>]},
+   {concat_op, {1, 11, nil}, '<>'},
+   {bin_string, {1, 14, nil}, [<<>>]}] = tokenize("\"f\\#{oo}\" <> \"\"").
+
 capture_test() ->
   % Parens precedence
   [{capture_op, {1, 1, nil}, '&'},


### PR DESCRIPTION
Fixes #12503. Running the example given in that issue with this build of Elixir now gives the expected columns.