### PR TITLE
Mention patter-filtering in comprehensions

### DIFF
--- a/lib/elixir/pages/cheatsheets/enum-cheat.cheatmd
+++ b/lib/elixir/pages/cheatsheets/enum-cheat.cheatmd
@@ -113,6 +113,15 @@ iex> for item <- cart, item.fruit =~ "e" do
 ]
 ```
 
+Pattern-matching in comprehensions acts as a filter as well:
+
+```elixir
+iex> for %{count: 1, fruit: fruit} <- cart do
+...>   fruit
+...> end
+["banana"]
+```
+
 ## Mapping
 {: .col-2}
 


### PR DESCRIPTION
I don't know if this deserves to be mentioned in the cheatsheet, but given that this can be both a useful pattern and a gotcha to be aware of, I thought maybe it could be a useful addition?
