### PR TITLE
Clarify difference between `Port.info/1` and `Port.info/2` in docs

### DIFF
--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -244,7 +244,8 @@ defmodule Port do
   end
 
   @doc """
-  Returns information about the `port` or `nil` if the port is closed.
+  Returns information about the `port`
+  (or `nil` if the port is closed).
 
   For more information, see `:erlang.port_info/1`.
   """
@@ -254,7 +255,8 @@ defmodule Port do
   end
 
   @doc """
-  Returns information about the `port` or `nil` if the port is closed.
+  Returns information about a specific field within
+  the `port` (or `nil` if the port is closed).
 
   For more information, see `:erlang.port_info/2`.
   """

--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -244,8 +244,7 @@ defmodule Port do
   end
 
   @doc """
-  Returns information about the `port`
-  (or `nil` if the port is closed).
+  Returns information about the `port` (or `nil` if the port is closed).
 
   For more information, see `:erlang.port_info/1`.
   """


### PR DESCRIPTION
This PR updates the documentation for `Port.info/2` to clarify how that function differs from `Port.info/1`. I'm only adding parentheses to the description in `Port.info/1` to keep it consistent with `Port.info/2` (and I did so there because the sentence might be confusing otherwise).