### PR TITLE
Fix supported time units

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1516,6 +1516,12 @@ defmodule DateTime do
         %{utc_offset: utc_offset2, std_offset: std_offset2} = datetime2,
         unit
       ) do
+    if not is_integer(unit) and
+         unit not in ~w(second millisecond microsecond nanosecond)a do
+      raise ArgumentError,
+            "unsupported time unit. Expected :day, :hour, :minute, :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got #{inspect(unit)}"
+    end
+
     naive_diff =
       (datetime1 |> to_iso_days() |> Calendar.ISO.iso_days_to_unit(unit)) -
         (datetime2 |> to_iso_days() |> Calendar.ISO.iso_days_to_unit(unit))

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -471,6 +471,12 @@ defmodule NaiveDateTime do
         unit
       )
       when is_integer(amount_to_add) do
+    if not is_integer(unit) and
+         unit not in ~w(second millisecond microsecond nanosecond)a do
+      raise ArgumentError,
+            "unsupported time unit. Expected :day, :hour, :minute, :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got #{inspect(unit)}"
+    end
+
     ppd = System.convert_time_unit(86400, :second, unit)
     precision = max(Calendar.ISO.time_unit_to_precision(unit), precision)
 
@@ -552,6 +558,12 @@ defmodule NaiveDateTime do
             "cannot calculate the difference between #{inspect(naive_datetime1)} and " <>
               "#{inspect(naive_datetime2)} because their calendars are not compatible " <>
               "and thus the result would be ambiguous"
+    end
+
+    if not is_integer(unit) and
+         unit not in ~w(second millisecond microsecond nanosecond)a do
+      raise ArgumentError,
+            "unsupported time unit. Expected :day, :hour, :minute, :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got #{inspect(unit)}"
     end
 
     units1 = naive_datetime1 |> to_iso_days() |> Calendar.ISO.iso_days_to_unit(unit)

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -758,39 +758,50 @@ defmodule DateTimeTest do
              %{datetime | microsecond: {0, 0}}
   end
 
-  test "diff/2" do
-    dt1 = %DateTime{
-      year: 100,
-      month: 2,
-      day: 28,
-      zone_abbr: "CET",
-      hour: 23,
-      minute: 0,
-      second: 7,
-      microsecond: {0, 0},
-      utc_offset: 3600,
-      std_offset: 0,
-      time_zone: "Europe/Warsaw"
-    }
+  describe "diff" do
+    test "diff with invalid time unit" do
+      dt = DateTime.utc_now()
 
-    dt2 = %DateTime{
-      year: -0004,
-      month: 2,
-      day: 29,
-      zone_abbr: "CET",
-      hour: 23,
-      minute: 0,
-      second: 7,
-      microsecond: {0, 0},
-      utc_offset: 3600,
-      std_offset: 0,
-      time_zone: "Europe/Warsaw"
-    }
+      message =
+        ~r/unsupported time unit\. Expected :day, :hour, :minute, :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got "day"/
 
-    assert DateTime.diff(dt1, dt2) == 3_281_904_000
+      assert_raise ArgumentError, message, fn -> DateTime.diff(dt, dt, "day") end
+    end
 
-    # Test with a non-struct map conforming to Calendar.datetime
-    assert DateTime.diff(Map.from_struct(dt1), Map.from_struct(dt2)) == 3_281_904_000
+    test "diff with valid time unit" do
+      dt1 = %DateTime{
+        year: 100,
+        month: 2,
+        day: 28,
+        zone_abbr: "CET",
+        hour: 23,
+        minute: 0,
+        second: 7,
+        microsecond: {0, 0},
+        utc_offset: 3600,
+        std_offset: 0,
+        time_zone: "Europe/Warsaw"
+      }
+
+      dt2 = %DateTime{
+        year: -0004,
+        month: 2,
+        day: 29,
+        zone_abbr: "CET",
+        hour: 23,
+        minute: 0,
+        second: 7,
+        microsecond: {0, 0},
+        utc_offset: 3600,
+        std_offset: 0,
+        time_zone: "Europe/Warsaw"
+      }
+
+      assert DateTime.diff(dt1, dt2) == 3_281_904_000
+
+      # Test with a non-struct map conforming to Calendar.datetime
+      assert DateTime.diff(Map.from_struct(dt1), Map.from_struct(dt2)) == 3_281_904_000
+    end
   end
 
   describe "from_naive" do

--- a/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
@@ -144,63 +144,85 @@ defmodule NaiveDateTimeTest do
     end
   end
 
-  test "add/2 with other calendars" do
-    assert ~N[2000-01-01 12:34:15.123456]
-           |> NaiveDateTime.convert!(Calendar.Holocene)
-           |> NaiveDateTime.add(10, :second) ==
-             %NaiveDateTime{
-               calendar: Calendar.Holocene,
-               year: 12000,
-               month: 1,
-               day: 1,
-               hour: 12,
-               minute: 34,
-               second: 25,
-               microsecond: {123_456, 6}
-             }
+  describe "add" do
+    test "add with invalid time unit" do
+      dt = NaiveDateTime.utc_now()
+
+      message =
+        ~r/unsupported time unit\. Expected :day, :hour, :minute, :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got "day"/
+
+      assert_raise ArgumentError, message, fn -> NaiveDateTime.add(dt, 1, "day") end
+    end
+
+    test "add with other calendars" do
+      assert ~N[2000-01-01 12:34:15.123456]
+             |> NaiveDateTime.convert!(Calendar.Holocene)
+             |> NaiveDateTime.add(10, :second) ==
+               %NaiveDateTime{
+                 calendar: Calendar.Holocene,
+                 year: 12000,
+                 month: 1,
+                 day: 1,
+                 hour: 12,
+                 minute: 34,
+                 second: 25,
+                 microsecond: {123_456, 6}
+               }
+    end
+
+    test "add with datetime" do
+      dt = %DateTime{
+        year: 2000,
+        month: 2,
+        day: 29,
+        zone_abbr: "CET",
+        hour: 23,
+        minute: 0,
+        second: 7,
+        microsecond: {0, 0},
+        utc_offset: 3600,
+        std_offset: 0,
+        time_zone: "Europe/Warsaw"
+      }
+
+      assert NaiveDateTime.add(dt, 21, :second) == ~N[2000-02-29 23:00:28]
+    end
   end
 
-  test "add/2 with datetime" do
-    dt = %DateTime{
-      year: 2000,
-      month: 2,
-      day: 29,
-      zone_abbr: "CET",
-      hour: 23,
-      minute: 0,
-      second: 7,
-      microsecond: {0, 0},
-      utc_offset: 3600,
-      std_offset: 0,
-      time_zone: "Europe/Warsaw"
-    }
+  describe "diff" do
+    test "diff with invalid time unit" do
+      dt = NaiveDateTime.utc_now()
 
-    assert NaiveDateTime.add(dt, 21, :second) == ~N[2000-02-29 23:00:28]
-  end
+      message =
+        ~r/unsupported time unit\. Expected :day, :hour, :minute, :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got "day"/
 
-  test "diff/2 with other calendars" do
-    assert ~N[2000-01-01 12:34:15.123456]
-           |> NaiveDateTime.convert!(Calendar.Holocene)
-           |> NaiveDateTime.add(10, :second)
-           |> NaiveDateTime.diff(~N[2000-01-01 12:34:15.123456]) == 10
-  end
+      assert_raise ArgumentError, message, fn -> NaiveDateTime.diff(dt, dt, "day") end
+    end
 
-  test "diff/2 with datetime" do
-    dt = %DateTime{
-      year: 2000,
-      month: 2,
-      day: 29,
-      zone_abbr: "CET",
-      hour: 23,
-      minute: 0,
-      second: 7,
-      microsecond: {0, 0},
-      utc_offset: 3600,
-      std_offset: 0,
-      time_zone: "Europe/Warsaw"
-    }
+    test "diff with other calendars" do
+      assert ~N[2000-01-01 12:34:15.123456]
+             |> NaiveDateTime.convert!(Calendar.Holocene)
+             |> NaiveDateTime.add(10, :second)
+             |> NaiveDateTime.diff(~N[2000-01-01 12:34:15.123456]) == 10
+    end
 
-    assert NaiveDateTime.diff(%{dt | second: 57}, dt, :second) == 50
+    test "diff with datetime" do
+      dt = %DateTime{
+        year: 2000,
+        month: 2,
+        day: 29,
+        zone_abbr: "CET",
+        hour: 23,
+        minute: 0,
+        second: 7,
+        microsecond: {0, 0},
+        utc_offset: 3600,
+        std_offset: 0,
+        time_zone: "Europe/Warsaw"
+      }
+
+      assert NaiveDateTime.diff(%{dt | second: 57}, dt, :second) == 50
+    end
   end
 
   test "convert/2" do


### PR DESCRIPTION
Fixes #12818 
Also add error messages to `DateTime.diff`, `DateTime.add`, `NaiveDateTime.add` and cover error messages with tests.