### PR TITLE
Add unbreakable space when citing on the man page

### DIFF
--- a/man/mix.1
+++ b/man/mix.1
@@ -52,11 +52,11 @@ An
 .Em archive ,
 in terms of Erlang/OTP, is the ZIP file with the
 .Em .ez
-extension which contains a precompiled OTP application with all its dependencies[1].
+extension which contains a precompiled OTP application with all its dependencies\~[1].
 .Pp
 An
 .Em application
-is an entity that helps to combine sets of components into a single unit to simplify their reusing in other systems[2].
+is an entity that helps to combine sets of components into a single unit to simplify their reusing in other systems\~[2].
 .Sh ENVIRONMENT
 .Bl -tag -width Ds
 .It Ev MIX_ARCHIVES


### PR DESCRIPTION
A minor change proposes adding space between text and reference to be more compliant with citation style.