### PR TITLE
Actually import case template functions into test case modules

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case_template.ex
+++ b/lib/ex_unit/lib/ex_unit/case_template.ex
@@ -13,9 +13,6 @@ defmodule ExUnit.CaseTemplate do
       `use ExUnit.Case` is available (same as if `MyCase` called `use
       ExUnit.Case` directly)
 
-    * All the functions and macros defined in `MyCase` are imported into
-      the test case
-
     * The `setup` and `setup_all` callbacks that you define in `MyCase`
       get used in the test case module
 


### PR DESCRIPTION
The [documentation](https://hexdocs.pm/ex_unit/ExUnit.CaseTemplate.html) states that when using `ExUnit.CaseTemplate` _All the functions and macros defined in MyCase are imported into the test case_, but that is not the case in my machine, on the main branch, without this change.