### PR TITLE
Use PID valid for 32-bit systems, followup to #12741

### DIFF
--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1364,8 +1364,8 @@ defmodule IEx.HelpersTest do
 
   describe "pid/1,3" do
     test "builds a PID from string" do
-      assert inspect(pid("0.32767.3276")) == "#PID<0.32767.3276>"
-      assert inspect(pid("0.5.6")) == "#PID<0.5.6>"
+      assert inspect(pid("0.32767.0")) == "#PID<0.32767.0>"
+      assert inspect(pid("0.5.0")) == "#PID<0.5.0>"
 
       assert_raise ArgumentError, fn ->
         pid("0.6.-6")
@@ -1381,8 +1381,8 @@ defmodule IEx.HelpersTest do
     end
 
     test "builds a PID from integers" do
-      assert inspect(pid(0, 32767, 3276)) == "#PID<0.32767.3276>"
-      assert inspect(pid(0, 5, 6)) == "#PID<0.5.6>"
+      assert inspect(pid(0, 32767, 0)) == "#PID<0.32767.0>"
+      assert inspect(pid(0, 5, 0)) == "#PID<0.5.0>"
 
       assert_raise FunctionClauseError, fn ->
         pid(0, 6, -6)


### PR DESCRIPTION
Unfortunately a previous commit  8bc67d384b0c21d9bbc7145829ecd49e128038b3 was not enough to fully address #12741. Here is a followup which completely fixes this issue. 

Here is an error log of the issue which addresses this patch:

```
..................................................................................................
  1) test pid/1,3 builds a PID from integers (IEx.HelpersTest)
     test/iex/helpers_test.exs:1383
     ** (ArgumentError) errors were found at the given arguments:
     
       * 1st argument: not a textual representation of a pid
     
     code: assert inspect(pid(0, 32767, 3276)) == "#PID<0.32767.3276>"
     stacktrace:
       :erlang.list_to_pid(~c"<0.32767.3276>")
       (iex 1.15.2) lib/iex/helpers.ex:1358: IEx.Helpers.pid/3
       test/iex/helpers_test.exs:1384: (test)
...
  2) test pid/1,3 builds a PID from string (IEx.HelpersTest)
     test/iex/helpers_test.exs:1366
     ** (ArgumentError) errors were found at the given arguments:
     
       * 1st argument: not a textual representation of a pid
     
     code: assert inspect(pid("0.32767.3276")) == "#PID<0.32767.3276>"
     stacktrace:
       :erlang.list_to_pid(~c"<0.32767.3276>")
       (iex 1.15.2) lib/iex/helpers.ex:1334: IEx.Helpers.pid/1
       test/iex/helpers_test.exs:1367: (test)
.................................................................................................................................................
```

Here are two buildlogs attached - one w/o this patch and another with this one.
* [build-w_o_patch.log](https://github.com/elixir-lang/elixir/files/11984781/build-w_o_patch.log)
* [build-with_patch.log](https://github.com/elixir-lang/elixir/files/11984790/build-with_patch.log)
