### PR TITLE
Revise the description of DSLs

### DIFF
--- a/lib/elixir/pages/meta-programming/domain-specific-languages.md
+++ b/lib/elixir/pages/meta-programming/domain-specific-languages.md
@@ -1,6 +1,6 @@
 # Domain-Specific Languages (DSLs)
 
-[Domain-specific Languages (DSLs)](https://en.wikipedia.org/wiki/Domain-specific_language) allow developers to tailor their application to a particular domain. You don't need macros in order to have a DSL: every data structure and every function you define in your module is part of your domain-specific language.
+[Domain-specific Languages (DSLs)](https://en.wikipedia.org/wiki/Domain-specific_language) are languages tailored to a specific application domain. You don't need macros in order to have a DSL: every data structure and every function you define in your module is part of your domain-specific language.
 
 For example, imagine we want to implement a `Validator` module which provides a data validation domain-specific language. We could implement it using data structures, functions, or macros. Let's see what those different DSLs would look like:
 


### PR DESCRIPTION
Since the first sentence is an intro to the DSLs and is a general outline, I recommend having a slightly more rigorous definition of DSLs.

Therefore, I took a one-sentence definition from the following paper, one of the most important research papers in the field:

Mernik, M., Heering, J., & Sloane, A. M. (2005). When and how to develop domain-specific languages. ACM computing surveys (CSUR), 37(4), 316-344