### PR TITLE
Add --no-runtime-exs

### DIFF
--- a/lib/mix/lib/mix/tasks/app.config.ex
+++ b/lib/mix/lib/mix/tasks/app.config.ex
@@ -31,10 +31,13 @@ defmodule Mix.Tasks.App.Config do
     {opts, _, _} = OptionParser.parse(args, switches: @switches)
 
     config = Mix.Project.config()
-    runtime = config[:config_path] |> Path.dirname() |> Path.join("runtime.exs")
 
-    if File.exists?(runtime) do
-      Mix.Tasks.Loadconfig.load_runtime(runtime)
+    unless "--no-runtime-exs" in args do
+      runtime = config[:config_path] |> Path.dirname() |> Path.join("runtime.exs")
+
+      if File.exists?(runtime) do
+        Mix.Tasks.Loadconfig.load_runtime(runtime)
+      end
     end
 
     if opts[:preload_modules] do

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -77,7 +77,8 @@ defmodule Mix.Tasks.Run do
           archives_check: :boolean,
           elixir_version_check: :boolean,
           parallel_require: :keep,
-          preload_modules: :boolean
+          preload_modules: :boolean,
+          runtime_exs: :boolean
         ],
         return_separator: true
       )


### PR DESCRIPTION
This adds a new CLI option to `mix run` that will skip loading the runtime.exs file.

This is useful when you want to load a VM with all of the project's code and dependencies, but don't want to actually start it in any way.

runtime.exs can use your project's dependencies, which might not be compiled yet if also using the `--no-compile` option.

Normally you can simply gate your entire runtime.exs file in a condition that checks for an environment variable, but in the case of developer tooling like a language server, you can't alter the code.

---

I'm not entirely sure if this is the best way to solve my problem, so I am interested in your thoughts here. I thought about
re-using the `--no-start` option to control whether the runtime.exs is executed, but I figured that is a backwards incompatible change, so I opted for a new option.

(If you think this is reasonable to include, I will add tests/docs)

For more context, I have run into a situation in [Next LS](https://github.com/elixir-tools/next-ls/issues/97#issuecomment-1623846151) where a user's runtime.exs fails due to the code not yet being compiled (because I are using the `--no-compile` flag).

I am intentionally not wanting any code to 'run', which is why I also pass the `--no-start` flag, which I think made me surprised that runtime.exs still ran.

LMKWYT
