### PR TITLE
consistently raise in case of invalid ANSI sequences in `IO.ANSI.format`

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -274,6 +274,8 @@ defmodule IO.ANSI do
   emitting actual ANSI codes. When `false`, no ANSI codes will be emitted.
   By default checks if ANSI is enabled using the `enabled?/0` function.
 
+  An `ArgumentError` will be raised if an invalid ANSI code is provided.
+
   ## Examples
 
       iex> IO.ANSI.format(["Hello, ", :red, :bright, "world!"], true)
@@ -315,6 +317,7 @@ defmodule IO.ANSI do
   end
 
   defp do_format(term, rem, acc, false, append_reset) when is_atom(term) do
+    format_sequence(term)
     do_format([], rem, acc, false, append_reset)
   end
 

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -90,6 +90,18 @@ defmodule IO.ANSITest do
     assert_raise ArgumentError, "invalid ANSI sequence specification: nil", fn ->
       IO.ANSI.format(["Hello!", nil], true)
     end
+
+    assert_raise ArgumentError, "invalid ANSI sequence specification: :brigh", fn ->
+      IO.ANSI.format([:brigh, "Hello!"], false)
+    end
+
+    assert_raise ArgumentError, "invalid ANSI sequence specification: nil", fn ->
+      IO.ANSI.format(["Hello!", nil], false)
+    end
+
+    assert_raise ArgumentError, "invalid ANSI sequence specification: :invalid", fn ->
+      IO.ANSI.format(:invalid, false)
+    end
   end
 
   test "colors" do


### PR DESCRIPTION
If `enabled` is set to `true` an invalid ANSI sequence will raise an `ArgumentError`. On the other hand if `enabled` is set to `false` no error is raised and the sequence is silently ignored.

This can lead to inconsistent behaviours for CLI commands based on a configuration setting. Additionally since in tests a common pattern is to disable ANSI sequences you may have successful tests but exceptions when executing the code in production with enabled ANSI sequences.