### PR TITLE
Add `Macro.Env.lookup_alias_as/2`

### DIFF
--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -236,6 +236,31 @@ defmodule Macro.Env do
   end
 
   @doc """
+  Returns the names of any aliases for the given module or atom.
+
+  ## Examples
+
+      iex> alias Foo.Bar
+      iex> Bar
+      Foo.Bar
+      iex> Macro.Env.lookup_alias_as(__ENV__, Foo.Bar)
+      [:Bar]
+      iex> alias Foo.Bar, as: Baz
+      iex> Baz
+      Foo.Bar
+      iex> Macro.Env.lookup_alias_as(__ENV__, Foo.Bar)
+      [:Bar, :Baz]
+      iex> Macro.Env.lookup_alias_as(__ENV__, Unknown)
+      []
+
+  """
+  @doc since: "1.15.0"
+  @spec lookup_alias_as(t, atom) :: [atom]
+  def lookup_alias_as(%{__struct__: Macro.Env, aliases: aliases}, atom) when is_atom(atom) do
+    for {name, ^atom} <- aliases, do: String.to_atom(hd(Module.split(name)))
+  end
+
+  @doc """
   Returns true if the given module has been required.
 
   ## Examples

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -244,12 +244,12 @@ defmodule Macro.Env do
       iex> Bar
       Foo.Bar
       iex> Macro.Env.lookup_alias_as(__ENV__, Foo.Bar)
-      [:Bar]
+      [:"Elixir.Bar"]
       iex> alias Foo.Bar, as: Baz
       iex> Baz
       Foo.Bar
       iex> Macro.Env.lookup_alias_as(__ENV__, Foo.Bar)
-      [:Bar, :Baz]
+      [:"Elixir.Bar", :"Elixir.Baz"]
       iex> Macro.Env.lookup_alias_as(__ENV__, Unknown)
       []
 
@@ -257,7 +257,7 @@ defmodule Macro.Env do
   @doc since: "1.15.0"
   @spec lookup_alias_as(t, atom) :: [atom]
   def lookup_alias_as(%{__struct__: Macro.Env, aliases: aliases}, atom) when is_atom(atom) do
-    for {name, ^atom} <- aliases, do: String.to_atom(hd(Module.split(name)))
+    for {name, ^atom} <- aliases, do: name
   end
 
   @doc """

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -244,12 +244,12 @@ defmodule Macro.Env do
       iex> Bar
       Foo.Bar
       iex> Macro.Env.lookup_alias_as(__ENV__, Foo.Bar)
-      [:"Elixir.Bar"]
+      [Elixir.Bar]
       iex> alias Foo.Bar, as: Baz
       iex> Baz
       Foo.Bar
       iex> Macro.Env.lookup_alias_as(__ENV__, Foo.Bar)
-      [:"Elixir.Bar", :"Elixir.Baz"]
+      [Elixir.Bar, Elixir.Baz]
       iex> Macro.Env.lookup_alias_as(__ENV__, Unknown)
       []
 


### PR DESCRIPTION
[Discussion on mailing list](https://groups.google.com/g/elixir-lang-core/c/3Ea3CuJH-3Q)

@josevalim, in your response on the mailing list, you wrote `fetch_alias_as`. I had originally thought of it as `fetch_aliased_as`, which read a bit better to me, but I do not feel strongly at all. If you would prefer `fetch_alias_as`, I'm happy to update and rebase this!