### PR TITLE
Use process dict directly

### DIFF
--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -70,10 +70,8 @@ defmodule Task.Supervised do
   end
 
   defp get_ancestors() do
-    with {:dictionary, dictionary} <- Process.info(self(), :dictionary),
-         {:"$ancestors", ancestors} <- :lists.keyfind(:"$ancestors", 1, dictionary) do
-      [self() | ancestors]
-    else
+    case :erlang.get(:"$ancestors") do
+      ancestors when is_list(ancestors) -> [self() | ancestors]
       _ -> [self()]
     end
   end


### PR DESCRIPTION
Note: I went with `:erlang.get` rather than `Process.get` since it was done this way [here](https://github.com/elixir-lang/elixir/blob/main/lib/elixir/lib/task.ex#L711) and it removes an extra match.