### PR TITLE
Add --no-exit option to mix format

### DIFF
--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -167,6 +167,14 @@ defmodule Mix.Tasks.FormatTest do
     assert output == ""
   end
 
+  test "checks that no error is raised with --check-formatted and --no-exit" do
+    capture_io("foo( )", fn ->
+      Mix.Tasks.Format.run(["--check-formatted", "--no-exit", "-"])
+    end)
+
+    assert_received {:mix_shell, :info, ["The following files are not formatted" <> _]}
+  end
+
   test "uses inputs and configuration from .formatter.exs", context do
     in_tmp(context.test, fn ->
       File.write!(".formatter.exs", """


### PR DESCRIPTION
I found a need for this today. I was setting up a mix alias like:
```elixir
check: [
  "format --check-formatted",
  "dialyzer --ignore-exit-status",
  "credo diff --from-git-merge-base develop --strict --mute-exit-status",
  "sobelow --verbose --strict --private --threshold medium"
]
```
However, if code isn't formatted, `--check-formatted` raises and error and returns a non-zero exit code, preventing the rest of the commands from running. In my case, I don't want that.

What I ended up doing is using a custom mix task:
```elixir
defmodule Mix.Tasks.CheckFormatWithoutExit do
  @moduledoc """
  Runs `mix format --check-formatted` and prints the result in the terminal without returning an error exit code.
  """
  use Mix.Task

  @spec run(list(binary())) :: :ok
  @impl Mix.Task
  def run(args) do
    Mix.Tasks.Format.run(["--check-formatted" | args])
    # I added this just for some feedback, but printing a message is totally optional.
    message = "Format is good!"
    message = [IO.ANSI.bright(), IO.ANSI.green(), message, IO.ANSI.reset()]
    Mix.shell().info(message)
  rescue
    e in Mix.Error ->
      message = [IO.ANSI.bright(), IO.ANSI.red(), e.message, IO.ANSI.reset()]
      Mix.shell().error(message)
      :ok
  end
end
```

Then I figured I could just add a new `--ignore-exit-status` flag and make a PR. 😄 