### PR TITLE
Consider mix alises in umbrella projects

### DIFF
--- a/lib/mix/test/fixtures/umbrella_test/apps/bar/mix.exs
+++ b/lib/mix/test/fixtures/umbrella_test/apps/bar/mix.exs
@@ -8,7 +8,8 @@ defmodule Bar.MixProject do
       # Choose something besides *_test.exs so that these test files don't
       # get accidentally swept up into the actual Mix test suite.
       test_pattern: "*_tests.exs",
-      test_coverage: [ignore_modules: [Bar, ~r/Ignore/]]
+      test_coverage: [ignore_modules: [Bar, ~r/Ignore/]],
+      aliases: [mytask: ["cmd echo bar_running"]]
     ]
   end
 end

--- a/lib/mix/test/fixtures/umbrella_test/apps/foo/mix.exs
+++ b/lib/mix/test/fixtures/umbrella_test/apps/foo/mix.exs
@@ -7,7 +7,8 @@ defmodule Foo.MixProject do
       version: "0.1.0",
       # Choose something besides *_test.exs so that these test files don't
       # get accidentally swept up into the actual Mix test suite.
-      test_pattern: "*_tests.exs"
+      test_pattern: "*_tests.exs",
+      aliases: [mytask: ["cmd echo foo_running"]]
     ]
   end
 end

--- a/lib/mix/test/mix/task_test.exs
+++ b/lib/mix/test/mix/task_test.exs
@@ -160,6 +160,40 @@ defmodule Mix.TaskTest do
     end)
   end
 
+  test "aliases considered for umbrella apps" do
+    in_fixture("umbrella_test", fn ->
+      Mix.Project.in_project(:umbrella, ".", fn _ ->
+        File.mkdir_p!("apps/baz/lib/")
+
+        File.write!("apps/baz/mix.exs", """
+        defmodule Baz.MixProject do
+          use Mix.Project
+
+          def project do
+            [
+              app: :baz,
+              version: "0.1.0"
+            ]
+          end
+        end
+        """)
+
+        File.write!("apps/baz/lib/baz.ex", """
+        defmodule Baz do
+          def hello do
+            :world
+          end
+        end
+        """)
+
+        assert [:ok, nil, :ok] = Mix.Task.run("mytask")
+
+        assert_received {:mix_shell, :run, ["foo_running" <> _]}
+        assert_received {:mix_shell, :run, ["bar_running" <> _]}
+      end)
+    end)
+  end
+
   test "reenable/1 for recursive inside umbrella child" do
     in_fixture("umbrella_dep/deps/umbrella", fn ->
       Mix.Project.in_project(:umbrella, ".", fn _ ->


### PR DESCRIPTION
Previously, when an alias existed within an umbrella child, running this from the umbrella root would result in an error that the mix task was not found.

This commit checks the aliases of the children, and if any of the children have the alias then it will be executed in the children. Any children that do not have the alias will be skipped.

I don't like the implementation here, so I'd appreciate any pointers for how to do this in 1 pass.

Closes #12572