### PR TITLE
Add "Comments" anti-pattern to the guides

### DIFF
--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -41,7 +41,7 @@ end
 
 We removed the unnecessary comments. We also added a `@five_min_in_seconds` module attribute, which serves the additional purpose of giving a name to the "magic" number `60 * 5`, making the code clearer and more expressive.
 
-#### Documentation
+#### Additional remarks
 
 Elixir makes a clear distinction between **public documentation** and code comments. The language has built-in first-class support for documentation through `@doc`, `@moduledoc`, and more. See the [*Writing documentation*](writing-documentation.html) guide for more information.
 

--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -4,7 +4,42 @@ This document outlines anti-patterns related to your code and particular Elixir 
 
 ## Comments
 
-TODO.
+#### Problem
+
+When you overuse comments or comment self-explanatory code, it can have the effect of making code *less readable*.
+
+#### Example
+
+```elixir
+# Returns the Unix timestamp of 5 minutes from the current time
+defp unix_five_min_from_now do
+  # Get the current time
+  now = DateTime.utc_now()
+
+  # Convert it to a Unix timestamp
+  unix_now = DateTime.to_unix(now, :second)
+
+  # Add five minutes in seconds
+  unix_now + (60 * 5)
+end
+```
+
+#### Refactoring
+
+Prefer clear and self-explanatory function names, module names, and variable names when possible. In the example above, the function name explains well what the function does, so you likely won't need the comment before it. The code also explains the operations well through variable names and clear function calls.
+
+You could refactor the code above like this:
+
+```elixir
+@five_min_in_seconds 60 * 5
+
+defp unix_five_min_from_now do
+  unix_now = DateTime.to_unix(DateTime.utc_now(), :second)
+  unix_now + @five_min_in_seconds
+end
+```
+
+We removed the unnecessary comments. We also added a `@five_min_in_seconds` module attribute, which serves the additional purpose of giving a name to the "magic" number `60 * 5`, making the code clearer and more expressive.
 
 ## Long parameter list
 

--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -41,6 +41,10 @@ end
 
 We removed the unnecessary comments. We also added a `@five_min_in_seconds` module attribute, which serves the additional purpose of giving a name to the "magic" number `60 * 5`, making the code clearer and more expressive.
 
+#### Documentation
+
+Elixir makes a clear distinction between **public documentation** and code comments. The language has built-in first-class support for documentation through `@doc`, `@moduledoc`, and more. See the [*Writing documentation*](writing-documentation.html) guide for more information.
+
 ## Long parameter list
 
 TODO.

--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -43,7 +43,7 @@ We removed the unnecessary comments. We also added a `@five_min_in_seconds` modu
 
 #### Additional remarks
 
-Elixir makes a clear distinction between **public documentation** and code comments. The language has built-in first-class support for documentation through `@doc`, `@moduledoc`, and more. See the [*Writing documentation*](writing-documentation.html) guide for more information.
+Elixir makes a clear distinction between **documentation** and code comments. The language has built-in first-class support for documentation through `@doc`, `@moduledoc`, and more. See the ["Writing documentation"](../references/writing-documentation.md) guide for more information.
 
 ## Long parameter list
 


### PR DESCRIPTION
@josevalim would you be open to mentioning the pattern (that I always use 😬) of doing `_five_min = 60 * 5`, to essentially replicate named arguments and stuff like that? I think it might make sense in this section.