### PR TITLE
Add Access.at/2

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -696,18 +696,27 @@ defmodule Access do
   """
   @spec at(integer) :: access_fun(data :: list, current_value :: term)
   def at(index) when is_integer(index) do
-    fn op, data, next -> at(op, data, index, next) end
+    fn op, data, next -> at(op, data, index, next, nil) end
   end
 
-  defp at(:get, data, index, next) when is_list(data) do
-    data |> Enum.at(index) |> next.()
+  @doc """
+  Same as `at/1`, but also accepts a default value in case the index does not exist.
+  """
+  @doc since: "1.15.6"
+  @spec at(integer, term) :: access_fun(data :: list, current_value :: term)
+  def at(index, default) when is_integer(index) do
+    fn op, data, next -> at(op, data, index, next, default) end
   end
 
-  defp at(:get_and_update, data, index, next) when is_list(data) do
-    get_and_update_at(data, index, next, [], fn -> nil end)
+  defp at(:get, data, index, next, default) when is_list(data) do
+    data |> Enum.at(index, default) |> next.()
   end
 
-  defp at(_op, data, _index, _next) do
+  defp at(:get_and_update, data, index, next, default) when is_list(data) do
+    get_and_update_at(data, index, next, [], fn -> default end)
+  end
+
+  defp at(_op, data, _index, _next, _default) do
     raise "Access.at/1 expected a list, got: #{inspect(data)}"
   end
 

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -650,6 +650,8 @@ defmodule Access do
   the longer it will take to access its index. Therefore index-based operations
   are generally avoided in favor of other functions in the `Enum` module.
 
+  A `default` value can be given since Elixir v1.16.
+
   The returned function is typically passed as an accessor to `Kernel.get_in/2`,
   `Kernel.get_and_update_in/3`, and friends.
 
@@ -694,17 +696,8 @@ defmodule Access do
       ** (RuntimeError) Access.at/1 expected a list, got: %{}
 
   """
-  @spec at(integer) :: access_fun(data :: list, current_value :: term)
-  def at(index) when is_integer(index) do
-    fn op, data, next -> at(op, data, index, next, nil) end
-  end
-
-  @doc """
-  Same as `at/1`, but also accepts a default value in case the index does not exist.
-  """
-  @doc since: "1.15.6"
   @spec at(integer, term) :: access_fun(data :: list, current_value :: term)
-  def at(index, default) when is_integer(index) do
+  def at(index, default \\ nil) when is_integer(index) do
     fn op, data, next -> at(op, data, index, next, default) end
   end
 

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -239,6 +239,23 @@ defmodule AccessTest do
     end
   end
 
+  describe "at/2" do
+    @test_list [1, 2, 3, 4, 5, 6]
+
+    test "accepts default value (get_in)" do
+      assert :default = get_in(@test_list, [Access.at(10, :default)])
+    end
+
+    test "accepts default value (get_and_update_in)" do
+      list = @test_list
+
+      assert {:default, ^list} =
+               get_and_update_in(list, [Access.at(10, :default)], fn :default ->
+                 {nil, nil}
+               end)
+    end
+  end
+
   describe "at!/1" do
     @test_list [1, 2, 3, 4, 5, 6]
 


### PR DESCRIPTION
Based on [this mailing list thread](https://groups.google.com/g/elixir-lang-core/c/nN6w-PkvK9s/m/Txzw9pmPAQAJ), adds `Access.at/2` which supports a default value in case the index does not exist.