### PR TITLE
Update typespec for enum `find_value`

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1216,7 +1216,7 @@ defmodule Enum do
       "no bools!"
 
   """
-  @spec find_value(t, any, (element -> any)) :: any | nil
+  @spec find_value(t, any, (element -> any)) :: any | default
   def find_value(enumerable, default \\ nil, fun)
 
   def find_value(enumerable, default, fun) when is_list(enumerable) do


### PR DESCRIPTION
`Enum.find` and `Enum.at` functions typespec returns `any` or `default` type, since `Enum.find_value` with similar output returns `nil`