### PR TITLE
Remove obsolete doc about :generated option in quote/1

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -837,8 +837,8 @@ defmodule Kernel.SpecialForms do
     * `:context` - sets the resolution context.
 
     * `:generated` - marks the given chunk as generated so it does not emit warnings.
-      Currently it only works on special forms (for example, you can annotate a `case`
-      but not an `if`).
+      It is also useful to avoid dialyzer reporting errors when macros generate
+      unused clauses.
 
     * `:file` - sets the quoted expressions to have the given file.
 


### PR DESCRIPTION
- Remove obsolete documentation disclaimer about `:generated` option in `quote/1` (now gets propagated)
- Precise that this can be used to ignore dialyzer errors, since this is not obvious it has this effect and can be useful knowledge