### PR TITLE
Remove erlang doc duplicates in IEx

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -293,6 +293,7 @@ defmodule IEx.Introspection do
               module.module_info(:exports)
           end
           |> Enum.sort()
+          |> Enum.dedup()
 
         result =
           for {^function, arity} <- exports,


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/12796

This fixes the issue, I'm not sure if this should/could be fixed upstream in `Code.fetch_docs` but will have a look.