### PR TITLE
Add missing reserved attributes

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -630,13 +630,13 @@ defmodule Module do
           "Ensures the given keys are always set when building the struct defined in the current module."
       },
       fallback_to_any: %{
-        doc: "If set to `true` generates a default protocol implementation for all types."
+        doc: "If set to `true` generates a default protocol implementation for all types (inside `defprotocol`)."
       },
       for: %{
-        doc: "A type the current protocol implementation is being defined for."
+        doc: "The current module/type a protocol implementation is being defined for (inside `defimpl`)."
       },
       protocol: %{
-        doc: "A current protocol being implemented"
+        doc: "The current protocol being implemented (inside `defimpl`)."
       },
       on_definition: %{
         doc:

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -630,10 +630,12 @@ defmodule Module do
           "Ensures the given keys are always set when building the struct defined in the current module."
       },
       fallback_to_any: %{
-        doc: "If set to `true` generates a default protocol implementation for all types (inside `defprotocol`)."
+        doc:
+          "If set to `true` generates a default protocol implementation for all types (inside `defprotocol`)."
       },
       for: %{
-        doc: "The current module/type a protocol implementation is being defined for (inside `defimpl`)."
+        doc:
+          "The current module/type a protocol implementation is being defined for (inside `defimpl`)."
       },
       protocol: %{
         doc: "The current protocol being implemented (inside `defimpl`)."

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -626,7 +626,8 @@ defmodule Module do
         doc: "Specifies that the current module implements a given behaviour."
       },
       enforce_keys: %{
-        doc: "Ensures the given keys are always set when building the struct defined in the current module."
+        doc:
+          "Ensures the given keys are always set when building the struct defined in the current module."
       },
       fallback_to_any: %{
         doc: "If set to `true` generates a default protocol implementation for all types."

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -625,6 +625,18 @@ defmodule Module do
       behaviour: %{
         doc: "Specifies that the current module implements a given behaviour."
       },
+      enforce_keys: %{
+        doc: "Ensures the given keys are always set when building the struct defined in the current module."
+      },
+      fallback_to_any: %{
+        doc: "If set to `true` generates a default protocol implementation for all types."
+      },
+      for: %{
+        doc: "A type the current protocol implementation is being defined for."
+      },
+      protocol: %{
+        doc: "A current protocol being implemented"
+      },
       on_definition: %{
         doc:
           "A hook that will be invoked when each function or macro in the current module is defined."


### PR DESCRIPTION
Discovered in https://github.com/elixir-lsp/elixir_sense/pull/219#issuecomment-1532906412

It seems some options discussed in https://github.com/elixir-lang/elixir/pull/10926 didn't make it to the final commit.

BTW we have a convention that underscored attributes are private and undocumented (`@__struct__`, `@__functions__`, `@__impl__`) and yet there is one publicly documented: `@__records__`. Should this one be included here? In my opinion we should list here all underscored ones as well. Reserved word has some meaning - expect things to break unless you know what you are doing.

