### PR TITLE
module.ex: correct a typo in @dialyzer suppression example

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -237,7 +237,7 @@ defmodule Module do
   Accepts an atom, a tuple, or a list of atoms and tuples. For example:
 
       defmodule MyModule do
-        @dialyzer {:nowarn_function, my_fun: 1}
+        @dialyzer {:nowarn_function, [my_fun: 1]}
 
         def my_fun(arg) do
           M.not_a_function(arg)


### PR DESCRIPTION
To match the code in module.ex as well as actual
test examples such as [1]

1. https://github.com/elixir-lang/elixir/blob/ee9d529bf2b500933c15f3247873f83e2332a6fe/lib/elixir/test/elixir/fixtures/dialyzer/remote_call.ex#L6