### PR TITLE
fix examples in with documentation

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1543,7 +1543,7 @@ defmodule Kernel.SpecialForms do
   area, as `{:ok, area}` or return `:error`. We could implement
   this function as:
 
-      def area(map) do
+      def area(opts) do
         case Map.fetch(opts, :width) do
           {:ok, width} ->
             case Map.fetch(opts, :height) do
@@ -1562,7 +1562,7 @@ defmodule Kernel.SpecialForms do
   While the code above works, it is quite verbose. Using `with`,
   we could rewrite it as:
 
-      def area(map) do
+      def area(opts) do
         with {:ok, width} <- Map.fetch(opts, :width),
              {:ok, height} <- Map.fetch(opts, :height) do
           {:ok, width * height}


### PR DESCRIPTION
In the documentation for the _with_ special form, examples of area function take a _map_ argument, but fetch from an undefined _opts_. Subsequent examples in the with section use _opts_, so I've corrected the functions to take the _opts_ argument.