### PR TITLE
Save column information on start delimiter tokens

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1410,7 +1410,7 @@ check_terminator({'end', {EndLine, _, _}}, [{'do', _, _, Indentation} | Terminat
 
   {ok, NewScope#elixir_tokenizer{terminators=Terminators}};
 
-check_terminator({End, {EndLine, EndColumn, _}}, [{Start, StartLine, StartColumn, _} | Terminators], Scope)
+check_terminator({End, {EndLine, EndColumn, _}}, [{Start, StartLine, _, _} | Terminators], Scope)
     when End == 'end'; End == ')'; End == ']'; End == '}'; End == '>>' ->
   case terminator(Start) of
     End ->

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -144,7 +144,7 @@ tokenize([], Line, Column, #elixir_tokenizer{cursor_completion=Cursor} = Scope, 
   AccTokens = cursor_complete(Line, CursorColumn, CursorTerminators, CursorTokens),
   {ok, Line, Column, AllWarnings, AccTokens};
 
-tokenize([], EndLine, Column, #elixir_tokenizer{terminators=[{Start, StartLine, _} | _]} = Scope, Tokens) ->
+tokenize([], EndLine, Column, #elixir_tokenizer{terminators=[{Start, StartLine, _, _} | _]} = Scope, Tokens) ->
   End = terminator(Start),
   Hint = missing_terminator_hint(Start, End, Scope),
   Message = "missing terminator: ~ts (for \"~ts\" starting at line ~B)",
@@ -1376,27 +1376,27 @@ handle_terminator(Rest, Line, Column, Scope, Token, Tokens) ->
       tokenize(Rest, Line, Column, New, [Token | Tokens])
   end.
 
-check_terminator({Start, {Line, _, _}}, Terminators, Scope)
+check_terminator({Start, {Line, Column, _}}, Terminators, Scope)
     when Start == '('; Start == '['; Start == '{'; Start == '<<' ->
   Indentation = Scope#elixir_tokenizer.indentation,
-  {ok, Scope#elixir_tokenizer{terminators=[{Start, Line, Indentation} | Terminators]}};
+  {ok, Scope#elixir_tokenizer{terminators=[{Start, Line, Column, Indentation} | Terminators]}};
 
-check_terminator({Start, {Line, _, _}}, Terminators, Scope) when Start == 'fn'; Start == 'do' ->
+check_terminator({Start, {Line, Column, _}}, Terminators, Scope) when Start == 'fn'; Start == 'do' ->
   Indentation = Scope#elixir_tokenizer.indentation,
 
   NewScope =
     case Terminators of
       %% If the do is indented equally or less than the previous do, it may be a missing end error!
-      [{Start, _, PreviousIndentation} = Previous | _] when Indentation =< PreviousIndentation ->
+      [{Start, _, _, PreviousIndentation} = Previous | _] when Indentation =< PreviousIndentation ->
         Scope#elixir_tokenizer{mismatch_hints=[Previous | Scope#elixir_tokenizer.mismatch_hints]};
 
       _ ->
         Scope
     end,
 
-  {ok, NewScope#elixir_tokenizer{terminators=[{Start, Line, Indentation} | Terminators]}};
+  {ok, NewScope#elixir_tokenizer{terminators=[{Start, Line, Column, Indentation} | Terminators]}};
 
-check_terminator({'end', {EndLine, _, _}}, [{'do', _, Indentation} | Terminators], Scope) ->
+check_terminator({'end', {EndLine, _, _}}, [{'do', _, _, Indentation} | Terminators], Scope) ->
   NewScope =
     %% If the end is more indented than the do, it may be a missing do error!
     case Scope#elixir_tokenizer.indentation > Indentation of
@@ -1410,7 +1410,7 @@ check_terminator({'end', {EndLine, _, _}}, [{'do', _, Indentation} | Terminators
 
   {ok, NewScope#elixir_tokenizer{terminators=Terminators}};
 
-check_terminator({End, {EndLine, EndColumn, _}}, [{Start, StartLine, _} | Terminators], Scope)
+check_terminator({End, {EndLine, EndColumn, _}}, [{Start, StartLine, StartColumn, _} | Terminators], Scope)
     when End == 'end'; End == ')'; End == ']'; End == '}'; End == '>>' ->
   case terminator(Start) of
     End ->
@@ -1449,7 +1449,7 @@ unexpected_token_or_reserved(_) -> "unexpected token: ".
 
 missing_terminator_hint(Start, End, #elixir_tokenizer{mismatch_hints=Hints}) ->
   case lists:keyfind(Start, 1, Hints) of
-    {Start, HintLine, _} ->
+    {Start, HintLine, _, _} ->
       io_lib:format("\n\n    HINT: it looks like the \"~ts\" on line ~B does not have a matching \"~ts\"",
                     [Start, HintLine, End]);
     false ->
@@ -1717,7 +1717,7 @@ error(Reason, Rest, #elixir_tokenizer{warnings=Warnings}, Tokens) ->
 cursor_complete(Line, Column, Terminators, Tokens) ->
   {AccTokens, _} =
     lists:foldl(
-      fun({Start, _, _}, {NewTokens, NewColumn}) ->
+      fun({Start, _, _, _}, {NewTokens, NewColumn}) ->
         End = terminator(Start),
         AccTokens = [{End, {Line, NewColumn, nil}} | NewTokens],
         AccColumn = NewColumn + length(erlang:atom_to_list(End)),
@@ -1769,7 +1769,7 @@ prune_tokens([{'{', _} | Tokens], ['}' | Opener], Terminators) ->
 prune_tokens([{'<<', _} | Tokens], ['>>' | Opener], Terminators) ->
   prune_tokens(Tokens, Opener, Terminators);
 %%% Handle anonymous functions
-prune_tokens(Tokens, [], [{'fn', _, _} | Terminators]) ->
+prune_tokens(Tokens, [], [{'fn', _, _, _} | Terminators]) ->
   prune_tokens(drop_including(Tokens, 'fn'), [], Terminators);
 prune_tokens([{'(', _}, {capture_op, _, _} | Tokens], [], [{'(', _, _} | Terminators]) ->
   prune_tokens(Tokens, [], Terminators);


### PR DESCRIPTION
This will allow us to use this information when building more detailed error messages about mismatched delimiters, allowing us to have access to both start and ending tokens' positions.