### PR TITLE
Clarify upgrade path for `Regex.regex?` (#12785)

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -299,7 +299,7 @@ defmodule Regex do
   end
 
   @doc false
-  @deprecated "Use Kernel.is_struct(xyz, Regex) or pattern match on %Regex{} instead"
+  @deprecated "Use Kernel.is_struct(term, Regex) or pattern match on %Regex{} instead"
   def regex?(term)
   def regex?(%Regex{}), do: true
   def regex?(_), do: false

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -299,7 +299,7 @@ defmodule Regex do
   end
 
   @doc false
-  @deprecated "Use Kernel.is_struct/2 or pattern match on %Regex{} instead"
+  @deprecated "Use Kernel.is_struct(xyz, Regex) or pattern match on %Regex{} instead"
   def regex?(term)
   def regex?(%Regex{}), do: true
   def regex?(_), do: false

--- a/lib/elixir/pages/references/compatibility-and-deprecations.md
+++ b/lib/elixir/pages/references/compatibility-and-deprecations.md
@@ -82,7 +82,7 @@ Version | Deprecated feature                                  | Replaced by (ava
 :-------| :-------------------------------------------------- | :---------------------------------------------------------------
 [v1.15] | `Calendar.ISO.day_of_week/3`                        | `Calendar.ISO.day_of_week/4` (v1.11)
 [v1.15] | `Exception.exception?/1`                            | `Kernel.is_exception/1` (v1.11)
-[v1.15] | `Regex.regex?/1`                                    | `Kernel.is_struct/2` (v1.11)
+[v1.15] | `Regex.regex?/1`                                    | `Kernel.is_struct/2` via `Kernel.is_struct(xyz, Regex)` (v1.11)
 [v1.15] | `Logger.warn/2`                                     | `Logger.warning/2` (v1.11)
 [v1.14] | `use Bitwise`                                       | `import Bitwise` (v1.0)
 [v1.14] | `~~~/1`                                             | `bnot/2` (v1.0)

--- a/lib/elixir/pages/references/compatibility-and-deprecations.md
+++ b/lib/elixir/pages/references/compatibility-and-deprecations.md
@@ -82,7 +82,7 @@ Version | Deprecated feature                                  | Replaced by (ava
 :-------| :-------------------------------------------------- | :---------------------------------------------------------------
 [v1.15] | `Calendar.ISO.day_of_week/3`                        | `Calendar.ISO.day_of_week/4` (v1.11)
 [v1.15] | `Exception.exception?/1`                            | `Kernel.is_exception/1` (v1.11)
-[v1.15] | `Regex.regex?/1`                                    | `Kernel.is_struct/2` via `Kernel.is_struct(xyz, Regex)` (v1.11)
+[v1.15] | `Regex.regex?/1`                                    | `Kernel.is_struct/2` (`Kernel.is_struct(term, Regex)` (v1.11)
 [v1.15] | `Logger.warn/2`                                     | `Logger.warning/2` (v1.11)
 [v1.14] | `use Bitwise`                                       | `import Bitwise` (v1.0)
 [v1.14] | `~~~/1`                                             | `bnot/2` (v1.0)

--- a/lib/elixir/pages/references/compatibility-and-deprecations.md
+++ b/lib/elixir/pages/references/compatibility-and-deprecations.md
@@ -82,7 +82,7 @@ Version | Deprecated feature                                  | Replaced by (ava
 :-------| :-------------------------------------------------- | :---------------------------------------------------------------
 [v1.15] | `Calendar.ISO.day_of_week/3`                        | `Calendar.ISO.day_of_week/4` (v1.11)
 [v1.15] | `Exception.exception?/1`                            | `Kernel.is_exception/1` (v1.11)
-[v1.15] | `Regex.regex?/1`                                    | `Kernel.is_struct/2` (`Kernel.is_struct(term, Regex)` (v1.11)
+[v1.15] | `Regex.regex?/1`                                    | `Kernel.is_struct/2` (`Kernel.is_struct(term, Regex)`) (v1.11)
 [v1.15] | `Logger.warn/2`                                     | `Logger.warning/2` (v1.11)
 [v1.14] | `use Bitwise`                                       | `import Bitwise` (v1.0)
 [v1.14] | `~~~/1`                                             | `bnot/2` (v1.0)


### PR DESCRIPTION
This addresses:
- #12785

Pending questions:
- [x] Unsure if the "xyz" style is good enough (there is no such thing in the code base at first glance) - EDIT: `term` is perfect
- [ ] Make sure that the resulting expression will be formatted as code in the docs
- [ ] How to make sure this will be seen on the versions where the warning appears (< 1.15), will this require a form of backport I presume?
