### PR TITLE
fix(logger): translate warning to warning instead of warn

### DIFF
--- a/lib/logger/lib/logger/backends/handler.ex
+++ b/lib/logger/lib/logger/backends/handler.ex
@@ -117,7 +117,7 @@ defmodule Logger.Backends.Handler do
   defp erlang_level_to_elixir_level(:alert), do: :error
   defp erlang_level_to_elixir_level(:critical), do: :error
   defp erlang_level_to_elixir_level(:error), do: :error
-  defp erlang_level_to_elixir_level(:warning), do: :warn
+  defp erlang_level_to_elixir_level(:warning), do: :warning
   defp erlang_level_to_elixir_level(:notice), do: :info
   defp erlang_level_to_elixir_level(:info), do: :info
   defp erlang_level_to_elixir_level(:debug), do: :debug


### PR DESCRIPTION
Translating an erlang :warning to an elixir :warn causes custom backends that still rely on this implementation to trigger the hard deprecation on `Logger.warn`.