### PR TITLE
add example of Enum.reduce/4 on a map to docs

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2478,6 +2478,9 @@ defmodule Enum do
       iex> Enum.reduce([1, 2, 3], 0, fn x, acc -> x + acc end)
       6
 
+      iex> Enum.reduce(%{a: 2, b: 3, c: 4}, %{}, fn {key, val}, acc -> Map.put(acc, key, val * 2) end)
+      %{a: 4, b: 6, c: 8}
+
   ## Reduce as a building block
 
   Reduce (sometimes called `fold`) is a basic building block in functional

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2478,8 +2478,8 @@ defmodule Enum do
       iex> Enum.reduce([1, 2, 3], 0, fn x, acc -> x + acc end)
       6
 
-      iex> Enum.reduce(%{a: 2, b: 3, c: 4}, %{}, fn {key, val}, acc -> Map.put(acc, key, val * 2) end)
-      %{a: 4, b: 6, c: 8}
+      iex> Enum.reduce(%{a: 2, b: 3, c: 4}, 0, fn {_key, val}, acc -> acc + val end)
+      9
 
   ## Reduce as a building block
 

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -235,6 +235,9 @@ defmodule Map do
       iex> Map.new([:a, :b], fn x -> {x, x} end)
       %{a: :a, b: :b}
 
+      iex> Map.new(%{a: 2, b: 3, c: 4}, fn {key, val} -> {key, val * 2} end)
+      %{a: 4, b: 6, c: 8}
+
   """
   @spec new(Enumerable.t(), (term -> {key, value})) :: map
   def new(enumerable, transform)


### PR DESCRIPTION
That maps show up in `Enum.reduce/4` as a `{key, value}` tuple may not be obvious to new users of Elixir, and after not using that function that way in a while, I found myself looking online to confirm the syntax. I thought it'd be nice if an example was in the docs, which will also make it show up in some IDEs.

I added this only on `Enum.reduce/4`, not `/3` because I couldn't think of a straighforward way one would use `Enum.reduce/3` with a map. (I can't think of when one would want to get back something like `{first_key_name: total_count}`)
