### PR TITLE
Maps AST representation docs fix

### DIFF
--- a/lib/elixir/pages/references/syntax-reference.md
+++ b/lib/elixir/pages/references/syntax-reference.md
@@ -310,7 +310,7 @@ end
 #=> {:<<>>, [], [1, 2, 3]}
 ```
 
-The same applies to maps, where each pair is treated as a list of tuples with two elements:
+The same applies to maps, where pairs are treated as a list of tuples with two elements:
 
 ```elixir
 quote do


### PR DESCRIPTION
The current description points to each (individual) map pair being treated as a list in the AST, while the snippet shows all pairs in a single map.