### PR TITLE
Update diagnostic type for compatibility with Mix.Task.Compiler.Diagnostic struct

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -198,11 +198,12 @@ defmodule Code do
   Diagnostics returned by the compiler and code evaluation.
   """
   @type diagnostic(severity) :: %{
-          file: Path.t(),
-          severity: severity,
-          message: String.t(),
-          position: position,
-          stacktrace: Exception.stacktrace()
+          required(:file) => Path.t(),
+          required(:severity) => severity,
+          required(:message) => String.t(),
+          required(:position) => position,
+          required(:stacktrace) => Exception.stacktrace(),
+          optional(any()) => any()
         }
 
   @typedoc "The line. 0 indicates no line."


### PR DESCRIPTION
Alternatively maybe the Code.print_diagnostic function should accept either this diagnostic map or the mix struct, or the call site should always construct a map. Currently the compiler is passing the struct: https://github.com/elixir-lang/elixir/blob/df521d308694b187fa1dc8835f1e5c8f7b79e4e8/lib/mix/lib/mix/compilers/elixir.ex#L712