### PR TITLE
docs(mix): update mix compile options

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.Compile do
       longer has an effect as Elixir will now copy those at release time
 
     * `:compilers` - compilers to run, defaults to `Mix.compilers/0`,
-      which are `[:yecc, :leex, :erlang, :elixir, :app]`.
+      which are `[:erlang, :elixir, :app]`.
 
     * `:consolidate_protocols` - when `true`, runs protocol
       consolidation via the `mix compile.protocols` task. The default


### PR DESCRIPTION
### Descriptions

Per https://github.com/elixir-lang/elixir/commit/b02808dd21130bdb4c3ade2ef78e90b5658d6f49, `:yecc` and `:leex` have been removed from the default compiler of Mix; however `Mix.Tasks.Compile`'s module document still contains the old info.

https://github.com/mnishiguchi/elixir/blob/b20ad8a1514008595bebe95ed9f8dfc67380a779/lib/mix/lib/mix/tasks/compile.ex#L20

### Changes

* remove `:yecc` and `:leex` from `Mix.compilers/0` 