### PR TITLE
Support parent relative paths in Path.relative_to

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -333,6 +333,7 @@ defmodule Path do
       Path.relative_to("/usr/local/foo", "/usr/local/foo")  #=> "."
       Path.relative_to("/usr/local/../foo", "/usr/foo")     #=> "."
       Path.relative_to("/usr/local/../foo/bar", "/usr/foo") #=> "bar"
+
   If `:force` is set to `true` paths are traversed up:
 
       Path.relative_to("/usr", "/usr/local", force: true)          #=> ".."

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -333,7 +333,6 @@ defmodule Path do
       Path.relative_to("/usr/local/foo", "/usr/local/foo")  #=> "."
       Path.relative_to("/usr/local/../foo", "/usr/foo")     #=> "."
       Path.relative_to("/usr/local/../foo/bar", "/usr/foo") #=> "bar"
-  
   If `:force` is set to `true` paths are traversed up:
 
       Path.relative_to("/usr", "/usr/local", force: true)          #=> ".."

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -117,6 +117,7 @@ defmodule PathTest do
 
       # on different volumes with force: true it should return the original path
       assert Path.relative_to("d:/usr/local", "c:/usr/local", force: true) == "d:/usr/local"
+      assert Path.relative_to("d:/usr/local", "c:/another/local", force: true) == "d:/usr/local"
     end
 
     test "type/1" do

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -230,10 +230,11 @@ defmodule PathTest do
     assert Path.relative_to_cwd(Path.dirname(File.cwd!()), force: true) == ".."
 
     splitted_cwd = Path.split(File.cwd!())
+    [slash | _rest] = splitted_cwd
     relative_to_root = List.duplicate("..", length(splitted_cwd) - 1)
 
-    assert Path.relative_to_cwd("/") == "/"
-    assert Path.relative_to_cwd("/", force: true) == Path.join(relative_to_root)
+    assert Path.relative_to_cwd(slash) == slash
+    assert Path.relative_to_cwd(slash, force: true) == Path.join(relative_to_root)
   end
 
   test "absname/1,2" do

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -229,9 +229,8 @@ defmodule PathTest do
 
     assert Path.relative_to_cwd(Path.dirname(File.cwd!()), force: true) == ".."
 
-    splitted_cwd = Path.split(File.cwd!())
-    [slash | _rest] = splitted_cwd
-    relative_to_root = List.duplicate("..", length(splitted_cwd) - 1)
+    [slash | splitted_cwd] = Path.split(File.cwd!())
+    relative_to_root = List.duplicate("..", length(splitted_cwd))
 
     assert Path.relative_to_cwd(slash) == slash
     assert Path.relative_to_cwd(slash, force: true) == Path.join(relative_to_root)

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -87,25 +87,36 @@ defmodule PathTest do
       assert Path.relative("../usr/local/bin") == "../usr/local/bin"
     end
 
-    test "relative_to/2" do
-      assert Path.relative_to("//usr/local/foo", "//usr/") == "local/foo"
+    test "relative_to/3" do
+      # should give same relative paths for both force true and false
+      for force <- [true, false] do
+        assert Path.relative_to("//usr/local/foo", "//usr/", force: force) == "local/foo"
 
-      assert Path.relative_to("D:/usr/local/foo", "D:/usr/") == "local/foo"
-      assert Path.relative_to("D:/usr/local/foo", "d:/usr/") == "local/foo"
-      assert Path.relative_to("d:/usr/local/foo", "D:/usr/") == "local/foo"
-      assert Path.relative_to("D:/usr/local/foo", "d:/") == "usr/local/foo"
-      assert Path.relative_to("D:/usr/local/foo", "D:/") == "usr/local/foo"
+        assert Path.relative_to("D:/usr/local/foo", "D:/usr/", force: force) == "local/foo"
+        assert Path.relative_to("D:/usr/local/foo", "d:/usr/", force: force) == "local/foo"
+        assert Path.relative_to("d:/usr/local/foo", "D:/usr/", force: force) == "local/foo"
+        assert Path.relative_to("D:/usr/local/foo", "d:/", force: force) == "usr/local/foo"
+        assert Path.relative_to("D:/usr/local/foo", "D:/", force: force) == "usr/local/foo"
 
-      assert Path.relative_to("d:/usr/local/foo/..", "d:/usr/local") == "."
+        assert Path.relative_to("d:/usr/local/foo/..", "d:/usr/local", force: force) == "."
+        assert Path.relative_to("d:/usr/local/../foo", "d:/usr/foo", force: force) == "."
+        assert Path.relative_to("d:/usr/local/../foo/bar", "d:/usr/foo", force: force) == "bar"
+        assert Path.relative_to("d:/usr/local/../foo/./bar", "d:/usr/foo", force: force) == "bar"
+
+        assert Path.relative_to("d:/usr/local/../foo/bar/..", "d:/usr/foo", force: force) == "."
+        assert Path.relative_to("d:/usr/local/foo/..", "d:/usr/local/..", force: force) == "local"
+        assert Path.relative_to("d:/usr/local/foo/..", "d:/usr/local/.", force: force) == "."
+      end
+
+      # different results for force: true
       assert Path.relative_to("d:/usr/local/../foo", "d:/usr/local") == "d:/usr/foo"
-      assert Path.relative_to("d:/usr/local/../foo", "d:/usr/foo") == "."
-      assert Path.relative_to("d:/usr/local/../foo/bar", "d:/usr/foo") == "bar"
-      assert Path.relative_to("d:/usr/local/../foo/./bar", "d:/usr/foo") == "bar"
-      assert Path.relative_to("d:/usr/local/../foo/../bar", "d:/usr/foo") == "d:/usr/bar"
-      assert Path.relative_to("d:/usr/local/../foo/bar/..", "d:/usr/foo") == "."
+      assert Path.relative_to("d:/usr/local/../foo", "d:/usr/local", force: true) == "../foo"
 
-      assert Path.relative_to("d:/usr/local/foo/..", "d:/usr/local/..") == "local"
-      assert Path.relative_to("d:/usr/local/foo/..", "d:/usr/local/.") == "."
+      assert Path.relative_to("d:/usr/local/../foo/../bar", "d:/usr/foo") == "d:/usr/bar"
+      assert Path.relative_to("d:/usr/local/../foo/../bar", "d:/usr/foo", force: true) == "../bar"
+
+      # on different volumes with force: true it should return the original path
+      assert Path.relative_to("d:/usr/local", "c:/usr/local", force: true) == "d:/usr/local"
     end
 
     test "type/1" do
@@ -156,24 +167,43 @@ defmodule PathTest do
       assert Path.relative([~c"/usr", ?/, "local/bin"]) == "usr/local/bin"
     end
 
-    test "relative_to/2" do
-      assert Path.relative_to("/usr/local/foo", "/usr/local") == "foo"
-      assert Path.relative_to("/usr/local/foo", "/") == "usr/local/foo"
+    test "relative_to/3" do
+      # subpaths of cwd, should give the same result for both force true and false
+      for force <- [false, true] do
+        assert Path.relative_to("/usr/local/foo", "/usr/local", force: force) == "foo"
+        assert Path.relative_to("/usr/local/foo", "/", force: force) == "usr/local/foo"
+        assert Path.relative_to("/usr/local/foo", "/usr/local/foo", force: force) == "."
+        assert Path.relative_to("/usr/local/foo/", "/usr/local/foo", force: force) == "."
+        assert Path.relative_to("/usr/local/foo", "/usr/local/foo/", force: force) == "."
+
+        assert Path.relative_to("/usr/local/foo/..", "/usr/local", force: force) == "."
+        assert Path.relative_to("/usr/local/../foo", "/usr/foo", force: force) == "."
+        assert Path.relative_to("/usr/local/../foo/bar", "/usr/foo", force: force) == "bar"
+        assert Path.relative_to("/usr/local/../foo/./bar", "/usr/foo", force: force) == "bar"
+        assert Path.relative_to("/usr/local/../foo/bar/..", "/usr/foo", force: force) == "."
+
+        assert Path.relative_to("/usr/local/foo/..", "/usr/local/..", force: force) == "local"
+        assert Path.relative_to("/usr/local/foo/..", "/usr/local/.", force: force) == "."
+      end
+
+      # Different relative paths for foce true/false
       assert Path.relative_to("/usr/local/foo", "/etc") == "/usr/local/foo"
-      assert Path.relative_to("/usr/local/foo", "/usr/local/foo") == "."
-      assert Path.relative_to("/usr/local/foo/", "/usr/local/foo") == "."
-      assert Path.relative_to("/usr/local/foo", "/usr/local/foo/") == "."
+      assert Path.relative_to("/usr/local/foo", "/etc", force: true) == "../usr/local/foo"
 
-      assert Path.relative_to("/usr/local/foo/..", "/usr/local") == "."
       assert Path.relative_to("/usr/local/../foo", "/usr/local") == "/usr/foo"
-      assert Path.relative_to("/usr/local/../foo", "/usr/foo") == "."
-      assert Path.relative_to("/usr/local/../foo/bar", "/usr/foo") == "bar"
-      assert Path.relative_to("/usr/local/../foo/./bar", "/usr/foo") == "bar"
-      assert Path.relative_to("/usr/local/../foo/../bar", "/usr/foo") == "/usr/bar"
-      assert Path.relative_to("/usr/local/../foo/bar/..", "/usr/foo") == "."
+      assert Path.relative_to("/usr/local/../foo", "/usr/local", force: true) == "../foo"
 
-      assert Path.relative_to("/usr/local/foo/..", "/usr/local/..") == "local"
-      assert Path.relative_to("/usr/local/foo/..", "/usr/local/.") == "."
+      assert Path.relative_to("/usr/local/../foo/../bar", "/usr/foo") == "/usr/bar"
+      assert Path.relative_to("/usr/local/../foo/../bar", "/usr/foo", force: true) == "../bar"
+
+      # More tests with force: true
+      assert Path.relative_to("/etc", "/usr/local/foo", force: true) == "../../../etc"
+      assert Path.relative_to(~c"/usr/local/foo", "/etc", force: true) == "../usr/local/foo"
+      assert Path.relative_to("/usr/local", "/usr/local/foo", force: true) == ".."
+      assert Path.relative_to("/usr/local/..", "/usr/local", force: true) == ".."
+
+      assert Path.relative_to("/usr/../etc/foo/../../bar", "/log/foo/../../usr/", force: true) ==
+               "../bar"
     end
 
     test "type/1" do
@@ -191,11 +221,19 @@ defmodule PathTest do
     end
   end
 
-  test "relative_to_cwd/1" do
+  test "relative_to_cwd/2" do
     assert Path.relative_to_cwd(__ENV__.file) == Path.relative_to(__ENV__.file, File.cwd!())
 
     assert Path.relative_to_cwd(to_charlist(__ENV__.file)) ==
              Path.relative_to(to_charlist(__ENV__.file), to_charlist(File.cwd!()))
+
+    assert Path.relative_to_cwd(Path.dirname(File.cwd!()), force: true) == ".."
+
+    splitted_cwd = Path.split(File.cwd!())
+    relative_to_root = List.duplicate("..", length(splitted_cwd) - 1)
+
+    assert Path.relative_to_cwd("/") == "/"
+    assert Path.relative_to_cwd("/", force: true) == Path.join(relative_to_root)
   end
 
   test "absname/1,2" do
@@ -261,7 +299,7 @@ defmodule PathTest do
     assert Path.expand("bar/../bar", "foo") == Path.expand("foo/bar")
   end
 
-  test "relative_to/2 (with relative paths)" do
+  test "relative_to/3 (with relative paths)" do
     assert Path.relative_to("foo", File.cwd!()) == "foo"
     assert Path.relative_to("./foo", File.cwd!()) == "foo"
     assert Path.relative_to("./foo/.", File.cwd!()) == "foo"

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -154,7 +154,7 @@ defimpl IEx.Info, for: Atom do
   end
 
   defp module_source_file(mod_info) do
-    default_or_apply(mod_info[:compile][:source], &Path.relative_to_cwd/1)
+    default_or_apply(mod_info[:compile][:source], &Path.relative_to_cwd(&1, []))
   end
 
   defp module_compile_options(mod_info) do

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -154,7 +154,7 @@ defimpl IEx.Info, for: Atom do
   end
 
   defp module_source_file(mod_info) do
-    default_or_apply(mod_info[:compile][:source], &Path.relative_to_cwd(&1, []))
+    default_or_apply(mod_info[:compile][:source], &Path.relative_to_cwd/1)
   end
 
   defp module_compile_options(mod_info) do

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -476,7 +476,9 @@ defmodule Mix.Utils do
       link =
         case :os.type() do
           {:win32, _} -> source
-          _ -> make_relative_path(source, target)
+          # We are needing the relative path to the parent dir since we are doing
+          # a symlink
+          _ -> Path.relative_to(source, Path.dirname(target), force: true)
         end
 
       case File.read_link(target) do
@@ -538,21 +540,6 @@ defmodule Mix.Utils do
 
         {:ok, files}
     end
-  end
-
-  # Make a relative path between the two given paths.
-  # Expects both paths to be fully expanded.
-  defp make_relative_path(source, target) do
-    do_make_relative_path(Path.split(source), Path.split(target))
-  end
-
-  defp do_make_relative_path([h | t1], [h | t2]) do
-    do_make_relative_path(t1, t2)
-  end
-
-  defp do_make_relative_path(source, target) do
-    base = List.duplicate("..", max(length(target) - 1, 0))
-    Path.join(base ++ source)
   end
 
   @doc """


### PR DESCRIPTION
Adds a `:force` option in `Path.relative_to` and `Path.relative_to_cwd` which allows up traversals.


## Initial PR body

`Path.relative_to` does not return proper relative paths in some cases. Some examples follow (also check the added tests):

```elixir
# If two relative paths are given where from is a subfolder of path
# it returns the path unchanged 
iex> Path.relative_to("foo", "foo/bar")
"foo" # wrong, implies ./foo/bar/foo - should be ../foo

# Paths are not properly expanded, all following should return "usr"
iex> Path.relative_to("/usr/../usr", "/")
"usr/../usr"

iex> Path.relative_to("/usr", "/etc/..")
"/usr"

iex> Path.relative_to("/./etc/../usr", "/")
"./etc/../usr"

# Relative paths to parent folders are never returned
iex> Path.relative_to("/usr/foo/tmp", "/usr/foo/bar/buzz")
"/usr/foo/tmp" # Should be ../../tmp
```

By expanding first the two paths we can easily calculate the number of "cd ups" and construct a relative path. The only case for which an absolute path should be returned is when it is not possible to `mv` from `from` to `path`. I think this can only happen in Windows when the two paths are in different drives, but I don't have access to a Windows machine to properly test it.

I found a similar implementation in `Mix.Utils` which I replaced with a call to `Path.relative_to` in a separate commit.~~