### PR TITLE
Add wildcard ("*") support in version requirements

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -532,6 +532,10 @@ defmodule Version do
       lexer(rest, "", maybe_prepend_buffer(buffer, acc))
     end
 
+    defp lexer("*", "", []) do
+      ["0.0.0", :>=]
+    end
+
     defp lexer(<<char::utf8, rest::binary>>, buffer, acc) do
       lexer(rest, <<buffer::binary, char::utf8>>, acc)
     end
@@ -574,7 +578,9 @@ defmodule Version do
 
     @spec parse_requirement(String.t()) :: {:ok, term} | :error
     def parse_requirement(source) do
-      revert_lexed(lexer(source), [])
+      source
+      |> lexer()
+      |> revert_lexed([])
     end
 
     def parse_version(string, approximate? \\ false) when is_binary(string) do

--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -329,10 +329,22 @@ defmodule VersionTest do
     assert Version.match?("1.2.3", req)
     refute Version.match?("1.2.4", req)
 
+    {:ok, wildcard} = Version.parse_requirement("*")
+    wildcard = Version.compile_requirement(wildcard)
+
+    assert Version.match?("0.0.0", wildcard)
+    assert Version.match?("1.2.4", wildcard)
+    assert Version.match?("2.1.2", wildcard)
+
     assert Version.parse_requirement("1 . 2 . 3") == :error
     assert Version.parse_requirement("== >= 1.2.3") == :error
     assert Version.parse_requirement("1.2.3 and or 4.5.6") == :error
     assert Version.parse_requirement(">= 1") == :error
     assert Version.parse_requirement("1.2.3 >=") == :error
+
+    assert Version.parse_requirement("1.*") == :error
+    assert Version.parse_requirement(">= *") == :error
+    assert Version.parse_requirement("* *") == :error
+    assert Version.parse_requirement("**") == :error
   end
 end


### PR DESCRIPTION
This adds a special version requirement, inspired by Cargo: `"*"`. It means "any version".

Usually, when we want such behaviour in Elixir, we write `">= 0.0.0"`, but this is not very
ergonomic.

The current implementation is a bit of a hack (it probably shouldn't be done at lexer level),
but I want to validate the idea.
