### PR TITLE
Support :codeberg mix deps

### DIFF
--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -40,20 +40,23 @@ defmodule Mix.SCM.Git do
       |> Keyword.put(:checkout, opts[:dest])
       |> sparse_opts()
       |> subdir_opts()
+      |> replace_hosting_service_shortcut(:github, &"https://github.com/#{&1}.git")
+      |> replace_hosting_service_shortcut(:codeberg, &"https://codeberg.org/#{&1}.git")
 
-    cond do
-      gh = opts[:github] ->
-        opts
-        |> Keyword.delete(:github)
-        |> Keyword.put(:git, "https://github.com/#{gh}.git")
-        |> validate_git_options()
+    if opts[:git] do
+      validate_git_options(opts)
+    else
+      nil
+    end
+  end
 
-      opts[:git] ->
-        opts
-        |> validate_git_options()
-
-      true ->
-        nil
+  defp replace_hosting_service_shortcut(opts, service, url_fun) do
+    if repo = opts[service] do
+      opts
+      |> Keyword.delete(service)
+      |> Keyword.put(:git, url_fun.(repo))
+    else
+      opts
     end
   end
 

--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -60,6 +60,16 @@ defmodule Mix.SCM.GitTest do
     end
   end
 
+  test "replaces public hosting service shortcuts" do
+    assert opts = Mix.SCM.Git.accepts_options(nil, github: "foo/bar")
+    assert {:git, "https://github.com/foo/bar.git"} in opts
+    refute Keyword.has_key?(opts, :github)
+
+    assert opts = Mix.SCM.Git.accepts_options(nil, codeberg: "foo/bar")
+    assert {:git, "https://codeberg.org/foo/bar.git"} in opts
+    refute Keyword.has_key?(opts, :codeberg)
+  end
+
   defp lock(opts \\ []) do
     [lock: {:git, "/repo", "abcdef0123456789", opts}]
   end


### PR DESCRIPTION
Hi :wave: 

This PR adds support for `codeberg: "owner/repo"`-style dependencies to mix, analogous to `:github`.

Disclaimer: I'm not in any way associated with [Codeberg](https://codeberg.org) and there aren't any noteworthy Elixir libraries hosted there yet, at least none that I know of. But I love their transparency and openness and I consider moving my public repositories there and they absolutely deserve the OSS community's support.

cheers,
malte