### PR TITLE
Consider meta :file when fetching env location

### DIFF
--- a/lib/elixir/src/elixir_locals.erl
+++ b/lib/elixir/src/elixir_locals.erl
@@ -107,9 +107,16 @@ ensure_no_undefined_local(Module, All, E) ->
 warn_unused_local(Module, All, Private, E) ->
   if_tracker(Module, [], fun(Tracker) ->
     {Unreachable, Warnings} = ?tracker:collect_unused_locals(Tracker, All, Private),
-    [elixir_errors:file_warn(Meta, E, ?MODULE, Error) || {Meta, Error} <- Warnings],
+    [do_warn_unused_local(Meta, E, ?MODULE, Error) || {Meta, Error} <- Warnings],
     Unreachable
   end).
+
+do_warn_unused_local(Meta, E, ?MODULE, Error) ->
+  Env = case lists:keyfind(file, 1, Meta) of 
+          {file, {File, _}} -> E#{file := File};
+          _ -> E
+        end,
+  elixir_errors:file_warn(Meta, Env, ?MODULE, Error).
 
 format_error({function_conflict, {Receiver, {Name, Arity}}}) ->
   io_lib:format("imported ~ts.~ts/~B conflicts with local function",

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -462,6 +462,19 @@ defmodule CodeTest do
     assert Keyword.get(compile, :source) != nil
   end
 
+  test "preserves module @file on unused locals warning" do
+    sample = """
+    defmodule PreservesModuleAtFile do
+      @file "foo-bar.ex"
+      defp bar, do: 1
+    end
+    """
+
+    assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
+      Code.eval_string(sample)
+    end) =~ "foo-bar.ex:3: "
+  end
+
   describe "compile_string/1" do
     test "compiles the given string" do
       assert [{CompileStringSample, _}] =

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -471,8 +471,8 @@ defmodule CodeTest do
     """
 
     assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
-      Code.eval_string(sample)
-    end) =~ "foo-bar.ex:3: "
+             Code.eval_string(sample)
+           end) =~ "foo-bar.ex:3: "
   end
 
   describe "compile_string/1" do


### PR DESCRIPTION
This pull requests uses the message defined in `meta[:file]`, which was previously being ignored by `env_format`, resulting in "nofile" locations when evaluating code snippets, even with `@file` set.

I've also tried fix this by updating `store_definition` in `elixir_def.erl` but it ended up breaking kind changes errors, which apparently are always setting up `meta[:file]` with the file path they're contained in, even for snippets.

So I'm not sure if this is the best way to fix it, but I'm open to suggestions!

Closes #12659