### PR TITLE
Fragment handle anonymous calls with extra spaces

### DIFF
--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -209,7 +209,10 @@ defmodule CodeFragmentTest do
       assert CF.cursor_context("hello.(\n") == {:anonymous_call, {:var, ~c"hello"}}
       assert CF.cursor_context("hello.(\r\n") == {:anonymous_call, {:var, ~c"hello"}}
 
+      assert CF.cursor_context("hello . (") == {:anonymous_call, {:var, ~c"hello"}}
+
       assert CF.cursor_context("@hello.(") == {:anonymous_call, {:module_attribute, ~c"hello"}}
+      assert CF.cursor_context("@hello . (") == {:anonymous_call, {:module_attribute, ~c"hello"}}
     end
 
     test "nested expressions" do


### PR DESCRIPTION
Sorry, I realized that in https://github.com/elixir-lang/elixir/pull/12846 I forgot to handle spaces (e.g. `fun . (`).
