### PR TITLE
Fix newlines in io.ex

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -594,11 +594,11 @@ defmodule IO do
 
   Another example where you might want to collect a user input
   every new line and break on an empty line, followed by removing
-  redundant new line characters (`"\n"`):
+  redundant new line characters (`"\\n"`):
 
       IO.stream(:stdio, :line)
-      |> Enum.take_while(&(&1 != "\n"))
-      |> Enum.map(&String.replace(&1, "\n", ""))
+      |> Enum.take_while(&(&1 != "\\n"))
+      |> Enum.map(&String.replace(&1, "\\n", ""))
 
   """
   @spec stream(device, :line | pos_integer) :: Enumerable.t()


### PR DESCRIPTION
Fix newlines in documentation for IO module. Tested the visual change by copy-pasting the paragraph before/after the fix into `Earmark.as_html(text)`, then making a screenshot of the rendered HTML.

Before:

<img width="670" alt="image" src="https://github.com/elixir-lang/elixir/assets/207112/e87ab72e-0e6f-4bee-a33f-af622f50248e">

After:

<img width="670" alt="image" src="https://github.com/elixir-lang/elixir/assets/207112/22cf2614-281a-4998-8c41-bdfd18c50ff3">