### PR TITLE
Add column information in more errors/warnings 

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -788,7 +788,10 @@ defmodule Exception do
   end
 
   defp format_location(opts) when is_list(opts) do
-    format_file_line(Keyword.get(opts, :file), Keyword.get(opts, :line), " ")
+    case opts[:column] do
+      nil -> format_file_line(Keyword.get(opts, :file), Keyword.get(opts, :line), " ")
+      col -> format_file_line_column(Keyword.get(opts, :file), Keyword.get(opts, :line), col, " ")
+    end
   end
 end
 

--- a/lib/elixir/lib/module/locals_tracker.ex
+++ b/lib/elixir/lib/module/locals_tracker.ex
@@ -33,7 +33,7 @@ defmodule Module.LocalsTracker do
   """
   def add_local({_set, bag}, from, to, meta, macro_dispatch?)
       when is_tuple(from) and is_tuple(to) and is_boolean(macro_dispatch?) do
-    put_edge(bag, {:local, from}, {to, get_line(meta), macro_dispatch?})
+    put_edge(bag, {:local, from}, {to, meta, macro_dispatch?})
     :ok
   end
 
@@ -221,7 +221,7 @@ defmodule Module.LocalsTracker do
   defp build_meta(line, meta) do
     case Keyword.get(meta, :file) do
       {file, _} -> [keep: {file, line}]
-      _ -> [line: line]
+      _ -> line
     end
   end
 

--- a/lib/elixir/lib/module/locals_tracker.ex
+++ b/lib/elixir/lib/module/locals_tracker.ex
@@ -217,11 +217,11 @@ defmodule Module.LocalsTracker do
 
   # We need to transform any file annotation in the function
   # definition into a keep annotation that is used by the
-  # error handling system in order to respect line/file.
-  defp build_meta(line, meta) do
+  # error handling system in order to respect position/file.
+  defp build_meta(pos, meta) do
     case Keyword.get(meta, :file) do
-      {file, _} -> [keep: {file, line}]
-      _ -> line
+      {file, _} -> [keep: {file, pos}]
+      _ -> pos
     end
   end
 

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -323,7 +323,7 @@ defmodule Module.Types.Of do
 
   defp warn(meta, context, warning) do
     {fun, arity} = context.function
-    location = {context.file, meta[:line] || 0, {context.module, fun, arity}}
+    location = {context.file, meta, {context.module, fun, arity}}
     %{context | warnings: [{__MODULE__, warning, location} | context.warnings]}
   end
 

--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -517,9 +517,9 @@ keep(Meta, #elixir_quote{file=nil, line=Line}) ->
 keep(Meta, #elixir_quote{file=File}) ->
   case lists:keytake(line, 1, Meta) of
     {value, {line, Line}, MetaNoLine} ->
-      [{keep, {File, Line}} | MetaNoLine];
+      [{keep, {File, [{line, Line}]}} | MetaNoLine];
     false ->
-      [{keep, {File, 0}} | Meta]
+      [{keep, {File, [{line, 0}]}} | Meta]
   end.
 
 line(Meta, true) ->

--- a/lib/elixir/src/elixir_utils.erl
+++ b/lib/elixir/src/elixir_utils.erl
@@ -172,11 +172,11 @@ generated(Meta) -> [{generated, true} | Meta].
 %% Macros add a file pair on location keep which we
 %% should take into account for error reporting.
 %%
-%% Returns {binary, integer} on location keep or nil.
+%% Returns {binary, list} on location keep or nil.
 
 meta_keep(Meta) ->
   case lists:keyfind(keep, 1, Meta) of
-    {keep, {File, Line} = Pair} when is_binary(File), is_integer(Line) ->
+    {keep, {File, Position} = Pair} when is_binary(File), is_list(Position) ->
       Pair;
     _ ->
       nil

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -21,7 +21,7 @@ defmodule Kernel.QuoteTest do
     line = __ENV__.line + 2
 
     assert quote(location: :keep, do: bar(1, 2, 3)) ==
-             {:bar, [keep: {__ENV__.file, line}], [1, 2, 3]}
+             {:bar, [keep: {__ENV__.file, [line: line]}], [1, 2, 3]}
   end
 
   test "fixed line" do


### PR DESCRIPTION
This pull request updates the compiler to pass the column information along in some cases rather than discarding it, allowing the diagnostics function to have access to this information.

I'm currently not sure if this is the most correct way of doing that and I also believe this pull request can be broken into smaller ones, while updating the unknown remote function call warning to include column information I think I've done some other changes that are relevant to the columns problem but not for this specific case. 

Currently there is only one test failing, which I couldn't figure out why it is failing yet.
```ex
  1) test inside function error (Kernel.QuoteTest.ErrorsTest)
     test/elixir/kernel/quote_test.exs:362
     match (=) failed
     The following variables were pinned:
       mod = Kernel.QuoteTest.ErrorsTest
       file = ~c"test/elixir/kernel/quote_test.exs"
     code:  assert [{^mod, :will_raise, 2, [file: ^file, line: @line] ++ _} | _] = __STACKTRACE__
     left:  [{^mod, :will_raise, 2, [file: ^file, line: 345] ++ _} | _]
     right: [
              {Kernel.QuoteTest.ErrorsTest, :will_raise, 2, [error_info: %{module: Exception}]},
              {Kernel.QuoteTest.ErrorsTest, :"test inside function error", 1, [file: ~c"test/elixir/kernel/quote_test.exs", line: 364]},
              {ExUnit.Runner, :exec_test, 2, [file: ~c"lib/ex_unit/runner.ex", line: 462]},
              {:timer, :tc, 1, [file: ~c"timer.erl", line: 235]},
              {ExUnit.Runner, :"-spawn_test_monitor/4-fun-1-", 5, [file: ~c"lib/ex_unit/runner.ex", line: 384]}
            ]
     stacktrace:
       test/elixir/kernel/quote_test.exs:369: (test)
```

I would like some reviews/feedback about these changes.

Small PR showcase:

Given this snippet:
 ```ex
 sample =  """
defmodule Foo do 
  def perform do 
    Foo.foo()
  end
end
"""

ast = Code.string_to_quoted!(sample, columns: true)
Code.eval_quoted(ast, [])
```

The current main branch compiler will output the following:
```sh
$ elixir test.exs
warning: Foo.foo/0 is undefined or private
  nofile:3: Foo.perform/0
```

With these changes, this is the new output:
```sh
$ elixir test.exs
warning: Foo.foo/0 is undefined or private
  nofile:3:8: Foo.perform/0
```

With this visualization, it does not seem to have that much of a difference, but having the majority of errors supporting column information would allow us to provide friendlier error messages in the future (showing the line content, arrows pointing exactly at which token the error occured, etc...)