### PR TITLE
Fix the log level :warn deprecation warnings from Logger.compare_levels

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -588,8 +588,8 @@ defmodule Logger do
   @spec compare_levels(level, level) :: :lt | :eq | :gt
   def compare_levels(left, right) do
     :logger.compare_levels(
-      elixir_level_to_erlang_level(left),
-      elixir_level_to_erlang_level(right)
+      do_elixir_level_to_erlang_level(left),
+      do_elixir_level_to_erlang_level(right)
     )
   end
 
@@ -1139,4 +1139,7 @@ defmodule Logger do
   end
 
   defp elixir_level_to_erlang_level(other), do: other
+
+  defp do_elixir_level_to_erlang_level(:warn), do: :warning
+  defp do_elixir_level_to_erlang_level(other), do: other
 end


### PR DESCRIPTION
Logger sends `:warn` as level to its backends on `Logger.warning(...)` for backward compatibilities.
However, if backends passes this level to `Logger.compare_levels(level, min_level)` , this emit the deprecation warning:

```
warning: the log level :warn is deprecated, use :warning instead
```

I think this is an inconsistent design, since it is popular pattern in several backends. For example:
- logger_json: https://github.com/Nebo15/logger_json/blob/master/lib/logger_json.ex#L123 ( `meet_levels?` calls `Logger.compare_levels` )
- sentry: https://github.com/getsentry/sentry-elixir/blob/master/lib/sentry/logger_backend.ex#L73

Until the level `:warn` is really deprecated and replaced with `:warning` , `Logger.compare_levels` shouldn't emit the deprecation warning.