### PR TITLE
Don't color IEx exception if it contains ANSI

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -400,7 +400,13 @@ defmodule IEx.Evaluator do
           [IEx.color(:eval_error, banner), pad(blame)]
 
         _ ->
-          [IEx.color(:eval_error, Exception.format_banner(kind, blamed, stacktrace))]
+          banner = Exception.format_banner(kind, blamed, stacktrace)
+
+          if String.contains?(banner, IO.ANSI.reset()) do
+            [banner]
+          else
+            [IEx.color(:eval_error, banner)]
+          end
       end
 
     stackdata = Exception.format_stacktrace(prune_stacktrace(stacktrace))

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -20,7 +20,7 @@ defmodule IEx.InteractionTest do
   end
 
   test "omits error color if exception has ansi reset character" do
-    enabled? = Application.get_env(:elixir, :ansi_enabled)
+    enabled? = IO.ANSI.enabled?()
     Application.put_env(:elixir, :ansi_enabled, true)
 
     expected = """

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -19,29 +19,27 @@ defmodule IEx.InteractionTest do
     assert capture_iex("1 + 2") == "3"
   end
 
-  if IO.ANSI.enabled?() do
-    test "omits error color if exception has ansi reset character" do
-      enabled? = Application.get_env(:elixir, :ansi_enabled)
-      Application.put_env(:elixir, :ansi_enabled, true)
+  test "omits error color if exception has ansi reset character" do
+    enabled? = Application.get_env(:elixir, :ansi_enabled)
+    Application.put_env(:elixir, :ansi_enabled, true)
 
-      expected = """
-      ** (SyntaxError) invalid syntax found on iex:1:4:
-         ┌─ \e[31merror: \e[0miex:1:4
-         │
-       1 │ a += 2
-         │ \e[31m   ^\e[0m
-         │
-         syntax error before: '='
-      """
+    expected = """
+    ** (SyntaxError) invalid syntax found on iex:1:4:
+       ┌─ \e[31merror: \e[0miex:1:4
+       │
+     1 │ a += 2
+       │ \e[31m   ^\e[0m
+       │
+       syntax error before: '='
+    """
 
-      opts = [colors: [enabled: true]]
-      output = capture_iex("a += 2", opts)
+    opts = [colors: [enabled: true]]
+    output = capture_iex("a += 2", opts)
 
-      refute String.starts_with?(output, IO.ANSI.red())
-      assert output =~ expected
+    refute String.starts_with?(output, IO.ANSI.red())
+    assert output =~ expected
 
-      Application.put_env(:elixir, :ansi_enabled, enabled?)
-    end
+    Application.put_env(:elixir, :ansi_enabled, enabled?)
   end
 
   test "invalid input" do


### PR DESCRIPTION
Similar to what happened on ex_unit on #12670, IEx is always printing exceptions as red and this conflicts with the the new exception's red ansi characters.

This pull request adds the same behavior of omitting the colors if we find an ansi reset in the formatted exception.

 Before:
![image](https://github.com/elixir-lang/elixir/assets/59743220/22594d19-1e49-4c9b-b47d-c42942a70a2e)

After:
![image](https://github.com/elixir-lang/elixir/assets/59743220/25d6f9d5-738c-4f55-a66f-72ddb9a8b6ef)

I can also add a test for this if needed :)