### PR TITLE
Fix unused function warning with overridables

### DIFF
--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -268,7 +268,8 @@ run_on_definition_callbacks(Kind, Module, Name, Args, Guards, Body, E) ->
   _ = [Mod:Fun(E, Kind, Name, Args, Guards, Body) || {Mod, Fun} <- lists:reverse(Callbacks)],
   ok.
 
-store_definition(CheckClauses, Kind, Meta, Name, Arity, File, Module, Defaults, Clauses) ->
+store_definition(CheckClauses, Kind, Meta, Name, Arity, File, Module, Defaults, Clauses)
+    when CheckClauses == all; CheckClauses == none; CheckClauses == unused_only ->
   {Set, Bag} = elixir_module:data_tables(Module),
   Tuple = {Name, Arity},
   HasBody = Clauses =/= [],

--- a/lib/elixir/src/elixir_overridable.erl
+++ b/lib/elixir/src/elixir_overridable.erl
@@ -91,7 +91,7 @@ store(Set, Module, Tuple, {_, Count, Def, Neighbours, Overridden}, Hidden) ->
   case Overridden of
     false ->
       ets:update_element(Set, {overridable, Tuple}, {?overridden_pos, true}),
-      elixir_def:store_definition(false, FinalKind, Meta, FinalName, FinalArity,
+      elixir_def:store_definition(none, FinalKind, Meta, FinalName, FinalArity,
                                   File, Module, Defaults, FinalClauses),
       elixir_locals:reattach({FinalName, FinalArity}, FinalKind, Module, Tuple, Neighbours, Meta);
     true ->


### PR DESCRIPTION
This fixes an oversight when I changed the type of `CheckClauses` from a boolean to `all | none | unused_only` in 
https://github.com/elixir-lang/elixir/pull/12832, but forgot to update one call site in `elixir_overridable`.

`false` was de facto behaving as `unused_only` since would fail both the `== none` and `== all` checks.
Added a guard too to prevent the propagation of this kind of error.