### PR TITLE
[docs] - update IO Inspect.Opts with :label description

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -39,6 +39,9 @@ defmodule Inspect.Opts do
     * `:inspect_fun` (since v1.9.0) - a function to build algebra documents.
       Defaults to `Inspect.Opts.default_inspect_fun/0`.
 
+    * `:label` - decorates the output with a label. The label will be printed
+      before the inspected `item`.
+
     * `:limit` - limits the number of items that are inspected for tuples,
       bitstrings, maps, lists and any other collection of items, with the exception of
       printable strings and printable charlists which use the `:printable_limit` option.


### PR DESCRIPTION
This pull request adds the `:label` option to the Inspect.Opts page.

Current version here:

https://hexdocs.pm/elixir/Inspect.Opts.html

`:label` is currently missing. It currently only gets a mention over in https://hexdocs.pm/elixir/IO.html#inspect/2.