### PR TITLE
Warn when using captured arg as match? pattern - WIP

### DIFF
--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -107,9 +107,18 @@ merge_and_check_unused_vars(Current, Unused, ClauseUnused, E) ->
       end;
 
     ({{Name, Kind}, _Count}, {Meta, Overridden}, Acc) ->
-      case (Kind == nil) andalso is_unused_var(Name) of
+      DisplayName = case Kind of
+        nil ->
+          Name;
+        elixir_fn ->
+          <<"x", Rest>> = atom_to_binary(Name),
+          binary_to_atom(<<"&", Rest>>);
+        _ ->
+          nil
+      end,
+      case (DisplayName /= nil) andalso is_unused_var(Name) of
         true ->
-          Warn = {unused_var, Name, Overridden},
+          Warn = {unused_var, DisplayName, Overridden},
           elixir_errors:file_warn(Meta, E, ?MODULE, Warn);
 
         false ->

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -610,7 +610,7 @@ mapfold(_Fun, S, E, [], Acc) ->
 %% Match/var helpers
 
 var_unused({_, Kind} = Pair, Meta, Version, Unused, Override) ->
-  case (Kind == nil) andalso should_warn(Meta) of
+  case (Kind == nil orelse Kind == elixir_fn) andalso should_warn(Meta) of
     true -> Unused#{{Pair, Version} => {Meta, Override}};
     false -> Unused
   end.


### PR DESCRIPTION
Attempt at fixing https://github.com/elixir-lang/elixir/issues/12612

Just opening as a draft to discuss the approach, this was the minimal change I managed to make it work:

<img width="730" alt="Screenshot 2023-07-06 at 22 47 08" src="https://github.com/elixir-lang/elixir/assets/11598866/9da45742-5b43-49c8-859a-d7e27739d8fb">

Consistent with what we get with `fn`:

<img width="708" alt="Screenshot 2023-07-06 at 22 53 57" src="https://github.com/elixir-lang/elixir/assets/11598866/9c46a99a-ec37-4857-9245-cc39e765df54">

