### PR TITLE
mark test cases as invalid when an exit occurs during setup_all

### DIFF
--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -293,8 +293,9 @@ defmodule ExUnit.Runner do
           {test_module, invalid_tests, []}
 
         {:DOWN, ^module_ref, :process, ^module_pid, error} ->
+          invalid_tests = Enum.map(tests, &%{&1 | state: {:invalid, test_module}})
           test_module = %{test_module | state: failed({:EXIT, module_pid}, error, [])}
-          {test_module, [], []}
+          {test_module, invalid_tests, []}
       end
 
     timeout = get_timeout(config, %{})

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -124,6 +124,22 @@ defmodule ExUnit.CallbacksTest do
              "** (MatchError) no match of right hand side value: :error"
   end
 
+  test "doesn't choke on setup_all exits" do
+    defmodule SetupAllExitTest do
+      use ExUnit.Case
+
+      setup_all _ do
+        Process.exit(self(), :error)
+      end
+
+      test "ok" do
+        assert true
+      end
+    end
+
+    assert capture_io(fn -> ExUnit.run() end) =~ "1 test, 0 failures, 1 invalid"
+  end
+
   test "doesn't choke on dead supervisor" do
     defmodule StartSupervisedErrorTest do
       use ExUnit.Case


### PR DESCRIPTION
Closes #12650 