### PR TITLE
Functions for async request/response to GenServer

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -1249,7 +1249,8 @@ defmodule GenServer do
       ...> end
       {:reply, :hello}
   """
-  @spec check_response(message, request_id) :: {:reply, reply} | {:error, {reason, server}} | :no_reply
+  @spec check_response(message, request_id) ::
+          {:reply, reply} | {:error, {reason, server}} | :no_reply
         when message: term, reply: term, reason: term
   defdelegate check_response(message, request_id), to: :gen_server
 


### PR DESCRIPTION
Since now OTP 24 is a minimal requirement we can add [`send_request/2`](https://www.erlang.org/doc/man/gen_server.html#send_request-2), [`receive_response/2`](https://www.erlang.org/doc/man/gen_server.html#receive_response-2), and friends.

Currently, those are just delegating to `:gen_server`, and docs are mostly adapted from original OTP docs.