### PR TITLE
Limit number of structs in iex autocomplete

### DIFF
--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -389,7 +389,7 @@ defmodule IEx.AutocompleteTest do
 
   test "completion for struct names" do
     assert {:yes, ~c"", entries} = expand(~c"%")
-    assert ~c"URI" in entries
+    assert ~c"Date" in entries
     assert ~c"IEx.History" in entries
     assert ~c"IEx.Server" in entries
 


### PR DESCRIPTION
Getting structs for iex autocomplete is expensive: modules need to be loaded and checked to see if they define structs. This means that autocompleting for an empty struct name or a short one can be very slow in codebases with many modules and dependencies. In my work codebase, it might take several seconds for the autocomplete to return something and iex get stuck meanwhile.

This PR limits the number of structs, so that if a query that would return too many results is made, iex returns the completion quickly enough.

Sample:
```
v0idpwn ~/oss/elixir [feat/limit-number-of-structs-in-autocomplete] $ ./bin/iex
Erlang/OTP 25 [erts-13.1.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Interactive Elixir (1.16.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> %<TAB>
Config.Provider            Date
Date.Range                 DateTime
DynamicSupervisor          File.Stat
File.Stream                GenEvent.Stream
HashDict                   HashSet
IEx.History                IEx.Server
IO.Stream                  Inspect.Opts
Logger.Backends.Console    Logger.Formatter
Macro.Env                  MapSet
NaiveDateTime              Range
•••
```