### PR TITLE
[ExUnit] Add process assertions

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -271,6 +271,7 @@ defmodule ExUnit.Case do
 
       import ExUnit.Callbacks
       import ExUnit.Assertions
+      import ExUnit.ProcessAssertions
       import ExUnit.Case, only: [describe: 2, test: 1, test: 2, test: 3]
       import ExUnit.DocTest
     end

--- a/lib/ex_unit/lib/ex_unit/process_assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/process_assertions.ex
@@ -1,0 +1,258 @@
+defmodule ExUnit.ProcessAssertions do
+  @moduledoc """
+  Assertions for testing processes.
+  """
+
+  defmacro assert_processes_started(launch_fun, lookup_list) do
+    quote do
+      check_processes(unquote(launch_fun), unquote(lookup_list), nil, :pid)
+    end
+  end
+
+  defmacro refute_processes_started(launch_fun, lookup_list) do
+    quote do
+      check_processes(unquote(launch_fun), unquote(lookup_list), nil, nil)
+    end
+  end
+
+  defmacro assert_processes_stopped(launch_fun, lookup_list) do
+    quote do
+      check_processes_stopped(unquote(launch_fun), unquote(lookup_list))
+    end
+  end
+
+  defmacro refute_processes_stopped(launch_fun, lookup_list) do
+    quote do
+      check_processes_survived(unquote(launch_fun), unquote(lookup_list))
+    end
+  end
+
+  defmacro assert_processes_survived(launch_fun, lookup_list) do
+    quote do
+      check_processes_survived(unquote(launch_fun), unquote(lookup_list))
+    end
+  end
+
+  defmacro refute_processes_survived(launch_fun, lookup_list) do
+    quote do
+      check_processes_stopped(unquote(launch_fun), unquote(lookup_list))
+    end
+  end
+
+  @timeout 1500
+  @task_timeout 1000
+
+  def check_processes(launch_fun, lookup_list, check_before, check_after) do
+    before_check = check_lookup_list(lookup_list, check_before, :before)
+
+    result_of_launch_fun = launch_fun.()
+
+    after_check = check_lookup_list(lookup_list, check_after, :after)
+
+    (List.wrap(before_check) ++ List.wrap(after_check))
+    |> collect_errors()
+    |> result_interpretation(result_of_launch_fun)
+  end
+
+  def check_processes_stopped(launch_fun, lookup_list) do
+    before_check = check_lookup_list(lookup_list, :pid, :before)
+
+    before_errors = collect_errors(before_check)
+
+    if Enum.empty?(before_errors) do
+      waiting_to_stop =
+        before_check
+        |> Enum.map(fn {:ok, name, pid} -> {name, pid} end)
+        |> Task.async_stream(
+          __MODULE__,
+          :await_stop,
+          [:after],
+          timeout: @timeout
+        )
+
+      result_of_launch_fun = launch_fun.()
+
+      after_check =
+        waiting_to_stop
+        |> Enum.to_list()
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      (List.wrap(before_check) ++ List.wrap(after_check))
+      |> collect_errors()
+      |> result_interpretation(result_of_launch_fun)
+    else
+      result_interpretation(before_errors, nil)
+    end
+  end
+
+  def await_stop({name, pid}, step) do
+    Process.monitor(pid)
+
+    receive do
+      {_, ref, :process, _object, reason} ->
+        Process.demonitor(ref)
+        {:ok, name, pid, ref, reason}
+    after
+      @task_timeout ->
+        {:error, "[#{step}] Process :#{stringify(name)} expected to be stopped but still alive"}
+    end
+  end
+
+  def check_processes_survived(launch_fun, lookup_list) do
+    before_found = check_lookup_list(lookup_list, :pid, :before)
+
+    result_of_launch_fun = launch_fun.()
+
+    after_found = check_lookup_list(lookup_list, :pid, :after)
+
+    collected_errors = collect_errors(List.wrap(before_found) ++ List.wrap(after_found))
+
+    if Enum.empty?(collected_errors) do
+      equality_errors =
+        before_found
+        |> Enum.zip(after_found)
+        |> Enum.map(fn {before_checked, after_checked} ->
+          ensure_equal(before_checked, after_checked)
+        end)
+        |> collect_errors()
+
+      result_interpretation(
+        List.wrap(collected_errors) ++ List.wrap(equality_errors),
+        result_of_launch_fun
+      )
+    else
+      result_interpretation(collected_errors, nil)
+    end
+  end
+
+  defp check_lookup_list(lookup_list, expected, step) do
+    names = check_list(lookup_list, expected, step, :names, :waiting_process)
+
+    registry = check_list(lookup_list, expected, step, :registry, :waiting_registry)
+
+    (List.wrap(names) ++ List.wrap(registry))
+    |> List.flatten()
+  end
+
+  defp check_list(lookup_list, expected, step, key, method) do
+    lookup_list
+    |> Keyword.get(key, [])
+    |> Task.async_stream(__MODULE__, method, [expected, step])
+    |> Enum.to_list()
+    |> Enum.map(fn {:ok, result} -> result end)
+  end
+
+  defp ensure_equal({:ok, name, pid}, {:ok, name, pid}) when is_pid(pid), do: {:ok, name}
+
+  defp ensure_equal({:ok, name, b_pid}, {:ok, name, a_pid})
+       when is_pid(b_pid) and is_pid(a_pid) do
+    {:error, "Expected that #{stringify(name)} have the same pids, 
+          but before calling launch function was #{b_pid} and after #{a_pid}"}
+  end
+
+  defp collect_errors(results_list) do
+    results_list
+    |> Enum.filter(&match?({:error, _}, &1))
+    |> Enum.map(fn {:error, value} -> value end)
+  end
+
+  def waiting_process(
+        process_name,
+        expected,
+        step,
+        start_time \\ :os.system_time(:millisecond)
+      )
+      when is_atom(process_name) do
+    timeout_reached = :os.system_time(:millisecond) - start_time > @timeout
+
+    case {Process.whereis(process_name), expected, timeout_reached} do
+      {pid, :pid, _} when is_pid(pid) ->
+        {:ok, process_name, pid}
+
+      {nil, nil, _} ->
+        {:ok, process_name, nil}
+
+      {_, :pid, true} ->
+        {:error, error_not_found(process_name, step)}
+
+      {_, nil, true} ->
+        {:error, error_found(process_name, step)}
+
+      {_, _, _} ->
+        :timer.sleep(10)
+        waiting_process(process_name, expected, step, start_time)
+    end
+  end
+
+  def waiting_registry({name, ids} = registry_pair, expected, step)
+      when is_tuple(registry_pair) and is_list(ids) do
+    ids
+    |> Enum.map(fn id -> {name, id} end)
+    |> Task.async_stream(__MODULE__, :waiting_registry, [expected, step])
+    |> Enum.to_list()
+    |> Enum.map(fn {:ok, result} -> result end)
+  end
+
+  def waiting_registry(
+        {name, id} = registry_pair,
+        expected,
+        step,
+        start_time \\ :os.system_time(:millisecond)
+      )
+      when is_tuple(registry_pair) do
+    timeout_reached = :os.system_time(:millisecond) - start_time > @timeout
+
+    case {Registry.lookup(name, id), expected, timeout_reached} do
+      {[{pid, nil}], :pid, _} when is_pid(pid) ->
+        {:ok, registry_pair, pid}
+
+      {[], nil, _} ->
+        {:ok, registry_pair, nil}
+
+      {_, :pid, true} ->
+        {:error, error_not_found(name, id, step)}
+
+      {_, nil, true} ->
+        {:error, error_found(name, id, step)}
+
+      {_, _, _} ->
+        :timer.sleep(500)
+        waiting_registry(registry_pair, expected, step, start_time)
+    end
+  end
+
+  defp result_interpretation(errors_list, result) do
+    case errors_list do
+      [] ->
+        result
+
+      errors_list ->
+        raise_errors(errors_list)
+    end
+  end
+
+  defp error_found(process_name, step) do
+    "[#{step}] Process :#{process_name} expected to not be started"
+  end
+
+  defp error_found(name, id, step) do
+    "[#{step}] Process :#{name} with id #{id} expected to not be started"
+  end
+
+  defp error_not_found(process_name, step) do
+    "[#{step}] Process :#{process_name} expected to be started, but not found"
+  end
+
+  defp error_not_found(name, id, step) do
+    "[#{step}] Process :#{name} with id #{id} expected to be started, but not found"
+  end
+
+  defp raise_errors(errors_list) do
+    errors = Enum.join(errors_list, ", \n")
+    raise "Some processes in incorrect state:\n #{errors}"
+  end
+
+  defp stringify([]), do: 'none'
+  defp stringify({atom, id}), do: "#{atom}: #{id}"
+  defp stringify(atom), do: "#{atom}"
+end

--- a/lib/ex_unit/test/ex_unit/process_test.exs
+++ b/lib/ex_unit/test/ex_unit/process_test.exs
@@ -1,0 +1,341 @@
+defmodule ExUnit.ProcessAssertionsTest.Registered do
+  use GenServer
+
+  @impl true
+  def init(value) do
+    {:ok, value}
+  end
+
+  def start_processes(registry, names) do
+    Enum.map(names, fn name -> start_link(registry, name) end)
+  end
+
+  def stop_processes(registry, names) do
+    Enum.map(names, fn name -> stop_process(registry, name) end)
+  end
+
+  def start_link(registry, name) do
+    GenServer.start(__MODULE__, nil, name: {:via, Registry, {registry, name}})
+  end
+
+  def stop_process(registry, name) do
+    case Registry.lookup(registry, name) do
+      [{pid, nil}] ->
+        Process.exit(pid, :shutdown)
+
+      _ ->
+        nil
+    end
+  end
+end
+
+defmodule ExUnit.ProcessAssertionsTest.Named do
+  use GenServer
+
+  @impl true
+  def init(stack) do
+    {:ok, stack}
+  end
+
+  def start_processes(names) do
+    Enum.map(names, fn name -> start_process(name) end)
+  end
+
+  def stop_processes(names) do
+    Enum.map(names, fn name -> stop_process(name) end)
+  end
+
+  def start_process(name) do
+    GenServer.start(__MODULE__, [], name: name)
+  end
+
+  def stop_process(name) do
+    case Process.whereis(name) do
+      nil ->
+        nil
+
+      pid ->
+        Process.exit(pid, :shutdown)
+    end
+  end
+end
+
+defmodule ExUnit.ProcessAssertionsTest.TestRegistry do
+  def wait_for_registry(name) do
+    case Registry.start_link(keys: :unique, name: name) do
+      {:ok, pid} when is_pid(pid) -> pid
+      _ -> wait_for_registry(name)
+    end
+  end
+end
+
+alias ExUnit.ProcessAssertionsTest.{Registered, Named, TestRegistry}
+
+defmodule ExUnit.ProcessAssertionsTest do
+  use ExUnit.Case, async: true
+
+  setup_all do
+    TestRegistry.wait_for_registry(:test_registry_one)
+    TestRegistry.wait_for_registry(:test_registry_two)
+    :ok
+  end
+
+  setup do
+    {:ok,
+     start_fun: fn ->
+       Registered.start_processes(:test_registry_one, [:agent_foo])
+
+       Registered.start_processes(:test_registry_two, [
+         :agent_bar,
+         :agent_baz
+       ])
+
+       Named.start_processes([:foo, :bar, :baz])
+       :processes_started
+     end,
+     stop_fun: fn ->
+       Registered.stop_processes(:test_registry_one, [:agent_foo])
+
+       Registered.stop_processes(:test_registry_two, [
+         :agent_bar,
+         :agent_baz
+       ])
+
+       Named.stop_processes([:foo, :bar, :baz])
+       :processes_stopped
+     end,
+     processes_spec: %{
+       registry: %{
+         test_registry_one: :agent_foo,
+         test_registry_two: [:agent_bar, :agent_baz]
+       },
+       names: [:foo, :bar, :baz]
+     }}
+  end
+
+  @message_before_and_after "Some processes in incorrect state:\n [before] Process :foo expected to not be started, \n[before] Process :bar expected to not be started, \n[before] Process :baz expected to not be started, \n[before] Process :test_registry_one with id agent_foo expected to not be started, \n[before] Process :test_registry_two with id agent_bar expected to not be started, \n[before] Process :test_registry_two with id agent_baz expected to not be started, \n[after] Process :foo expected to not be started, \n[after] Process :bar expected to not be started, \n[after] Process :baz expected to not be started, \n[after] Process :test_registry_one with id agent_foo expected to not be started, \n[after] Process :test_registry_two with id agent_bar expected to not be started, \n[after] Process :test_registry_two with id agent_baz expected to not be started"
+
+  @message_before "Some processes in incorrect state:\n [before] Process :foo expected to not be started, \n[before] Process :bar expected to not be started, \n[before] Process :baz expected to not be started, \n[before] Process :test_registry_one with id agent_foo expected to not be started, \n[before] Process :test_registry_two with id agent_bar expected to not be started, \n[before] Process :test_registry_two with id agent_baz expected to not be started"
+
+  @message_after "Some processes in incorrect state:\n [after] Process :foo expected to be started, but not found, \n[after] Process :bar expected to be started, but not found, \n[after] Process :baz expected to be started, but not found, \n[after] Process :test_registry_one with id agent_foo expected to be started, but not found, \n[after] Process :test_registry_two with id agent_bar expected to be started, but not found, \n[after] Process :test_registry_two with id agent_baz expected to be started, but not found"
+
+  @message_alive "Some processes in incorrect state:\n [after] Process :foo expected to be stopped but still alive, \n[after] Process :bar expected to be stopped but still alive, \n[after] Process :baz expected to be stopped but still alive, \n[after] Process :test_registry_one: agent_foo expected to be stopped but still alive, \n[after] Process :test_registry_two: agent_bar expected to be stopped but still alive, \n[after] Process :test_registry_two: agent_baz expected to be stopped but still alive"
+
+  test "assert_processes_started success", %{
+    start_fun: start_fun,
+    stop_fun: stop_fun,
+    processes_spec: %{registry: registry, names: names}
+  } do
+    assert :processes_started ==
+             assert_processes_started(
+               start_fun,
+               registry: registry,
+               names: names
+             )
+
+    stop_fun.()
+  end
+
+  test "assert_processes_started failed", %{
+    start_fun: start_fun,
+    stop_fun: stop_fun,
+    processes_spec: %{registry: registry, names: names}
+  } do
+    start_fun.()
+
+    assert_raise(
+      RuntimeError,
+      @message_before,
+      fn ->
+        assert_processes_started(
+          start_fun,
+          registry: registry,
+          names: names
+        )
+      end
+    )
+
+    stop_fun.()
+  end
+
+  test "refute_processes_started success", %{
+    processes_spec: %{registry: registry, names: names}
+  } do
+    assert :processes_not_started ==
+             refute_processes_started(
+               fn -> :processes_not_started end,
+               registry: registry,
+               names: names
+             )
+  end
+
+  test "refute_processes_started failed", %{
+    start_fun: start_fun,
+    stop_fun: stop_fun,
+    processes_spec: %{registry: registry, names: names}
+  } do
+    start_fun.()
+
+    assert_raise(
+      RuntimeError,
+      @message_before_and_after,
+      fn ->
+        refute_processes_started(
+          start_fun,
+          registry: registry,
+          names: names
+        )
+      end
+    )
+
+    stop_fun.()
+  end
+
+  test "assert_processes_stopped success", %{
+    start_fun: start_fun,
+    stop_fun: stop_fun,
+    processes_spec: %{registry: registry, names: names}
+  } do
+    start_fun.()
+
+    assert :processes_stopped ==
+             assert_processes_stopped(
+               stop_fun,
+               registry: registry,
+               names: names
+             )
+  end
+
+  test "assert_processes_stopped failed", %{
+    start_fun: start_fun,
+    stop_fun: stop_fun,
+    processes_spec: %{registry: registry, names: names}
+  } do
+    start_fun.()
+
+    assert_raise(
+      RuntimeError,
+      @message_alive,
+      fn ->
+        assert_processes_stopped(
+          fn -> :processes_not_stopped end,
+          registry: registry,
+          names: names
+        )
+      end
+    )
+
+    stop_fun.()
+  end
+
+  test "refute_processes_stopped success", %{
+    start_fun: start_fun,
+    stop_fun: stop_fun,
+    processes_spec: %{registry: registry, names: names}
+  } do
+    start_fun.()
+
+    assert :processes_not_stopped ==
+             refute_processes_stopped(
+               fn -> :processes_not_stopped end,
+               registry: registry,
+               names: names
+             )
+
+    stop_fun.()
+  end
+
+  test "refute_processes_stopped failed", %{
+    start_fun: start_fun,
+    stop_fun: stop_fun,
+    processes_spec: %{registry: registry, names: names}
+  } do
+    start_fun.()
+
+    assert_raise(
+      RuntimeError,
+      @message_after,
+      fn ->
+        refute_processes_stopped(
+          stop_fun,
+          registry: registry,
+          names: names
+        )
+      end
+    )
+  end
+
+  test "assert_processes_survived success", %{
+    start_fun: start_fun,
+    stop_fun: stop_fun,
+    processes_spec: %{registry: registry, names: names}
+  } do
+    start_fun.()
+
+    assert :processes_not_stopped ==
+             assert_processes_survived(
+               fn -> :processes_not_stopped end,
+               registry: registry,
+               names: names
+             )
+
+    stop_fun.()
+  end
+
+  test "assert_processes_survived failed", %{
+    start_fun: start_fun,
+    stop_fun: stop_fun,
+    processes_spec: %{registry: registry, names: names}
+  } do
+    start_fun.()
+
+    assert_raise(
+      RuntimeError,
+      @message_after,
+      fn ->
+        assert_processes_survived(
+          stop_fun,
+          registry: registry,
+          names: names
+        )
+      end
+    )
+  end
+
+  test "refute_processes_survived success", %{
+    start_fun: start_fun,
+    stop_fun: stop_fun,
+    processes_spec: %{registry: registry, names: names}
+  } do
+    start_fun.()
+
+    assert :processes_stopped ==
+             refute_processes_survived(
+               stop_fun,
+               registry: registry,
+               names: names
+             )
+  end
+
+  test "refute_processes_survived failed", %{
+    start_fun: start_fun,
+    stop_fun: stop_fun,
+    processes_spec: %{registry: registry, names: names}
+  } do
+    start_fun.()
+
+    assert_raise(
+      RuntimeError,
+      @message_alive,
+      fn ->
+        refute_processes_survived(
+          fn -> :processes_not_stopped end,
+          registry: registry,
+          names: names
+        )
+      end
+    )
+
+    stop_fun.()
+  end
+end


### PR DESCRIPTION
Hi team,

I am submitting a pull request to add new assertions to ExUnit that will allow testing of process side effects when invoking functions that start or stop several processes. These new assertions are `assert_processes_started`, `assert_processes_stopped`, and `assert_processes_survived` macros in the `ExUnit.ProcessAssertions` module.

The new macros will take in two arguments - the function that starts or stops the processes and a list of expected process side effects. The expected process side effects will be in the form of a keyword list, where each key represents a process and the value is a list of expected side effects for that process. When assertion succeeds, it returns the result of passed function.

```
    assert :processes_started ==
      assert_processes_started(
        fn -> :processes_started end,
        registry: %{
          test_registry_one: :agent_foo,
          test_registry_two: [:agent_bar, :agent_baz]
        },
        names: [:foo, :bar, :baz]
        }
    )
```

These new assertions will be useful for testing complex systems where multiple processes are started or stopped, and side effects need to be validated. I have tested the new macros thoroughly and have included unit tests to ensure they are working as expected.

Thank you for considering this pull request.

Best regards, Oleg