### PR TITLE
Always respect options passed to capture_log

### DIFF
--- a/lib/ex_unit/test/ex_unit/capture_log_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_log_test.exs
@@ -114,6 +114,19 @@ defmodule ExUnit.CaptureLogTest do
 
       assert log == "id=123 | hello"
     end
+
+    @tag capture_log: true
+    test "respect options with capture_log: true" do
+      options = [format: "$metadata| $message", metadata: [:id], colors: [enabled: false]]
+
+      assert {4, log} =
+               with_log(options, fn ->
+                 Logger.info("hello", id: 123)
+                 2 + 2
+               end)
+
+      assert log == "id=123 | hello"
+    end
   end
 
   defp wait_capture_removal() do


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/12720

[`update_handler_config/3`](https://www.erlang.org/doc/man/logger.html#update_handler_config-3)seems to work but I'm not sure if there is a need for a more involved fix, and if this might create issues when used concurrently with different options?