### PR TITLE
Check formatting when running tests for specific projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ lib/$(1)/ebin/Elixir.$(2).beam: $(wildcard lib/$(1)/lib/*.ex) $(wildcard lib/$(1
 	@ rm -rf lib/$(1)/ebin
 	$(Q) cd lib/$(1) && ../../$$(ELIXIRC) "lib/**/*.ex" -o ebin
 
-test_$(1): compile $(1)
+test_$(1): test_formatted $(1)
 	@ echo "==> $(1) (ex_unit)"
 	$(Q) cd lib/$(1) && ../../bin/elixir -r "test/test_helper.exs" -pr "test/**/$(TEST_FILES)";
 endef


### PR DESCRIPTION
This change allows us to have `make test_ex_unit` for example, to run the formatting checks.

I think this is helpful since it allows us to fix formatting errors fast rather than fix a bunch of them later (or possibly pushing without running the entire suite and causing the CI to fail on formatting)