### PR TITLE
Fix typo in documentation by removing duplicated `async: true` option

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case_template.ex
+++ b/lib/ex_unit/lib/ex_unit/case_template.ex
@@ -130,7 +130,7 @@ defmodule ExUnit.CaseTemplate do
   The second argument passed to `use MyCase` gets forwarded to `using/2` too:
 
       defmodule SomeTestCase do
-        use MyCase, async: true, import_helpers: true, async: true
+        use MyCase, async: true, import_helpers: true
 
         test "the truth" do
           # truth/0 comes from MyApp.TestHelpers:


### PR DESCRIPTION
Fix typo in documentation.