### PR TITLE
Parser honors :static_atoms_encoder for multi-letter sigils

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1138,7 +1138,10 @@ defmodule Code do
     * syntax keywords (`fn`, `do`, `else`, and so on)
 
     * atoms containing interpolation (`:"#{1 + 1} is two"`), as these
-      atoms are constructed at runtime.
+      atoms are constructed at runtime
+
+    * atoms used to represent single-letter sigils like `:sigil_X`
+      (but multi-letter sigils like `:sigil_XYZ` are encoded).
 
   """
   @spec string_to_quoted(List.Chars.t(), keyword) ::

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -248,7 +248,7 @@ parse_error(Location, File, <<"syntax error before: ">>, Keyword, Input)
 
 %% Produce a human-readable message for errors before a sigil
 parse_error(Location, File, <<"syntax error before: ">>, <<"{sigil,", _Rest/binary>> = Full, Input) ->
-  {sigil, _, Sigil, [Content | _], _, _, _} = parse_erl_term(Full),
+  {sigil, _, Sigil, _Atom, [Content | _], _, _, _} = parse_erl_term(Full),
   Content2 = case is_binary(Content) of
     true -> Content;
     false -> <<>>

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -939,7 +939,7 @@ build_access(Expr, {List, Meta}) ->
 
 %% Interpolation aware
 
-build_sigil({sigil, Location, _SigilName, Atom, Parts, Modifiers, Indentation, Delimiter}) ->
+build_sigil({sigil, Location, Atom, Parts, Modifiers, Indentation, Delimiter}) ->
   Meta = meta_from_location(Location),
   MetaWithDelimiter = [{delimiter, Delimiter} | Meta],
   MetaWithIndentation = meta_with_indentation(Meta, Indentation),

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -939,11 +939,11 @@ build_access(Expr, {List, Meta}) ->
 
 %% Interpolation aware
 
-build_sigil({sigil, Location, Sigil, Parts, Modifiers, Indentation, Delimiter}) ->
+build_sigil({sigil, Location, _SigilName, Atom, Parts, Modifiers, Indentation, Delimiter}) ->
   Meta = meta_from_location(Location),
   MetaWithDelimiter = [{delimiter, Delimiter} | Meta],
   MetaWithIndentation = meta_with_indentation(Meta, Indentation),
-  {list_to_atom("sigil_" ++ Sigil),
+  {Atom,
    MetaWithDelimiter,
    [{'<<>>', MetaWithIndentation, string_parts(Parts)}, Modifiers]}.
 

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1603,7 +1603,7 @@ add_sigil_token(SigilName, Line, Column, NewLine, NewColumn, Parts, Rest, Scope,
   case MaybeEncoded of
     {ok, Atom} ->
       {Final, Modifiers} = collect_modifiers(Rest, []),
-      Token = {sigil, {Line, TokenColumn, nil}, SigilName, Atom, Parts, Modifiers, Indentation, Delimiter},
+      Token = {sigil, {Line, TokenColumn, nil}, Atom, Parts, Modifiers, Indentation, Delimiter},
       NewColumnWithModifiers = NewColumn + length(Modifiers),
       tokenize(Final, NewLine, NewColumnWithModifiers, Scope, [Token | Tokens]);
 

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -261,22 +261,22 @@ vc_merge_conflict_test() ->
     tokenize_error("<<<<<<< HEAD\n[1, 2, 3]").
 
 sigil_terminator_test() ->
-  [{sigil, {1, 1, nil}, "r", sigil_r, [<<"foo">>], "", nil, <<"/">>}] = tokenize("~r/foo/"),
-  [{sigil, {1, 1, nil}, "r", sigil_r, [<<"foo">>], "", nil, <<"[">>}] = tokenize("~r[foo]"),
-  [{sigil, {1, 1, nil}, "r", sigil_r, [<<"foo">>], "", nil, <<"\"">>}] = tokenize("~r\"foo\""),
-  [{sigil, {1, 1, nil}, "r", sigil_r, [<<"foo">>], "", nil, <<"/">>},
+  [{sigil, {1, 1, nil}, sigil_r, [<<"foo">>], "", nil, <<"/">>}] = tokenize("~r/foo/"),
+  [{sigil, {1, 1, nil}, sigil_r, [<<"foo">>], "", nil, <<"[">>}] = tokenize("~r[foo]"),
+  [{sigil, {1, 1, nil}, sigil_r, [<<"foo">>], "", nil, <<"\"">>}] = tokenize("~r\"foo\""),
+  [{sigil, {1, 1, nil}, sigil_r, [<<"foo">>], "", nil, <<"/">>},
    {comp_op, {1, 9, nil}, '=='},
    {identifier, {1, 12, _}, bar}] = tokenize("~r/foo/ == bar"),
-  [{sigil, {1, 1, nil}, "r", sigil_r, [<<"foo">>], "iu", nil, <<"/">>},
+  [{sigil, {1, 1, nil}, sigil_r, [<<"foo">>], "iu", nil, <<"/">>},
    {comp_op, {1, 11, nil}, '=='},
    {identifier, {1, 14, _}, bar}] = tokenize("~r/foo/iu == bar"),
-  [{sigil, {1, 1, nil}, "M", sigil_M, [<<"1 2 3">>], "u8", nil, <<"[">>}] = tokenize("~M[1 2 3]u8").
+  [{sigil, {1, 1, nil}, sigil_M, [<<"1 2 3">>], "u8", nil, <<"[">>}] = tokenize("~M[1 2 3]u8").
 
 sigil_heredoc_test() ->
-  [{sigil, {1, 1, nil}, "S", sigil_S, [<<"sigil heredoc\n">>], "", 0, <<"\"\"\"">>}] = tokenize("~S\"\"\"\nsigil heredoc\n\"\"\""),
-  [{sigil, {1, 1, nil}, "S", sigil_S, [<<"sigil heredoc\n">>], "", 0, <<"'''">>}] = tokenize("~S'''\nsigil heredoc\n'''"),
-  [{sigil, {1, 1, nil}, "S", sigil_S, [<<"sigil heredoc\n">>], "", 2, <<"\"\"\"">>}] = tokenize("~S\"\"\"\n  sigil heredoc\n  \"\"\""),
-  [{sigil, {1, 1, nil}, "s", sigil_s, [<<"sigil heredoc\n">>], "", 2, <<"\"\"\"">>}] = tokenize("~s\"\"\"\n  sigil heredoc\n  \"\"\"").
+  [{sigil, {1, 1, nil}, sigil_S, [<<"sigil heredoc\n">>], "", 0, <<"\"\"\"">>}] = tokenize("~S\"\"\"\nsigil heredoc\n\"\"\""),
+  [{sigil, {1, 1, nil}, sigil_S, [<<"sigil heredoc\n">>], "", 0, <<"'''">>}] = tokenize("~S'''\nsigil heredoc\n'''"),
+  [{sigil, {1, 1, nil}, sigil_S, [<<"sigil heredoc\n">>], "", 2, <<"\"\"\"">>}] = tokenize("~S\"\"\"\n  sigil heredoc\n  \"\"\""),
+  [{sigil, {1, 1, nil}, sigil_s, [<<"sigil heredoc\n">>], "", 2, <<"\"\"\"">>}] = tokenize("~s\"\"\"\n  sigil heredoc\n  \"\"\"").
 
 invalid_sigil_delimiter_test() ->
   {1, 1, "invalid sigil delimiter: ", Message} = tokenize_error("~s\\"),

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -261,22 +261,22 @@ vc_merge_conflict_test() ->
     tokenize_error("<<<<<<< HEAD\n[1, 2, 3]").
 
 sigil_terminator_test() ->
-  [{sigil, {1, 1, nil}, "r", [<<"foo">>], "", nil, <<"/">>}] = tokenize("~r/foo/"),
-  [{sigil, {1, 1, nil}, "r", [<<"foo">>], "", nil, <<"[">>}] = tokenize("~r[foo]"),
-  [{sigil, {1, 1, nil}, "r", [<<"foo">>], "", nil, <<"\"">>}] = tokenize("~r\"foo\""),
-  [{sigil, {1, 1, nil}, "r", [<<"foo">>], "", nil, <<"/">>},
+  [{sigil, {1, 1, nil}, "r", sigil_r, [<<"foo">>], "", nil, <<"/">>}] = tokenize("~r/foo/"),
+  [{sigil, {1, 1, nil}, "r", sigil_r, [<<"foo">>], "", nil, <<"[">>}] = tokenize("~r[foo]"),
+  [{sigil, {1, 1, nil}, "r", sigil_r, [<<"foo">>], "", nil, <<"\"">>}] = tokenize("~r\"foo\""),
+  [{sigil, {1, 1, nil}, "r", sigil_r, [<<"foo">>], "", nil, <<"/">>},
    {comp_op, {1, 9, nil}, '=='},
    {identifier, {1, 12, _}, bar}] = tokenize("~r/foo/ == bar"),
-  [{sigil, {1, 1, nil}, "r", [<<"foo">>], "iu", nil, <<"/">>},
+  [{sigil, {1, 1, nil}, "r", sigil_r, [<<"foo">>], "iu", nil, <<"/">>},
    {comp_op, {1, 11, nil}, '=='},
    {identifier, {1, 14, _}, bar}] = tokenize("~r/foo/iu == bar"),
-  [{sigil, {1, 1, nil}, "M", [<<"1 2 3">>], "u8", nil, <<"[">>}] = tokenize("~M[1 2 3]u8").
+  [{sigil, {1, 1, nil}, "M", sigil_M, [<<"1 2 3">>], "u8", nil, <<"[">>}] = tokenize("~M[1 2 3]u8").
 
 sigil_heredoc_test() ->
-  [{sigil, {1, 1, nil}, "S", [<<"sigil heredoc\n">>], "", 0, <<"\"\"\"">>}] = tokenize("~S\"\"\"\nsigil heredoc\n\"\"\""),
-  [{sigil, {1, 1, nil}, "S", [<<"sigil heredoc\n">>], "", 0, <<"'''">>}] = tokenize("~S'''\nsigil heredoc\n'''"),
-  [{sigil, {1, 1, nil}, "S", [<<"sigil heredoc\n">>], "", 2, <<"\"\"\"">>}] = tokenize("~S\"\"\"\n  sigil heredoc\n  \"\"\""),
-  [{sigil, {1, 1, nil}, "s", [<<"sigil heredoc\n">>], "", 2, <<"\"\"\"">>}] = tokenize("~s\"\"\"\n  sigil heredoc\n  \"\"\"").
+  [{sigil, {1, 1, nil}, "S", sigil_S, [<<"sigil heredoc\n">>], "", 0, <<"\"\"\"">>}] = tokenize("~S\"\"\"\nsigil heredoc\n\"\"\""),
+  [{sigil, {1, 1, nil}, "S", sigil_S, [<<"sigil heredoc\n">>], "", 0, <<"'''">>}] = tokenize("~S'''\nsigil heredoc\n'''"),
+  [{sigil, {1, 1, nil}, "S", sigil_S, [<<"sigil heredoc\n">>], "", 2, <<"\"\"\"">>}] = tokenize("~S\"\"\"\n  sigil heredoc\n  \"\"\""),
+  [{sigil, {1, 1, nil}, "s", sigil_s, [<<"sigil heredoc\n">>], "", 2, <<"\"\"\"">>}] = tokenize("~s\"\"\"\n  sigil heredoc\n  \"\"\"").
 
 invalid_sigil_delimiter_test() ->
   {1, 1, "invalid sigil delimiter: ", Message} = tokenize_error("~s\\"),


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/12705

As discussed, an exception is made for one-letter sigils to prevent potential regressions, and since there is no risk of atom exhaustion for `26 * 2` possibilities. 