### PR TITLE
Code.with_diagnostics/2 formats paths as relative

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -571,7 +571,7 @@ defmodule Code do
     try do
       result = fun.()
       {diagnostics, _log?} = :erlang.get(:elixir_code_diagnostics)
-      {result, post_process_diagnostics(diagnostics)}
+      {result, Enum.reverse(diagnostics)}
     after
       if value == :undefined do
         :erlang.erase(:elixir_code_diagnostics)
@@ -579,13 +579,6 @@ defmodule Code do
         :erlang.put(:elixir_code_diagnostics, value)
       end
     end
-  end
-
-  defp post_process_diagnostics(diagnostics) do
-    # reverse + map in one pass
-    Enum.reduce(diagnostics, [], fn diagnostic, acc ->
-      [%{diagnostic | file: Path.relative_to_cwd(diagnostic.file)} | acc]
-    end)
   end
 
   @doc """

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -571,7 +571,7 @@ defmodule Code do
     try do
       result = fun.()
       {diagnostics, _log?} = :erlang.get(:elixir_code_diagnostics)
-      {result, Enum.reverse(diagnostics)}
+      {result, post_process_diagnostics(diagnostics)}
     after
       if value == :undefined do
         :erlang.erase(:elixir_code_diagnostics)
@@ -579,6 +579,13 @@ defmodule Code do
         :erlang.put(:elixir_code_diagnostics, value)
       end
     end
+  end
+
+  defp post_process_diagnostics(diagnostics) do
+    # reverse + map in one pass
+    Enum.reduce(diagnostics, [], fn diagnostic, acc ->
+      [%{diagnostic | file: Path.relative_to_cwd(diagnostic.file)} | acc]
+    end)
   end
 
   @doc """

--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -632,11 +632,11 @@ defmodule Kernel.ParallelCompiler do
         spawn_workers(queue, spawned, waiting, files, result, warnings, errors, state)
 
       {:diagnostic, %{severity: :warning} = diagnostic} ->
-        warnings = [format_diagnostic(diagnostic) | warnings]
+        warnings = [Module.ParallelChecker.format_diagnostic_file(diagnostic) | warnings]
         wait_for_messages(queue, spawned, waiting, files, result, warnings, errors, state)
 
       {:diagnostic, %{severity: :error} = diagnostic} ->
-        errors = [format_diagnostic(diagnostic) | errors]
+        errors = [Module.ParallelChecker.format_diagnostic_file(diagnostic) | errors]
         wait_for_messages(queue, spawned, waiting, files, result, warnings, errors, state)
 
       {:file_ok, child_pid, ref, file, lexical} ->
@@ -675,10 +675,6 @@ defmodule Kernel.ParallelCompiler do
           wait_for_messages(queue, spawned, waiting, files, result, warnings, errors, state)
         end
     end
-  end
-
-  defp format_diagnostic(diagnostic) do
-    %{diagnostic | file: Path.absname(diagnostic.file)}
   end
 
   defp return_error(errors, warnings) do

--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -632,11 +632,11 @@ defmodule Kernel.ParallelCompiler do
         spawn_workers(queue, spawned, waiting, files, result, warnings, errors, state)
 
       {:diagnostic, %{severity: :warning} = diagnostic} ->
-        warnings = [diagnostic | warnings]
+        warnings = [format_diagnostic(diagnostic) | warnings]
         wait_for_messages(queue, spawned, waiting, files, result, warnings, errors, state)
 
       {:diagnostic, %{severity: :error} = diagnostic} ->
-        errors = [diagnostic | errors]
+        errors = [format_diagnostic(diagnostic) | errors]
         wait_for_messages(queue, spawned, waiting, files, result, warnings, errors, state)
 
       {:file_ok, child_pid, ref, file, lexical} ->
@@ -675,6 +675,10 @@ defmodule Kernel.ParallelCompiler do
           wait_for_messages(queue, spawned, waiting, files, result, warnings, errors, state)
         end
     end
+  end
+
+  defp format_diagnostic(diagnostic) do
+    %{diagnostic | file: Path.absname(diagnostic.file)}
   end
 
   defp return_error(errors, warnings) do

--- a/lib/elixir/lib/module/parallel_checker.ex
+++ b/lib/elixir/lib/module/parallel_checker.ex
@@ -169,6 +169,7 @@ defmodule Module.ParallelChecker do
   defp collect_results(count, diagnostics) do
     receive do
       {:diagnostic, diagnostic} ->
+        diagnostic = format_diagnostic_file(diagnostic)
         collect_results(count, [diagnostic | diagnostics])
 
       {__MODULE__, _module, new_diagnostics} ->
@@ -285,6 +286,11 @@ defmodule Module.ParallelChecker do
       :all -> :all
       list when is_list(list) -> no_warn_undefined ++ list
     end
+  end
+
+  @doc false
+  def format_diagnostic_file(%{file: file} = diagnostic) do
+    %{diagnostic | file: file && Path.absname(file)}
   end
 
   ## Warning helpers

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -38,7 +38,7 @@ print_diagnostic(#{severity := Severity, message := Message, stacktrace := Stack
 emit_diagnostic(Severity, Position, File, Message, Stacktrace) ->
   Diagnostic = #{
     severity => Severity,
-    file => if File =:= nil -> nil; true -> filename:absname(File) end,
+    file => File,
     position => Position,
     message => unicode:characters_to_binary(Message),
     stacktrace => Stacktrace

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -162,6 +162,27 @@ defmodule CodeTest do
       :code.purge(CodeTest.CheckerWarning)
       :code.delete(CodeTest.CheckerWarning)
     end
+
+    test "formats diagnostic file paths as relatives" do
+      {_, diagnostics} =
+        Code.with_diagnostics(fn ->
+          try do
+            Code.eval_string("x", [])
+          rescue
+            e -> e
+          end
+        end)
+
+      assert [
+               %{
+                 message: "undefined variable \"x\"",
+                 position: 1,
+                 file: "nofile",
+                 stacktrace: [],
+                 severity: :error
+               }
+             ] = diagnostics
+    end
   end
 
   describe "eval_quoted/1" do


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/12585

I'm not sure if this is the way we want to close this, but it seems that the expected format for compiler diagnostics is absolute paths, so if we want to have `Code.with_diagnostics/2` return relative paths, I believe this is where we should format it?