### PR TITLE
Fix typos and unclosed brackets

### DIFF
--- a/lib/elixir/pages/references/operators.md
+++ b/lib/elixir/pages/references/operators.md
@@ -72,8 +72,8 @@ Elixir provides the following built-in comparison operators (all of which can be
 
   * [`==`](`==/2`) - equal to
   * [`===`](`===/2`) - strictly equal to
-  * [`!=`](`!=/2`) - inequal to
-  * [`!==`](`!==/2`) - strictly inequal to
+  * [`!=`](`!=/2`) - not equal to
+  * [`!==`](`!==/2`) - strictly not equal to
   * [`<`](`</2`) - less-than
   * [`>`](`>/2`) - greater-than
   * [`<=`](`<=/2`) - less-than or equal to

--- a/lib/elixir/pages/references/patterns-and-guards.md
+++ b/lib/elixir/pages/references/patterns-and-guards.md
@@ -280,7 +280,7 @@ You can find the built-in list of guards [in the `Kernel` module](Kernel.html#gu
     [`<`](`</2`), [`<=`](`<=/2`), [`>`](`>/2`), [`>=`](`>=/2`))
   * strictly boolean operators ([`and`](`and/2`), [`or`](`or/2`), [`not`](`not/1`)). Note [`&&`](`&&/2`), [`||`](`||/2`), and [`!`](`!/1`) sibling operators are **not allowed** as they're not *strictly* boolean - meaning they don't require arguments to be booleans
   * arithmetic unary operators ([`+`](`+/1`), [`-`](`-/1`))
-  * arithmetic binary operators [`+`](`+/2`), [`-`](`-/2`), [`*`](`*/2`), [`/`](`//2`))
+  * arithmetic binary operators ([`+`](`+/2`), [`-`](`-/2`), [`*`](`*/2`), [`/`](`//2`))
   * [`in`](`in/2`) and [`not in`](`in/2`) operators (as long as the right-hand side is a list or a range)
   * "type-check" functions (`is_list/1`, `is_number/1`, and the like)
   * functions that work on built-in datatypes (`abs/1`, `hd/1`, `map_size/1`, and others)


### PR DESCRIPTION
There's some ambiguity about the word `inequal`, so I suggest replacing it with the stricter `not equal`