### PR TITLE
Add Supervisor.module_spec/0 type

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -620,7 +620,7 @@ defmodule Supervisor do
   A module-based child spec.
 
   This is a form of child spec that you can pass to functions such as `child_spec/2`,
-  `start_child/2`, and `start_link/2`.
+  `start_child/2`, and `start_link/2`, in addition to the normalized `t:child_spec/0`.
 
   A module-based child spec can be:
 

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -641,7 +641,11 @@ defmodule Supervisor do
 
     * a child specification (see `t:child_spec/0`)
 
-    * a module-based child specification (see `t:module_spec/0`)
+    * a module, where the supervisor calls `module.child_spec([])`
+      to retrieve the child specification (see `t:module_spec/0`)
+
+    * a `{module, arg}` tuple, where the supervisor calls `module.child_spec(arg)`
+      to retrieve the child specification (see `t:module_spec/0`)
 
     * a (old) Erlang-style child specification (see
       [`:supervisor.child_spec()`](`t::supervisor.child_spec/0`))


### PR DESCRIPTION
We don't have a type for something that can be started or passed to `Supervisor.child_spec/2`, which is what this PR introduces.

The name is 100% up for discussion. 😄 

I didn't include `:supervisor.child_spec()` in the typespec because `Supervisor.child_spec/2` doesn't accept the old tuple format, so it would have to have its own typespec. I think this is a fairly good compromise.