### PR TITLE
Fix infinite recursion in do_get_file_line

### DIFF
--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -91,7 +91,7 @@ get_file_line(File, LineNumber) ->
   ok = file:close(IoDevice),
   NoNewline.
 
-do_get_file_line(IoDevice, LN) when LN =< 1 ->
+do_get_file_line(IoDevice, 1) ->
   Line = io:get_line(IoDevice, ""),
   unicode:characters_to_binary(Line);
 do_get_file_line(IoDevice, N) ->

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -84,6 +84,7 @@ extract_line(L) -> L.
 extract_column({_, C}) -> C;
 extract_column(_) -> nil.
 
+get_file_line(_, 0) -> nil;
 get_file_line(File, LineNumber) ->
   {ok, IoDevice} = file:open(File, [read, {encoding, unicode}]),
   Line = do_get_file_line(IoDevice, LineNumber),

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -91,7 +91,7 @@ get_file_line(File, LineNumber) ->
   ok = file:close(IoDevice),
   NoNewline.
 
-do_get_file_line(IoDevice, 1) ->
+do_get_file_line(IoDevice, LN) when LN =< 1 ->
   Line = io:get_line(IoDevice, ""),
   unicode:characters_to_binary(Line);
 do_get_file_line(IoDevice, N) ->


### PR DESCRIPTION
While implementing fancy error reporting for diagnostics, I've noticed when the line was zero, `do_get_file_line` would get stuck into infinite recursion. This PR just tweaks the base case to avoid this issue.

I also think we should not even try to read the file if the line number is zero, even if it is readable.