### PR TITLE
Fixed GenServer.server type

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -765,7 +765,7 @@ defmodule GenServer do
   This is either a plain PID or a value representing a registered name.
   See the "Name registration" section of this document for more information.
   """
-  @type server :: pid | name | {atom, node}
+  @type server :: pid | name | {atom, node} | {:via, module(), term()}
 
   @typedoc """
   Tuple describing the client of a call request.


### PR DESCRIPTION
"Name registration" section lists `via` tuples as valid server names, while the type has no declaration. This PR fixes it