### PR TITLE
Support precision in NaiveDateTime/DateTime.utc_now

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -194,7 +194,7 @@ defmodule DateTime do
   @doc since: "1.15.0"
   @spec utc_now(:microsecond | :millisecond | :second, Calendar.calendar()) :: t
   def utc_now(time_unit, calendar) when time_unit in [:microsecond, :millisecond, :second] do
-    utc_now(calendar) |> truncate(time_unit)
+    System.os_time(time_unit) |> from_unix!(time_unit, calendar)
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -148,7 +148,8 @@ defmodule DateTime do
   use `System.os_time/1` instead.
 
   You can also pass a time unit to automatically
-  truncate the resulting datetime.
+  truncate the resulting datetime. This is available
+  since v1.15.0.
 
   ## Examples
 
@@ -162,9 +163,8 @@ defmodule DateTime do
 
   """
   @spec utc_now(Calendar.calendar() | :microsecond | :millisecond | :second) :: t
-
-  def utc_now(calendar_or_timeunit \\ Calendar.ISO) do
-    case calendar_or_timeunit do
+  def utc_now(calendar_or_time_unit \\ Calendar.ISO) do
+    case calendar_or_time_unit do
       unit when unit in [:microsecond, :millisecond, :second] ->
         utc_now() |> truncate(unit)
 
@@ -191,6 +191,7 @@ defmodule DateTime do
       {0, 0}
 
   """
+  @doc since: "1.15.0"
   @spec utc_now(System.time_unit(), Calendar.calendar()) :: t
   def utc_now(time_unit, calendar) when time_unit in [:microsecond, :millisecond, :second] do
     utc_now(calendar) |> truncate(time_unit)

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -165,7 +165,7 @@ defmodule DateTime do
   @spec utc_now(Calendar.calendar() | :native | :microsecond | :millisecond | :second) :: t
   def utc_now(calendar_or_time_unit \\ Calendar.ISO) do
     case calendar_or_time_unit do
-      unit when unit in [:microsecond, :millisecond, :second] ->
+      unit when unit in [:microsecond, :millisecond, :second, :native] ->
         utc_now(unit, Calendar.ISO)
 
       calendar ->

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -162,7 +162,7 @@ defmodule DateTime do
       {0, 0}
 
   """
-  @spec utc_now(Calendar.calendar() | :microsecond | :millisecond | :second) :: t
+  @spec utc_now(Calendar.calendar() | :native | :microsecond | :millisecond | :second) :: t
   def utc_now(calendar_or_time_unit \\ Calendar.ISO) do
     case calendar_or_time_unit do
       unit when unit in [:microsecond, :millisecond, :second] ->
@@ -192,7 +192,7 @@ defmodule DateTime do
 
   """
   @doc since: "1.15.0"
-  @spec utc_now(:microsecond | :millisecond | :second, Calendar.calendar()) :: t
+  @spec utc_now(:native | :microsecond | :millisecond | :second, Calendar.calendar()) :: t
   def utc_now(time_unit, calendar) when time_unit in [:native, :microsecond, :millisecond, :second] do
     System.os_time(time_unit) |> from_unix!(time_unit, calendar)
   end

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -147,16 +147,53 @@ defmodule DateTime do
   If you want the current time in Unix seconds,
   use `System.os_time/1` instead.
 
+  You can also pass a time unit to automatically
+  truncate the resulting datetime.
+
   ## Examples
 
       iex> datetime = DateTime.utc_now()
       iex> datetime.time_zone
       "Etc/UTC"
 
+      iex> datetime = DateTime.utc_now(:second)
+      iex> datetime.microsecond
+      {0, 0}
+
   """
-  @spec utc_now(Calendar.calendar()) :: t
-  def utc_now(calendar \\ Calendar.ISO) do
-    System.os_time() |> from_unix!(:native, calendar)
+  @spec utc_now(Calendar.calendar() | :microsecond | :millisecond | :second) :: t
+
+  def utc_now(calendar_or_timeunit \\ Calendar.ISO) do
+    case calendar_or_timeunit do
+      unit when unit in [:microsecond, :millisecond, :second] ->
+        utc_now() |> truncate(unit)
+
+      calendar ->
+        System.os_time() |> from_unix!(:native, calendar)
+    end
+  end
+
+  @doc """
+  Returns the current datetime in UTC, supporting 
+  a specific calendar and precision.
+
+  If you want the current time in Unix seconds,
+  use `System.os_time/1` instead.
+
+  ## Examples
+
+      iex> datetime = DateTime.utc_now(:microsecond, Calendar.ISO)
+      iex> datetime.time_zone
+      "Etc/UTC"
+
+      iex> datetime = DateTime.utc_now(:second, Calendar.ISO)
+      iex> datetime.microsecond
+      {0, 0}
+
+  """
+  @spec utc_now(System.time_unit(), Calendar.calendar()) :: t
+  def utc_now(time_unit, calendar) when time_unit in [:microsecond, :millisecond, :second] do
+    utc_now(calendar) |> truncate(time_unit)
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -193,7 +193,8 @@ defmodule DateTime do
   """
   @doc since: "1.15.0"
   @spec utc_now(:native | :microsecond | :millisecond | :second, Calendar.calendar()) :: t
-  def utc_now(time_unit, calendar) when time_unit in [:native, :microsecond, :millisecond, :second] do
+  def utc_now(time_unit, calendar)
+      when time_unit in [:native, :microsecond, :millisecond, :second] do
     System.os_time(time_unit) |> from_unix!(time_unit, calendar)
   end
 

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -166,10 +166,10 @@ defmodule DateTime do
   def utc_now(calendar_or_time_unit \\ Calendar.ISO) do
     case calendar_or_time_unit do
       unit when unit in [:microsecond, :millisecond, :second] ->
-        utc_now() |> truncate(unit)
+        utc_now(unit, Calendar.ISO)
 
       calendar ->
-        System.os_time() |> from_unix!(:native, calendar)
+        utc_now(:native, calendar)
     end
   end
 
@@ -193,7 +193,7 @@ defmodule DateTime do
   """
   @doc since: "1.15.0"
   @spec utc_now(:microsecond | :millisecond | :second, Calendar.calendar()) :: t
-  def utc_now(time_unit, calendar) when time_unit in [:microsecond, :millisecond, :second] do
+  def utc_now(time_unit, calendar) when time_unit in [:native, :microsecond, :millisecond, :second] do
     System.os_time(time_unit) |> from_unix!(time_unit, calendar)
   end
 

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -192,7 +192,7 @@ defmodule DateTime do
 
   """
   @doc since: "1.15.0"
-  @spec utc_now(System.time_unit(), Calendar.calendar()) :: t
+  @spec utc_now(:microsecond | :millisecond | :second, Calendar.calendar()) :: t
   def utc_now(time_unit, calendar) when time_unit in [:microsecond, :millisecond, :second] do
     utc_now(calendar) |> truncate(time_unit)
   end

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -127,7 +127,8 @@ defmodule NaiveDateTime do
   end
 
   def utc_now(time_unit) when time_unit in [:microsecond, :millisecond, :second] do
-    DateTime.utc_now()
+    DateTime.utc_now(time_unit)
+    |> DateTime.to_naive()
     |> DateTime.to_naive()
     |> truncate(time_unit)
   end

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -107,7 +107,7 @@ defmodule NaiveDateTime do
 
   """
   @doc since: "1.4.0"
-  @spec utc_now(Calendar.calendar() | :microsecond | :millisecond | :second) :: t
+  @spec utc_now(Calendar.calendar() | :native | :microsecond | :millisecond | :second) :: t
   def utc_now(calendar_or_time_unit \\ Calendar.ISO)
 
   def utc_now(Calendar.ISO) do
@@ -155,8 +155,8 @@ defmodule NaiveDateTime do
 
   """
   @doc since: "1.15.0"
-  @spec utc_now(:microsecond | :millisecond | :second, Calendar.calendar()) :: t
-  def utc_now(time_unit, calendar) when time_unit in [:microsecond, :millisecond, :second] do
+  @spec utc_now(:native | :microsecond | :millisecond | :second, Calendar.calendar()) :: t
+  def utc_now(time_unit, calendar) when time_unit in [:native, :microsecond, :millisecond, :second] do
     DateTime.utc_now(time_unit, calendar) |> DateTime.to_naive()
   end
 

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -160,7 +160,7 @@ defmodule NaiveDateTime do
   @doc since: "1.15.0"
   @spec utc_now(:microsecond | :millisecond | :second, Calendar.calendar()) :: t
   def utc_now(time_unit, calendar) when time_unit in [:microsecond, :millisecond, :second] do
-    utc_now(calendar) |> truncate(time_unit)
+    DateTime.utc_now(time_unit, calendar) |> DateTime.to_naive()
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -93,7 +93,7 @@ defmodule NaiveDateTime do
   to `NaiveDateTime`, it will keep the time zone information.
 
   You can also provide a time unit to automatically truncate
-  the naive datetime.
+  the naive datetime. This is available since v1.15.0.
 
   ## Examples
 
@@ -108,7 +108,7 @@ defmodule NaiveDateTime do
   """
   @doc since: "1.4.0"
   @spec utc_now(Calendar.calendar() | :microsecond | :millisecond | :second) :: t
-  def utc_now(calendar \\ Calendar.ISO)
+  def utc_now(calendar_or_time_unit \\ Calendar.ISO)
 
   def utc_now(Calendar.ISO) do
     {:ok, {year, month, day}, {hour, minute, second}, microsecond} =
@@ -156,8 +156,9 @@ defmodule NaiveDateTime do
       {0, 0}
 
   """
+  @doc since: "1.15.0"
   @spec utc_now(:microsecond | :millisecond | :second, Calendar.calendar()) :: t
-  def utc_now(time_unit, calendar) do
+  def utc_now(time_unit, calendar) when time_unit in [:microsecond, :millisecond, :second] do
     utc_now(calendar) |> truncate(time_unit)
   end
 

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -126,7 +126,7 @@ defmodule NaiveDateTime do
     }
   end
 
-  def utc_now(time_unit) when time_unit in [:microsecond, :millisecond, :second] do
+  def utc_now(time_unit) when time_unit in [:microsecond, :millisecond, :second, :native] do
     utc_now(time_unit, Calendar.ISO)
   end
 

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -92,15 +92,22 @@ defmodule NaiveDateTime do
   Prefer using `DateTime.utc_now/0` when possible as, opposite
   to `NaiveDateTime`, it will keep the time zone information.
 
+  You can also provide a time unit to automatically truncate
+  the naive datetime.
+
   ## Examples
 
       iex> naive_datetime = NaiveDateTime.utc_now()
       iex> naive_datetime.year >= 2016
       true
 
+      iex> naive_datetime = NaiveDateTime.utc_now(:second)
+      iex> naive_datetime.microsecond
+      {0, 0}
+
   """
   @doc since: "1.4.0"
-  @spec utc_now(Calendar.calendar()) :: t
+  @spec utc_now(Calendar.calendar() | :microsecond | :millisecond | :second) :: t
   def utc_now(calendar \\ Calendar.ISO)
 
   def utc_now(Calendar.ISO) do
@@ -119,10 +126,39 @@ defmodule NaiveDateTime do
     }
   end
 
+  def utc_now(time_unit) when time_unit in [:microsecond, :millisecond, :second] do
+    DateTime.utc_now()
+    |> DateTime.to_naive()
+    |> truncate(time_unit)
+  end
+
   def utc_now(calendar) do
     calendar
     |> DateTime.utc_now()
     |> DateTime.to_naive()
+  end
+
+  @doc """
+  Returns the current naive datetime in UTC, supporting a specific
+  calendar and precision.
+
+  Prefer using `DateTime.utc_now/2` when possible as, opposite
+  to `NaiveDateTime`, it will keep the time zone information.
+
+  ## Examples
+
+      iex> naive_datetime = NaiveDateTime.utc_now(:second, Calendar.ISO)
+      iex> naive_datetime.year >= 2016
+      true
+
+      iex> naive_datetime = NaiveDateTime.utc_now(:second, Calendar.ISO)
+      iex> naive_datetime.microsecond
+      {0, 0}
+
+  """
+  @spec utc_now(:microsecond | :millisecond | :second, Calendar.calendar()) :: t
+  def utc_now(time_unit, calendar) do
+    utc_now(calendar) |> truncate(time_unit)
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -156,7 +156,8 @@ defmodule NaiveDateTime do
   """
   @doc since: "1.15.0"
   @spec utc_now(:native | :microsecond | :millisecond | :second, Calendar.calendar()) :: t
-  def utc_now(time_unit, calendar) when time_unit in [:native, :microsecond, :millisecond, :second] do
+  def utc_now(time_unit, calendar)
+      when time_unit in [:native, :microsecond, :millisecond, :second] do
     DateTime.utc_now(time_unit, calendar) |> DateTime.to_naive()
   end
 

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -127,10 +127,7 @@ defmodule NaiveDateTime do
   end
 
   def utc_now(time_unit) when time_unit in [:microsecond, :millisecond, :second] do
-    DateTime.utc_now(time_unit)
-    |> DateTime.to_naive()
-    |> DateTime.to_naive()
-    |> truncate(time_unit)
+    utc_now(time_unit, Calendar.ISO)
   end
 
   def utc_now(calendar) do


### PR DESCRIPTION
This pull request adds support for passing a time unit to `NaiveDateTime` and `DateTime`'s  `utc_now/1` and creates an alternative `utc_now/2` that accepts both a custom time unit and calendar.

Closes #12557