### PR TITLE
[ExUnit] Expose compile-time test and tag information

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -771,7 +771,7 @@ defmodule ExUnit.Case do
 
   This is used by third-party utilities to allow compile-time configuration
   using test tags without having to explicitly pass the test context at
-  run-time. It is indented to be invoked in macros before the test module
+  run-time. It is intended to be invoked in macros before the test module
   is compiled.
 
   Raises if called with a module that has already been compiled.

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -777,12 +777,12 @@ defmodule ExUnit.Case do
   Raises if called with a module that has already been compiled.
   """
   @doc since: "1.15.0"
-  @spec most_recent_registered_test(env) :: ExUnit.Test.t() | nil
-  def most_recent_registered_test(%{module: mod}) do
-    most_recent_registered_test(mod)
+  @spec get_last_registered_test(env) :: ExUnit.Test.t() | nil
+  def get_last_registered_test(%{module: mod}) do
+    get_last_registered_test(mod)
   end
 
-  def most_recent_registered_test(mod) when is_atom(mod) do
+  def get_last_registered_test(mod) when is_atom(mod) do
     Module.get_last_attribute(mod, :ex_unit_tests)
   end
 

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -765,6 +765,27 @@ defmodule ExUnit.Case do
     end
   end
 
+  @doc """
+  Returns the most recently registered test case as an `%ExUnit.Test{}`
+  struct.
+
+  This is used by third-party utilities to allow compile-time configuration
+  using test tags without having to explicitly pass the test context at
+  run-time. It is indented to be invoked in macros before the test module
+  is compiled.
+
+  Raises if called with a module that has already been compiled.
+  """
+  @doc since: "1.15.0"
+  @spec most_recent_registered_test(env) :: ExUnit.Test.t() | nil
+  def most_recent_registered_test(%{module: mod}) do
+    most_recent_registered_test(mod)
+  end
+
+  def most_recent_registered_test(mod) when is_atom(mod) do
+    Module.get_last_attribute(mod, :ex_unit_tests)
+  end
+
   defp validate_tags(tags) do
     for tag <- @reserved, Map.has_key?(tags, tag) do
       raise "cannot set tag #{inspect(tag)} because it is reserved by ExUnit"

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -262,3 +262,55 @@ defmodule ExUnit.BadOptsCase do
     end
   end
 end
+
+defmodule ExUnit.CaseTest.MostRecentRegisteredTestHelper do
+  defmacro escaped_most_recent_registered_test do
+    Macro.escape(ExUnit.Case.most_recent_registered_test(__CALLER__))
+  end
+end
+
+defmodule ExUnit.CaseTest.MostRecentRegisteredTestTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaseTest.MostRecentRegisteredTestHelper
+
+  most_recent = ExUnit.Case.most_recent_registered_test(__MODULE__)
+
+  test "should return nil if called before any test has been registered" do
+    assert unquote(most_recent) == nil
+  end
+
+  test "should return the current test if call is within test body", %{test: name} do
+    assert %ExUnit.Test{
+             name: ^name,
+             module: __MODULE__,
+             state: nil,
+             time: 0
+           } = escaped_most_recent_registered_test()
+  end
+
+  most_recent = ExUnit.Case.most_recent_registered_test(__MODULE__)
+
+  test "should return the previous test if call is outside test body" do
+    assert %ExUnit.Test{name: :"test should return the current test if call is within test body"} =
+             unquote(Macro.escape(most_recent))
+  end
+
+  test "raises if given module is already compiled" do
+    assert_raise ArgumentError, ~r/could not call Module\.get_last_attribute\/2/, fn ->
+      ExUnit.Case.most_recent_registered_test(__MODULE__)
+    end
+  end
+
+  @moduletag tag1: :foo
+  describe "tags" do
+    @describetag tag2: :bar
+
+    @tag tag3: :baz
+    test "should include data available in test context", context do
+      assert %ExUnit.Test{tags: %{tag1: :foo, tag2: :bar, tag3: :baz} = tags} =
+               escaped_most_recent_registered_test()
+
+      assert tags == Map.take(context, Map.keys(tags))
+    end
+  end
+end

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -263,20 +263,20 @@ defmodule ExUnit.BadOptsCase do
   end
 end
 
-defmodule ExUnit.CaseTest.MostRecentRegisteredTestHelper do
-  defmacro escaped_most_recent_registered_test do
-    Macro.escape(ExUnit.Case.most_recent_registered_test(__CALLER__))
+defmodule ExUnit.CaseTest.GetLastRegisteredTestHelper do
+  defmacro escaped_get_last_registered_test do
+    Macro.escape(ExUnit.Case.get_last_registered_test(__CALLER__))
   end
 end
 
-defmodule ExUnit.CaseTest.MostRecentRegisteredTestTest do
+defmodule ExUnit.CaseTest.GetLastRegisteredTestTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaseTest.MostRecentRegisteredTestHelper
+  import ExUnit.CaseTest.GetLastRegisteredTestHelper
 
-  most_recent = ExUnit.Case.most_recent_registered_test(__MODULE__)
+  last = ExUnit.Case.get_last_registered_test(__MODULE__)
 
   test "returns nil if called before any test has been registered" do
-    assert unquote(most_recent) == nil
+    assert unquote(last) == nil
   end
 
   test "returns the current test if call is within test body", %{test: name} do
@@ -285,19 +285,19 @@ defmodule ExUnit.CaseTest.MostRecentRegisteredTestTest do
              module: __MODULE__,
              state: nil,
              time: 0
-           } = escaped_most_recent_registered_test()
+           } = escaped_get_last_registered_test()
   end
 
-  most_recent = ExUnit.Case.most_recent_registered_test(__MODULE__)
+  last = ExUnit.Case.get_last_registered_test(__MODULE__)
 
   test "returns the previous test if call is outside test body" do
     assert %ExUnit.Test{name: :"test returns the current test if call is within test body"} =
-             unquote(Macro.escape(most_recent))
+             unquote(Macro.escape(last))
   end
 
   test "raises if given module is already compiled" do
     assert_raise ArgumentError, ~r/could not call Module\.get_last_attribute\/2/, fn ->
-      ExUnit.Case.most_recent_registered_test(__MODULE__)
+      ExUnit.Case.get_last_registered_test(__MODULE__)
     end
   end
 
@@ -308,7 +308,7 @@ defmodule ExUnit.CaseTest.MostRecentRegisteredTestTest do
     @tag tag3: :baz
     test "includes data available in test context", context do
       assert %ExUnit.Test{tags: %{tag1: :foo, tag2: :bar, tag3: :baz} = tags} =
-               escaped_most_recent_registered_test()
+               escaped_get_last_registered_test()
 
       assert tags == Map.take(context, Map.keys(tags))
     end

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -275,11 +275,11 @@ defmodule ExUnit.CaseTest.MostRecentRegisteredTestTest do
 
   most_recent = ExUnit.Case.most_recent_registered_test(__MODULE__)
 
-  test "should return nil if called before any test has been registered" do
+  test "returns nil if called before any test has been registered" do
     assert unquote(most_recent) == nil
   end
 
-  test "should return the current test if call is within test body", %{test: name} do
+  test "returns the current test if call is within test body", %{test: name} do
     assert %ExUnit.Test{
              name: ^name,
              module: __MODULE__,
@@ -290,8 +290,8 @@ defmodule ExUnit.CaseTest.MostRecentRegisteredTestTest do
 
   most_recent = ExUnit.Case.most_recent_registered_test(__MODULE__)
 
-  test "should return the previous test if call is outside test body" do
-    assert %ExUnit.Test{name: :"test should return the current test if call is within test body"} =
+  test "returns the previous test if call is outside test body" do
+    assert %ExUnit.Test{name: :"test returns the current test if call is within test body"} =
              unquote(Macro.escape(most_recent))
   end
 
@@ -306,7 +306,7 @@ defmodule ExUnit.CaseTest.MostRecentRegisteredTestTest do
     @describetag tag2: :bar
 
     @tag tag3: :baz
-    test "should include data available in test context", context do
+    test "includes data available in test context", context do
       assert %ExUnit.Test{tags: %{tag1: :foo, tag2: :bar, tag3: :baz} = tags} =
                escaped_most_recent_registered_test()
 


### PR DESCRIPTION
Note: I wanted to post a proposal before opening this PR, but don't have time this moment and thought it better to put this out there. Happy to post a proposal later tonight if desired.

---

This PR introduces a new function, `ExUnit.Case.most_recent_registered_test/1`, primarily to allow library authors blessed access to compile-time test and tag information.

As tests are defined, `ExUnit.Case.register_test/6` builds `%ExUnit.Test{}` structs and inserts them into the `:ex_unit_tests` module attribute of the case module. These structs contain useful contextual information, namely the aggregated and normalized test tags from the module, describe, and test level (as well as registered tags). These tags are very versatile and useful for confirmation -- I'm using them heavily in [Mneme](https://hexdocs.pm/mneme/Mneme.html#module-configuration).

To my knowledge, there are currently two "blessed" ways to access test tags. The first and most obvious is through `context`:

```elixir
@tag some_tag: :foo
test "some test", context do
  assert context[:some_tag] == :foo
end
```

The second is through a custom `ExUnit.Formatter`, which will receive the test struct (containing tags) at various points during test execution.

For libraries wishing to use tags for flexible configuration, then, there are three options:

1. Require that users pass configuration at each call site, which is cumbersome;
2. Register or wrap the ExUnit formatter and wait for the `{:test_started, test}` event (this is what Mneme currently does);
3. Access the private `:ex_unit_tests` module attribute at compile-time.

`ExUnit.Case.most_recent_registered_test/1` is essentially making option (3) above a part of the public API.

My reasoning behind the name of the function:

* `most_recent` implies execution order as opposed to physical location in the test module (`last_registered_test` would be ambiguous).
* `registered` hints at a compile-time operation, whereas something like `most_recent_test` could be confused with something that returns the result of whatever test last ran.

I don't feel strongly about the name.

---

Happy to receive feedback on this and thanks for any review!