### PR TITLE
Fix bad error in mix test --failed with path

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -558,13 +558,19 @@ defmodule Mix.Tasks.Test do
     test_pattern = project[:test_pattern] || "*_test.exs"
     warn_test_pattern = project[:warn_test_pattern] || "*_test.ex"
 
+    files_with_matched_path = Mix.Utils.extract_files(test_files, test_pattern)
+
     matched_test_files =
-      test_files
-      |> Mix.Utils.extract_files(test_pattern)
+      files_with_matched_path
       |> filter_to_allowed_files(allowed_files)
       |> filter_by_partition(shell, partitions)
 
-    display_warn_test_pattern(test_files, test_pattern, matched_test_files, warn_test_pattern)
+    display_warn_test_pattern(
+      test_files,
+      test_pattern,
+      files_with_matched_path,
+      warn_test_pattern
+    )
 
     case CT.require_and_run(matched_test_files, test_paths, test_elixirc_options, opts) do
       {:ok, %{excluded: excluded, failures: failures, total: total}} ->
@@ -593,7 +599,7 @@ defmodule Mix.Tasks.Test do
           opts[:stale] ->
             Mix.shell().info("No stale tests")
 
-          files == [] ->
+          opts[:failed] || files == [] ->
             Mix.shell().info("There are no tests to run")
 
           true ->

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -237,6 +237,11 @@ defmodule Mix.Tasks.TestTest do
         # Nothing should get run if we try it again since everything is passing.
         assert mix(["test", "--failed"]) =~ "There are no tests to run"
 
+        # When everything is passing and a file is passed, we return the proper message
+        output = mix(["test", "test/passing_and_failing_test_failed.exs", "--failed"])
+        assert output =~ "There are no tests to run"
+        refute output =~ "does not match"
+
         # `--failed` and `--stale` cannot be combined
         output = mix(["test", "--failed", "--stale"])
         assert output =~ "Combining --failed and --stale is not supported"


### PR DESCRIPTION
If the specified path had no failed tests, mix would say it didn't match the pattern, even if it did.

Closes #12547 