### PR TITLE
Fix typo in Kernel/Structural-comparison docs

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -172,7 +172,7 @@ defmodule Kernel do
 
   ## Structural comparison
 
-  The function in this module perform structural comparison. This allows
+  The functions in this module perform structural comparison. This allows
   different data types to be compared using comparison operators:
 
   ```elixir


### PR DESCRIPTION
Add a missing `s` at the end of the word `functions`, in the documentation section on structural comparison.

The sentence becomes:
```
The functions in this module perform structural comparison.
```