### PR TITLE
Document whitespace rules for keyword syntax

### DIFF
--- a/lib/elixir/pages/references/syntax-reference.md
+++ b/lib/elixir/pages/references/syntax-reference.md
@@ -470,6 +470,8 @@ Atoms with foreign characters, such as whitespace, must be wrapped in quotes. Th
 
 Remember that, because lists and two-element tuples are quoted literals, by definition keywords are also literals (in fact, the only reason tuples with two elements are quoted literals is to support keywords as literals).
 
+In order to be valid keyword syntax, `:` cannot be preceded by any whitespace (`foo : 1` is invalid) and has to be followed by whitespace (`foo:1` is invalid).
+
 ### Keywords as last arguments
 
 Elixir also supports a syntax where if the last argument of a call is a keyword list then the square brackets can be skipped. This means that the following:


### PR DESCRIPTION
I don't think this syntax rule was documented in the syntax reference, although it is rejected by the compiler in practice. Would it be a good idea to mention it?

I think there might be value in it especially since this is different from many languages like python or javascript.

### Side note

Also wonder if we could improve the error messages. This one is nice:

<img width="556" alt="Screenshot 2023-07-08 at 10 44 44" src="https://github.com/elixir-lang/elixir/assets/11598866/faa66d67-327b-485b-8706-c4ad2794cbed">

But this one might be confusing:

<img width="561" alt="Screenshot 2023-07-08 at 10 44 39" src="https://github.com/elixir-lang/elixir/assets/11598866/567396bb-0a2b-400f-8809-09a8be9427b7">