### PR TITLE
Report correct position for duplicate struct fields diagnostic

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5364,7 +5364,8 @@ defmodule Kernel do
   """
   defmacro defstruct(fields) do
     quote bind_quoted: [fields: fields, bootstrapped?: bootstrapped?(Enum)] do
-      {struct, derive, kv, body} = Kernel.Utils.defstruct(__MODULE__, fields, bootstrapped?)
+      {struct, derive, kv, body} =
+        Kernel.Utils.defstruct(__MODULE__, fields, bootstrapped?, __ENV__)
 
       case derive do
         [] -> :ok

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -100,7 +100,7 @@ defmodule Kernel.Utils do
   @doc """
   Callback for defstruct.
   """
-  def defstruct(module, fields, bootstrapped?) do
+  def defstruct(module, fields, bootstrapped?, env) do
     {set, bag} = :elixir_module.data_tables(module)
 
     if :ets.member(set, :__struct__) do
@@ -152,7 +152,7 @@ defmodule Kernel.Utils do
       end
 
     # TODO: Make it raise on v2.0
-    warn_on_duplicate_struct_key(:lists.keysort(1, fields))
+    warn_on_duplicate_struct_key(:lists.keysort(1, fields), env)
 
     foreach = fn
       key when is_atom(key) ->
@@ -227,17 +227,17 @@ defmodule Kernel.Utils do
     end
   end
 
-  defp warn_on_duplicate_struct_key([]) do
+  defp warn_on_duplicate_struct_key([], _) do
     :ok
   end
 
-  defp warn_on_duplicate_struct_key([{key, _} | [{key, _} | _] = rest]) do
-    IO.warn("duplicate key #{inspect(key)} found in struct")
-    warn_on_duplicate_struct_key(rest)
+  defp warn_on_duplicate_struct_key([{key, _} | [{key, _} | _] = rest], env) do
+    IO.warn("duplicate key #{inspect(key)} found in struct", env)
+    warn_on_duplicate_struct_key(rest, env)
   end
 
-  defp warn_on_duplicate_struct_key([_ | rest]) do
-    warn_on_duplicate_struct_key(rest)
+  defp warn_on_duplicate_struct_key([_ | rest], env) do
+    warn_on_duplicate_struct_key(rest, env)
   end
 
   @doc """

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -97,7 +97,7 @@ defmodule Macro.Env do
   ]
 
   # Define the __struct__ callbacks by hand for bootstrap reasons.
-  {struct, [], kv, body} = Kernel.Utils.defstruct(__MODULE__, fields, false)
+  {struct, [], kv, body} = Kernel.Utils.defstruct(__MODULE__, fields, false, __ENV__)
   def __struct__(), do: unquote(:elixir_quote.escape(struct, false, :none))
   def __struct__(unquote(kv)), do: unquote(body)
 

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -55,21 +55,6 @@ defmodule CodeTest do
                end)
     end
 
-    test "reports correct position for duplicate struct fields" do
-      file = Path.absname("test/elixir/code_test.exs")
-      line = __ENV__.line + 5
-
-      assert {_, [%{file: ^file, position: ^line}]} =
-               Code.with_diagnostics(fn ->
-                 defmodule CodeTest.DuplicateStructField do
-                   defstruct [:foo, :bar, foo: 1]
-                 end
-               end)
-    after
-      :code.purge(CodeTest.DuplicateStructField)
-      :code.delete(CodeTest.DuplicateStructField)
-    end
-
     test "includes column information on unused variables" do
       assert {_, [%{position: {1, 12}}]} =
                Code.with_diagnostics(fn ->

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -55,6 +55,21 @@ defmodule CodeTest do
                end)
     end
 
+    test "reports correct position for duplicate struct fields" do
+      file = Path.absname("test/elixir/code_test.exs")
+      line = __ENV__.line + 5
+
+      assert {_, [%{file: ^file, position: ^line}]} =
+               Code.with_diagnostics(fn ->
+                 defmodule CodeTest.DuplicateStructField do
+                   defstruct [:foo, :bar, foo: 1]
+                 end
+               end)
+    after
+      :code.purge(CodeTest.DuplicateStructField)
+      :code.delete(CodeTest.DuplicateStructField)
+    end
+
     test "includes column information on unused variables" do
       assert {_, [%{position: {1, 12}}]} =
                Code.with_diagnostics(fn ->

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -2116,7 +2116,7 @@ defmodule Kernel.WarningTest do
 
   test "defstruct warns with duplicate keys" do
     assert_warn_eval(
-      ["nofile:2: ", "duplicate key :foo found in struct"],
+      ["nofile:2: TestMod", "duplicate key :foo found in struct"],
       """
       defmodule TestMod do
         defstruct [:foo, :bar, foo: 1]


### PR DESCRIPTION
This pull request fixes the diagnostic position that was being reported in the duplicate struct fields diagnostic.

Now we get the env from inside the defstruct macro and bring it to the IO.warn call   