### PR TITLE
Document what an @external_resource path is relative to.

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -262,8 +262,9 @@ defmodule Module do
   [`mix compile.elixir`](https://hexdocs.pm/mix/Mix.Tasks.Compile.Elixir.html).
 
   The specified file path provided is interpreted as relative to
-  the folder containing the project's `mix.exs`, not the file where
-  `@external_resource` is declared.
+  the folder containing the project's `mix.exs`, which is the
+  current working directory, not the file where `@external_resource`
+  is declared.
 
   If the external resource does not exist, the module still has
   a dependency on it, causing the module to be recompiled as soon

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -261,6 +261,10 @@ defmodule Module do
   in case any of the external resources change, see for example:
   [`mix compile.elixir`](https://hexdocs.pm/mix/Mix.Tasks.Compile.Elixir.html).
 
+  The specified file path provided is interpreted as relative to
+  the folder containing the project's `mix.exs`, not the file where
+  `@external_resource` is declared.
+
   If the external resource does not exist, the module still has
   a dependency on it, causing the module to be recompiled as soon
   as the file is added.


### PR DESCRIPTION
This had me stumped for a second, thought it was worth clarifying.