### PR TITLE
Pass `%*` to `env.bat` and document accordingly

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -578,6 +578,21 @@ defmodule Mix.Tasks.Release do
   )
   ```
 
+  Inside `env.sh` and `env.bat` files you can access command-line arguments given to release commands.
+  For example, given this `env.sh.eex`:
+
+  ```bash
+  echo $@
+  ```
+
+  or this `env.bat.eex`:
+
+  ```bash
+  echo %*
+  ```
+
+  starting the release with `bin/myapp start --foo bar baz` will print `start --foo bar baz`.
+
   ## Application configuration
 
   Mix provides two mechanisms for configuring the application environment

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -297,7 +297,7 @@ defmodule Mix.Tasks.Release.Init do
     if not defined RELEASE_PROG (set RELEASE_PROG=%~nx0)
     set RELEASE_COMMAND=%~1
     set REL_VSN_DIR=!RELEASE_ROOT!\releases\!RELEASE_VSN!
-    call "!REL_VSN_DIR!\env.bat"
+    call "!REL_VSN_DIR!\env.bat" %*
 
     if not defined RELEASE_COOKIE (set /p RELEASE_COOKIE=<!RELEASE_ROOT!\releases\COOKIE)
     if not defined RELEASE_MODE (set RELEASE_MODE=embedded)


### PR DESCRIPTION
On UNIX, `$@` was already available in `env.sh`. This patch adds similar capability for `env.bat`.

For a more complete example, users can:

```sh
# env.sh.eex
export MYAPP_ARGS="$@"
```

and then:

```elixir
# lib/myapp/application.ex
def start(_type, _args) do
  if args = System.get_env("MYAPP_ARGS") do
    args
    |> OptionParser.split()
    |> # ...
  end
end
```

Parsing command-line arguments in Elixir is not ideal given various escaping rules and whitespace handling so depending on their needs, users might instead leave this up to the shell:

```sh
# env.sh.eex
i=1
export MYAPP_ARGC=$#
for arg; do
  export "MYAPP_ARG$i"="$arg"
  i=$((i + 1))
done
```

```elixir
# lib/myapp/application.ex
def start(_type, _args) do
  if argc = System.get_env("MYAPP_ARGC") do
    for i <- 1..System.to_integer(argc) do
      System.fetch_env!("MYAPP_ARG#{i}")
    end
  end
end
```