### PR TITLE
Fix typo in naming-conventions.md

### DIFF
--- a/lib/elixir/pages/naming-conventions.md
+++ b/lib/elixir/pages/naming-conventions.md
@@ -65,7 +65,7 @@ The version without `!` is preferred when you want to handle different outcomes 
       {:error, reason} -> # handle the error caused by `reason`
     end
 
-However, if you expect the outcome to always to be successful (for instance, if you expect the file always to exist), the bang variation can be more convenient and will raise a more helpful error message (than a failed pattern match) on failure.
+However, if you expect the outcome to always be successful (for instance, if you expect the file always to exist), the bang variation can be more convenient and will raise a more helpful error message (than a failed pattern match) on failure.
 
 More examples of paired functions: `Base.decode16/2` and `Base.decode16!/2`, `File.cwd/0` and `File.cwd!/0`.
 


### PR DESCRIPTION
The quality of the documentation is top-notch, a pleasure to read :clap: 