### PR TITLE
Fix bug in surround_context alias handling

### DIFF
--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -753,7 +753,7 @@ defmodule Code.Fragment do
     end
   end
 
-  defp take_alias([h | t], acc) when h in ?A..?Z or h in ?a..?z or h in ?0..9 or h == ?_,
+  defp take_alias([h | t], acc) when h in ?A..?Z or h in ?a..?z or h in ?0..?9 or h == ?_,
     do: take_alias(t, [h | acc])
 
   defp take_alias(rest, acc) do

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -738,6 +738,14 @@ defmodule CodeFragmentTest do
                  end: {3, 5}
                }
       end
+
+      for i <- 1..11 do
+        assert CF.surround_context("Foo.Bar.Baz.foo(bar)", {1, i}) == %{
+                 context: {:alias, ~c"Foo.Bar.Baz"},
+                 begin: {1, 1},
+                 end: {1, 12}
+               }
+      end
     end
 
     test "underscored special forms" do


### PR DESCRIPTION
Close #12829

It was actually a missing `?` in the range, so `?( = 40` was in `?0..9 = 48..9` 😅