### PR TITLE
Consistently use backticks when documenting boolean returns

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -578,7 +578,7 @@ defmodule Date do
   end
 
   @doc """
-  Returns true if the first date is strictly earlier than the second.
+  Returns `true` if the first date is strictly earlier than the second.
 
   ## Examples
 
@@ -597,7 +597,7 @@ defmodule Date do
   end
 
   @doc """
-  Returns true if the first date is strictly later than the second.
+  Returns `true` if the first date is strictly later than the second.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -174,7 +174,7 @@ defmodule DateTime do
   end
 
   @doc """
-  Returns the current datetime in UTC, supporting 
+  Returns the current datetime in UTC, supporting
   a specific calendar and precision.
 
   If you want the current time in Unix seconds,
@@ -1427,7 +1427,7 @@ defmodule DateTime do
   end
 
   @doc """
-  Returns true if the first datetime is strictly earlier than the second.
+  Returns `true` if the first datetime is strictly earlier than the second.
 
   ## Examples
 
@@ -1446,7 +1446,7 @@ defmodule DateTime do
   end
 
   @doc """
-  Returns true if the first datetime is strictly later than the second.
+  Returns `true` if the first datetime is strictly later than the second.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -1073,7 +1073,7 @@ defmodule NaiveDateTime do
   end
 
   @doc """
-  Returns true if the first `NaiveDateTime` is strictly earlier than the second.
+  Returns `true` if the first `NaiveDateTime` is strictly earlier than the second.
 
   ## Examples
 
@@ -1092,7 +1092,7 @@ defmodule NaiveDateTime do
   end
 
   @doc """
-  Returns true if the first `NaiveDateTime` is strictly later than the second.
+  Returns `true` if the first `NaiveDateTime` is strictly later than the second.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -599,7 +599,7 @@ defmodule Time do
   end
 
   @doc """
-  Returns true if the first time is strictly earlier than the second.
+  Returns `true` if the first time is strictly earlier than the second.
 
   ## Examples
 
@@ -618,7 +618,7 @@ defmodule Time do
   end
 
   @doc """
-  Returns true if the first time is strictly later than the second.
+  Returns `true` if the first time is strictly later than the second.
 
   ## Examples
 

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1929,7 +1929,7 @@ defmodule Code do
   end
 
   @doc """
-  Returns true if the current process can await for module compilation.
+  Returns `true` if the current process can await for module compilation.
 
   When compiling Elixir code via `Kernel.ParallelCompiler`, which is
   used by Mix and `elixirc`, calling a module that has not yet been

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2495,7 +2495,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns true if `term` is a struct; otherwise returns `false`.
+  Returns `true` if `term` is a struct; otherwise returns `false`.
 
   Allowed in guard tests.
 
@@ -2531,7 +2531,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns true if `term` is a struct of `name`; otherwise returns `false`.
+  Returns `true` if `term` is a struct of `name`; otherwise returns `false`.
 
   `is_struct/2` does not check that `name` exists and is a valid struct.
   If you want such validations, you must pattern match on the struct
@@ -2579,7 +2579,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns true if `term` is an exception; otherwise returns `false`.
+  Returns `true` if `term` is an exception; otherwise returns `false`.
 
   Allowed in guard tests.
 
@@ -2617,7 +2617,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns true if `term` is an exception of `name`; otherwise returns `false`.
+  Returns `true` if `term` is an exception of `name`; otherwise returns `false`.
 
   Allowed in guard tests.
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -438,7 +438,7 @@ defmodule Macro do
   def generate_arguments(amount, context), do: generate_arguments(amount, context, &var/2)
 
   @doc """
-  Returns the path to the node in `ast` which `fun` returns true.
+  Returns the path to the node in `ast` which `fun` returns `true`.
 
   The path is a list, starting with the node in which `fun` returns
   true, followed by all of its parents.

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -269,7 +269,7 @@ defmodule Macro.Env do
   end
 
   @doc """
-  Returns true if the given module has been required.
+  Returns `true` if the given module has been required.
 
   ## Examples
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -283,7 +283,7 @@ defmodule Module do
         end
       end
 
-  Note that this is only valid for exceptions/diagnostics that come from the 
+  Note that this is only valid for exceptions/diagnostics that come from the
   definition inner scope (which includes its patterns and guards). For example:
 
       defmodule MyModule do # <---- module definition
@@ -296,9 +296,9 @@ defmodule Module do
         def unused(_), do: true
       end
 
-  If you run this code with the second "unused" definition commented, you will 
-  see that `hello.ex` is used as the stacktrace when reporting warnings, but if 
-  you uncomment it you'll see that the error will not mention `bye.ex`, because 
+  If you run this code with the second "unused" definition commented, you will
+  see that `hello.ex` is used as the stacktrace when reporting warnings, but if
+  you uncomment it you'll see that the error will not mention `bye.ex`, because
   it's a module-level error rather than an expression-level error.
 
   ### `@moduledoc`
@@ -1120,7 +1120,7 @@ defmodule Module do
   Use `Kernel.function_exported?/3` and `Kernel.macro_exported?/3` to check for
   public functions and macros respectively in compiled modules.
 
-  Note that `defines?` returns false for functions and macros that have
+  Note that `defines?` returns `false` for functions and macros that have
   been defined but then marked as overridable and no other implementation
   has been provided. You can check the overridable status by calling
   `overridable?/2`.
@@ -1355,8 +1355,8 @@ defmodule Module do
   @doc """
   Deletes a definition from a module.
 
-  It returns true if the definition exists and it was removed,
-  otherwise it returns false.
+  It returns `true` if the definition exists and it was removed,
+  otherwise it returns `false`.
   """
   @doc since: "1.12.0"
   @spec delete_definition(module, definition) :: boolean()
@@ -1462,7 +1462,7 @@ defmodule Module do
   Returns `true` if `tuple` in `module` was marked as overridable
   at some point.
 
-  Note `overridable?/2` returns true even if the definition was
+  Note `overridable?/2` returns `true` even if the definition was
   already overridden. You can use `defines?/2` to see if a definition
   exists or one is pending.
   """

--- a/lib/elixir/lib/module/types/unify.ex
+++ b/lib/elixir/lib/module/types/unify.ex
@@ -531,7 +531,7 @@ defmodule Module.Types.Unify do
   end
 
   @doc """
-  Returns true if it is a singleton type.
+  Returns `true` if it is a singleton type.
 
   Only atoms are singleton types. Unbound vars are not
   considered singleton types.

--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -112,8 +112,8 @@ defmodule Mix.Generator do
   @doc """
   Prompts the user to overwrite the file if it exists.
 
-  Returns false if the file exists and the user forbade
-  to override it. Returns true otherwise.
+  Returns `false` if the file exists and the user forbade
+  to override it. Returns `true` otherwise.
   """
   @doc since: "1.9.0"
   @spec overwrite?(Path.t()) :: boolean
@@ -130,9 +130,9 @@ defmodule Mix.Generator do
   Prompts the user to overwrite the file if it exists.
 
   The contents are compared to avoid asking the user to
-  override if the contents did not change. Returns false
+  override if the contents did not change. Returns `false`
   if the file exists and the content is the same or the
-  user forbade to override it. Returns true otherwise.
+  user forbade to override it. Returns `true` otherwise.
   """
   @doc since: "1.9.0"
   @spec overwrite?(Path.t(), iodata) :: boolean

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -761,7 +761,7 @@ defmodule Mix.Release do
   @doc """
   Copies ERTS if the release is configured to do so.
 
-  Returns true if the release was copied, false otherwise.
+  Returns `true` if the release was copied, `false` otherwise.
   """
   @spec copy_erts(t) :: boolean()
   def copy_erts(%{erts_source: nil}) do

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -202,7 +202,7 @@ defmodule Mix.Task do
   @doc """
   Indicates if the current task is recursing.
 
-  This returns true if a task is marked as recursive
+  This returns `true` if a task is marked as recursive
   and it is being executed inside an umbrella project.
   """
   @doc since: "1.8.0"
@@ -246,7 +246,7 @@ defmodule Mix.Task do
   @doc """
   Checks if the given `task` name is an alias.
 
-  Returns false if the given name is not an alias or if it is not a task.
+  Returns `false` if the given name is not an alias or if it is not a task.
 
   For more information about task aliasing, take a look at the
   ["Aliases"](https://hexdocs.pm/mix/Mix.html#module-aliases) section in the


### PR DESCRIPTION
Many functions returning booleans are quoting them with backticks ([example](https://hexdocs.pm/elixir/Kernel.html#is_boolean/1)), but several cases didn't ([example](https://hexdocs.pm/elixir/Kernel.html#is_exception/1)).
