### PR TITLE
Bump Ubuntu version for builds.hex.pm.yml

### DIFF
--- a/.github/workflows/builds.hex.pm.yml
+++ b/.github/workflows/builds.hex.pm.yml
@@ -30,7 +30,7 @@ jobs:
           - otp: 26
             otp_version: '26.0'
             build_docs: build_docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
We need newer OTP so that we get nsis 3.08 (not 3.06)
