### PR TITLE
Add an example to Map.get documentation where key is present, but value is nil

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -517,8 +517,6 @@ defmodule Map do
       3
       iex> Map.get(%{a: nil}, :a, 1)
       nil
-      iex> Map.get(%{a: nil}, :a) || 1
-      1
 
   """
   @spec get(map, key, value) :: value

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -515,6 +515,10 @@ defmodule Map do
       nil
       iex> Map.get(%{a: 1}, :b, 3)
       3
+      iex> Map.get(%{a: nil}, :a, 1)
+      nil
+      iex> Map.get(%{a: nil}, :a) || 1
+      1
 
   """
   @spec get(map, key, value) :: value


### PR DESCRIPTION
The behaviour of Map.get/3 is clear from the documentation.

However, it might not be immediately obvious that a nil value under a key does not lead to the default value being returned, so it might be worth adding an example to illustrate.