### PR TITLE
Capture negative step slice warnings in tests

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2231,7 +2231,7 @@ defmodule String do
   If the first position is after the string ends or after
   the last position of the range, it returns an empty string:
 
-      iex> String.slice("elixir", 10..3)
+      iex> String.slice("elixir", 10..3//1)
       ""
       iex> String.slice("a", 1..1500)
       ""

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -220,7 +220,11 @@ defmodule RangeTest do
       assert Enum.member?(desc, 2)
       assert Enum.count(desc) == 3
       assert Enum.drop(desc, 1) == [2, 1]
-      assert Enum.slice([1, 2, 3, 4, 5, 6], desc) == []
+
+      assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
+               assert Enum.slice([1, 2, 3, 4, 5, 6], desc) == []
+             end) =~ "negative steps are not supported in Enum.slice/2, pass 3..1//1 instead"
+
       # testing private Enum.aggregate
       assert Enum.max(desc) == 3
       assert Enum.sum(desc) == 6
@@ -233,7 +237,10 @@ defmodule RangeTest do
       desc = %{__struct__: Range, first: 3, last: 1}
 
       assert String.slice("elixir", asc) == "lix"
-      assert String.slice("elixir", desc) == ""
+
+      assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
+               assert String.slice("elixir", desc) == ""
+             end) =~ "negative steps are not supported in String.slice/2, pass 3..1//1 instead"
     end
   end
 end

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -751,7 +751,7 @@ defmodule StringTest do
   end
 
   test "slice/2" do
-    assert String.slice("elixir", 0..-2) == "elixi"
+    assert String.slice("elixir", 0..-2//1) == "elixi"
     assert String.slice("elixir", 1..3) == "lix"
     assert String.slice("elixir", -5..-3) == "lix"
     assert String.slice("elixir", -5..3) == "lix"
@@ -770,15 +770,19 @@ defmodule StringTest do
     assert String.slice("ειξήριολ", 9..9) == ""
     assert String.slice("", 0..0) == ""
     assert String.slice("", 1..1) == ""
-    assert String.slice("あいうえお", -2..-4) == ""
-    assert String.slice("あいうえお", -10..-15) == ""
-    assert String.slice("hello あいうえお Unicode", 8..-1) == "うえお Unicode"
+    assert String.slice("あいうえお", -2..-4//1) == ""
+    assert String.slice("あいうえお", -10..-15//1) == ""
+    assert String.slice("hello あいうえお Unicode", 8..-1//1) == "うえお Unicode"
     assert String.slice("abc", -1..14) == "c"
-    assert String.slice("a·̀ͯ‿.⁀:", 0..-2) == "a·̀ͯ‿.⁀"
+    assert String.slice("a·̀ͯ‿.⁀:", 0..-2//1) == "a·̀ͯ‿.⁀"
 
     assert_raise FunctionClauseError, fn ->
       String.slice(nil, 0..1)
     end
+
+    assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
+             assert String.slice("elixir", 0..-2) == "elixi"
+           end) =~ "negative steps are not supported in String.slice/2, pass 0..-2//1 instead"
   end
 
   test "slice/2 with steps" do


### PR DESCRIPTION
In 4 out of 10 times, I'm getting the following warnings:

<img width="838" alt="Screenshot 2023-08-05 at 14 38 07" src="https://github.com/elixir-lang/elixir/assets/11598866/2736fef7-d7e6-4500-85f1-42cdbbab7dfb">

This PR captures and asserts these (they weren't tested yet).