### PR TITLE
Fix regex inspect for escaped hash

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -408,6 +408,7 @@ defimpl Inspect, for: Regex do
 
   defp normalize(<<?\\, ?\\, rest::binary>>, acc), do: normalize(rest, <<acc::binary, ?\\, ?\\>>)
   defp normalize(<<?\\, ?/, rest::binary>>, acc), do: normalize(rest, <<acc::binary, ?/>>)
+  defp normalize(<<?\\, ?#, ?{, rest::binary>>, acc), do: normalize(rest, <<acc::binary, ?#, ?{>>)
   defp normalize(<<char, rest::binary>>, acc), do: normalize(rest, <<acc::binary, char>>)
   defp normalize(<<>>, acc), do: acc
 

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -866,6 +866,9 @@ defmodule Inspect.OthersTest do
   test "regex" do
     assert inspect(~r(foo)m) == "~r/foo/m"
 
+    assert inspect(~R'#{2,}') == ~S"~r/\#{2,}/"
+    assert inspect(~r[\\\#{2,}]iu) == ~S"~r/\\\#{2,}/iu"
+
     assert inspect(Regex.compile!("a\\/b")) == "~r/a\\/b/"
 
     assert inspect(Regex.compile!("\a\b\d\e\f\n\r\s\t\v/")) ==


### PR DESCRIPTION
Removes extra backslash using normalize function, although it assumes that `\#` and `#` are equivalent regular expressions in Erlang.

```elixir
iex> ~R/#{2,}/
~r/\#{2,}/
iex> ~r/\#{2,}/
~r/\#{2,}/
iex> ~R/\#{2,}/
~r/\#{2,}/
```

Closes #12901.