### PR TITLE
Warn on unused defp/defmacrop using unquote/1

### DIFF
--- a/lib/elixir/test/elixir/kernel/overridable_test.exs
+++ b/lib/elixir/test/elixir/kernel/overridable_test.exs
@@ -138,8 +138,6 @@ defmodule Kernel.Overridable do
     end
   end
 
-  defmacrop private_macro(x \\ raise("never called"))
-
   defmacrop private_macro(x) do
     quote do
       unquote(x) + 100

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -641,8 +641,18 @@ defmodule Kernel.WarningTest do
       end
       """
     )
+
+    assert_warn_eval(
+      ["nofile:3: ", "function b/0 is unused\n"],
+      ~S"""
+      defmodule Sample5 do
+        def a, do: nil
+        defp b(), do: unquote(1)
+      end
+      """
+    )
   after
-    purge([Sample1, Sample2, Sample3, Sample4])
+    purge([Sample1, Sample2, Sample3, Sample4, Sample5])
   end
 
   test "unused cyclic functions" do
@@ -673,8 +683,19 @@ defmodule Kernel.WarningTest do
       end
       """
     )
+
+    assert_warn_eval(
+      ["nofile:2: ", "macro hello/0 is unused\n"],
+      ~S"""
+      defmodule Sample2 do
+        defmacrop hello do
+          quote do: unquote(1)
+        end
+      end
+      """
+    )
   after
-    purge(Sample)
+    purge([Sample, Sample2])
   end
 
   test "shadowing" do

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -734,14 +734,6 @@ defmodule KernelTest do
       assert result =~ ":lists.member(rand(), [1 | some_call()]"
     end
 
-    defp quote_case_in(left, right) do
-      quote do
-        case 0 do
-          _ when unquote(left) in unquote(right) -> true
-        end
-      end
-    end
-
     test "is optimized" do
       assert expand_to_string(quote(do: foo in [])) ==
                "_ = foo\nfalse"


### PR DESCRIPTION
Closes #12812

~This works, but I am not sure why Check needed to be `false` in the first place.
Therefore I am not sure what side effect it can have, although tests are passing.
The fix might need to be somewhere else, maybe around [here](https://github.com/elixir-lang/elixir/blob/main/lib/elixir/lib/kernel.ex#L5202-L5206), but I would need more pointers.~

Edit: New approach: warn for unused funs/macros/defaults disregarding of having unquotes, keep disabling other warnings (`late_function_head`, `ungrouped_arity`...)