### PR TITLE
Add MistmatchedDelimiterError

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -942,13 +942,11 @@ defmodule MismatchedDelimiterError do
   @impl true
   def message(%{
         start_position: _start_position,
-        end_position: end_position,
+        end_position: {line, column},
         description: description,
         file: file,
         snippet: snippet
       }) do
-    {line, column, _} = end_position
-
     snippet =
       :elixir_errors.format_snippet({line, column}, file, description, snippet, :error, [], nil)
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -937,20 +937,38 @@ defmodule MismatchedDelimiterError do
   - `fn a -> )`
   """
 
-  defexception [:file, :start_position, :end_position, :snippet, description: "syntax error"]
+  defexception [
+    :file,
+    :line,
+    :column,
+    :end_line,
+    :end_column,
+    :snippet,
+    description: "mismatched delimiter error"
+  ]
 
   @impl true
   def message(%{
-        start_position: _start_position,
-        end_position: {line, column},
+        line: _start_line,
+        column: _start_column,
+        end_line: end_line,
+        end_column: end_column,
         description: description,
         file: file,
         snippet: snippet
       }) do
     snippet =
-      :elixir_errors.format_snippet({line, column}, file, description, snippet, :error, [], nil)
+      :elixir_errors.format_snippet(
+        {end_line, end_column},
+        file,
+        description,
+        snippet,
+        :error,
+        [],
+        nil
+      )
 
-    format_message(file, line, column, snippet)
+    format_message(file, end_line, end_column, snippet)
   end
 
   defp format_message(file, line, column, message) do

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -928,6 +928,39 @@ defmodule SystemLimitError do
   defexception message: "a system limit has been reached"
 end
 
+defmodule MismatchedDelimiterError do
+  @moduledoc """
+  An exception raised when a mismatched delimiter is found when parsing code.
+
+  For example:
+  - `[1, 2, 3}`
+  - `fn a -> )`
+  """
+
+  defexception [:file, :start_position, :end_position, :snippet, description: "syntax error"]
+
+  @impl true
+  def message(%{
+        start_position: _start_position,
+        end_position: end_position,
+        description: description,
+        file: file,
+        snippet: snippet
+      }) do
+    {line, column, _} = end_position
+
+    snippet =
+      :elixir_errors.format_snippet({line, column}, file, description, snippet, :error, [], nil)
+
+    format_message(file, line, column, snippet)
+  end
+
+  defp format_message(file, line, column, message) do
+    location = Exception.format_file_line_column(Path.relative_to_cwd(file), line, column)
+    "mismatched delimiter found on " <> location <> "\n" <> message
+  end
+end
+
 defmodule SyntaxError do
   @moduledoc """
   An exception raised when there's a syntax error when parsing code.

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -455,11 +455,9 @@ string_to_tokens(String, StartLine, StartColumn, File, Opts) when is_integer(Sta
       (lists:keyfind(warnings, 1, Opts) /= {warnings, false}) andalso
         [elixir_errors:erl_warn(L, File, M) || {L, M} <- lists:reverse(Warnings)],
       {ok, Tokens};
-    {error, {Line, Column, {ErrorPrefix, ErrorSuffix}, Token}, _Rest, _Warnings, _SoFar} ->
-      Location = [{line, Line}, {column, Column}],
+    {error, {Location, {ErrorPrefix, ErrorSuffix}, Token}, _Rest, _Warnings, _SoFar} ->
       {error, {Location, {to_binary(ErrorPrefix), to_binary(ErrorSuffix)}, to_binary(Token)}};
-    {error, {Line, Column, Error, Token}, _Rest, _Warnings, _SoFar} ->
-      Location = [{line, Line}, {column, Column}],
+    {error, {Location, Error, Token}, _Rest, _Warnings, _SoFar} ->
       {error, {Location, to_binary(Error), to_binary(Token)}}
   end.
 

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -374,15 +374,9 @@ parse_error(Location, File, Error, <<"[", _/binary>> = Full, Input) when is_bina
 %% Given a string prefix and suffix to insert the token inside the error message rather than append it
 parse_error(Location, File, {ErrorPrefix, ErrorSuffix}, Token, Input) when is_binary(ErrorPrefix), is_binary(ErrorSuffix), is_binary(Token) ->
   Message = <<ErrorPrefix/binary, Token/binary, ErrorSuffix/binary >>,
-
-  case lists:keyfind(line, 1, Location) of
-     {line, {_, _, _} = Start} ->
-      case lists:keyfind(column, 1, Location) of
-         {column, {_, _, _} = End} ->
-           raise_mismatched_delimiter(Start, End, File, Input, Message)
-       end;
-     _ ->
-      raise_snippet(Location, File, Input, 'Elixir.SyntaxError', Message)
+  case lists:keyfind(error_type, 1, Location) of
+    {error_type, mismatched_delimiter} -> raise_mismatched_delimiter(Location, File, Input, Message);
+    _ -> raise_snippet(Location, File, Input, 'Elixir.SyntaxError', Message)
   end;
 
 %% Misplaced char tokens (for example, {char, _, 97}) are translated by Erlang into
@@ -404,10 +398,14 @@ parse_erl_term(Term) ->
   {ok, Parsed} = erl_parse:parse_term(Tokens ++ [{dot, 1}]),
   Parsed.
 
-raise_mismatched_delimiter({_, _, _} = StartPosition, {EndLine, EndCol, _} = EndPosition, File, Input, Message) ->
+raise_mismatched_delimiter(Location, File, Input, Message) ->
+  {line, StartLine} = lists:keyfind(line, 1, Location),
+  {column, StartCol} = lists:keyfind(column, 1, Location),
+  {end_line, EndLine} = lists:keyfind(end_line, 1, Location),
+  {end_column, EndCol} = lists:keyfind(end_column, 1, Location),
   {InputString, InputStartLine, _} = Input,
   Snippet = snippet_line(InputString, [{line, EndLine}, {column, EndCol}], InputStartLine),
-  raise('Elixir.MismatchedDelimiterError', Message, [{file, File}, {snippet, Snippet}, {start_position, StartPosition}, {end_position, EndPosition}]).
+  raise('Elixir.MismatchedDelimiterError', Message, [{file, File}, {snippet, Snippet}, {start_position, {StartLine, StartCol}}, {end_position, {EndLine, EndCol}}]).
 
 raise_reserved(Location, File, Input, Keyword) ->
   raise_snippet(Location, File, Input, 'Elixir.SyntaxError',

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -374,8 +374,8 @@ parse_error(Location, File, Error, <<"[", _/binary>> = Full, Input) when is_bina
 %% Given a string prefix and suffix to insert the token inside the error message rather than append it
 parse_error(Location, File, {ErrorPrefix, ErrorSuffix}, Token, Input) when is_binary(ErrorPrefix), is_binary(ErrorSuffix), is_binary(Token) ->
   Message = <<ErrorPrefix/binary, Token/binary, ErrorSuffix/binary >>,
-  case lists:keyfind(error_type, 1, Location) of
-    {error_type, mismatched_delimiter} -> raise_mismatched_delimiter(Location, File, Input, Message);
+  case pop_key(Location, error_type) of
+    {mismatched_delimiter, Loc} -> raise_mismatched_delimiter(Loc, File, Input, Message);
     _ -> raise_snippet(Location, File, Input, 'Elixir.SyntaxError', Message)
   end;
 
@@ -398,14 +398,20 @@ parse_erl_term(Term) ->
   {ok, Parsed} = erl_parse:parse_term(Tokens ++ [{dot, 1}]),
   Parsed.
 
+pop_key(List, Key) ->
+  lists:foldr(fun(Elem, {KeyAcc, ListAcc}) ->
+                case Elem of
+                  {K, V} when K =:= Key -> {V, ListAcc};
+                   _ -> {KeyAcc, [Elem | ListAcc]}
+                end
+              end, {nil, []}, List).
+
 raise_mismatched_delimiter(Location, File, Input, Message) ->
-  {line, StartLine} = lists:keyfind(line, 1, Location),
-  {column, StartCol} = lists:keyfind(column, 1, Location),
   {end_line, EndLine} = lists:keyfind(end_line, 1, Location),
   {end_column, EndCol} = lists:keyfind(end_column, 1, Location),
   {InputString, InputStartLine, _} = Input,
   Snippet = snippet_line(InputString, [{line, EndLine}, {column, EndCol}], InputStartLine),
-  raise('Elixir.MismatchedDelimiterError', Message, [{file, File}, {snippet, Snippet}, {start_position, {StartLine, StartCol}}, {end_position, {EndLine, EndCol}}]).
+  raise('Elixir.MismatchedDelimiterError', Message,  Location ++ [{file, File}, {snippet, Snippet}]).
 
 raise_reserved(Location, File, Input, Keyword) ->
   raise_snippet(Location, File, Input, 'Elixir.SyntaxError',

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1410,7 +1410,7 @@ check_terminator({'end', {EndLine, _, _}}, [{'do', _, Indentation} | Terminators
 
   {ok, NewScope#elixir_tokenizer{terminators=Terminators}};
 
-check_terminator({End, {EndLine, EndColumn, _}}, [{Start, {StartLine, _, _}, _} | Terminators], Scope)
+check_terminator({End, {EndLine, EndColumn, _} = E}, [{Start, {StartLine, _, _} = S, _} | Terminators], Scope)
     when End == 'end'; End == ')'; End == ']'; End == '}'; End == '>>' ->
   case terminator(Start) of
     End ->
@@ -1422,7 +1422,7 @@ check_terminator({End, {EndLine, EndColumn, _}}, [{Start, {StartLine, _, _}, _} 
           "\n\n    HINT: the \"~ts\" on line ~B is missing terminator \"~ts\"",
           [Start, StartLine, ExpectedEnd]
         ),
-      {error, {EndLine, EndColumn, {unexpected_token_or_reserved(End), Suffix}, [atom_to_list(End)]}}
+      {error, {S, E, {unexpected_token_or_reserved(End), Suffix}, [atom_to_list(End)]}}
   end;
 
 check_terminator({'end', {Line, Column, _}}, [], #elixir_tokenizer{mismatch_hints=Hints}) ->

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -149,7 +149,7 @@ tokenize([], EndLine, Column, #elixir_tokenizer{terminators=[{Start, {StartLine,
   Hint = missing_terminator_hint(Start, End, Scope),
   Message = "missing terminator: ~ts (for \"~ts\" starting at line ~B)",
   Formatted = io_lib:format(Message, [End, Start, StartLine]),
-  error({EndLine, Column, [Formatted, Hint], []}, [], Scope, Tokens);
+  error({?LOC(EndLine, Column), [Formatted, Hint], []}, [], Scope, Tokens);
 
 tokenize([], Line, Column, #elixir_tokenizer{} = Scope, Tokens) ->
   #elixir_tokenizer{ascii_identifiers_only=Ascii, warnings=Warnings} = Scope,
@@ -160,7 +160,7 @@ tokenize([], Line, Column, #elixir_tokenizer{} = Scope, Tokens) ->
 
 tokenize(("<<<<<<<" ++ _) = Original, Line, 1, Scope, Tokens) ->
   FirstLine = lists:takewhile(fun(C) -> C =/= $\n andalso C =/= $\r end, Original),
-  Reason = {Line, 1, "found an unexpected version control marker, please resolve the conflicts: ", FirstLine},
+  Reason = {?LOC(Line, 1), "found an unexpected version control marker, please resolve the conflicts: ", FirstLine},
   error(Reason, Original, Scope, Tokens);
 
 % Base integers
@@ -390,7 +390,7 @@ tokenize([${ | Rest], Line, Column, Scope, [{'%', _} | _] = Tokens) ->
     "If you want to define a map, write %{...}, with no spaces.\n"
     "If you want to define a struct, write %StructName{...}.\n\n"
     "Syntax error before: ",
-  error({Line, Column, Message, [${]}, Rest, Scope, Tokens);
+  error({?LOC(Line, Column), Message, [${]}, Rest, Scope, Tokens);
 
 tokenize([T | Rest], Line, Column, Scope, Tokens) when T =:= $(; T =:= ${; T =:= $[ ->
   Token = {list_to_atom([T]), {Line, Column, nil}},
@@ -553,7 +553,7 @@ tokenize([$: | String] = Original, Line, Column, Scope, Tokens) ->
 tokenize([H | T], Line, Column, Scope, Tokens) when ?is_digit(H) ->
   case tokenize_number(T, [H], 1, false) of
     {error, Reason, Original} ->
-      error({Line, Column, Reason, Original}, T, Scope, Tokens);
+      error({?LOC(Line, Column), Reason, Original}, T, Scope, Tokens);
     {[I | Rest], Number, Original, _Length} when ?is_upcase(I); ?is_downcase(I); I == $_ ->
       if
         Number == 0, (I =:= $x) orelse (I =:= $o) orelse (I =:= $b), Rest == [],
@@ -570,7 +570,7 @@ tokenize([H | T], Line, Column, Scope, Tokens) when ?is_digit(H) ->
               [[I], Original]
             ),
 
-          error({Line, Column, Msg, [I]}, T, Scope, Tokens)
+          error({?LOC(Line, Column), Msg, [I]}, T, Scope, Tokens)
       end;
     {Rest, Number, Original, Length} when is_integer(Number) ->
       Token = {int, {Line, Column, Number}, Original},
@@ -595,13 +595,13 @@ tokenize(";" ++ Rest, Line, Column, Scope, [Top | _] = Tokens) when element(1, T
   tokenize(Rest, Line, Column + 1, Scope, [{';', {Line, Column, 0}} | Tokens]);
 
 tokenize("\\" = Original, Line, Column, Scope, Tokens) ->
-  error({Line, Column, "invalid escape \\ at end of file", []}, Original, Scope, Tokens);
+  error({?LOC(Line, Column), "invalid escape \\ at end of file", []}, Original, Scope, Tokens);
 
 tokenize("\\\n" = Original, Line, Column, Scope, Tokens) ->
-  error({Line, Column, "invalid escape \\ at end of file", []}, Original, Scope, Tokens);
+  error({?LOC(Line, Column), "invalid escape \\ at end of file", []}, Original, Scope, Tokens);
 
 tokenize("\\\r\n" = Original, Line, Column, Scope, Tokens) ->
-  error({Line, Column, "invalid escape \\ at end of file", []}, Original, Scope, Tokens);
+  error({?LOC(Line, Column), "invalid escape \\ at end of file", []}, Original, Scope, Tokens);
 
 tokenize("\\\n" ++ Rest, Line, _Column, Scope, Tokens) ->
   tokenize_eol(Rest, Line, Scope, Tokens);
@@ -618,11 +618,11 @@ tokenize("\r\n" ++ Rest, Line, Column, Scope, Tokens) ->
 % Others
 
 tokenize([$%, $( | Rest], Line, Column, Scope, Tokens) ->
-  Reason = {Line, Column, "expected %{ to define a map, got: ", [$%, $(]},
+  Reason = {?LOC(Line, Column), "expected %{ to define a map, got: ", [$%, $(]},
   error(Reason, Rest, Scope, Tokens);
 
 tokenize([$%, $[ | Rest], Line, Column, Scope, Tokens) ->
-  Reason = {Line, Column, "expected %{ to define a map, got: ", [$%, $[]},
+  Reason = {?LOC(Line, Column), "expected %{ to define a map, got: ", [$%, $[]},
   error(Reason, Rest, Scope, Tokens);
 
 tokenize([$%, ${ | T], Line, Column, Scope, Tokens) ->
@@ -649,15 +649,15 @@ tokenize(String, Line, Column, OriginalScope, Tokens) ->
 
         [$: | T] when hd(T) =/= $: ->
           AtomName = atom_to_list(Atom) ++ [$:],
-          Reason = {Line, Column, "keyword argument must be followed by space after: ", AtomName},
+          Reason = {?LOC(Line, Column), "keyword argument must be followed by space after: ", AtomName},
           error(Reason, String, Scope, Tokens);
 
         _ when HasAt ->
-          Reason = {Line, Column, invalid_character_error(Kind, $@), atom_to_list(Atom)},
+          Reason = {?LOC(Line, Column), invalid_character_error(Kind, $@), atom_to_list(Atom)},
           error(Reason, String, Scope, Tokens);
 
         _ when Atom == '__aliases__'; Atom == '__block__' ->
-          error({Line, Column, "reserved token: ", atom_to_list(Atom)}, Rest, Scope, Tokens);
+          error({?LOC(Line, Column), "reserved token: ", atom_to_list(Atom)}, Rest, Scope, Tokens);
 
         _ when Kind == alias ->
           tokenize_alias(Rest, Line, Column, Unencoded, Atom, Length, Ascii, Special, Scope, Tokens);
@@ -702,7 +702,7 @@ unexpected_token([T | Rest], Line, Column, Scope, Tokens) ->
       false ->
         io_lib:format("\"~ts\" (column ~p, code point U+~4.16.0B)", [[T], Column, T])
     end,
-  error({Line, Column, "unexpected token: ", Message}, Rest, Scope, Tokens).
+  error({?LOC(Line, Column), "unexpected token: ", Message}, Rest, Scope, Tokens).
 
 tokenize_eol(Rest, Line, Scope, Tokens) ->
   {StrippedRest, Indentation} = strip_horizontal_space(Rest, 0),
@@ -918,7 +918,7 @@ handle_dot([$., H | T] = Original, Line, Column, DotInfo, Scope, Tokens) when ?i
       end;
     {_NewLine, _NewColumn, _Parts, Rest, NewScope} ->
       Message = "interpolation is not allowed when calling function/macro. Found interpolation in a call starting with: ",
-      error({Line, Column, Message, [H]}, Rest, NewScope, Tokens);
+      error({?LOC(Line, Column), Message, [H]}, Rest, NewScope, Tokens);
     {error, Reason} ->
       interpolation_error(Reason, Original, Scope, Tokens, " (for function name starting at line ~B)", [Line])
   end;
@@ -975,7 +975,7 @@ is_unnecessary_quote(_Parts, _Scope) ->
 unsafe_to_atom(Part, Line, Column, #elixir_tokenizer{}) when
     is_binary(Part) andalso byte_size(Part) > 255;
     is_list(Part) andalso length(Part) > 255 ->
-  {error, {Line, Column, "atom length must be less than system limit: ", elixir_utils:characters_to_list(Part)}};
+  {error, {?LOC(Line, Column), "atom length must be less than system limit: ", elixir_utils:characters_to_list(Part)}};
 unsafe_to_atom(Part, Line, Column, #elixir_tokenizer{static_atoms_encoder=StaticAtomsEncoder}) when
     is_function(StaticAtomsEncoder) ->
   Value = elixir_utils:characters_to_binary(Part),
@@ -983,13 +983,13 @@ unsafe_to_atom(Part, Line, Column, #elixir_tokenizer{static_atoms_encoder=Static
     {ok, Term} ->
       {ok, Term};
     {error, Reason} when is_binary(Reason) ->
-      {error, {Line, Column, elixir_utils:characters_to_list(Reason) ++ ": ", elixir_utils:characters_to_list(Part)}}
+      {error, {?LOC(Line, Column), elixir_utils:characters_to_list(Reason) ++ ": ", elixir_utils:characters_to_list(Part)}}
   end;
 unsafe_to_atom(Binary, Line, Column, #elixir_tokenizer{existing_atoms_only=true}) when is_binary(Binary) ->
   try
     {ok, binary_to_existing_atom(Binary, utf8)}
   catch
-    error:badarg -> {error, {Line, Column, "unsafe atom does not exist: ", elixir_utils:characters_to_list(Binary)}}
+    error:badarg -> {error, {?LOC(Line, Column), "unsafe atom does not exist: ", elixir_utils:characters_to_list(Binary)}}
   end;
 unsafe_to_atom(Binary, _Line, _Column, #elixir_tokenizer{}) when is_binary(Binary) ->
   {ok, binary_to_atom(Binary, utf8)};
@@ -997,7 +997,7 @@ unsafe_to_atom(List, Line, Column, #elixir_tokenizer{existing_atoms_only=true}) 
   try
     {ok, list_to_existing_atom(List)}
   catch
-    error:badarg -> {error, {Line, Column, "unsafe atom does not exist: ", List}}
+    error:badarg -> {error, {?LOC(Line, Column), "unsafe atom does not exist: ", List}}
   end;
 unsafe_to_atom(List, _Line, _Column, #elixir_tokenizer{}) when is_list(List) ->
   {ok, list_to_atom(List)}.
@@ -1031,7 +1031,7 @@ extract_heredoc_with_interpolation(Line, Column, Scope, Interpol, T, H) ->
 
     error ->
       Message = "heredoc allows only whitespace characters followed by a new line after opening ",
-      {error, {Line, Column + 3, io_lib:format(Message, []), [H, H, H]}}
+      {error, {?LOC(Line, Column + 3), io_lib:format(Message, []), [H, H, H]}}
   end.
 
 extract_heredoc_header("\r\n" ++ Rest) ->
@@ -1092,7 +1092,7 @@ unescape_tokens(Tokens, Line, Column, #elixir_tokenizer{unescape=true}) ->
       {ok, Result};
 
     {error, Message, Token} ->
-      {error, {Line, Column, Message ++ ". Syntax error after: ", Token}}
+      {error, {?LOC(Line, Column), Message ++ ". Syntax error after: ", Token}}
   end;
 unescape_tokens(Tokens, _Line, _Column, #elixir_tokenizer{unescape=false}) ->
   {ok, tokens_to_binary(Tokens)}.
@@ -1189,7 +1189,7 @@ tokenize_comment([], Acc) ->
 
 error_comment(H, Comment, Line, Column, Scope, Tokens) ->
   Token = io_lib:format("\\u~4.16.0B", [H]),
-  Reason = {Line, Column, "invalid bidirectional formatting character in comment: ", Token},
+  Reason = {?LOC(Line, Column), "invalid bidirectional formatting character in comment: ", Token},
   error(Reason, Comment, Scope, Tokens).
 
 preserve_comments(Line, Column, Tokens, Comment, Rest, Scope) ->
@@ -1242,10 +1242,10 @@ tokenize_identifier(String, Line, Column, Scope, MaybeKeyword) ->
         no_suggestion ->
           %% we append a pointer to more info if we aren't appending a suggestion
           MoreInfo = "\nSee https://hexdocs.pm/elixir/unicode-syntax.html for more information.",
-          {error, {Line, Column, {Prefix, Suffix ++ MoreInfo}, Wrong}};
+          {error, {?LOC(Line, Column), {Prefix, Suffix ++ MoreInfo}, Wrong}};
 
-        {_, {Line, WrongColumn, _, SuggestionMessage}} = _SuggestionError ->
-          {error, {Line, WrongColumn, {Prefix, Suffix ++ SuggestionMessage}, Wrong}}
+        {_, {Location, _, SuggestionMessage}} = _SuggestionError ->
+          {error, {Location, {Prefix, Suffix ++ SuggestionMessage}, Wrong}}
       end;
 
     {error, {unexpected_token, Wrong}} ->
@@ -1279,7 +1279,7 @@ suggest_simpler_unexpected_token_in_error(Wrong, Line, WrongColumn, Scope) ->
                                     "You could write the above in a similar way that is accepted by Elixir:",
                                     Simpler,
                                     "See https://hexdocs.pm/elixir/unicode-syntax.html for more information."),
-           {error, {Line, WrongColumn, "unexpected token: ", Message}};
+           {error, {?LOC(Line, WrongColumn), "unexpected token: ", Message}};
          _other ->
            no_suggestion
        end;
@@ -1289,7 +1289,7 @@ suggest_simpler_unexpected_token_in_error(Wrong, Line, WrongColumn, Scope) ->
                                "You could write the above in a compatible format that is accepted by Elixir:",
                                NFKC,
                                "See https://hexdocs.pm/elixir/unicode-syntax.html for more information."),
-          {error, {Line, WrongColumn, "unexpected token: ", Message}}
+          {error, {?LOC(Line, WrongColumn), "unexpected token: ", Message}}
     end.
 
 suggest_change(Intro, WrongForm, Hint, HintedForm, Ending) ->
@@ -1311,7 +1311,7 @@ tokenize_alias(Rest, Line, Column, Unencoded, Atom, Length, Ascii, Special, Scop
   if
     not Ascii or (Special /= []) ->
       Invalid = hd([C || C <- Unencoded, (C < $A) or (C > 127)]),
-      Reason = {Line, Column, invalid_character_error("alias (only ASCII characters, without punctuation, are allowed)", Invalid), Unencoded},
+      Reason = {?LOC(Line, Column), invalid_character_error("alias (only ASCII characters, without punctuation, are allowed)", Invalid), Unencoded},
       error(Reason, Unencoded ++ Rest, Scope, Tokens);
 
     true ->
@@ -1343,8 +1343,8 @@ interpolation_error(Reason, Rest, Scope, Tokens, Extension, Args) ->
   error(interpolation_format(Reason, Extension, Args), Rest, Scope, Tokens).
 
 interpolation_format({string, Line, Column, Message, Token}, Extension, Args) ->
-  {Line, Column, [Message, io_lib:format(Extension, Args)], Token};
-interpolation_format({_, _, _, _} = Reason, _Extension, _Args) ->
+  {?LOC(Line, Column), [Message, io_lib:format(Extension, Args)], Token};
+interpolation_format({_, _, _} = Reason, _Extension, _Args) ->
   Reason.
 
 %% Terminators
@@ -1363,7 +1363,7 @@ handle_terminator(Rest, _, _, Scope, {'(', {Line, Column, _}}, [{alias, _, Alias
       [Alias]
     ),
 
-  error({Line, Column, Reason, ["("]}, atom_to_list(Alias) ++ [$( | Rest], Scope, Tokens);
+  error({?LOC(Line, Column), Reason, ["("]}, atom_to_list(Alias) ++ [$( | Rest], Scope, Tokens);
 handle_terminator(Rest, Line, Column, #elixir_tokenizer{terminators=none} = Scope, Token, Tokens) ->
   tokenize(Rest, Line, Column, Scope, [Token | Tokens]);
 handle_terminator(Rest, Line, Column, Scope, Token, Tokens) ->
@@ -1410,7 +1410,7 @@ check_terminator({'end', {EndLine, _, _}}, [{'do', _, Indentation} | Terminators
 
   {ok, NewScope#elixir_tokenizer{terminators=Terminators}};
 
-check_terminator({End, {EndLine, EndColumn, _} = E}, [{Start, {StartLine, _, _} = S, _} | Terminators], Scope)
+check_terminator({End, {EndLine, EndColumn, _}}, [{Start, {StartLine, StartColumn, _}, _} | Terminators], Scope)
     when End == 'end'; End == ')'; End == ']'; End == '}'; End == '>>' ->
   case terminator(Start) of
     End ->
@@ -1422,7 +1422,9 @@ check_terminator({End, {EndLine, EndColumn, _} = E}, [{Start, {StartLine, _, _} 
           "\n\n    HINT: the \"~ts\" on line ~B is missing terminator \"~ts\"",
           [Start, StartLine, ExpectedEnd]
         ),
-      {error, {S, E, {unexpected_token_or_reserved(End), Suffix}, [atom_to_list(End)]}}
+      StartLoc = ?LOC(StartLine, StartColumn),
+      EndLoc = [{end_line, EndLine}, {end_column, EndColumn}, {error_type, mismatched_delimiter}],
+      {error, {StartLoc ++ EndLoc, {unexpected_token_or_reserved(End), Suffix}, [atom_to_list(End)]}}
   end;
 
 check_terminator({'end', {Line, Column, _}}, [], #elixir_tokenizer{mismatch_hints=Hints}) ->
@@ -1435,11 +1437,11 @@ check_terminator({'end', {Line, Column, _}}, [], #elixir_tokenizer{mismatch_hint
         ""
     end,
 
-  {error, {Line, Column, {"unexpected reserved word: ", Suffix}, "end"}};
+  {error, {?LOC(Line, Column), {"unexpected reserved word: ", Suffix}, "end"}};
 
 check_terminator({End, {Line, Column, _}}, [], _Scope)
     when End == ')'; End == ']'; End == '}'; End == '>>' ->
-  {error, {Line, Column, "unexpected token: ", atom_to_list(End)}};
+  {error, {?LOC(Line, Column), "unexpected token: ", atom_to_list(End)}};
 
 check_terminator(_, _, Scope) ->
   {ok, Scope}.
@@ -1503,7 +1505,7 @@ tokenize_keyword(terminator, Rest, Line, Column, Atom, Length, Scope, Tokens) ->
     {ok, [Check | T]} ->
       handle_terminator(Rest, Line, Column + Length, Scope, Check, T);
     {error, Message, Token} ->
-      error({Line, Column, Message, Token}, Token ++ Rest, Scope, Tokens)
+      error({?LOC(Line, Column), Message, Token}, Token ++ Rest, Scope, Tokens)
   end;
 
 tokenize_keyword(token, Rest, Line, Column, Atom, Length, Scope, Tokens) ->
@@ -1538,7 +1540,7 @@ tokenize_sigil([$~ | T], Line, Column, Scope, Tokens) ->
       tokenize_sigil_contents(Rest, Name, NewLine, NewColumn, NewScope, NewTokens);
 
     {error, Message, Token} ->
-      Reason = {Line, Column, Message, Token},
+      Reason = {?LOC(Line, Column), Message, Token},
       error(Reason, T, Scope, Tokens)
   end.
 
@@ -1587,7 +1589,7 @@ tokenize_sigil_contents([H | _] = Original, SigilName, Line, Column, Scope, Toke
     "//, ||, \"\", '', (), [], {}, <>",
   Message = io_lib:format(MessageString, [[H], Column, H]),
   ErrorColumn = Column - 1 - length(SigilName),
-  error({Line, ErrorColumn, "invalid sigil delimiter: ", Message}, [$~] ++ SigilName ++ Original, Scope, Tokens);
+  error({?LOC(Line, ErrorColumn), "invalid sigil delimiter: ", Message}, [$~] ++ SigilName ++ Original, Scope, Tokens);
 
 % Incomplete sigil.
 tokenize_sigil_contents([], _SigilName, Line, Column, Scope, Tokens) ->

--- a/lib/elixir/src/elixir_tokenizer.hrl
+++ b/lib/elixir/src/elixir_tokenizer.hrl
@@ -12,6 +12,7 @@
 -define(is_quote(S), (S =:= $" orelse S =:= $')).
 -define(is_sigil(S), (S =:= $/ orelse S =:= $< orelse S =:= $" orelse S =:= $' orelse
                       S =:= $[ orelse S =:= $( orelse S =:= ${ orelse S =:= $|)).
+-define(LOC(Line, Column), [{line, Line}, {column, Column}]).
 
 %% Spaces
 -define(is_horizontal_space(S), (S =:= $\s orelse S =:= $\t)).

--- a/lib/elixir/test/erlang/string_test.erl
+++ b/lib/elixir/test/erlang/string_test.erl
@@ -76,7 +76,7 @@ extract_interpolations_with_an_escaped_character_test() ->
    ] = extract_interpolations("f#{?\\a > ?\\a   }").
 
 extract_interpolations_with_invalid_expression_inside_interpolation_test() ->
-  {1, 4, "unexpected token: ", _} = extract_interpolations("f#{:1}o").
+  {[{line, 1}, {column, 4}], "unexpected token: ", _} = extract_interpolations("f#{:1}o").
 
 %% Bin strings
 

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -42,7 +42,7 @@ scientific_test() ->
   [{flt, {1, 1, 0.1}, "1.0e-1"}] = tokenize("1.0e-1"),
   [{flt, {1, 1, 0.1}, "1.0E-1"}] = tokenize("1.0E-1"),
   [{flt, {1, 1, 1.2345678e-7}, "1_234.567_8e-10"}] = tokenize("1_234.567_8e-10"),
-  {1, 1, "invalid float number ", "1.0e309"} = tokenize_error("1.0e309").
+  {[{line, 1}, {column, 1}], "invalid float number ", "1.0e309"} = tokenize_error("1.0e309").
 
 hex_bin_octal_test() ->
   [{int, {1, 1, 255}, "0xFF"}] = tokenize("0xFF"),
@@ -65,7 +65,7 @@ quoted_atom_test() ->
 
 oversized_atom_test() ->
   OversizedAtom = string:copies("a", 256),
-  {1, 1, "atom length must be less than system limit: ", OversizedAtom} =
+  {[{line, 1}, {column, 1}], "atom length must be less than system limit: ", OversizedAtom} =
     tokenize_error([$: | OversizedAtom]).
 
 op_atom_test() ->
@@ -96,7 +96,7 @@ float_test() ->
   [{flt, {1, 3, 12.3}, "12.3"}, {flt, {1, 9, 23.4}, "23.4"}] = tokenize("  12.3  23.4  "),
   [{flt, {1, 1, 12.3}, "00_12.3_00"}] = tokenize("00_12.3_00"),
   OversizedFloat = string:copies("9", 310) ++ ".0",
-  {1, 1, "invalid float number ", OversizedFloat} = tokenize_error(OversizedFloat).
+  {[{line, 1}, {column, 1}], "invalid float number ", OversizedFloat} = tokenize_error(OversizedFloat).
 
 identifier_test() ->
   [{identifier, {1, 1, _}, abc}] = tokenize("abc "),
@@ -257,7 +257,7 @@ capture_test() ->
    {int, {1,6,3}, "3"}] = tokenize("..///3").
 
 vc_merge_conflict_test() ->
-  {1, 1, "found an unexpected version control marker, please resolve the conflicts: ", "<<<<<<< HEAD"} =
+  {[{line, 1}, {column, 1}], "found an unexpected version control marker, please resolve the conflicts: ", "<<<<<<< HEAD"} =
     tokenize_error("<<<<<<< HEAD\n[1, 2, 3]").
 
 sigil_terminator_test() ->
@@ -279,5 +279,5 @@ sigil_heredoc_test() ->
   [{sigil, {1, 1, nil}, sigil_s, [<<"sigil heredoc\n">>], "", 2, <<"\"\"\"">>}] = tokenize("~s\"\"\"\n  sigil heredoc\n  \"\"\"").
 
 invalid_sigil_delimiter_test() ->
-  {1, 1, "invalid sigil delimiter: ", Message} = tokenize_error("~s\\"),
+  {[{line, 1}, {column, 1}], "invalid sigil delimiter: ", Message} = tokenize_error("~s\\"),
   true = lists:prefix("\"\\\" (column 3, code point U+005C)", lists:flatten(Message)).

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -45,7 +45,7 @@ defmodule IEx.InteractionTest do
   test "invalid input" do
     output = capture_iex("if true do ) false end")
 
-    assert output =~ "** (SyntaxError) invalid syntax found on iex:1:12:"
+    assert output =~ "** (MismatchedDelimiterError) mismatched delimiter found on iex:1:12:"
     assert output =~ "unexpected token: )"
     assert output =~ "iex:1:12"
     assert output =~ "if true do ) false end"


### PR DESCRIPTION
This PR adds a new exception, MismatchedDelimiterError, that will contain necessary information such as start and end position so that we can build nice-looking error messages with it.

The only thing I'm not very happy with my implementation is the way we're passing the start and end information from the tokenizer (reusing existing {line, column} structure), so I'm open to suggestions here