### PR TITLE
Align error snippet with stacktrace on single digit lines

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -895,7 +895,11 @@ defmodule SyntaxError do
       :elixir_errors.format_snippet(file, {line, column}, description, snippet, :error, [])
 
     location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
-    format_fancy(location, formatted_snippet)
+    padding = if line < 10, do: " ", else: ""
+
+    formatted_snippet
+    |> pad_snippet(padding)
+    |> format_fancy(location)
   end
 
   @impl true
@@ -909,12 +913,18 @@ defmodule SyntaxError do
       :elixir_errors.format_snippet(file, {line, column}, description, nil, :error, [])
 
     location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
-    padded = "   " <> String.replace(formatted_snippet, "\n", "\n   ")
-    format_fancy(location, padded)
+
+    formatted_snippet
+    |> pad_snippet("   ")
+    |> format_fancy(location)
   end
 
-  defp format_fancy(location, formatted_snippet) do
+  defp format_fancy(formatted_snippet, location) do
     "invalid syntax found on " <> location <> "\n" <> formatted_snippet <> "\n"
+  end
+
+  defp pad_snippet(formatted_snippet, padding) do
+    padding <> String.replace(formatted_snippet, "\n", "\n#{padding}")
   end
 end
 
@@ -930,11 +940,15 @@ defmodule TokenMissingError do
         snippet: snippet
       })
       when not is_nil(snippet) and not is_nil(column) do
-    fancy =
+    formatted_snippet =
       :elixir_errors.format_snippet(file, {line, column}, description, snippet, :error, [])
 
     location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
-    format_fancy(location, fancy)
+    padding = if line < 10, do: " ", else: ""
+
+    formatted_snippet
+    |> pad_snippet(padding)
+    |> format_fancy(location)
   end
 
   @impl true
@@ -944,14 +958,22 @@ defmodule TokenMissingError do
         column: column,
         description: description
       }) do
-    fancy = :elixir_errors.format_snippet(file, {line, column}, description, nil, :error, [])
+    formatted_snippet =
+      :elixir_errors.format_snippet(file, {line, column}, description, nil, :error, [])
+
     location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
-    padded = "   " <> String.replace(fancy, "\n", "\n   ")
-    format_fancy(location, padded)
+
+    formatted_snippet
+    |> pad_snippet("   ")
+    |> format_fancy(location)
   end
 
-  defp format_fancy(location, fancy) do
-    "token missing on " <> location <> "\n" <> fancy <> "\n"
+  defp format_fancy(formatted_snippet, location) do
+    "token missing on " <> location <> "\n" <> formatted_snippet <> "\n"
+  end
+
+  defp pad_snippet(formatted_snippet, padding) do
+    padding <> String.replace(formatted_snippet, "\n", "\n#{padding}")
   end
 end
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -895,11 +895,7 @@ defmodule SyntaxError do
       :elixir_errors.format_snippet(file, {line, column}, description, snippet, :error, [])
 
     location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
-    padding = if line < 10, do: " ", else: ""
-
-    formatted_snippet
-    |> pad_snippet(padding)
-    |> format_fancy(location)
+    format_fancy(location, formatted_snippet)
   end
 
   @impl true
@@ -913,18 +909,12 @@ defmodule SyntaxError do
       :elixir_errors.format_snippet(file, {line, column}, description, nil, :error, [])
 
     location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
-
-    formatted_snippet
-    |> pad_snippet("   ")
-    |> format_fancy(location)
+    padded = "   " <> String.replace(formatted_snippet, "\n", "\n   ")
+    format_fancy(location, padded)
   end
 
-  defp format_fancy(formatted_snippet, location) do
+  defp format_fancy(location, formatted_snippet) do
     "invalid syntax found on " <> location <> "\n" <> formatted_snippet <> "\n"
-  end
-
-  defp pad_snippet(formatted_snippet, padding) do
-    padding <> String.replace(formatted_snippet, "\n", "\n#{padding}")
   end
 end
 
@@ -940,15 +930,11 @@ defmodule TokenMissingError do
         snippet: snippet
       })
       when not is_nil(snippet) and not is_nil(column) do
-    formatted_snippet =
+    fancy =
       :elixir_errors.format_snippet(file, {line, column}, description, snippet, :error, [])
 
     location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
-    padding = if line < 10, do: " ", else: ""
-
-    formatted_snippet
-    |> pad_snippet(padding)
-    |> format_fancy(location)
+    format_fancy(location, fancy)
   end
 
   @impl true
@@ -958,22 +944,14 @@ defmodule TokenMissingError do
         column: column,
         description: description
       }) do
-    formatted_snippet =
-      :elixir_errors.format_snippet(file, {line, column}, description, nil, :error, [])
-
+    fancy = :elixir_errors.format_snippet(file, {line, column}, description, nil, :error, [])
     location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
-
-    formatted_snippet
-    |> pad_snippet("   ")
-    |> format_fancy(location)
+    padded = "   " <> String.replace(fancy, "\n", "\n   ")
+    format_fancy(location, padded)
   end
 
-  defp format_fancy(formatted_snippet, location) do
-    "token missing on " <> location <> "\n" <> formatted_snippet <> "\n"
-  end
-
-  defp pad_snippet(formatted_snippet, padding) do
-    padding <> String.replace(formatted_snippet, "\n", "\n#{padding}")
+  defp format_fancy(location, fancy) do
+    "token missing on " <> location <> "\n" <> fancy <> "\n"
   end
 end
 

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -127,7 +127,8 @@ format_snippet(File, Position, Message, Snippet, Severity, Stacktrace) ->
                       end,
   LineNumber = extract_line(Position),
   LineDigits = get_line_number_digits(LineNumber, 1),
-  Spacing = n_spaces(LineDigits + 1),
+  Spacing = n_spaces(max(2, LineDigits) + 1),
+  LineNumberSpacing = if LineDigits =:= 1 -> 1; true -> 0 end,
   {FormattedLine, ColumnsTrimmed} = format_line(Content),
   Location = format_location(Position, File, Stacktrace),
 
@@ -139,17 +140,17 @@ format_snippet(File, Position, Message, Snippet, Severity, Stacktrace) ->
   Formatted = io_lib:format(
     " ~ts┌─ ~ts~ts\n"
     " ~ts│\n"
-    " ~p │ ~ts\n"
+    " ~ts~p │ ~ts\n"
     " ~ts│ ~ts\n"
     " ~ts│\n"
     " ~ts~ts",
     [
      Spacing, prefix(Severity), Location,
      Spacing,
-     LineNumber, FormattedLine,
+     n_spaces(LineNumberSpacing), LineNumber, FormattedLine,
      Spacing, Highlight,
      Spacing,
-     Spacing, format_message(Message, LineDigits, 2)
+     Spacing, format_message(Message, LineDigits, 2 + LineNumberSpacing)
     ]),
 
   unicode:characters_to_binary(Formatted).

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -14,12 +14,12 @@ defmodule Kernel.DiagnosticsTest do
     test "SyntaxError (snippet)" do
       expected = """
       ** (SyntaxError) invalid syntax found on nofile:1:17:
-         ┌─ error: nofile:1:17
-         │
-       1 │ [1, 2, 3, 4, 5, *]
-         │                 ^
-         │
-         syntax error before: '*'
+          ┌─ error: nofile:1:17
+          │
+        1 │ [1, 2, 3, 4, 5, *]
+          │                 ^
+          │
+          syntax error before: '*'
       """
 
       output =
@@ -36,12 +36,12 @@ defmodule Kernel.DiagnosticsTest do
     test "TokenMissingError (snippet)" do
       expected = """
       ** (TokenMissingError) token missing on nofile:1:4:
-         ┌─ error: nofile:1:4
-         │
-       1 │ 1 +
-         │    ^
-         │
-         syntax error: expression is incomplete
+          ┌─ error: nofile:1:4
+          │
+        1 │ 1 +
+          │    ^
+          │
+          syntax error: expression is incomplete
       """
 
       output =
@@ -76,12 +76,12 @@ defmodule Kernel.DiagnosticsTest do
     test "keeps trailing whitespace if under threshold" do
       expected = """
       ** (SyntaxError) invalid syntax found on nofile:1:23:
-         ┌─ error: nofile:1:23
-         │
-       1 │                   a + 😎
-         │                       ^
-         │
-         unexpected token: "😎" (column 23, code point U+****)
+          ┌─ error: nofile:1:23
+          │
+        1 │                   a + 😎
+          │                       ^
+          │
+          unexpected token: "😎" (column 23, code point U+****)
       """
 
       output =
@@ -98,12 +98,12 @@ defmodule Kernel.DiagnosticsTest do
     test "limits trailing whitespace if too many" do
       expected = """
       ** (SyntaxError) invalid syntax found on nofile:1:43:
-         ┌─ error: nofile:1:43
-         │
-       1 │ ...                   a + 😎
-         │                           ^
-         │
-         unexpected token: "😎" (column 43, code point U+****)
+          ┌─ error: nofile:1:43
+          │
+        1 │ ...                   a + 😎
+          │                           ^
+          │
+          unexpected token: "😎" (column 43, code point U+****)
       """
 
       output =
@@ -125,12 +125,12 @@ defmodule Kernel.DiagnosticsTest do
 
       expected = """
       ** (TokenMissingError) token missing on nofile:1:4:
-         ┌─ error: nofile:1:4
-         │
-       1 │ 1 -
-         │    ^
-         │
-         syntax error: expression is incomplete
+          ┌─ error: nofile:1:4
+          │
+        1 │ 1 -
+          │    ^
+          │
+          syntax error: expression is incomplete
 
           nofile:10: :fake.fun/3
           nofile:10: :real.fun/2
@@ -139,6 +139,36 @@ defmodule Kernel.DiagnosticsTest do
       output =
         capture_raise(
           """
+          1 -
+          """,
+          TokenMissingError,
+          fake_stacktrace
+        )
+
+      assert output == expected
+    end
+
+    test "2-digit line errors stay aligned with stacktrace" do
+      fake_stacktrace = [
+        {:fake, :fun, 3, [file: "nofile", line: 10]}
+      ]
+
+      expected = """
+      ** (TokenMissingError) token missing on nofile:12:4:
+          ┌─ error: nofile:12:4
+          │
+       12 │ 1 -
+          │    ^
+          │
+          syntax error: expression is incomplete
+
+          nofile:10: :fake.fun/3
+      """
+
+      output =
+        capture_raise(
+          """
+          #{String.duplicate("\n", 10)}
           1 -
           """,
           TokenMissingError,

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -14,12 +14,12 @@ defmodule Kernel.DiagnosticsTest do
     test "SyntaxError (snippet)" do
       expected = """
       ** (SyntaxError) invalid syntax found on nofile:1:17:
-         ┌─ error: nofile:1:17
-         │
-       1 │ [1, 2, 3, 4, 5, *]
-         │                 ^
-         │
-         syntax error before: '*'
+          ┌─ error: nofile:1:17
+          │
+        1 │ [1, 2, 3, 4, 5, *]
+          │                 ^
+          │
+          syntax error before: '*'
       """
 
       output =
@@ -36,12 +36,12 @@ defmodule Kernel.DiagnosticsTest do
     test "TokenMissingError (snippet)" do
       expected = """
       ** (TokenMissingError) token missing on nofile:1:4:
-         ┌─ error: nofile:1:4
-         │
-       1 │ 1 +
-         │    ^
-         │
-         syntax error: expression is incomplete
+          ┌─ error: nofile:1:4
+          │
+        1 │ 1 +
+          │    ^
+          │
+          syntax error: expression is incomplete
       """
 
       output =
@@ -76,12 +76,12 @@ defmodule Kernel.DiagnosticsTest do
     test "keeps trailing whitespace if under threshold" do
       expected = """
       ** (SyntaxError) invalid syntax found on nofile:1:23:
-         ┌─ error: nofile:1:23
-         │
-       1 │                   a + 😎
-         │                       ^
-         │
-         unexpected token: "😎" (column 23, code point U+****)
+          ┌─ error: nofile:1:23
+          │
+        1 │                   a + 😎
+          │                       ^
+          │
+          unexpected token: "😎" (column 23, code point U+****)
       """
 
       output =
@@ -98,12 +98,12 @@ defmodule Kernel.DiagnosticsTest do
     test "limits trailing whitespace if too many" do
       expected = """
       ** (SyntaxError) invalid syntax found on nofile:1:43:
-         ┌─ error: nofile:1:43
-         │
-       1 │ ...                   a + 😎
-         │                           ^
-         │
-         unexpected token: "😎" (column 43, code point U+****)
+          ┌─ error: nofile:1:43
+          │
+        1 │ ...                   a + 😎
+          │                           ^
+          │
+          unexpected token: "😎" (column 43, code point U+****)
       """
 
       output =
@@ -125,12 +125,12 @@ defmodule Kernel.DiagnosticsTest do
 
       expected = """
       ** (TokenMissingError) token missing on nofile:1:4:
-         ┌─ error: nofile:1:4
-         │
-       1 │ 1 -
-         │    ^
-         │
-         syntax error: expression is incomplete
+          ┌─ error: nofile:1:4
+          │
+        1 │ 1 -
+          │    ^
+          │
+          syntax error: expression is incomplete
 
           nofile:10: :fake.fun/3
           nofile:10: :real.fun/2
@@ -139,6 +139,36 @@ defmodule Kernel.DiagnosticsTest do
       output =
         capture_raise(
           """
+          1 -
+          """,
+          TokenMissingError,
+          fake_stacktrace
+        )
+
+      assert output == expected
+    end
+
+    test "2-digit line errors stay aligned 1-digit line errors" do
+      fake_stacktrace = [
+        {:fake, :fun, 3, [file: "nofile", line: 10]}
+      ]
+
+      expected = """
+      ** (TokenMissingError) token missing on nofile:12:4:
+          ┌─ error: nofile:12:4
+          │
+       12 │ 1 -
+          │    ^
+          │
+          syntax error: expression is incomplete
+
+          nofile:10: :fake.fun/3
+      """
+
+      output =
+        capture_raise(
+          """
+          #{String.duplicate("\n", 10)}
           1 -
           """,
           TokenMissingError,
@@ -180,12 +210,12 @@ defmodule Kernel.DiagnosticsTest do
       File.write!(path, source)
 
       expected = """
-         ┌─ warning: #{path}:3:22: Sample.a/0
-         │
-       3 │   defp a, do: Unknown.b()
-         │                      ~
-         │
-         Unknown.b/0 is undefined (module Unknown is not available or is yet to be defined)
+          ┌─ warning: #{path}:3:22: Sample.a/0
+          │
+        3 │   defp a, do: Unknown.b()
+          │                      ~
+          │
+          Unknown.b/0 is undefined (module Unknown is not available or is yet to be defined)
 
       """
 
@@ -208,12 +238,12 @@ defmodule Kernel.DiagnosticsTest do
       File.write!(path, source)
 
       expected = """
-         ┌─ warning: #{path}:3: Sample.a/0
-         │
-       3 │   defp a, do: Unknown.b()
-         │   ~~~~~~~~~~~~~~~~~~~~~~~
-         │
-         Unknown.b/0 is undefined (module Unknown is not available or is yet to be defined)
+          ┌─ warning: #{path}:3: Sample.a/0
+          │
+        3 │   defp a, do: Unknown.b()
+          │   ~~~~~~~~~~~~~~~~~~~~~~~
+          │
+          Unknown.b/0 is undefined (module Unknown is not available or is yet to be defined)
 
       """
 
@@ -262,31 +292,31 @@ defmodule Kernel.DiagnosticsTest do
       File.write!(path, source)
 
       expected = """
-         ┌─ warning: #{path}:8:14: Sample.atom_case/0
-         │
-       8 │       _ when is_atom(v) -> :ok
-         │              ~
-         │
-         incompatible types:
-         
-             binary() !~ atom()
-         
-         in expression:
-         
-             # #{path}:8
-             is_atom(v)
-         
-         where "v" was given the type binary() in:
-         
-             # #{path}:5
-             v = "bc"
-         
-         where "v" was given the type atom() in:
-         
-             # #{path}:8
-             is_atom(v)
-         
-         Conflict found at
+          ┌─ warning: #{path}:8:14: Sample.atom_case/0
+          │
+        8 │       _ when is_atom(v) -> :ok
+          │              ~
+          │
+          incompatible types:
+          
+              binary() !~ atom()
+          
+          in expression:
+          
+              # #{path}:8
+              is_atom(v)
+          
+          where "v" was given the type binary() in:
+          
+              # #{path}:5
+              v = "bc"
+          
+          where "v" was given the type atom() in:
+          
+              # #{path}:8
+              is_atom(v)
+          
+          Conflict found at
 
       """
 
@@ -356,12 +386,12 @@ defmodule Kernel.DiagnosticsTest do
       File.write!(path, source)
 
       expected = """
-         ┌─ warning: #{path}:5:52: Sample.a/0
-         │
-       5 │ ...                   Unknown.bar(:test)
-         │                              ~
-         │
-         Unknown.bar/1 is undefined (module Unknown is not available or is yet to be defined)
+          ┌─ warning: #{path}:5:52: Sample.a/0
+          │
+        5 │ ...                   Unknown.bar(:test)
+          │                              ~
+          │
+          Unknown.bar/1 is undefined (module Unknown is not available or is yet to be defined)
 
       """
 
@@ -442,17 +472,17 @@ defmodule Kernel.DiagnosticsTest do
       File.write!(path, source)
 
       expected = """
-         ┌─ warning: #{path}:5:12: Sample.a/0
-         │
-       5 │     Unknown.bar()
-         │            ~
-         │
-         Unknown.bar/0 is undefined (module Unknown is not available or is yet to be defined)
-         
-         Invalid call also found at 3 other locations:
-           #{path}:6:12: Sample.a/0
-           #{path}:7:12: Sample.a/0
-           #{path}:8:12: Sample.a/0
+          ┌─ warning: #{path}:5:12: Sample.a/0
+          │
+        5 │     Unknown.bar()
+          │            ~
+          │
+          Unknown.bar/0 is undefined (module Unknown is not available or is yet to be defined)
+          
+          Invalid call also found at 3 other locations:
+            #{path}:6:12: Sample.a/0
+            #{path}:7:12: Sample.a/0
+            #{path}:8:12: Sample.a/0
 
       """
 
@@ -481,17 +511,17 @@ defmodule Kernel.DiagnosticsTest do
       File.write!(path, source)
 
       expected = """
-         ┌─ warning: #{path}:5: Sample.a/0
-         │
-       5 │     Unknown.bar()
-         │     ~~~~~~~~~~~~~
-         │
-         Unknown.bar/0 is undefined (module Unknown is not available or is yet to be defined)
-         
-         Invalid call also found at 3 other locations:
-           #{path}:6: Sample.a/0
-           #{path}:7: Sample.a/0
-           #{path}:8: Sample.a/0
+          ┌─ warning: #{path}:5: Sample.a/0
+          │
+        5 │     Unknown.bar()
+          │     ~~~~~~~~~~~~~
+          │
+          Unknown.bar/0 is undefined (module Unknown is not available or is yet to be defined)
+          
+          Invalid call also found at 3 other locations:
+            #{path}:6: Sample.a/0
+            #{path}:7: Sample.a/0
+            #{path}:8: Sample.a/0
 
       """
 

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -14,12 +14,12 @@ defmodule Kernel.DiagnosticsTest do
     test "SyntaxError (snippet)" do
       expected = """
       ** (SyntaxError) invalid syntax found on nofile:1:17:
-          ┌─ error: nofile:1:17
-          │
-        1 │ [1, 2, 3, 4, 5, *]
-          │                 ^
-          │
-          syntax error before: '*'
+         ┌─ error: nofile:1:17
+         │
+       1 │ [1, 2, 3, 4, 5, *]
+         │                 ^
+         │
+         syntax error before: '*'
       """
 
       output =
@@ -36,12 +36,12 @@ defmodule Kernel.DiagnosticsTest do
     test "TokenMissingError (snippet)" do
       expected = """
       ** (TokenMissingError) token missing on nofile:1:4:
-          ┌─ error: nofile:1:4
-          │
-        1 │ 1 +
-          │    ^
-          │
-          syntax error: expression is incomplete
+         ┌─ error: nofile:1:4
+         │
+       1 │ 1 +
+         │    ^
+         │
+         syntax error: expression is incomplete
       """
 
       output =
@@ -76,12 +76,12 @@ defmodule Kernel.DiagnosticsTest do
     test "keeps trailing whitespace if under threshold" do
       expected = """
       ** (SyntaxError) invalid syntax found on nofile:1:23:
-          ┌─ error: nofile:1:23
-          │
-        1 │                   a + 😎
-          │                       ^
-          │
-          unexpected token: "😎" (column 23, code point U+****)
+         ┌─ error: nofile:1:23
+         │
+       1 │                   a + 😎
+         │                       ^
+         │
+         unexpected token: "😎" (column 23, code point U+****)
       """
 
       output =
@@ -98,12 +98,12 @@ defmodule Kernel.DiagnosticsTest do
     test "limits trailing whitespace if too many" do
       expected = """
       ** (SyntaxError) invalid syntax found on nofile:1:43:
-          ┌─ error: nofile:1:43
-          │
-        1 │ ...                   a + 😎
-          │                           ^
-          │
-          unexpected token: "😎" (column 43, code point U+****)
+         ┌─ error: nofile:1:43
+         │
+       1 │ ...                   a + 😎
+         │                           ^
+         │
+         unexpected token: "😎" (column 43, code point U+****)
       """
 
       output =
@@ -125,12 +125,12 @@ defmodule Kernel.DiagnosticsTest do
 
       expected = """
       ** (TokenMissingError) token missing on nofile:1:4:
-          ┌─ error: nofile:1:4
-          │
-        1 │ 1 -
-          │    ^
-          │
-          syntax error: expression is incomplete
+         ┌─ error: nofile:1:4
+         │
+       1 │ 1 -
+         │    ^
+         │
+         syntax error: expression is incomplete
 
           nofile:10: :fake.fun/3
           nofile:10: :real.fun/2
@@ -139,36 +139,6 @@ defmodule Kernel.DiagnosticsTest do
       output =
         capture_raise(
           """
-          1 -
-          """,
-          TokenMissingError,
-          fake_stacktrace
-        )
-
-      assert output == expected
-    end
-
-    test "2-digit line errors stay aligned with stacktrace" do
-      fake_stacktrace = [
-        {:fake, :fun, 3, [file: "nofile", line: 10]}
-      ]
-
-      expected = """
-      ** (TokenMissingError) token missing on nofile:12:4:
-          ┌─ error: nofile:12:4
-          │
-       12 │ 1 -
-          │    ^
-          │
-          syntax error: expression is incomplete
-
-          nofile:10: :fake.fun/3
-      """
-
-      output =
-        capture_raise(
-          """
-          #{String.duplicate("\n", 10)}
           1 -
           """,
           TokenMissingError,

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -25,12 +25,12 @@ defmodule IEx.InteractionTest do
 
     expected = """
     ** (SyntaxError) invalid syntax found on iex:1:4:
-       ┌─ \e[31merror: \e[0miex:1:4
-       │
-     1 │ a += 2
-       │ \e[31m   ^\e[0m
-       │
-       syntax error before: '='
+        ┌─ \e[31merror: \e[0miex:1:4
+        │
+      1 │ a += 2
+        │ \e[31m   ^\e[0m
+        │
+        syntax error before: '='
     """
 
     opts = [colors: [enabled: true]]


### PR DESCRIPTION
This pull request adds one more padding space to the error snippet when we're in single-digit line, so that it stays aligned with the stacktrace.

We go from this:
```
$ elixir -e "1 +* 2"
** (SyntaxError) invalid syntax found on nofile:1:4:
   ┌─ error: nofile:1:4
   │
 1 │ 1 +* 2
   │    ^
   │
   syntax error before: '*'

    (elixir 1.16.0-dev) lib/code.ex:542: Code.validated_eval_string/3
```

To this:
```
$ elixir -e "1 +* 2"
** (SyntaxError) invalid syntax found on nofile:1:4:
    ┌─ error: nofile:1:4
    │
  1 │ 1 +* 2
    │    ^
    │
    syntax error before: '*'

    (elixir 1.16.0-dev) lib/code.ex:542: Code.validated_eval_string/3
```