### PR TITLE
Improve File.ls/1 docs

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1630,9 +1630,10 @@ defmodule File do
   @doc """
   Returns the list of files in the given directory.
 
-  Since directories are considered files by the file system, they will also be
-  inlcuded. Also note that hidden files are not ignored and the results are not
-  sorted.
+  Hidden files are not ignored and the results are *not* sorted.
+
+  Since directories are considered files by the file system,
+  they are also included in the returned value.
 
   Returns `{:ok, files}` in case of success,
   `{:error, reason}` otherwise.

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1630,6 +1630,10 @@ defmodule File do
   @doc """
   Returns the list of files in the given directory.
 
+  Since directories are considered files by the file system, they will also be
+  inlcuded. Also note that hidden files are not ignored and the results are not
+  sorted.
+
   Returns `{:ok, files}` in case of success,
   `{:error, reason}` otherwise.
   """


### PR DESCRIPTION
Updates the `File.ls` documentation to mention that directories are included in the result list.

The text inspired by the documentation of `:file.list_dir` that we use: https://www.erlang.org/doc/man/file.html#list_dir-1

I've also thought about adding an example of listing only non-directory files by using `File.ls |> Enum.reject(&File.is_dir?/1)` but I think we don't need that much here. 

Closes #12731