### PR TITLE
Mention where to find valid `on: capture` options in `Regex.split/{2..3}`.

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -512,7 +512,8 @@ defmodule Regex do
 
     * `:on` - specifies which captures to split the string on, and in what
       order. Defaults to `:first` which means captures inside the regex do not
-      affect the splitting process.
+      affect the splitting process. Check the moduledoc for `Regex`
+      to see the possible capture values.
 
     * `:include_captures` - when `true`, includes in the result the matches of
       the regular expression. The matches are not counted towards the maximum


### PR DESCRIPTION
This mirrors the useful note in [`Regex.run/3`](https://hexdocs.pm/elixir/Regex.html#run/3) that would have saved me some confusion.