### PR TITLE
Update man page with package manager

### DIFF
--- a/man/elixir.1.in
+++ b/man/elixir.1.in
@@ -56,4 +56,5 @@ If the file doesn't exist when a node starts, it will be created.
 .Bl -tag -width Ds
 .It Main website: https://elixir-lang.org
 .It Documentation: https://elixir-lang.org/docs.html
+.It Package manager: https://hex.pm
 .El

--- a/man/mix.1
+++ b/man/mix.1
@@ -145,4 +145,5 @@ Allows locking down the project dependencies with a proper version range before 
 .Bl -tag -width Ds
 .It Main website: https://elixir-lang.org
 .It Documentation: https://elixir-lang.org/docs.html
+.It Package manager: https://hex.pm
 .El


### PR DESCRIPTION
Pull request proposes a minor update of two man-pages (Elixir & Mix), where I added a link to the Hex package manager. Several programming languages have their package manager mentioned on the man page; hence, I believe that Elixir should also have this.