### PR TITLE
Optimize Enum.map/2 for ranges

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1693,6 +1693,10 @@ defmodule Enum do
     :lists.map(fun, enumerable)
   end
 
+  def map(first..last//step, fun) do
+    map_range(first, last, step, fun)
+  end
+
   def map(enumerable, fun) do
     reduce(enumerable, [], R.map(fun)) |> :lists.reverse()
   end
@@ -4033,7 +4037,8 @@ defmodule Enum do
 
   ## Helpers
 
-  @compile {:inline, entry_to_string: 1, reduce: 3, reduce_by: 3, reduce_enumerable: 3}
+  @compile {:inline,
+            entry_to_string: 1, reduce: 3, reduce_by: 3, reduce_enumerable: 3, map_range: 4}
 
   defp entry_to_string(entry) when is_binary(entry), do: entry
   defp entry_to_string(entry), do: String.Chars.to_string(entry)
@@ -4330,6 +4335,18 @@ defmodule Enum do
 
   defp join_non_empty_list([first | rest], joiner, acc) do
     join_non_empty_list(rest, joiner, [joiner, entry_to_string(first) | acc])
+  end
+
+  ## map
+
+  defp map_range(first, last, step, fun)
+       when step > 0 and first <= last
+       when step < 0 and first >= last do
+    [fun.(first) | map_range(first + step, last, step, fun)]
+  end
+
+  defp map_range(_first, _last, _step, _fun) do
+    []
   end
 
   ## map_intersperse

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -4038,7 +4038,12 @@ defmodule Enum do
   ## Helpers
 
   @compile {:inline,
-            entry_to_string: 1, reduce: 3, reduce_by: 3, reduce_enumerable: 3, map_range: 4}
+            entry_to_string: 1,
+            reduce: 3,
+            reduce_by: 3,
+            reduce_enumerable: 3,
+            reduce_range: 5,
+            map_range: 4}
 
   defp entry_to_string(entry) when is_binary(entry), do: entry
   defp entry_to_string(entry), do: String.Chars.to_string(entry)

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -1862,6 +1862,8 @@ defmodule EnumTest.Range do
     assert Enum.map(1..3, fn x -> x * 2 end) == [2, 4, 6]
     assert Enum.map(-1..-3, fn x -> x * 2 end) == [-2, -4, -6]
     assert Enum.map(1..10//2, fn x -> x * 2 end) == [2, 6, 10, 14, 18]
+    assert Enum.map(3..1//-2, fn x -> x * 2 end) == [6, 2]
+    assert Enum.map(0..1//-1, fn x -> x * 2 end) == []
   end
 
   test "map_every/3" do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -1861,6 +1861,7 @@ defmodule EnumTest.Range do
   test "map/2" do
     assert Enum.map(1..3, fn x -> x * 2 end) == [2, 4, 6]
     assert Enum.map(-1..-3, fn x -> x * 2 end) == [-2, -4, -6]
+    assert Enum.map(1..10//2, fn x -> x * 2 end) == [2, 6, 10, 14, 18]
   end
 
   test "map_every/3" do


### PR DESCRIPTION
Adding a specialized implementation of `Enum.map/2` for ranges leads to a noticeable speed improvement ([~1.40x](https://github.com/sabiwara/elixir_benches/commit/14c8e3a7b327591e3eaa6fb708758d371223c427)).

- the implementation is based on the existing [`Enum.reduce/3`](https://github.com/elixir-lang/elixir/blob/89e3ecc944f2eb5508e4614c3a1e3279086bdbea/lib/elixir/lib/enum.ex#L4348-L4356) implementation
- when benchmarking, I noticed that inlining the private helpers made a huge difference and could also speed-up `reduce_range/5`, so I added it as well
- this will also impact `for` which compiles to `Enum.map/2` in some cases since 1.15