### PR TITLE
Improve UndefinedFunctionError for mis-cased module

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1343,12 +1343,12 @@ defmodule UndefinedFunctionError do
   end
 
   defp hint(module, function, arity, _loaded?) do
-    normalized_module = normalized_module_name(module)
+    downcased_module = downcase_module_name(module)
 
     candidate =
       :code.all_available()
       |> Enum.find(fn {name, _, _} ->
-        normalized_module_name(name) == normalized_module
+        downcase_module_name(name) == downcased_module
       end)
 
     with {_, _, _} <- candidate,
@@ -1360,18 +1360,14 @@ defmodule UndefinedFunctionError do
     end
   end
 
-  defp load_module_filename({name, path, loaded?}) do
-    if loaded? do
-      {:module, name |> to_string() |> String.to_existing_atom()}
-    else
-      path
-      |> Path.rootname(".beam")
-      |> String.to_charlist()
-      |> :code.load_abs()
-    end
+  defp load_module_filename({name, _path, _loaded?}) do
+    name
+    |> to_string()
+    |> String.to_atom()
+    |> Code.ensure_loaded()
   end
 
-  defp normalized_module_name(module) do
+  defp downcase_module_name(module) do
     module
     |> to_string()
     |> String.downcase()

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1352,7 +1352,7 @@ defmodule UndefinedFunctionError do
       end)
 
     with {_, _, _} <- candidate,
-         {:module, module} <- load_module_filename(candidate),
+         {:module, module} <- load_module(candidate),
          true <- function_exported?(module, function, arity) do
       ". Did you mean:\n\n      * #{Exception.format_mfa(module, function, arity)}\n"
     else
@@ -1360,7 +1360,7 @@ defmodule UndefinedFunctionError do
     end
   end
 
-  defp load_module_filename({name, _path, _loaded?}) do
+  defp load_module({name, _path, _loaded?}) do
     name
     |> to_string()
     |> String.to_atom()

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1346,8 +1346,7 @@ defmodule UndefinedFunctionError do
     downcased_module = downcase_module_name(module)
 
     candidate =
-      :code.all_available()
-      |> Enum.find(fn {name, _, _} ->
+      Enum.find(:code.all_available(), fn {name, _, _} ->
         downcase_module_name(name) == downcased_module
       end)
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1370,7 +1370,7 @@ defmodule UndefinedFunctionError do
   defp downcase_module_name(module) do
     module
     |> to_string()
-    |> String.downcase()
+    |> String.downcase(:ascii)
   end
 
   @doc false

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1362,8 +1362,7 @@ defmodule UndefinedFunctionError do
 
   defp load_module({name, _path, _loaded?}) do
     name
-    |> to_string()
-    |> String.to_atom()
+    |> List.to_atom()
     |> Code.ensure_loaded()
   end
 

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -596,11 +596,14 @@ defmodule ExceptionTest do
     end
 
     test "annotates undefined function error with module suggestions" do
-      assert blame_message(Enu, & &1.map(&1, 1)) == """
-             function Enu.map/2 is undefined (module Enu is not available). Did you mean:
+      assert blame_message(ENUM, & &1.map(&1, 1)) == """
+             function ENUM.map/2 is undefined (module ENUM is not available). Did you mean:
 
                    * Enum.map/2
              """
+
+      assert blame_message(ENUM, & &1.not_a_function(&1, 1)) ==
+               "function ENUM.not_a_function/2 is undefined (module ENUM is not available)"
     end
 
     test "annotates undefined function clause error with macro hints" do

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -595,6 +595,14 @@ defmodule ExceptionTest do
       assert message =~ "* set_cookie/2"
     end
 
+    test "annotates undefined function error with module suggestions" do
+      assert blame_message(Enu, & &1.map(&1, 1)) == """
+             function Enu.map/2 is undefined (module Enu is not available). Did you mean:
+
+                   * Enum.map/2
+             """
+    end
+
     test "annotates undefined function clause error with macro hints" do
       assert blame_message(Integer, & &1.is_odd(1)) ==
                "function Integer.is_odd/1 is undefined or private. However, there is " <>


### PR DESCRIPTION
This PR improves the error messages when a module is correctly spelled, but has mis-cased letters.

We will now get error messages like

```elixir
iex(1)> ENum.map([1, 2, 3], & &1 + 1)

09:39:24.348 [error] beam/beam_load.c(180): Error loading module 'Elixir.ENum':
  module name in object code is 'Elixir.Enum'



09:39:24.355 [error] beam/beam_load.c(180): Error loading module 'Elixir.ENum':
  module name in object code is 'Elixir.Enum'


** (UndefinedFunctionError) function ENum.map/2 is undefined (module ENum is not available). Did you mean:

      * Enum.map/2

    ENum.map([1, 2, 3], #Function<42.125776118/1 in :erl_eval.expr/6>)
    iex:1: (file)
```

## Motivation

I saw two experienced developers who are new to Elixir get stuck on this issue on the same day, not including a mention on Twitter!

[Twitter Conversation](https://twitter.com/davydog187/status/1687628454240428034?s=20)

## Follow ups
Initially, I wanted to capture 3 use cases. This PR only solves for case 1, the other two I will explore as follow ups

1. The module is miscased .e.g. `ENum` -> `Enum`
2. The module is misspelled, e.g. `Enu` -> `Enum`
3. The module is not qualified `SomeModule` -> `Namespace.SomeModule`

## Prior Art
* https://groups.google.com/g/elixir-lang-core/c/-IHneszMheI/m/cCCxHB9PBwAJ
* https://github.com/elixir-lang/elixir/pull/5665