### PR TITLE
Fix generated docs_config.js on CI

### DIFF
--- a/.github/workflows/builds.hex.pm.yml
+++ b/.github/workflows/builds.hex.pm.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 50
+          fetch-depth: 0
       - uses: ./.github/workflows/release_pre_built
         with:
           otp_version: ${{ matrix.otp_version }}

--- a/.github/workflows/builds.hex.pm.yml
+++ b/.github/workflows/builds.hex.pm.yml
@@ -34,7 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 50
+      - name: Get tags
+        run: git fetch --tags origin
       - uses: ./.github/workflows/release_pre_built
         with:
           otp_version: ${{ matrix.otp_version }}


### PR DESCRIPTION
The generated https://hexdocs.pm/elixir/docs_config.js is missing all tags.

I haven't tested this fix but seems like this could be the issue: https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches