### PR TITLE
Reword grouped warnings message

### DIFF
--- a/lib/elixir/lib/module/parallel_checker.ex
+++ b/lib/elixir/lib/module/parallel_checker.ex
@@ -330,7 +330,7 @@ defmodule Module.ParallelChecker do
 
     [
       message,
-      "\n\nInvalid call also found at #{total_locations} other #{locations_plural}:",
+      "\n\nSimilar warning found at #{total_locations} other #{locations_plural}:",
       locations
     ]
     |> IO.iodata_to_binary()

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -410,7 +410,7 @@ defmodule Kernel.DiagnosticsTest do
        ┌─ warning: nofile:3:12: Sample.a/0
        Unknown.bar/0 is undefined (module Unknown is not available or is yet to be defined)
        
-       Invalid call also found at 3 other locations:
+       Similar warning found at 3 other locations:
          nofile:4:12: Sample.a/0
          nofile:5:12: Sample.a/0
          nofile:6:12: Sample.a/0
@@ -449,7 +449,7 @@ defmodule Kernel.DiagnosticsTest do
          │
          Unknown.bar/0 is undefined (module Unknown is not available or is yet to be defined)
          
-         Invalid call also found at 3 other locations:
+         Similar warning found at 3 other locations:
            #{path}:6:12: Sample.a/0
            #{path}:7:12: Sample.a/0
            #{path}:8:12: Sample.a/0
@@ -488,7 +488,7 @@ defmodule Kernel.DiagnosticsTest do
          │
          Unknown.bar/0 is undefined (module Unknown is not available or is yet to be defined)
          
-         Invalid call also found at 3 other locations:
+         Similar warning found at 3 other locations:
            #{path}:6: Sample.a/0
            #{path}:7: Sample.a/0
            #{path}:8: Sample.a/0

--- a/lib/elixir/test/elixir/module/types/integration_test.exs
+++ b/lib/elixir/test/elixir/module/types/integration_test.exs
@@ -287,10 +287,10 @@ defmodule Module.Types.IntegrationTest do
       warnings = [
         "A2.no_func/0 is undefined (module A2 is not available or is yet to be defined)",
         "a.ex:8: A.d/0",
-        "Invalid call also found at 1 other location:",
+        "Similar warning found at 1 other location:",
         "external_source.ex:5: A.b/0",
         "A.no_func/0 is undefined or private",
-        "Invalid call also found at 1 other location:",
+        "Similar warning found at 1 other location:",
         "a.ex:2: A.a/0",
         "a.ex:7: A.c/0"
       ]
@@ -641,11 +641,11 @@ defmodule Module.Types.IntegrationTest do
       warnings = [
         "A.__struct__/0 is deprecated. oops",
         "a.ex:4: A.match/1",
-        "Invalid call also found at 1 other location:",
+        "Similar warning found at 1 other location:",
         "a.ex:5: A.build/1",
         "A.__struct__/0 is deprecated. oops",
         "b.ex:2: B.match/1",
-        "Invalid call also found at 1 other location:",
+        "Similar warning found at 1 other location:",
         "b.ex:3: B.build/1"
       ]
 


### PR DESCRIPTION
Rewords grouped warnings message from `"Invalid call also found at"` to `"Similar warning found at"`.