### PR TITLE
Add `Access.at/2` which accepts a default value

### DIFF
--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -215,15 +215,16 @@ defmodule AccessTest do
     end
   end
 
-  describe "at/1" do
+  describe "at/2" do
     @test_list [1, 2, 3, 4, 5, 6]
 
     test "returns element from the end if index is negative" do
       assert get_in(@test_list, [Access.at(-2)]) == 5
     end
 
-    test "returns nil if index is out of bounds counting from the end" do
+    test "returns default if index is out of bounds counting from the end" do
       assert get_in(@test_list, [Access.at(-10)]) == nil
+      assert get_in(@test_list, [Access.at(-10, 0)]) == 0
     end
 
     test "updates the element counting from the end if index is negative" do
@@ -232,10 +233,14 @@ defmodule AccessTest do
              end) == {5, [1, 2, 3, 4, :foo, 6]}
     end
 
-    test "returns nil and does not update if index is out of bounds" do
+    test "returns default and does not update if index is out of bounds" do
       assert get_and_update_in(@test_list, [Access.at(-10)], fn prev ->
                {prev, :foo}
              end) == {nil, [1, 2, 3, 4, 5, 6]}
+
+      assert get_and_update_in(@test_list, [Access.at(-10, 0)], fn prev ->
+               {prev, :foo}
+             end) == {0, [1, 2, 3, 4, 5, 6]}
     end
   end
 


### PR DESCRIPTION
This adds `Access.at/2` which will accept a default value. 

I encountered a discrepancy in how `Access.at` works with `update_in` and `get_and_update_in` as compared to `Access.key`:

```elixir
# The default is not used and the function is not applied
[] = update_in([], [Access.at(-10, 0)], &(&1 + 1))

# The default is used first and then the function is applied
%{a: 2} = update_in(%{}, [Access.key(:a, 1)], &(&1 + 1))

# Doesn't work the same as Map.update
%{a: 1} = Map.update(%{}, :a, 0, &(&1 + 1))
```

I didn't attempt to reconcile this, but I am curious if they _should_ work the same one way or another.