### PR TITLE
Improve UndefinedFunctionError for unqualified module

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1342,7 +1342,7 @@ defmodule UndefinedFunctionError do
       hint_for_loaded_module(module, function, arity, nil)
   end
 
-  @max_suggestions 10
+  @max_suggestions 5
   defp hint(module, function, arity, _loaded?) do
     downcased_module = downcase_module_name(module)
     stripped_module = module |> Atom.to_string() |> String.replace_leading("Elixir.", "")

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -596,6 +596,25 @@ defmodule ExceptionTest do
     end
 
     test "annotates undefined function error with module suggestions" do
+      import PathHelpers
+
+      modules = [
+        Namespace.A.One,
+        Namespace.A.Two,
+        Namespace.A.Three,
+        Namespace.B.One,
+        Namespace.B.Two,
+        Namespace.B.Three
+      ]
+
+      for module <- modules do
+        write_beam(
+          defmodule module do
+            def foo, do: :bar
+          end
+        )
+      end
+
       assert blame_message(ENUM, & &1.map(&1, 1)) == """
              function ENUM.map/2 is undefined (module ENUM is not available). Did you mean:
 
@@ -604,6 +623,18 @@ defmodule ExceptionTest do
 
       assert blame_message(ENUM, & &1.not_a_function(&1, 1)) ==
                "function ENUM.not_a_function/2 is undefined (module ENUM is not available)"
+
+      assert blame_message(One, & &1.foo()) == """
+             function One.foo/0 is undefined (module One is not available). Did you mean:
+
+                   * Namespace.A.One.foo/0
+                   * Namespace.B.One.foo/0
+             """
+
+      for module <- modules do
+        :code.delete(module)
+        :code.purge(module)
+      end
     end
 
     test "annotates undefined function clause error with macro hints" do


### PR DESCRIPTION
This PR builds off of #12839, handling the case where a developer forgets to alias a module, resulting in UndefinedFunctionError.

Imagine we have the following modules in our Elixir program.

```elixir
def MyAppWeb.Context.Event do
  def foo, do: :bar
end
def MyAppWeb.OtherContext.Event do
  def foo, do: :bar
end
```

If the developer attempts to reference this module, but forgets to type the alias, they will now get module suggestions like.

```elixir
** (UndefinedFunctionError) function Event.foo/0 is undefined (module Event is not available). Did you mean:

      * MyAppWeb.Context.Event.foo/0
      * MyAppWeb.OtherContext.Event.foo/0

    Event.foo()
    iex:4: (file)
```

**TODO**

- [x] Clean up implementation. I wanted to get it working first to demonstrate the idea
- [x] Test on some real codebases with many modules to check the number of false positives