### PR TITLE
Expand captured args with regular context

### DIFF
--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -133,6 +133,8 @@ format_error({unused_var, Name, Overridden}) ->
   case atom_to_list(Name) of
     "_" ++ _ ->
       io_lib:format("unknown compiler variable \"~ts\" (expected one of __MODULE__, __ENV__, __DIR__, __CALLER__, __STACKTRACE__)", [Name]);
+    "&" ++ _ ->
+      io_lib:format("variable \"~ts\" is unused (this might happen when using a capture argument as a pattern)", [Name]);
     _ when Overridden ->
       io_lib:format("variable \"~ts\" is unused (there is a variable with the same name in the context, use the pin operator (^) to match on it or prefix this variable with underscore if it is not meant to be used)", [Name]);
     _ ->

--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -129,6 +129,9 @@ validate(_Meta, [], _Pos, _E) ->
   [].
 
 escape({'&', _, [Pos]}, _E, Dict) when is_integer(Pos), Pos > 0 ->
+  % Using a nil context here to emit warnings when variable is unused.
+  % This might pollute user space but is unlikely because variables
+  % named :"&1" are not valid syntax.
   Var = {list_to_atom([$& | integer_to_list(Pos)]), [], nil},
   {Var, orddict:store(Pos, Var, Dict)};
 escape({'&', Meta, [Pos]}, E, _Dict) when is_integer(Pos) ->

--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -129,7 +129,7 @@ validate(_Meta, [], _Pos, _E) ->
   [].
 
 escape({'&', _, [Pos]}, _E, Dict) when is_integer(Pos), Pos > 0 ->
-  Var = {list_to_atom([$x | integer_to_list(Pos)]), [], ?var_context},
+  Var = {list_to_atom([$& | integer_to_list(Pos)]), [], nil},
   {Var, orddict:store(Pos, Var, Dict)};
 escape({'&', Meta, [Pos]}, E, _Dict) when is_integer(Pos) ->
   file_error(Meta, E, ?MODULE, {invalid_arity_for_capture, Pos});

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -892,21 +892,25 @@ defmodule Kernel.WarningTest do
   end
 
   test "duplicate map keys" do
-    output =
-      capture_err(fn ->
-        defmodule DuplicateMapKeys do
-          assert %{a: :b, a: :c} == %{a: :c}
-          assert %{m: :n, m: :o, m: :p} == %{m: :p}
-          assert %{1 => 2, 1 => 3} == %{1 => 3}
-        end
-      end)
+    assert_warn_eval(
+      [
+        "key :a will be overridden in map",
+        "nofile:4:11\n",
+        "key :m will be overridden in map",
+        "nofile:5:11\n",
+        "key 1 will be overridden in map",
+        "nofile:6:11\n"
+      ],
+      """
+      defmodule DuplicateMapKeys do
+        import ExUnit.Assertions
 
-    assert output =~ "key :a will be overridden in map"
-    assert output =~ "warning_test.exs:874\n"
-    assert output =~ "key :m will be overridden in map"
-    assert output =~ "warning_test.exs:875\n"
-    assert output =~ "key 1 will be overridden in map"
-    assert output =~ "warning_test.exs:876\n"
+        assert %{a: :b, a: :c} == %{a: :c}
+        assert %{m: :n, m: :o, m: :p} == %{m: :p}
+        assert %{1 => 2, 1 => 3} == %{1 => 3}
+      end
+      """
+    )
 
     assert map_size(%{System.unique_integer() => 1, System.unique_integer() => 2}) == 2
   end

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -452,6 +452,30 @@ defmodule Kernel.WarningTest do
     purge(RedefineSample)
   end
 
+  test "unused variable because re-declared in a match? pattern" do
+    assert_warn_eval(
+      [
+        "nofile:1:16",
+        "variable \"x\" is unused (there is a variable with the same name in the context,",
+        "variable \"x\" is unused (if the variable is not meant to be used,"
+      ],
+      """
+      fn x -> match?(x, :value) end
+      """
+    )
+
+    assert_warn_eval(
+      [
+        "nofile:1",
+        "variable \"&1\" is unused (there is a variable with the same name in the context,",
+        "variable \"&1\" is unused (if the variable is not meant to be used,"
+      ],
+      """
+      &match?(&1, :value)
+      """
+    )
+  end
+
   test "useless literal" do
     message = "code block contains unused literal \"oops\""
 

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -467,8 +467,8 @@ defmodule Kernel.WarningTest do
     assert_warn_eval(
       [
         "nofile:1",
-        "variable \"&1\" is unused (there is a variable with the same name in the context,",
-        "variable \"&1\" is unused (if the variable is not meant to be used,"
+        "variable \"&1\" is unused (this might happen when using a capture argument as a pattern)",
+        "variable \"&1\" is unused (this might happen when using a capture argument as a pattern)"
       ],
       """
       &match?(&1, :value)


### PR DESCRIPTION
Instead of expanding `&1` as `{:x1, _, :elixir_fn}`, we'll expand it in the default context with the name `&1`:

```elixir
{:"&1", _, nil}
```

Close https://github.com/elixir-lang/elixir/issues/12612

Commit [Rewrite test depending on current line](https://github.com/elixir-lang/elixir/commit/270d72365c84f7e64711c2e19febb18953ba9690) fixed a test that was really annoying to keep up to date 🙂