### PR TITLE
Expand dots in relative_to and deprecate relative cwd

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -321,40 +321,20 @@ defmodule Path do
 
   With absolute paths:
 
-      iex> Path.relative_to("/usr/local/foo", "/usr/local")
-      "foo"
-
-      iex> Path.relative_to("/usr/local/foo", "/")
-      "usr/local/foo"
-
-      iex> Path.relative_to("/usr/local/foo", "/etc")
-      "/usr/local/foo"
-
-      iex> Path.relative_to("/usr/local/foo", "/usr/local/foo")
-      "."
-
-      iex> Path.relative_to("/usr/local/../foo", "/usr/foo")
-      "."
-
-      iex> Path.relative_to("/usr/local/../foo/bar", "/usr/foo")
-      "bar"
+      Path.relative_to("/usr/local/foo", "/usr/local")      #=> "foo"
+      Path.relative_to("/usr/local/foo", "/")               #=> "usr/local/foo"
+      Path.relative_to("/usr/local/foo", "/etc")            #=> "/usr/local/foo"
+      Path.relative_to("/usr/local/foo", "/usr/local/foo")  #=> "."
+      Path.relative_to("/usr/local/../foo", "/usr/foo")     #=> "."
+      Path.relative_to("/usr/local/../foo/bar", "/usr/foo") #=> "bar"
 
   Relative paths have "." and ".." expanded but kept as relative:
 
-      iex> Path.relative_to(".", "/usr/local")
-      "."
-
-      iex> Path.relative_to("foo", "/usr/local")
-      "foo"
-
-      iex> Path.relative_to("foo/../bar", "/usr/local")
-      "bar"
-
-      iex> Path.relative_to("foo/..", "/usr/local")
-      "."
-
-      iex> Path.relative_to("../foo", "/usr/local")
-      "../foo"
+      Path.relative_to(".", "/usr/local")          #=> "."
+      Path.relative_to("foo", "/usr/local")        #=> "foo"
+      Path.relative_to("foo/../bar", "/usr/local") #=> "bar"
+      Path.relative_to("foo/..", "/usr/local")     #=> "."
+      Path.relative_to("../foo", "/usr/local")     #=> "../foo"
 
   """
   @spec relative_to(t, t) :: binary

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -242,6 +242,12 @@ defmodule Path do
       Path.relative("/bar/foo.ex")      #=> "bar/foo.ex"
 
   """
+  # Note this function does not expand paths because the behaviour
+  # is ambiguous. If we expand it before converting to relative, then
+  # "/usr/../../foo" means "/foo". If we expand it after, it means "../foo".
+  # We could expand only relative paths but it is best to say it never
+  # expands and then provide a `Path.expand_relative` function (or an
+  # option) if desired.
   @spec relative(t) :: binary
   def relative(name) do
     relative(name, major_os_type())
@@ -361,7 +367,10 @@ defmodule Path do
       # cwd must be an absolute path, if not, compute common path for backwards compatibility
       # TODO: Raise on Elixir v2.0
       not split_absolute?(split_cwd, os_type) ->
-        IO.warn("the second argument to Path.relative_to/2 must be an absolute path, got: #{inspect(cwd)}")
+        IO.warn(
+          "the second argument to Path.relative_to/2 must be an absolute path, got: #{inspect(cwd)}"
+        )
+
         relative_to(split_path, split_cwd, split_path)
 
       # If source is a relative path, expand ./.. as much as possible and return it

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -57,6 +57,26 @@ defmodule PathTest do
     assert_raise ArgumentError, ~r/null byte/, fn -> Path.wildcard("foo\0bar") end
   end
 
+  test "relative_to/2 (with relative paths)" do
+    assert Path.relative_to("foo", "/") == "foo"
+    assert Path.relative_to("./foo", "/") == "foo"
+    assert Path.relative_to("./foo/.", "/") == "foo"
+    assert Path.relative_to("./foo/./bar/.", "/") == "foo/bar"
+    assert Path.relative_to("../foo/./bar/.", "/") == "../foo/bar"
+    assert Path.relative_to("../foo/./bar/..", "/") == "../foo"
+    assert Path.relative_to("../foo/../bar/..", "/") == ".."
+    assert Path.relative_to("./foo/../bar/..", "/") == "."
+
+    ExUnit.CaptureIO.capture_io(:stderr, fn ->
+      assert Path.relative_to("usr/local/foo", "usr/local") == "foo"
+      assert Path.relative_to("usr/local/foo", "etc") == "usr/local/foo"
+      assert Path.relative_to(~c"usr/local/foo", "etc") == "usr/local/foo"
+
+      assert Path.relative_to("usr/local/foo", "usr/local") == "foo"
+      assert Path.relative_to(["usr", ?/, ~c"local/foo"], ~c"usr/local") == "foo"
+    end)
+  end
+
   describe "Windows" do
     @describetag :windows
 
@@ -93,8 +113,19 @@ defmodule PathTest do
       assert Path.relative_to("d:/usr/local/foo", "D:/usr/") == "local/foo"
       assert Path.relative_to("D:/usr/local/foo", "d:/") == "usr/local/foo"
       assert Path.relative_to("D:/usr/local/foo", "D:/") == "usr/local/foo"
-      assert Path.relative_to("D:/usr/local/foo", "d:") == "D:/usr/local/foo"
-      assert Path.relative_to("D:/usr/local/foo", "D:") == "D:/usr/local/foo"
+      assert Path.relative_to("D:/usr/local/foo", "d:") == "d:/usr/local/foo"
+      assert Path.relative_to("D:/usr/local/foo", "D:") == "d:/usr/local/foo"
+
+      assert Path.relative_to("d:/usr/local/foo/..", "d:/usr/local") == "."
+      assert Path.relative_to("d:/usr/local/../foo", "d:/usr/local") == "/usr/foo"
+      assert Path.relative_to("d:/usr/local/../foo", "d:/usr/foo") == "."
+      assert Path.relative_to("d:/usr/local/../foo/bar", "d:/usr/foo") == "bar"
+      assert Path.relative_to("d:/usr/local/../foo/./bar", "d:/usr/foo") == "bar"
+      assert Path.relative_to("d:/usr/local/../foo/../bar", "d:/usr/foo") == "/usr/bar"
+      assert Path.relative_to("d:/usr/local/../foo/bar/..", "d:/usr/foo") == "."
+
+      assert Path.relative_to("d:/usr/local/foo/..", "d:/usr/local/..") == "local"
+      assert Path.relative_to("d:/usr/local/foo/..", "d:/usr/local/.") == "."
     end
 
     test "type/1" do
@@ -143,6 +174,26 @@ defmodule PathTest do
       assert Path.relative("/") == "."
       assert Path.relative(~c"/") == "."
       assert Path.relative([~c"/usr", ?/, "local/bin"]) == "usr/local/bin"
+    end
+
+    test "relative_to/2" do
+      assert Path.relative_to("/usr/local/foo", "/usr/local") == "foo"
+      assert Path.relative_to("/usr/local/foo", "/") == "usr/local/foo"
+      assert Path.relative_to("/usr/local/foo", "/etc") == "/usr/local/foo"
+      assert Path.relative_to("/usr/local/foo", "/usr/local/foo") == "."
+      assert Path.relative_to("/usr/local/foo/", "/usr/local/foo") == "."
+      assert Path.relative_to("/usr/local/foo", "/usr/local/foo/") == "."
+
+      assert Path.relative_to("/usr/local/foo/..", "/usr/local") == "."
+      assert Path.relative_to("/usr/local/../foo", "/usr/local") == "/usr/foo"
+      assert Path.relative_to("/usr/local/../foo", "/usr/foo") == "."
+      assert Path.relative_to("/usr/local/../foo/bar", "/usr/foo") == "bar"
+      assert Path.relative_to("/usr/local/../foo/./bar", "/usr/foo") == "bar"
+      assert Path.relative_to("/usr/local/../foo/../bar", "/usr/foo") == "/usr/bar"
+      assert Path.relative_to("/usr/local/../foo/bar/..", "/usr/foo") == "."
+
+      assert Path.relative_to("/usr/local/foo/..", "/usr/local/..") == "local"
+      assert Path.relative_to("/usr/local/foo/..", "/usr/local/.") == "."
     end
 
     test "type/1" do
@@ -230,25 +281,7 @@ defmodule PathTest do
     assert Path.expand("bar/../bar", "foo") == Path.expand("foo/bar")
   end
 
-  test "relative_to/2" do
-    assert Path.relative_to("/usr/local/foo", "/usr/local") == "foo"
-    assert Path.relative_to("/usr/local/foo", "/") == "usr/local/foo"
-    assert Path.relative_to("/usr/local/foo", "/etc") == "/usr/local/foo"
-    assert Path.relative_to("/usr/local/foo", "/usr/local/foo") == "."
-    assert Path.relative_to("/usr/local/foo/", "/usr/local/foo") == "."
-    assert Path.relative_to("/usr/local/foo", "/usr/local/foo/") == "."
-
-    assert Path.relative_to("/usr/local/foo/..", "/usr/local") == "."
-    assert Path.relative_to("/usr/local/../foo", "/usr/local") == "/usr/foo"
-    assert Path.relative_to("/usr/local/../foo", "/usr/foo") == "."
-    assert Path.relative_to("/usr/local/../foo/bar", "/usr/foo") == "bar"
-    assert Path.relative_to("/usr/local/../foo/./bar", "/usr/foo") == "bar"
-    assert Path.relative_to("/usr/local/../foo/../bar", "/usr/foo") == "/usr/bar"
-    assert Path.relative_to("/usr/local/../foo/bar/..", "/usr/foo") == "."
-
-    assert Path.relative_to("/usr/local/foo/..", "/usr/local/..") == "local"
-    assert Path.relative_to("/usr/local/foo/..", "/usr/local/.") == "."
-
+  test "relative_to/2 (with relative paths)" do
     assert Path.relative_to("foo", "/") == "foo"
     assert Path.relative_to("./foo", "/") == "foo"
     assert Path.relative_to("./foo/.", "/") == "foo"

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -262,14 +262,14 @@ defmodule PathTest do
   end
 
   test "relative_to/2 (with relative paths)" do
-    assert Path.relative_to("foo", File.cwd!) == "foo"
-    assert Path.relative_to("./foo", File.cwd!) == "foo"
-    assert Path.relative_to("./foo/.", File.cwd!) == "foo"
-    assert Path.relative_to("./foo/./bar/.", File.cwd!) == "foo/bar"
-    assert Path.relative_to("../foo/./bar/.", File.cwd!) == "../foo/bar"
-    assert Path.relative_to("../foo/./bar/..", File.cwd!) == "../foo"
-    assert Path.relative_to("../foo/../bar/..", File.cwd!) == ".."
-    assert Path.relative_to("./foo/../bar/..", File.cwd!) == "."
+    assert Path.relative_to("foo", File.cwd!()) == "foo"
+    assert Path.relative_to("./foo", File.cwd!()) == "foo"
+    assert Path.relative_to("./foo/.", File.cwd!()) == "foo"
+    assert Path.relative_to("./foo/./bar/.", File.cwd!()) == "foo/bar"
+    assert Path.relative_to("../foo/./bar/.", File.cwd!()) == "../foo/bar"
+    assert Path.relative_to("../foo/./bar/..", File.cwd!()) == "../foo"
+    assert Path.relative_to("../foo/../bar/..", File.cwd!()) == ".."
+    assert Path.relative_to("./foo/../bar/..", File.cwd!()) == "."
 
     ExUnit.CaptureIO.capture_io(:stderr, fn ->
       assert Path.relative_to("usr/local/foo", "usr/local") == "foo"

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -238,12 +238,34 @@ defmodule PathTest do
     assert Path.relative_to("/usr/local/foo/", "/usr/local/foo") == "."
     assert Path.relative_to("/usr/local/foo", "/usr/local/foo/") == "."
 
-    assert Path.relative_to("usr/local/foo", "usr/local") == "foo"
-    assert Path.relative_to("usr/local/foo", "etc") == "usr/local/foo"
-    assert Path.relative_to(~c"usr/local/foo", "etc") == "usr/local/foo"
+    assert Path.relative_to("/usr/local/foo/..", "/usr/local") == "."
+    assert Path.relative_to("/usr/local/../foo", "/usr/local") == "/usr/foo"
+    assert Path.relative_to("/usr/local/../foo", "/usr/foo") == "."
+    assert Path.relative_to("/usr/local/../foo/bar", "/usr/foo") == "bar"
+    assert Path.relative_to("/usr/local/../foo/./bar", "/usr/foo") == "bar"
+    assert Path.relative_to("/usr/local/../foo/../bar", "/usr/foo") == "/usr/bar"
+    assert Path.relative_to("/usr/local/../foo/bar/..", "/usr/foo") == "."
 
-    assert Path.relative_to("usr/local/foo", "usr/local") == "foo"
-    assert Path.relative_to(["usr", ?/, ~c"local/foo"], ~c"usr/local") == "foo"
+    assert Path.relative_to("/usr/local/foo/..", "/usr/local/..") == "local"
+    assert Path.relative_to("/usr/local/foo/..", "/usr/local/.") == "."
+
+    assert Path.relative_to("foo", "/") == "foo"
+    assert Path.relative_to("./foo", "/") == "foo"
+    assert Path.relative_to("./foo/.", "/") == "foo"
+    assert Path.relative_to("./foo/./bar/.", "/") == "foo/bar"
+    assert Path.relative_to("../foo/./bar/.", "/") == "../foo/bar"
+    assert Path.relative_to("../foo/./bar/..", "/") == "../foo"
+    assert Path.relative_to("../foo/../bar/..", "/") == ".."
+    assert Path.relative_to("./foo/../bar/..", "/") == "."
+
+    ExUnit.CaptureIO.capture_io(:stderr, fn ->
+      assert Path.relative_to("usr/local/foo", "usr/local") == "foo"
+      assert Path.relative_to("usr/local/foo", "etc") == "usr/local/foo"
+      assert Path.relative_to(~c"usr/local/foo", "etc") == "usr/local/foo"
+
+      assert Path.relative_to("usr/local/foo", "usr/local") == "foo"
+      assert Path.relative_to(["usr", ?/, ~c"local/foo"], ~c"usr/local") == "foo"
+    end)
   end
 
   test "safe_relative/1" do

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -95,15 +95,13 @@ defmodule PathTest do
       assert Path.relative_to("d:/usr/local/foo", "D:/usr/") == "local/foo"
       assert Path.relative_to("D:/usr/local/foo", "d:/") == "usr/local/foo"
       assert Path.relative_to("D:/usr/local/foo", "D:/") == "usr/local/foo"
-      assert Path.relative_to("D:/usr/local/foo", "d:") == "d:/usr/local/foo"
-      assert Path.relative_to("D:/usr/local/foo", "D:") == "d:/usr/local/foo"
 
       assert Path.relative_to("d:/usr/local/foo/..", "d:/usr/local") == "."
-      assert Path.relative_to("d:/usr/local/../foo", "d:/usr/local") == "/usr/foo"
+      assert Path.relative_to("d:/usr/local/../foo", "d:/usr/local") == "d:/usr/foo"
       assert Path.relative_to("d:/usr/local/../foo", "d:/usr/foo") == "."
       assert Path.relative_to("d:/usr/local/../foo/bar", "d:/usr/foo") == "bar"
       assert Path.relative_to("d:/usr/local/../foo/./bar", "d:/usr/foo") == "bar"
-      assert Path.relative_to("d:/usr/local/../foo/../bar", "d:/usr/foo") == "/usr/bar"
+      assert Path.relative_to("d:/usr/local/../foo/../bar", "d:/usr/foo") == "d:/usr/bar"
       assert Path.relative_to("d:/usr/local/../foo/bar/..", "d:/usr/foo") == "."
 
       assert Path.relative_to("d:/usr/local/foo/..", "d:/usr/local/..") == "local"
@@ -264,14 +262,14 @@ defmodule PathTest do
   end
 
   test "relative_to/2 (with relative paths)" do
-    assert Path.relative_to("foo", "/") == "foo"
-    assert Path.relative_to("./foo", "/") == "foo"
-    assert Path.relative_to("./foo/.", "/") == "foo"
-    assert Path.relative_to("./foo/./bar/.", "/") == "foo/bar"
-    assert Path.relative_to("../foo/./bar/.", "/") == "../foo/bar"
-    assert Path.relative_to("../foo/./bar/..", "/") == "../foo"
-    assert Path.relative_to("../foo/../bar/..", "/") == ".."
-    assert Path.relative_to("./foo/../bar/..", "/") == "."
+    assert Path.relative_to("foo", File.cwd!) == "foo"
+    assert Path.relative_to("./foo", File.cwd!) == "foo"
+    assert Path.relative_to("./foo/.", File.cwd!) == "foo"
+    assert Path.relative_to("./foo/./bar/.", File.cwd!) == "foo/bar"
+    assert Path.relative_to("../foo/./bar/.", File.cwd!) == "../foo/bar"
+    assert Path.relative_to("../foo/./bar/..", File.cwd!) == "../foo"
+    assert Path.relative_to("../foo/../bar/..", File.cwd!) == ".."
+    assert Path.relative_to("./foo/../bar/..", File.cwd!) == "."
 
     ExUnit.CaptureIO.capture_io(:stderr, fn ->
       assert Path.relative_to("usr/local/foo", "usr/local") == "foo"

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -57,26 +57,6 @@ defmodule PathTest do
     assert_raise ArgumentError, ~r/null byte/, fn -> Path.wildcard("foo\0bar") end
   end
 
-  test "relative_to/2 (with relative paths)" do
-    assert Path.relative_to("foo", "/") == "foo"
-    assert Path.relative_to("./foo", "/") == "foo"
-    assert Path.relative_to("./foo/.", "/") == "foo"
-    assert Path.relative_to("./foo/./bar/.", "/") == "foo/bar"
-    assert Path.relative_to("../foo/./bar/.", "/") == "../foo/bar"
-    assert Path.relative_to("../foo/./bar/..", "/") == "../foo"
-    assert Path.relative_to("../foo/../bar/..", "/") == ".."
-    assert Path.relative_to("./foo/../bar/..", "/") == "."
-
-    ExUnit.CaptureIO.capture_io(:stderr, fn ->
-      assert Path.relative_to("usr/local/foo", "usr/local") == "foo"
-      assert Path.relative_to("usr/local/foo", "etc") == "usr/local/foo"
-      assert Path.relative_to(~c"usr/local/foo", "etc") == "usr/local/foo"
-
-      assert Path.relative_to("usr/local/foo", "usr/local") == "foo"
-      assert Path.relative_to(["usr", ?/, ~c"local/foo"], ~c"usr/local") == "foo"
-    end)
-  end
-
   describe "Windows" do
     @describetag :windows
 
@@ -108,6 +88,8 @@ defmodule PathTest do
     end
 
     test "relative_to/2" do
+      assert Path.relative_to("//usr/local/foo", "//usr/") == "local/foo"
+
       assert Path.relative_to("D:/usr/local/foo", "D:/usr/") == "local/foo"
       assert Path.relative_to("D:/usr/local/foo", "d:/usr/") == "local/foo"
       assert Path.relative_to("d:/usr/local/foo", "D:/usr/") == "local/foo"

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1334,7 +1334,7 @@ defmodule IEx.HelpersTest do
                    Sample.run()
                  end
                end) =~
-                 "redefining module Sample (current version loaded from ./Elixir.Sample.beam)"
+                 "redefining module Sample (current version loaded from Elixir.Sample.beam)"
       end)
     after
       # Clean up old version produced by the r helper


### PR DESCRIPTION
The function already assumes there are no symlinks, so expanding dots does not add additional uncertainty.