### PR TITLE
Convert Logger's default_handler config into maps

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -174,7 +174,7 @@ defmodule Logger do
   `config/config.exs`), under the `:logger` key, before your application
   is started:
 
-    * `:default_formatter` - a keyword lists which configures the
+    * `:default_formatter` - a keyword list which configures the
       default formatter used by the default handler. See `Logger.Formatter`
       for the full list of configuration.
 
@@ -220,6 +220,33 @@ defmodule Logger do
           max_no_bytes: 10_000_000,
           max_no_files: 5
         }
+
+  While the [`:logger_std_h`](`:logger_std_h`) handler only accepts `:config`
+  as a map, `Logger` allows you to define it in the `:default_handler`
+  in your boot configuration with a keyword list. This will ***not*** work when
+  configuring [`:logger_std_h`](`:logger_std_h`) directly through Erlang APIs
+  or as an [Erlang/OTP handler](module-erlang-otp-handlers), but it allows you
+  to use the keyword list "deep merge" feature of `Config.config/3` in your
+  `:default_handler`, to override its behaviour with repeated declarations.
+  For example, to use a modified configuration during development:
+
+      # config/config.exs
+      config :logger, :default_handler,
+        config: [
+          file: ~c"system.log",
+          filesync_repeat_interval: 5000,
+          file_check: 5000,
+          max_no_bytes: 10_000_000,
+          max_no_files: 5
+        ]
+      import_config "#{config_env()}.exs"
+
+      # config/dev.exs
+      config :logger, :default_handler,
+        config: [
+          file: ~c"dev.log",
+          max_no_files: 1
+        ]
 
   See [`:logger_std_h`](`:logger_std_h`) for all relevant configuration,
   including overload protection. Or set `:default_handler` to false to

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -223,10 +223,10 @@ defmodule Logger do
 
   > #### Keywords or maps {: .tip}
   >
-  > While Erlang's logger expects `config` to be a map, Elixir's Logger
+  > While Erlang's logger expects `:config` to be a map, Elixir's Logger
   > allows the default handler configuration to be set with keyword lists.
-  > This allows your `config/*.exs` files, such as `config/dev.exs`,
-  > to override individual keys defined in config/config.exs.
+  > For example, this allows your `config/*.exs` files, such as `config/dev.exs`,
+  > to override individual keys defined in `config/config.exs`.
   >
   > When reading the handler configuration using Erlang's APIs,
   > the configuration will always be read (and written) as a map.

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -213,25 +213,6 @@ defmodule Logger do
   built-in support for log rotation:
 
       config :logger, :default_handler,
-        config: %{
-          file: ~c"system.log",
-          filesync_repeat_interval: 5000,
-          file_check: 5000,
-          max_no_bytes: 10_000_000,
-          max_no_files: 5
-        }
-
-  While the [`:logger_std_h`](`:logger_std_h`) handler only accepts `:config`
-  as a map, `Logger` allows you to define it in the `:default_handler`
-  in your boot configuration with a keyword list. This will ***not*** work when
-  configuring [`:logger_std_h`](`:logger_std_h`) directly through Erlang APIs
-  or as an [Erlang/OTP handler](module-erlang-otp-handlers), but it allows you
-  to use the keyword list "deep merge" feature of `Config.config/3` in your
-  `:default_handler`, to override its behaviour with repeated declarations.
-  For example, to use a modified configuration during development:
-
-      # config/config.exs
-      config :logger, :default_handler,
         config: [
           file: ~c"system.log",
           filesync_repeat_interval: 5000,
@@ -239,14 +220,16 @@ defmodule Logger do
           max_no_bytes: 10_000_000,
           max_no_files: 5
         ]
-      import_config "#{config_env()}.exs"
 
-      # config/dev.exs
-      config :logger, :default_handler,
-        config: [
-          file: ~c"dev.log",
-          max_no_files: 1
-        ]
+  > #### Keywords or maps {: .tip}
+  >
+  > While Erlang's logger expects `config` to be a map, Elixir's Logger
+  > allows the default handler configuration to be set with keyword lists.
+  > This allows your `config/*.exs` files, such as `config/dev.exs`,
+  > to override individual keys defined in config/config.exs.
+  >
+  > When reading the handler configuration using Erlang's APIs,
+  > the configuration will always be read (and written) as a map.
 
   See [`:logger_std_h`](`:logger_std_h`) for all relevant configuration,
   including overload protection. Or set `:default_handler` to false to

--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -124,13 +124,7 @@ defmodule Logger.App do
         |> Keyword.put_new(:filter_default, :log)
         |> Keyword.put_new(:module, :logger_std_h)
         |> Keyword.put_new_lazy(:formatter, &Logger.default_formatter/0)
-        |> Keyword.replace_lazy(:config, fn handler_config ->
-          if Keyword.keyword?(handler_config) do
-            Enum.into(handler_config, %{})
-          else
-            handler_config
-          end
-        end)
+        |> Keyword.replace_lazy(:config, &Map.new/1)
         |> Map.new()
 
       case :logger.add_handler(:default, config.module, config) do

--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -124,6 +124,13 @@ defmodule Logger.App do
         |> Keyword.put_new(:filter_default, :log)
         |> Keyword.put_new(:module, :logger_std_h)
         |> Keyword.put_new_lazy(:formatter, &Logger.default_formatter/0)
+        |> Keyword.replace_lazy(:config, fn handler_config ->
+          if Keyword.keyword?(handler_config) do
+            Enum.into(handler_config, %{})
+          else
+            handler_config
+          end
+        end)
         |> Map.new()
 
       case :logger.add_handler(:default, config.module, config) do


### PR DESCRIPTION
See discussion [here](https://groups.google.com/g/elixir-lang-core/c/T3v2JJWOR-g/m/FvDCTVo8HQAJ?utm_medium=email&utm_source=footer).

If the `:config` provided to `:default_handler` is a keyword list, we will now convert it into a map as expected by `:logger_std_h`, to support deep `Config.config` keyword list merging.

This implementation does not touch things that are not keyword lists, passing them through to `:logger_std_h` verbatim so it can issue its own error messages as appropriate.