### PR TITLE
Use new domain repo.hex.pm => builds.hex.pm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ TODO: Mention :console vs Logger.Backends.Console
 
   * [Mix.Project] `:preferred_cli_env` is deprecated in favor of `:preferred_envs` in `def cli`
   * [Mix.Project] `:preferred_cli_target` is deprecated in favor of `:preferred_targets` in `def cli`
+  * [mix local] The environment variable `HEX_MIRROR` is deprecated in favor of `HEX_BUILDS_URL`
 
 ### 4. Hard deprecations
 

--- a/lib/mix/lib/mix/hex.ex
+++ b/lib/mix/lib/mix/hex.ex
@@ -2,7 +2,7 @@ defmodule Mix.Hex do
   @moduledoc false
   @compile {:no_warn_undefined, Hex}
   @hex_requirement ">= 0.19.0"
-  @hex_mirror "https://builds.hex.pm"
+  @hex_builds_url "https://builds.hex.pm"
 
   @doc """
   Returns `true` if `Hex` is loaded or installed.
@@ -70,9 +70,9 @@ defmodule Mix.Hex do
   end
 
   @doc """
-  Returns the URL to the Hex mirror.
+  Returns the URL to the Hex build assets.
   """
-  def mirror do
-    System.get_env("HEX_MIRROR") || @hex_mirror
+  def url do
+    System.get_env("HEX_BUILDS_URL") || System.get_env("HEX_MIRROR") || @hex_builds_url
   end
 end

--- a/lib/mix/lib/mix/hex.ex
+++ b/lib/mix/lib/mix/hex.ex
@@ -2,7 +2,7 @@ defmodule Mix.Hex do
   @moduledoc false
   @compile {:no_warn_undefined, Hex}
   @hex_requirement ">= 0.19.0"
-  @hex_mirror "https://repo.hex.pm"
+  @hex_mirror "https://builds.hex.pm"
 
   @doc """
   Returns `true` if `Hex` is loaded or installed.

--- a/lib/mix/lib/mix/local.ex
+++ b/lib/mix/lib/mix/local.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Local do
   @moduledoc false
 
-  @public_keys_html "https://repo.hex.pm/installs/public_keys.html"
+  @public_keys_html "https://builds.hex.pm/installs/public_keys.html"
 
   @in_memory_key """
   -----BEGIN PUBLIC KEY-----

--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Local.Hex do
   ## Mirrors
 
   If you want to change the [default mirror](https://builds.hex.pm)
-  used for fetching Hex, set the `HEX_MIRROR` environment variable.
+  used for fetching Hex, set the `HEX_BUILDS_URL` environment variable.
   """
   @switches [if_missing: :boolean, force: :boolean]
 
@@ -66,17 +66,17 @@ defmodule Mix.Tasks.Local.Hex do
   end
 
   defp run_install(version, argv) do
-    hex_mirror = Mix.Hex.mirror()
+    hex_url = Mix.Hex.url()
 
     {elixir_version, hex_version, sha512} =
       Mix.Local.find_matching_versions_from_signed_csv!(
         "Hex",
         version,
-        hex_mirror <> @hex_list_path
+        hex_url <> @hex_list_path
       )
 
     url =
-      (hex_mirror <> @hex_archive_path)
+      (hex_url <> @hex_archive_path)
       |> String.replace("[ELIXIR_VERSION]", elixir_version)
       |> String.replace("[HEX_VERSION]", hex_version)
 

--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Local.Hex do
 
   ## Mirrors
 
-  If you want to change the [default mirror](https://repo.hex.pm)
+  If you want to change the [default mirror](https://builds.hex.pm)
   used for fetching Hex, set the `HEX_MIRROR` environment variable.
   """
   @switches [if_missing: :boolean, force: :boolean]

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Local.Rebar do
 
   ## Mirrors
 
-  If you want to change the [default mirror](https://repo.hex.pm)
+  If you want to change the [default mirror](https://builds.hex.pm)
   to use for fetching `rebar` please set the `HEX_MIRROR` environment variable.
   """
 

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Local.Rebar do
   ## Mirrors
 
   If you want to change the [default mirror](https://builds.hex.pm)
-  to use for fetching `rebar` please set the `HEX_MIRROR` environment variable.
+  to use for fetching `rebar` please set the `HEX_BUILDS_URL` environment variable.
   """
 
   @switches [force: :boolean, sha512: :string, if_missing: :boolean]
@@ -107,14 +107,14 @@ defmodule Mix.Tasks.Local.Rebar do
   end
 
   defp install_from_s3(manager, list_url, escript_url, opts) do
-    hex_mirror = Mix.Hex.mirror()
-    list_url = hex_mirror <> list_url
+    hex_url = Mix.Hex.url()
+    list_url = hex_url <> list_url
 
     {elixir_version, rebar_version, sha512} =
       Mix.Local.find_matching_versions_from_signed_csv!("Rebar", _version = nil, list_url)
 
     url =
-      (hex_mirror <> escript_url)
+      (hex_url <> escript_url)
       |> String.replace("[ELIXIR_VERSION]", elixir_version)
       |> String.replace("[REBAR_VERSION]", rebar_version)
 


### PR DESCRIPTION
The domain change is backwards compatible because repo.hex.pm will redirect to builds.hex.pm in the future and we are correctly following the redirects.