### PR TITLE
Indent some Markdown guides

### DIFF
--- a/lib/elixir/pages/anti-patterns/design-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/design-anti-patterns.md
@@ -13,58 +13,58 @@ TODO
 
 ## Working with invalid data
 
-* **Problem:** This anti-pattern refers to a function that does not validate its parameters' types and therefore can produce internal non-predicted behavior. When an error is raised inside a function due to an invalid parameter value, this can confuse the developers and make it harder to locate and fix the error.
+  * **Problem:** This anti-pattern refers to a function that does not validate its parameters' types and therefore can produce internal non-predicted behavior. When an error is raised inside a function due to an invalid parameter value, this can confuse the developers and make it harder to locate and fix the error.
 
-* **Example:** An example of this anti-pattern is when a function receives an invalid parameter and then passes it to other functions, either from the same library or a third-party. This will cause an error raised deep inside, which may be confusing for the developer who is working with invalid data. As shown next, the function `foo/1` is a user-facing API which doesn't validate its parameters at the boundary. In this way, it is possible that invalid data will be passed through, causing a "mysterious error".
-  
-  ```elixir
-  defmodule MyLibrary do
-    def foo(invalid_data) do
-      ...
-      MyLibrary.Internal.sum(1, invalid_data)
-      ...
+  * **Example:** An example of this anti-pattern is when a function receives an invalid parameter and then passes it to other functions, either from the same library or a third-party. This will cause an error raised deep inside, which may be confusing for the developer who is working with invalid data. As shown next, the function `foo/1` is a user-facing API which doesn't validate its parameters at the boundary. In this way, it is possible that invalid data will be passed through, causing a "mysterious error".
+
+    ```elixir
+    defmodule MyLibrary do
+      def foo(invalid_data) do
+        ...
+        MyLibrary.Internal.sum(1, invalid_data)
+        ...
+      end
     end
-  end
-  
-  #...Use examples...
-  
-  # with valid data is ok
-  iex(1)> MyLibrary.foo(2)
-  3
-  
-  #with invalid data cause a confusing error deep inside
-  iex(2)> MyLibrary.foo("José")
-  ** (ArithmeticError) bad argument in arithmetic expression: 1 + "José"
-    :erlang.+(1, "José")
-    my_library.ex:4: MyLibrary.Internal.sum/2
-  ```
 
-* **Refactoring:** To remove this anti-pattern, the client code must validate input parameters at the boundary with the user, via guard clauses or pattern matching. This will prevent errors from occurring deeply, making them easier to understand. This refactoring will also allow libraries to be implemented without worrying about creating internal protection mechanisms. The next code illustrates the refactoring of `foo/1`, removing this anti-pattern:
+    #...Use examples...
 
-  ```elixir
-  defmodule MyLibrary do
-    def foo(data) when is_integer(data) do
-      ...
-      MyLibrary.Internal.sum(1, data)
-      ...
+    # with valid data is ok
+    iex(1)> MyLibrary.foo(2)
+    3
+
+    #with invalid data cause a confusing error deep inside
+    iex(2)> MyLibrary.foo("José")
+    ** (ArithmeticError) bad argument in arithmetic expression: 1 + "José"
+      :erlang.+(1, "José")
+      my_library.ex:4: MyLibrary.Internal.sum/2
+    ```
+
+  * **Refactoring:** To remove this anti-pattern, the client code must validate input parameters at the boundary with the user, via guard clauses or pattern matching. This will prevent errors from occurring deeply, making them easier to understand. This refactoring will also allow libraries to be implemented without worrying about creating internal protection mechanisms. The next code illustrates the refactoring of `foo/1`, removing this anti-pattern:
+
+    ```elixir
+    defmodule MyLibrary do
+      def foo(data) when is_integer(data) do
+        ...
+        MyLibrary.Internal.sum(1, data)
+        ...
+      end
     end
-  end
-  
-  #...Use examples...
-  
-  #with valid data is ok
-  iex(1)> MyLibrary.foo(2)
-  3
-  
-  # with invalid data errors are easy to locate and fix
-  iex(2)> MyLibrary.foo("José")
-  ** (FunctionClauseError) no function clause matching in MyLibrary.foo/1
-    The following arguments were given to MyLibrary.foo/1:
-        # 1
-        "José"
-    my_library.ex:2: MyLibrary.foo/1
-  ```
-  
+
+    #...Use examples...
+
+    #with valid data is ok
+    iex(1)> MyLibrary.foo(2)
+    3
+
+    # with invalid data errors are easy to locate and fix
+    iex(2)> MyLibrary.foo("José")
+    ** (FunctionClauseError) no function clause matching in MyLibrary.foo/1
+      The following arguments were given to MyLibrary.foo/1:
+          # 1
+          "José"
+      my_library.ex:2: MyLibrary.foo/1
+    ```
+
 ## Alternative return types
 
 TODO

--- a/lib/elixir/pages/anti-patterns/design-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/design-anti-patterns.md
@@ -13,57 +13,57 @@ TODO
 
 ## Working with invalid data
 
-  * **Problem:** This anti-pattern refers to a function that does not validate its parameters' types and therefore can produce internal non-predicted behavior. When an error is raised inside a function due to an invalid parameter value, this can confuse the developers and make it harder to locate and fix the error.
+**Problem:** This anti-pattern refers to a function that does not validate its parameters' types and therefore can produce internal non-predicted behavior. When an error is raised inside a function due to an invalid parameter value, this can confuse the developers and make it harder to locate and fix the error.
 
-  * **Example:** An example of this anti-pattern is when a function receives an invalid parameter and then passes it to other functions, either from the same library or a third-party. This will cause an error raised deep inside, which may be confusing for the developer who is working with invalid data. As shown next, the function `foo/1` is a user-facing API which doesn't validate its parameters at the boundary. In this way, it is possible that invalid data will be passed through, causing a "mysterious error".
+**Example:** An example of this anti-pattern is when a function receives an invalid parameter and then passes it to other functions, either from the same library or a third-party. This will cause an error raised deep inside, which may be confusing for the developer who is working with invalid data. As shown next, the function `foo/1` is a user-facing API which doesn't validate its parameters at the boundary. In this way, it is possible that invalid data will be passed through, causing a "mysterious error".
 
-    ```elixir
-    defmodule MyLibrary do
-      def foo(invalid_data) do
-        ...
-        MyLibrary.Internal.sum(1, invalid_data)
-        ...
-      end
-    end
+```elixir
+defmodule MyLibrary do
+  def foo(invalid_data) do
+    ...
+    MyLibrary.Internal.sum(1, invalid_data)
+    ...
+  end
+end
 
-    #...Use examples...
+#...Use examples...
 
-    # with valid data is ok
-    iex(1)> MyLibrary.foo(2)
-    3
+# with valid data is ok
+iex(1)> MyLibrary.foo(2)
+3
 
-    #with invalid data cause a confusing error deep inside
-    iex(2)> MyLibrary.foo("José")
-    ** (ArithmeticError) bad argument in arithmetic expression: 1 + "José"
-      :erlang.+(1, "José")
-      my_library.ex:4: MyLibrary.Internal.sum/2
-    ```
+#with invalid data cause a confusing error deep inside
+iex(2)> MyLibrary.foo("José")
+** (ArithmeticError) bad argument in arithmetic expression: 1 + "José"
+  :erlang.+(1, "José")
+  my_library.ex:4: MyLibrary.Internal.sum/2
+```
 
-  * **Refactoring:** To remove this anti-pattern, the client code must validate input parameters at the boundary with the user, via guard clauses or pattern matching. This will prevent errors from occurring deeply, making them easier to understand. This refactoring will also allow libraries to be implemented without worrying about creating internal protection mechanisms. The next code illustrates the refactoring of `foo/1`, removing this anti-pattern:
+**Refactoring:** To remove this anti-pattern, the client code must validate input parameters at the boundary with the user, via guard clauses or pattern matching. This will prevent errors from occurring deeply, making them easier to understand. This refactoring will also allow libraries to be implemented without worrying about creating internal protection mechanisms. The next code illustrates the refactoring of `foo/1`, removing this anti-pattern:
 
-    ```elixir
-    defmodule MyLibrary do
-      def foo(data) when is_integer(data) do
-        ...
-        MyLibrary.Internal.sum(1, data)
-        ...
-      end
-    end
+```elixir
+defmodule MyLibrary do
+  def foo(data) when is_integer(data) do
+    ...
+    MyLibrary.Internal.sum(1, data)
+    ...
+  end
+end
 
-    #...Use examples...
+#...Use examples...
 
-    #with valid data is ok
-    iex(1)> MyLibrary.foo(2)
-    3
+#with valid data is ok
+iex(1)> MyLibrary.foo(2)
+3
 
-    # with invalid data errors are easy to locate and fix
-    iex(2)> MyLibrary.foo("José")
-    ** (FunctionClauseError) no function clause matching in MyLibrary.foo/1
-      The following arguments were given to MyLibrary.foo/1:
-          # 1
-          "José"
-      my_library.ex:2: MyLibrary.foo/1
-    ```
+# with invalid data errors are easy to locate and fix
+iex(2)> MyLibrary.foo("José")
+** (FunctionClauseError) no function clause matching in MyLibrary.foo/1
+  The following arguments were given to MyLibrary.foo/1:
+      # 1
+      "José"
+  my_library.ex:2: MyLibrary.foo/1
+```
 
 ## Alternative return types
 

--- a/lib/elixir/pages/anti-patterns/process-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/process-anti-patterns.md
@@ -4,57 +4,57 @@ This document outlines anti-patterns related to processes and process-based abst
 
 ## Code organization by process
 
-* **Problem:** This anti-pattern refers to code that is unnecessarily organized by processes. A process itself does not represent an anti-pattern, but it should only be used to model runtime properties (for example: concurrency, access to shared resources, and event scheduling). When a process is used for code organization, it can create bottlenecks in the system.
+  * **Problem:** This anti-pattern refers to code that is unnecessarily organized by processes. A process itself does not represent an anti-pattern, but it should only be used to model runtime properties (e.g., concurrency, access to shared resources, and event scheduling). When a process is used for code organization, it can create bottlenecks in the system.
 
-* **Example:** An example of this anti-pattern, as shown below, is a library that implements arithmetic operations (such as `add` and `subtract`) by means of a `GenSever` process. If the number of calls to this single process grows, this code organization can compromise the system performance, therefore becoming a bottleneck.
+  * **Example:** An example of this anti-pattern, as shown below, is a library that implements arithmetic operations (e.g., add, subtract) by means of a `GenSever` process. If the number of calls to this single process grows, this code organization can compromise the system performance, therefore becoming a bottleneck.
 
-  ```elixir
-  defmodule Calculator do
-    @moduledoc """
-    Calculator that performs two basic arithmetic operations.
-    This code is unnecessarily organized by a GenServer process.
-    """
+    ```elixir
+    defmodule Calculator do
+      use GenServer
 
-    use GenServer
+      @moduledoc """
+        Calculator that performs two basic arithmetic operations.
+        This code is unnecessarily organized by a GenServer process.
+      """
 
-    @doc """
-    Function to perform the sum of two values.
-    """
-    def add(a, b, pid) do
-      GenServer.call(pid, {:add, a, b})
+      @doc """
+        Function to perform the sum of two values.
+      """
+      def add(a, b, pid) do
+        GenServer.call(pid, {:add, a, b})
+      end
+
+      @doc """
+        Function to perform subtraction of two values.
+      """
+      def subtract(a, b, pid) do
+        GenServer.call(pid, {:subtract, a, b})
+      end
+
+      def init(init_arg) do
+        {:ok, init_arg}
+      end
+
+      def handle_call({:add, a, b}, _from, state) do
+        {:reply, a + b, state}
+      end
+
+      def handle_call({:subtract, a, b}, _from, state) do
+        {:reply, a - b, state}
+      end
     end
 
-    @doc """
-    Function to perform subtraction of two values.
-    """
-    def subtract(a, b, pid) do
-      GenServer.call(pid, {:subtract, a, b})
-    end
+    # Start a generic server process
+    iex(1)> {:ok, pid} = GenServer.start_link(Calculator, :init)
+    {:ok, #PID<0.132.0>}
 
-    def init(init_arg) do
-      {:ok, init_arg}
-    end
+    #...Use examples...
+    iex(2)> Calculator.add(1, 5, pid)
+    6
 
-    def handle_call({:add, a, b}, _from, state) do
-      {:reply, a + b, state}
-    end
-
-    def handle_call({:subtract, a, b}, _from, state) do
-      {:reply, a - b, state}
-    end
-  end
-
-  # Start a generic server process
-  iex(1)> {:ok, pid} = GenServer.start_link(Calculator, :init)
-  {:ok, #PID<0.132.0>}
-
-  #...Use examples...
-  iex(2)> Calculator.add(1, 5, pid)
-  6
-
-  iex(3)> Calculator.subtract(2, 3, pid)
-  -1
-  ```
+    iex(3)> Calculator.subtract(2, 3, pid)
+    -1
+    ```
 
 * **Refactoring:** In Elixir, as shown next, code organization must be done only by modules and functions. Whenever possible, a library should not impose specific behavior (such as parallelization) on its clients. It is better to delegate this behavioral decision to the developers of clients, thus increasing the potential for code reuse of a library.
 
@@ -84,129 +84,136 @@ TODO.
 
 ## Unsupervised processes
 
-* **Problem:** In Elixir, creating a process outside a supervision tree is not an anti-pattern in itself. However, when code creates a large number of long-running processes outside a supervision tree, this can cause problems with the visibility, restart, and shutdown of a system, preventing developers from fully controlling their applications.
+  * **Problem:** In Elixir, creating a process outside a supervision tree is not an anti-pattern in itself. However, when code creates a large number of long-running processes outside a supervision tree, this can make visibility and monitoring of these processes difficult, preventing developers from fully controlling their applications.
 
-* **Example:** The following code example seeks to illustrate a module responsible for maintaining a numerical `Counter` through a `GenServer` process outside a supervision tree. Multiple counters can be created simultaneously by a client (one process for each counter), making these unsupervised processes difficult to manage.
+  * **Example:** The following code example seeks to illustrate a library responsible for maintaining a numerical `Counter` through a `GenServer` process outside a supervision tree. Multiple counters can be created simultaneously by a client (one process for each counter), making these unsupervised processes difficult to manage. This can cause problems with the initialization, restart, and shutdown of a system.
 
-  ```elixir
-  defmodule Counter do
-    @moduledoc """
-    Global counter implemented through a GenServer process
-    outside a supervision tree.
-    """
+    ```elixir
+    defmodule Counter do
+      use GenServer
 
-    use GenServer
+      @moduledoc """
+        Global counter implemented through a GenServer process
+        outside a supervision tree.
+      """
 
-    @doc """
-    Starts a counter.
-    """
-    def start_link(initial_value) when is_integer(initial_value) do
-      GenServer.start(__MODULE__, initial_value, name: __MODULE__)
+      @doc """
+        Function to create a counter.
+          initial_value: any integer value.
+          pid_name: optional parameter to define the process name.
+                    Default is Counter.
+      """
+      def start(initial_value, pid_name \\ __MODULE__)
+        when is_integer(initial_value) do
+        GenServer.start(__MODULE__, initial_value, name: pid_name)
+      end
+
+      @doc """
+        Function to get the counter's current value.
+          pid_name: optional parameter to inform the process name.
+                    Default is Counter.
+      """
+      def get(pid_name \\ __MODULE__) do
+        GenServer.call(pid_name, :get)
+      end
+
+      @doc """
+        Function to changes the counter's current value.
+        Returns the updated value.
+          value: amount to be added to the counter.
+          pid_name: optional parameter to inform the process name.
+                    Default is Counter.
+      """
+      def bump(value, pid_name \\ __MODULE__) do
+        GenServer.call(pid_name, {:bump, value})
+        get(pid_name)
+      end
+
+      ## Callbacks
+
+      @impl true
+      def init(counter) do
+        {:ok, counter}
+      end
+
+      @impl true
+      def handle_call(:get, _from, counter) do
+        {:reply, counter, counter}
+      end
+
+      def handle_call({:bump, value}, _from, counter) do
+        {:reply, counter, counter + value}
+      end
     end
 
-    @doc """
-    Get the counter's current value.
-    """
-    def get do
-      GenServer.call(__MODULE__, :get)
+    #...Use examples...
+
+    iex(1)> Counter.start(0)
+    {:ok, #PID<0.115.0>}
+
+    iex(2)> Counter.get()
+    0
+
+    iex(3)> Counter.start(15, C2)
+    {:ok, #PID<0.120.0>}
+
+    iex(4)> Counter.get(C2)
+    15
+
+    iex(5)> Counter.bump(-3, C2)
+    12
+
+    iex(6)> Counter.bump(7)
+    7
+    ```
+
+  * **Refactoring:** To ensure that clients of a library have full control over their systems, regardless of the number of processes used and the lifetime of each one, all processes must be started inside a supervision tree. As shown below, this code uses a [`Supervisor`](https://hexdocs.pm/elixir/main/Supervisor.html) as a supervision tree. When this Elixir application is started, two different counters (`Counter` and `C2`) are also started as child processes of the `Supervisor` named `App.Supervisor`. Both are initialized with zero. By means of this supervision tree, it is possible to manage the lifecycle of all child processes (e.g., stopping or restarting each one), improving the visibility of the entire app.
+
+    ```elixir
+    defmodule SupervisedProcess.Application do
+      use Application
+
+      @impl true
+      def start(_type, _args) do
+        children = [
+          # The counters are Supervisor children started via Counter.start(0).
+          %{
+            id: Counter,
+            start: {Counter, :start, [0]}
+          },
+          %{
+            id: C2,
+            start: {Counter, :start, [0, C2]}
+          }
+        ]
+
+        opts = [strategy: :one_for_one, name: App.Supervisor]
+        Supervisor.start_link(children, opts)
+      end
     end
 
-    @doc """
-    Changes the counter's current value by `amount`.
-    """
-    def bump(amount) when is_integer(amount) do
-      GenServer.call(__MODULE__, {:bump, amount})
-    end
+    #...Use examples...
 
-    ## Callbacks
+    iex(1)> Supervisor.count_children(App.Supervisor)
+    %{active: 2, specs: 2, supervisors: 0, workers: 2}
 
-    @impl true
-    def init(counter) do
-      {:ok, counter}
-    end
+    iex(2)> Counter.get(Counter)
+    0
 
-    @impl true
-    def handle_call(:get, _from, counter) do
-      {:reply, counter, counter}
-    end
+    iex(3)> Counter.get(C2)
+    0
 
-    def handle_call({:bump, value}, _from, counter) do
-      {:reply, counter + value, counter + value}
-    end
-  end
+    iex(4)> Counter.bump(7, Counter)
+    7
 
-  #...Use examples...
+    iex(5)> Supervisor.terminate_child(App.Supervisor, Counter)
+    iex(6)> Supervisor.count_children(App.Supervisor)
+    %{active: 1, specs: 2, supervisors: 0, workers: 2}  #only one active
 
-  iex(1)> Counter.start_link(0)
-  {:ok, #PID<0.115.0>}
+    iex(7)> Counter.get(Counter)   #Error because it was previously terminated
+    ** (EXIT) no process: the process is not alive...
 
-  iex(2)> Counter.get()
-  0
-
-  iex(3)> Counter.bump(7)
-  7
-
-  iex(4)> Counter.bump(-3)
-  4
-  ```
-
-* **Refactoring:** To ensure observability and control over the lifecycle of processes, all processes must be started inside a supervision tree. As shown below, this code uses a `Supervisor` as a supervision tree. When this Elixir application is started, two different counters (`Counter` and `C2`) are also started as child processes of the `Supervisor` named `MyApp.Supervisor`. Both are initialized with zero. By means of this supervision tree, it is possible to manage the lifecycle of all child processes (stopping or restarting each one), improving the visibility of the entire app.
-
-  ```elixir
-  defmodule MyApp.Application do
-    use Application
-
-    @impl true
-    def start(_type, _args) do
-      children = [
-        {Counter, 0}
-      ]
-
-      opts = [strategy: :one_for_one, name: MyApp.Supervisor]
-      Supervisor.start_link(children, opts)
-    end
-  end
-
-  #...Use examples...
-
-  iex(1)> Supervisor.count_children(MyApp.Supervisor)
-  %{active: 1, specs: 1, supervisors: 0, workers: 1}
-
-  iex(2)> Counter.get()
-  0
-
-  iex(3)> Counter.bump(7)
-  7
-
-  iex(4)> Supervisor.terminate_child(MyApp.Supervisor, Counter)
-  iex(5)> Supervisor.count_children(MyApp.Supervisor)
-  %{active: 0, specs: 0, supervisors: 0, workers: 0}
-
-  iex(6)> Counter.get()   #Error because it was previously terminated
-  ** (EXIT) no process: the process is not alive...
-
-  iex(7)> Supervisor.restart_child(MyApp.Supervisor, Counter)
-  iex(8)> Counter.get()   #after the restart, this process can be accessed again
-  0
-  ```
-
-  The application module above follows the same template as the one generated by `mix new my_app --sup`.
-
-* **Additional remarks:** One of the few times where it is acceptable to start a process outside of a supervision tree is with `Task.async/1` and `Task.await/2`. Opposite to `Task.start_link/1`, the async/await mechanism gives you full control over the spawned process life cycle - which is also why you must always call `Task.await/2` after starting a task with `Task.async/1`. Even though, if your application is spawning multiple async processes, you should consider using `Task.Supervisor` for the reasons outlined above.
-
-  Futhermore, if you are implementing a library, you should allow the users of your library to supervise processes inside their own supervision tree whenever possible. For example, the [Ecto](https://github.com/elixir-ecto/ecto) library requires you to start your database repository inside your supervision tree:
-
-  ```elixir
-  defmodule MyApp.Application do
-    use Application
-
-    @impl true
-    def start(_type, _args) do
-      children = [
-        {MyApp.Repo, url: ...}
-      ]
-
-      ...
-  ```
-
-  This has benefits as it allows users of your library to configure and customize how the processes are started and supervised. Internally, the `Ecto` library also has its own supervision tree with its own processes, but those processes are not user-facing and instead are internal to Ecto's implementation.
+    iex(8)> Supervisor.restart_child(App.Supervisor, Counter)
+    iex(9)> Counter.get(Counter)   #after the restart, this process can be accessed again
+    0
+    ```

--- a/lib/elixir/pages/anti-patterns/process-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/process-anti-patterns.md
@@ -4,79 +4,79 @@ This document outlines anti-patterns related to processes and process-based abst
 
 ## Code organization by process
 
-  * **Problem:** This anti-pattern refers to code that is unnecessarily organized by processes. A process itself does not represent an anti-pattern, but it should only be used to model runtime properties (e.g., concurrency, access to shared resources, and event scheduling). When a process is used for code organization, it can create bottlenecks in the system.
+**Problem:** This anti-pattern refers to code that is unnecessarily organized by processes. A process itself does not represent an anti-pattern, but it should only be used to model runtime properties (e.g., concurrency, access to shared resources, and event scheduling). When a process is used for code organization, it can create bottlenecks in the system.
 
-  * **Example:** An example of this anti-pattern, as shown below, is a library that implements arithmetic operations (e.g., add, subtract) by means of a `GenSever` process. If the number of calls to this single process grows, this code organization can compromise the system performance, therefore becoming a bottleneck.
+**Example:** An example of this anti-pattern, as shown below, is a library that implements arithmetic operations (e.g., add, subtract) by means of a `GenSever` process. If the number of calls to this single process grows, this code organization can compromise the system performance, therefore becoming a bottleneck.
 
-    ```elixir
-    defmodule Calculator do
-      use GenServer
+```elixir
+defmodule Calculator do
+  use GenServer
 
-      @moduledoc """
-        Calculator that performs two basic arithmetic operations.
-        This code is unnecessarily organized by a GenServer process.
-      """
+  @moduledoc """
+    Calculator that performs two basic arithmetic operations.
+    This code is unnecessarily organized by a GenServer process.
+  """
 
-      @doc """
-        Function to perform the sum of two values.
-      """
-      def add(a, b, pid) do
-        GenServer.call(pid, {:add, a, b})
-      end
-
-      @doc """
-        Function to perform subtraction of two values.
-      """
-      def subtract(a, b, pid) do
-        GenServer.call(pid, {:subtract, a, b})
-      end
-
-      def init(init_arg) do
-        {:ok, init_arg}
-      end
-
-      def handle_call({:add, a, b}, _from, state) do
-        {:reply, a + b, state}
-      end
-
-      def handle_call({:subtract, a, b}, _from, state) do
-        {:reply, a - b, state}
-      end
-    end
-
-    # Start a generic server process
-    iex(1)> {:ok, pid} = GenServer.start_link(Calculator, :init)
-    {:ok, #PID<0.132.0>}
-
-    #...Use examples...
-    iex(2)> Calculator.add(1, 5, pid)
-    6
-
-    iex(3)> Calculator.subtract(2, 3, pid)
-    -1
-    ```
-
-* **Refactoring:** In Elixir, as shown next, code organization must be done only by modules and functions. Whenever possible, a library should not impose specific behavior (such as parallelization) on its clients. It is better to delegate this behavioral decision to the developers of clients, thus increasing the potential for code reuse of a library.
-
-  ```elixir
-  defmodule Calculator do
-    def add(a, b) do
-      a + b
-    end
-
-    def subtract(a, b) do
-      a - b
-    end
+  @doc """
+    Function to perform the sum of two values.
+  """
+  def add(a, b, pid) do
+    GenServer.call(pid, {:add, a, b})
   end
 
-  #...Use examples...
+  @doc """
+    Function to perform subtraction of two values.
+  """
+  def subtract(a, b, pid) do
+    GenServer.call(pid, {:subtract, a, b})
+  end
 
-  iex(1)> Calculator.add(1, 5)
-  6
+  def init(init_arg) do
+    {:ok, init_arg}
+  end
 
-  iex(2)> Calculator.subtract(2, 3)
-  -1
-  ```
+  def handle_call({:add, a, b}, _from, state) do
+    {:reply, a + b, state}
+  end
+
+  def handle_call({:subtract, a, b}, _from, state) do
+    {:reply, a - b, state}
+  end
+end
+
+# Start a generic server process
+iex(1)> {:ok, pid} = GenServer.start_link(Calculator, :init)
+{:ok, #PID<0.132.0>}
+
+#...Use examples...
+iex(2)> Calculator.add(1, 5, pid)
+6
+
+iex(3)> Calculator.subtract(2, 3, pid)
+-1
+```
+
+**Refactoring:** In Elixir, as shown next, code organization must be done only by modules and functions. Whenever possible, a library should not impose specific behavior (such as parallelization) on its clients. It is better to delegate this behavioral decision to the developers of clients, thus increasing the potential for code reuse of a library.
+
+```elixir
+defmodule Calculator do
+  def add(a, b) do
+    a + b
+  end
+
+  def subtract(a, b) do
+    a - b
+  end
+end
+
+#...Use examples...
+
+iex(1)> Calculator.add(1, 5)
+6
+
+iex(2)> Calculator.subtract(2, 3)
+-1
+```
 
 ## Scattered process interfaces
 
@@ -84,136 +84,136 @@ TODO.
 
 ## Unsupervised processes
 
-  * **Problem:** In Elixir, creating a process outside a supervision tree is not an anti-pattern in itself. However, when code creates a large number of long-running processes outside a supervision tree, this can make visibility and monitoring of these processes difficult, preventing developers from fully controlling their applications.
+**Problem:** In Elixir, creating a process outside a supervision tree is not an anti-pattern in itself. However, when code creates a large number of long-running processes outside a supervision tree, this can make visibility and monitoring of these processes difficult, preventing developers from fully controlling their applications.
 
-  * **Example:** The following code example seeks to illustrate a library responsible for maintaining a numerical `Counter` through a `GenServer` process outside a supervision tree. Multiple counters can be created simultaneously by a client (one process for each counter), making these unsupervised processes difficult to manage. This can cause problems with the initialization, restart, and shutdown of a system.
+**Example:** The following code example seeks to illustrate a library responsible for maintaining a numerical `Counter` through a `GenServer` process outside a supervision tree. Multiple counters can be created simultaneously by a client (one process for each counter), making these unsupervised processes difficult to manage. This can cause problems with the initialization, restart, and shutdown of a system.
 
-    ```elixir
-    defmodule Counter do
-      use GenServer
+```elixir
+defmodule Counter do
+  use GenServer
 
-      @moduledoc """
-        Global counter implemented through a GenServer process
-        outside a supervision tree.
-      """
+  @moduledoc """
+    Global counter implemented through a GenServer process
+    outside a supervision tree.
+  """
 
-      @doc """
-        Function to create a counter.
-          initial_value: any integer value.
-          pid_name: optional parameter to define the process name.
-                    Default is Counter.
-      """
-      def start(initial_value, pid_name \\ __MODULE__)
-        when is_integer(initial_value) do
-        GenServer.start(__MODULE__, initial_value, name: pid_name)
-      end
+  @doc """
+    Function to create a counter.
+      initial_value: any integer value.
+      pid_name: optional parameter to define the process name.
+                Default is Counter.
+  """
+  def start(initial_value, pid_name \\ __MODULE__)
+    when is_integer(initial_value) do
+    GenServer.start(__MODULE__, initial_value, name: pid_name)
+  end
 
-      @doc """
-        Function to get the counter's current value.
-          pid_name: optional parameter to inform the process name.
-                    Default is Counter.
-      """
-      def get(pid_name \\ __MODULE__) do
-        GenServer.call(pid_name, :get)
-      end
+  @doc """
+    Function to get the counter's current value.
+      pid_name: optional parameter to inform the process name.
+                Default is Counter.
+  """
+  def get(pid_name \\ __MODULE__) do
+    GenServer.call(pid_name, :get)
+  end
 
-      @doc """
-        Function to changes the counter's current value.
-        Returns the updated value.
-          value: amount to be added to the counter.
-          pid_name: optional parameter to inform the process name.
-                    Default is Counter.
-      """
-      def bump(value, pid_name \\ __MODULE__) do
-        GenServer.call(pid_name, {:bump, value})
-        get(pid_name)
-      end
+  @doc """
+    Function to changes the counter's current value.
+    Returns the updated value.
+      value: amount to be added to the counter.
+      pid_name: optional parameter to inform the process name.
+                Default is Counter.
+  """
+  def bump(value, pid_name \\ __MODULE__) do
+    GenServer.call(pid_name, {:bump, value})
+    get(pid_name)
+  end
 
-      ## Callbacks
+  ## Callbacks
 
-      @impl true
-      def init(counter) do
-        {:ok, counter}
-      end
+  @impl true
+  def init(counter) do
+    {:ok, counter}
+  end
 
-      @impl true
-      def handle_call(:get, _from, counter) do
-        {:reply, counter, counter}
-      end
+  @impl true
+  def handle_call(:get, _from, counter) do
+    {:reply, counter, counter}
+  end
 
-      def handle_call({:bump, value}, _from, counter) do
-        {:reply, counter, counter + value}
-      end
-    end
+  def handle_call({:bump, value}, _from, counter) do
+    {:reply, counter, counter + value}
+  end
+end
 
-    #...Use examples...
+#...Use examples...
 
-    iex(1)> Counter.start(0)
-    {:ok, #PID<0.115.0>}
+iex(1)> Counter.start(0)
+{:ok, #PID<0.115.0>}
 
-    iex(2)> Counter.get()
-    0
+iex(2)> Counter.get()
+0
 
-    iex(3)> Counter.start(15, C2)
-    {:ok, #PID<0.120.0>}
+iex(3)> Counter.start(15, C2)
+{:ok, #PID<0.120.0>}
 
-    iex(4)> Counter.get(C2)
-    15
+iex(4)> Counter.get(C2)
+15
 
-    iex(5)> Counter.bump(-3, C2)
-    12
+iex(5)> Counter.bump(-3, C2)
+12
 
-    iex(6)> Counter.bump(7)
-    7
-    ```
+iex(6)> Counter.bump(7)
+7
+```
 
-  * **Refactoring:** To ensure that clients of a library have full control over their systems, regardless of the number of processes used and the lifetime of each one, all processes must be started inside a supervision tree. As shown below, this code uses a [`Supervisor`](https://hexdocs.pm/elixir/main/Supervisor.html) as a supervision tree. When this Elixir application is started, two different counters (`Counter` and `C2`) are also started as child processes of the `Supervisor` named `App.Supervisor`. Both are initialized with zero. By means of this supervision tree, it is possible to manage the lifecycle of all child processes (e.g., stopping or restarting each one), improving the visibility of the entire app.
+**Refactoring:** To ensure that clients of a library have full control over their systems, regardless of the number of processes used and the lifetime of each one, all processes must be started inside a supervision tree. As shown below, this code uses a [`Supervisor`](https://hexdocs.pm/elixir/main/Supervisor.html) as a supervision tree. When this Elixir application is started, two different counters (`Counter` and `C2`) are also started as child processes of the `Supervisor` named `App.Supervisor`. Both are initialized with zero. By means of this supervision tree, it is possible to manage the lifecycle of all child processes (e.g., stopping or restarting each one), improving the visibility of the entire app.
 
-    ```elixir
-    defmodule SupervisedProcess.Application do
-      use Application
+```elixir
+defmodule SupervisedProcess.Application do
+  use Application
 
-      @impl true
-      def start(_type, _args) do
-        children = [
-          # The counters are Supervisor children started via Counter.start(0).
-          %{
-            id: Counter,
-            start: {Counter, :start, [0]}
-          },
-          %{
-            id: C2,
-            start: {Counter, :start, [0, C2]}
-          }
-        ]
+  @impl true
+  def start(_type, _args) do
+    children = [
+      # The counters are Supervisor children started via Counter.start(0).
+      %{
+        id: Counter,
+        start: {Counter, :start, [0]}
+      },
+      %{
+        id: C2,
+        start: {Counter, :start, [0, C2]}
+      }
+    ]
 
-        opts = [strategy: :one_for_one, name: App.Supervisor]
-        Supervisor.start_link(children, opts)
-      end
-    end
+    opts = [strategy: :one_for_one, name: App.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end
 
-    #...Use examples...
+#...Use examples...
 
-    iex(1)> Supervisor.count_children(App.Supervisor)
-    %{active: 2, specs: 2, supervisors: 0, workers: 2}
+iex(1)> Supervisor.count_children(App.Supervisor)
+%{active: 2, specs: 2, supervisors: 0, workers: 2}
 
-    iex(2)> Counter.get(Counter)
-    0
+iex(2)> Counter.get(Counter)
+0
 
-    iex(3)> Counter.get(C2)
-    0
+iex(3)> Counter.get(C2)
+0
 
-    iex(4)> Counter.bump(7, Counter)
-    7
+iex(4)> Counter.bump(7, Counter)
+7
 
-    iex(5)> Supervisor.terminate_child(App.Supervisor, Counter)
-    iex(6)> Supervisor.count_children(App.Supervisor)
-    %{active: 1, specs: 2, supervisors: 0, workers: 2}  #only one active
+iex(5)> Supervisor.terminate_child(App.Supervisor, Counter)
+iex(6)> Supervisor.count_children(App.Supervisor)
+%{active: 1, specs: 2, supervisors: 0, workers: 2}  #only one active
 
-    iex(7)> Counter.get(Counter)   #Error because it was previously terminated
-    ** (EXIT) no process: the process is not alive...
+iex(7)> Counter.get(Counter)   #Error because it was previously terminated
+** (EXIT) no process: the process is not alive...
 
-    iex(8)> Supervisor.restart_child(App.Supervisor, Counter)
-    iex(9)> Counter.get(Counter)   #after the restart, this process can be accessed again
-    0
-    ```
+iex(8)> Supervisor.restart_child(App.Supervisor, Counter)
+iex(9)> Counter.get(Counter)   #after the restart, this process can be accessed again
+0
+```


### PR DESCRIPTION
This is what we generally use in Elixir, so I think we should do it in the anti-patterns guides too.

cc @lucasvegi 