### PR TITLE
Disable ANSI when stdout is not a valid file descriptor

### DIFF
--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -60,7 +60,7 @@ start(_Type, _Args) ->
     {ok, _} -> ok;
     undefined ->
       %% Remove prim_tty module check as well as checks from scripts on Erlang/OTP 26
-      ANSIEnabled = erlang:module_loaded(prim_tty) andalso prim_tty:isatty(stdout),
+      ANSIEnabled = erlang:module_loaded(prim_tty) andalso (prim_tty:isatty(stdout) == true),
       application:set_env(elixir, ansi_enabled, ANSIEnabled)
   end,
 


### PR DESCRIPTION
Fixes issue reported in https://github.com/elixir-lang/elixir/pull/12564 comments.

According to https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fileno?view=msvc-170 when there is no associated output stream to `stdout`, `_fileno` returns `-2` without setting an error, which causes otp to return `ebadf` on `prim_tty:isatty`. Its not clear yet if this behaviour is intended, and a bug report will be filed for otp.

Either way, considering that the signature of the function is `true | false | ebadf`, I think elixir should use `== true` as a condition to enable ANSI.