### PR TITLE
Clarify that Code.with_diagnostics/2 does not rescue

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -564,7 +564,7 @@ defmodule Code do
   > #### Rescuing compilation errors {: .info}
   >
   > `with_diagnostics/2` does not automatically handle exceptions,
-  > so compilation errors will still be raised.
+  > so compilation errors may be raised.
   > Compilation errors can be retrieved by adding a `try/1` in `fun`:
   >
   >     {result, all_errors_and_warnings} =

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -561,6 +561,21 @@ defmodule Code do
     * `:log` - if the diagnostics should be logged as they happen.
       Defaults to `false`.
 
+  > #### Rescuing compilation errors {: .info}
+  >
+  > `with_diagnostics/2` does not automatically handle exceptions,
+  > so compilation errors will still be raised.
+  > Compilation errors can be retrieved by adding a `try/1` in `fun`:
+  >
+  >     {result, all_errors_and_warnings} =
+  >       Code.with_diagnostics(fn ->
+  >         try do
+  >           Code.compile_quoted(quoted)
+  >         rescue
+  >           err -> err
+  >         end
+  >       end)
+
   """
   @doc since: "1.15.0"
   @spec with_diagnostics(keyword(), (-> result)) :: {result, [diagnostic(:warning | :error)]}

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -570,9 +570,9 @@ defmodule Code do
   >     {result, all_errors_and_warnings} =
   >       Code.with_diagnostics(fn ->
   >         try do
-  >           Code.compile_quoted(quoted)
+  >           {:ok, Code.compile_quoted(quoted)}
   >         rescue
-  >           err -> err
+  >           err -> {:error, err}
   >         end
   >       end)
 


### PR DESCRIPTION
Clarification following this [discussion](https://github.com/elixir-lang/elixir/issues/12276#issuecomment-1616246865).

Alternatively, since it seems a fairly common use case, I wonder if a `rescue: true` option wouldn't improve the ergonomics here?