### PR TITLE
Cleanup erlang shell docs

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -830,8 +830,15 @@ defmodule IEx.Introspection do
   defp print_erlang_doc(mod, fun, arity, docs) do
     heading = Exception.format_mfa(mod, fun, arity)
     opts = IEx.Config.ansi_docs()
-    IO.ANSI.Docs.print_headings([heading], opts)
-    :shell_docs.render(mod, fun, arity, docs) |> IO.puts()
+
+    case :shell_docs.render(mod, fun, arity, docs) do
+      {:error, :function_missing} ->
+        docs_not_found("#{inspect(mod)}.#{fun}")
+
+      chardata ->
+        IO.ANSI.Docs.print_headings([heading], opts)
+        IO.puts(chardata)
+    end
   end
 
   defp no_beam(module) do

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -691,7 +691,10 @@ defmodule IEx.Introspection do
   def t({module, type}) when is_atom(module) and is_atom(type) do
     case get_docs(module, [:type]) do
       {:erlang, _, _, erl_docs} ->
-        :shell_docs.render_type(module, type, erl_docs) |> IO.puts()
+        case :shell_docs.render_type(module, type, erl_docs) do
+          {:error, :type_missing} -> types_not_found_or_private("#{inspect(module)}.#{type}")
+          iodata -> IO.puts(iodata)
+        end
 
       {_, format, docs, _} ->
         case Typespec.fetch_types(module) do
@@ -722,7 +725,10 @@ defmodule IEx.Introspection do
   def t({module, type, arity}) when is_atom(module) and is_atom(type) and is_integer(arity) do
     case get_docs(module, [:type]) do
       {:erlang, _, _, erl_docs} ->
-        :shell_docs.render_type(module, type, arity, erl_docs) |> IO.puts()
+        case :shell_docs.render_type(module, type, arity, erl_docs) do
+          {:error, :type_missing} -> types_not_found_or_private("#{inspect(module)}.#{type}")
+          chardata -> IO.puts(chardata)
+        end
 
       {_, format, docs, _} ->
         case Typespec.fetch_types(module) do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -343,6 +343,11 @@ defmodule IEx.HelpersTest do
       assert captured =~ "-spec sleep(Time) -> ok when Time :: timeout()."
     end
 
+    test "handles non-existing Erlang module function" do
+      captured = capture_io(fn -> h(:timer.baz() / 1) end)
+      assert captured =~ "No documentation for :timer.baz was found"
+    end
+
     test "prints module documentation" do
       assert "\n                                  IEx.Helpers\n\nWelcome to Interactive Elixir" <>
                _ = capture_io(fn -> h(IEx.Helpers) end)

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1013,6 +1013,18 @@ defmodule IEx.HelpersTest do
       captured = capture_io(fn -> t(:erlang.iovec()) end)
       assert captured =~ "-type iovec() :: [binary()]"
       assert captured =~ "A list of binaries."
+
+      captured = capture_io(fn -> t(:erlang.iovec() / 0) end)
+      assert captured =~ "-type iovec() :: [binary()]"
+      assert captured =~ "A list of binaries."
+    end
+
+    test "handles non-existing types from erlang module" do
+      captured = capture_io(fn -> t(:erlang.foo()) end)
+      assert captured =~ "No type information for :erlang.foo was found or :erlang.foo is private"
+
+      captured = capture_io(fn -> t(:erlang.foo() / 1) end)
+      assert captured =~ "No type information for :erlang.foo was found or :erlang.foo is private"
     end
   end
 


### PR DESCRIPTION
Sorry this should have been done in https://github.com/elixir-lang/elixir/pull/12803, I spent some more time cleaning up afterwards.

Mostly:
- `t` for a single type would be fetching the docs at least twice, possibly more (`get_docs` was called in a loop) => fetch once
- error handling wasn't done for non-existing types and functions

Before
<img width="824" alt="Screenshot 2023-07-20 at 8 50 36" src="https://github.com/elixir-lang/elixir/assets/11598866/188b08bd-b5f0-4053-8662-0694be3fb4aa">

After
<img width="310" alt="Screenshot 2023-07-20 at 8 50 48" src="https://github.com/elixir-lang/elixir/assets/11598866/dd340973-c931-4ba4-9241-4a341635f23b">
