### PR TITLE
Introduce `Mix.Project.deps_tree/1`

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -538,6 +538,27 @@ defmodule Mix.Project do
     traverse_deps(opts, fn %{opts: opts} -> opts[:dest] end)
   end
 
+  @doc """
+  Returns the dependencies of all dependencies as a map.
+
+  ## Options
+
+    * `:depth` - only returns dependencies to the depth level,
+      a depth of `1` will only return top-level dependencies
+    * `:parents` - starts the dependency traversal from the
+      given parents instead of the application root
+
+  ## Examples
+
+      Mix.Project.deps_tree()
+      #=> %{foo: [:bar, :baz], bar: [], baz: []}
+
+  """
+  @spec deps_tree(keyword) :: %{optional(atom) => [atom]}
+  def deps_tree(opts \\ []) when is_list(opts) do
+    traverse_deps(opts, fn %{deps: deps} -> Enum.map(deps, & &1.app) end)
+  end
+
   defp traverse_deps(opts, fun) do
     all_deps = Mix.Dep.cached()
     parents = opts[:parents]

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -84,10 +84,10 @@ defmodule Mix.DepTest do
       assert paths[:ok] =~ "deps/ok"
       assert paths[:uncloned] =~ "deps/uncloned"
 
-      paths = Mix.Project.deps_scms()
-      assert map_size(paths) == 6
-      assert paths[:ok] == Mix.SCM.Path
-      assert paths[:uncloned] == Mix.SCM.Git
+      scms = Mix.Project.deps_scms()
+      assert map_size(scms) == 6
+      assert scms[:ok] == Mix.SCM.Path
+      assert scms[:uncloned] == Mix.SCM.Git
     end)
   end
 


### PR DESCRIPTION
Partial Implementation of https://github.com/jshmrtn/mix-dependency-submission/issues/5#issuecomment-1494907802 as discussed with @josevalim 

While implementing this feature, I noticed that `Mix.Project.traverse_deps/2` allways returns paths for nested dependencies instead of calling the `fun` argument. This PR also solves that and tests it directly with the new `deps_tree` tests.