### PR TITLE
add relative_to for formatter_for_file

### DIFF
--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -523,6 +523,35 @@ defmodule Mix.Tasks.FormatTest do
     end)
   end
 
+  test "uses inputs and configuration from :root path", context do
+    in_tmp(context.test, fn ->
+      File.write!(".formatter.exs", """
+      [
+        locals_without_parens: [foo: 1]
+      ]
+      """)
+
+      File.mkdir_p!("lib")
+
+      File.write!("lib/a.ex", """
+      foo bar baz
+      """)
+
+      root = File.cwd!()
+
+      {formatter_function, _options} =
+        File.cd!("lib", fn ->
+          Mix.Tasks.Format.formatter_for_file("lib/a.ex", root: root)
+        end)
+
+      assert formatter_function.("""
+             foo bar baz
+             """) == """
+             foo bar(baz)
+             """
+    end)
+  end
+
   test "reads exported configuration from subdirectories", context do
     in_tmp(context.test, fn ->
       File.write!(".formatter.exs", """


### PR DESCRIPTION
This address https://github.com/elixir-lsp/elixir-ls/issues/526 and https://groups.google.com/g/elixir-lang-core/c/r5FA-4_Fu9o/m/rZiFgGOJBAAJ

In the case of IDE trying to format snippets or files, it is possible that another task is running concurrently that may change `cwd` while we are recovering the formatter options. This end up showing as the formatter failing. It is particularly visible for people using "Format on Save", as recompilation usually happens at save time.

To avoid the problem, I introduce a new option as discussed above, `:relative_to`. I did not expand the general `mix format` to accept the option, as it is right now only documented to work from the root of the project and I did not see a need for it.

I reused the `prefix` concept that was already existing for plugins, apps, deps, and subdirectories, as I considered that it was quite close to what I am doing here. I added a simple test, I do not know if you want more. I am also not a fan of the name of the option, maybe `:root_path` would make more sense?