### PR TITLE
Use printf instead of echo to output flags

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -233,7 +233,7 @@ set -- "$ERTS_BIN$ERL_EXEC" -noshell -elixir_root "$SCRIPT_PATH"/../lib -pa "$SC
 if [ -n "$RUN_ERL_PIPE" ]; then
   ESCAPED=""
   for PART in "$@"; do
-    ESCAPED="$ESCAPED $(echo "$PART" | sed 's@[^a-zA-Z0-9_/-]@\\&@g')"
+    ESCAPED="$ESCAPED $(printf '%s' "$PART" | sed 's@[^a-zA-Z0-9_/-]@\\&@g')"
   done
   mkdir -p "$RUN_ERL_PIPE"
   mkdir -p "$RUN_ERL_LOG"


### PR DESCRIPTION
Fixes: #12677

using printf here prevents an error when outputting the filtered flag `-e` as doing this with `echo "-e"` doesn't output anything (deleting the option we wanted to filter). 

This is explained here better than I ever could: https://unix.stackexchange.com/a/65819