### PR TITLE
Provide procs config option to fprof

### DIFF
--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -194,6 +194,7 @@ defmodule Mix.Tasks.Profile.Fprof do
       IO.puts("Warmup...")
       fun.()
     end
+    apply_opts = Keyword.take(opts, [:procs])
 
     {return_value, file_to_remove} =
       if Keyword.get(opts, :trace_to_file, false) do
@@ -204,12 +205,12 @@ defmodule Mix.Tasks.Profile.Fprof do
           |> Path.expand()
           |> String.to_charlist()
 
-        result = :fprof.apply(fun, [], file: filename)
+        result = :fprof.apply(fun, [], [{:file, filename} | apply_opts])
         :fprof.profile(file: filename)
         {result, trace_file}
       else
         {:ok, tracer} = :fprof.profile([:start])
-        {:fprof.apply(fun, [], tracer: tracer), nil}
+        {:fprof.apply(fun, [], [{:tracer, tracer} | apply_opts]), nil}
       end
 
     {:ok, analyse_dest} = StringIO.open("")


### PR DESCRIPTION
So we could pass procs list and collect profiling for cases like gen_server calls.

I was trying to use Benchee and profiling and it was lacking the major fprof feature: profiling more than one process.
So, I've added the feature here:

```elixir
Benchee.run(
  %{
    "cets" => fn -> :ok = :cets.insert(:cets_user, {newId.(), "alice"}) end
  },
  profile_after: {:fprof, [sort: :own, procs: [pid1]]}
)
```

`pid1` is a process of a gen_server. So, with `procs` we now see time spent in `gen_server.handle_msg`:

```elixir
                                                                   CNT    ACC (ms)    OWN (ms)
Total                                                               45       0.399       0.157
:fprof.apply_start_stop/4                                            0       0.399       0.016
:ets.insert/2                                                        2       0.011       0.011
:gen_server.loop/7                                                   1       0.257       0.010
:erlang.send/3                                                       1       0.008       0.008
:cets_call.do_wait_for_updated/2                                     2       0.137       0.008
:lists.delete/2                                                      1       0.007       0.007
:erlang.send/2                                                       1       0.007       0.007
:cets_call.wait_response/2                                           1       0.333       0.007
:cets_call.wait_for_updated/2                                        1       0.152       0.006
:cets_call.async_operation/2                                         1       0.027       0.005
anonymous fn/1 in :elixir_compiler_1.__FILE__/1                      1       0.373       0.004
:cets_call.delete_from_mon_tab/2                                     1       0.006       0.004
:cets.replicate/4                                                    1       0.022       0.004
:cets.handle_op/3                                                    1       0.039       0.004
:cets."-replicate/4-lc$^0/1-0-"/2                                    2       0.015       0.004
:gen_server.try_dispatch/4                                           1       0.045       0.003
:gen_server.handle_msg/6                                             1       0.247       0.003
:gen_server.do_send/2                                                1       0.010       0.003
:gen_server.do_cast/2                                                1       0.014       0.003
:gen_server.decode_msg/9                                             1       0.250       0.003
:erlang.demonitor/2                                                  1       0.003       0.003
anonymous fn/0 in :elixir_compiler_1.__FILE__/1                      1       0.005       0.003
:cets.send_to_remote/2                                               1       0.011       0.003
:cets.handle_cast/2                                                  1       0.042       0.003
:cets.do_table_op/2                                                  1       0.011       0.003
:gen_server.handle_common_reply/8                                    1       0.198       0.002
:gen_server.cast/2                                                   1       0.016       0.002
:ets.delete/2                                                        1       0.002       0.002
:erlang.whereis/1                                                    1       0.002       0.002
:erlang.unique_integer/1                                             1       0.002       0.002
:erlang.monitor/2                                                    1       0.002       0.002
:cets_call.where/1                                                   1       0.004       0.002
:cets_call.sync_operation/2                                          1       0.362       0.002
:cets.insert/2                                                       1       0.364       0.002
:cets.do_op/2                                                        1       0.013       0.002
:gen_server.try_dispatch/3                                           1       0.046       0.001
:gen_server.cast_msg/1                                               1       0.001       0.001
:proc_lib.init_p_do_apply/3                                          0       0.257       0.000
:undefined                                                           0       0.000       0.000
:suspend                                                             6       0.499       0.000
```

as before we only could see the part of the profiling:

```elixir
                                                                   CNT    ACC (ms)    OWN (ms)
Total                                                               25       0.365       0.094
:fprof.apply_start_stop/4                                            0       0.365       0.015
:cets_call.do_wait_for_updated/2                                     2       0.164       0.011
:erlang.send/2                                                       1       0.009       0.009
:cets_call.wait_response/2                                           1       0.305       0.007
:erlang.unique_integer/1                                             1       0.006       0.006
anonymous fn/1 in :elixir_compiler_1.__FILE__/1                      1       0.350       0.005
:cets_call.wait_for_updated/2                                        1       0.178       0.005
:cets_call.async_operation/2                                         1       0.028       0.005
:gen_server.do_send/2                                                1       0.012       0.003
:gen_server.do_cast/2                                                1       0.016       0.003
:ets.delete/2                                                        1       0.003       0.003
:erlang.demonitor/2                                                  1       0.003       0.003
:cets_call.delete_from_mon_tab/2                                     1       0.006       0.003
:lists.delete/2                                                      1       0.002       0.002
:erlang.whereis/1                                                    1       0.002       0.002
:erlang.monitor/2                                                    1       0.002       0.002
anonymous fn/0 in :elixir_compiler_1.__FILE__/1                      1       0.008       0.002
:cets_call.where/1                                                   1       0.004       0.002
:cets_call.sync_operation/2                                          1       0.335       0.002
:cets.insert/2                                                       1       0.337       0.002
:gen_server.cast_msg/1                                               1       0.001       0.001
:gen_server.cast/2                                                   1       0.017       0.001
:undefined                                                           0       0.000       0.000
:suspend                                                             3       0.271       0.000
```

TODO: tests, docs.
This PR is more of a feature request. We can pass `apply_opts` (more generic) or `procs` (more specific).
Anyway, without docs it is a bit useless, so I would have to write them first, after I figure out how :)