### PR TITLE
Avoid error log in test

### DIFF
--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -357,8 +357,10 @@ defmodule ModuleTest do
         def world, do: true
       end
 
-    assert_raise CompileError, fn ->
-      {:module, Elixir, _, _} = Module.create(Elixir, contents, __ENV__)
+    assert_raise CompileError, ~r/cannot compile module Elixir/, fn ->
+      Code.with_diagnostics(fn ->
+        Module.create(Elixir, contents, __ENV__)
+      end)
     end
   end
 


### PR DESCRIPTION
Very occasionally (less than 1 in 10 runs?), I'm seeing an error log when running tests:

<img width="989" alt="Screenshot 2023-08-05 at 14 58 15" src="https://github.com/elixir-lang/elixir/assets/11598866/603540a3-4038-45f6-86a4-3520ab2c68e1">

There's probably a race condition on a global flag, this test being `async`?

Note: Because I can't reproduce it consistently, it is hard to confirm that my fix works 🙃
