### PR TITLE
Tighten guards on String.downcase/1, closes #12592

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -911,7 +911,7 @@ defmodule String do
     String.Unicode.downcase(string, [], mode)
   end
 
-  defp downcase_ascii(<<char, rest::bits>>) when char >= ?A and char <= ?Z,
+  defp downcase_ascii(<<char, rest::bits>>) when is_integer(char) and char >= ?A and char <= ?Z,
     do: [char + 32 | downcase_ascii(rest)]
 
   defp downcase_ascii(<<char, rest::bits>>), do: [char | downcase_ascii(rest)]


### PR DESCRIPTION
```
> elixir --version
Erlang/OTP 26 [erts-14.0] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit:ns] [dtrace] [sharing-preserving]

Elixir 1.15.0-rc.0 (536dcb3) (compiled with Erlang/OTP 26)
> mix test
Compiling 1 file (.ex)
Generated mime app
...............
Finished in 0.3 seconds (0.3s async, 0.00s sync)
9 doctests, 6 tests, 0 failures

Randomized with seed 902735
```

Prior to this patch, on FreeBSD, with OTP-26.0 and Elixir 1.15.0-rc.0, compilation
fails in modules such as `Plug.Mime`:

```
== Compilation error in file lib/mime.ex ==
** (CompileError) lib/mime.ex: internal error in pass beam_ssa_opt: exception error: undefined function beam_bounds:'+'/2
  in function  beam_call_types:arith_type/2 (beam_call_types.erl, line 895)
  in call from beam_ssa_type:ranges_propagate_types/2 (beam_ssa_type.erl, line 861)
  in call from beam_ssa_type:ranges_is/3 (beam_ssa_type.erl, line 837)
  in call from beam_ssa_type:ranges/3 (beam_ssa_type.erl, line 824)
  in call from beam_ssa_opt:ssa_opt_ranges/1 (beam_ssa_opt.erl, line 448)
  in call from compile:run_sub_passes_1/3 (compile.erl, line 419)
  in call from beam_ssa_opt:phase/4 (beam_ssa_opt.erl, line 114)
    (stdlib 5.0) lists.erl:1686: :lists.foreach_1/2
```