### PR TITLE
fix: correctly trace inlined functions

### DIFF
--- a/lib/elixir/test/elixir/kernel/tracers_test.exs
+++ b/lib/elixir/test/elixir/kernel/tracers_test.exs
@@ -118,6 +118,7 @@ defmodule Kernel.TracersTest do
     require Integer
     true = Integer.is_odd(1)
     {1, ""} = Integer.parse("1")
+    "foo" = Atom.to_string(:foo)
     """)
 
     assert_receive {{:remote_macro, meta, Integer, :is_odd, 1}, _}
@@ -127,6 +128,10 @@ defmodule Kernel.TracersTest do
     assert_receive {{:remote_function, meta, Integer, :parse, 1}, _}
     assert meta[:line] == 3
     assert meta[:column] == 19
+
+    assert_receive {{:remote_function, meta, Atom, :to_string, 1}, _}
+    assert meta[:line] == 4
+    assert meta[:column] == 14
   end
 
   test "traces remote via captures" do


### PR DESCRIPTION
Currently just have a test that reproduces the bug, will work more on trying to fix the issue.

I was looking at the elixir_dispatch module where the inlining seems to happen, but I'm not exactly sure where
this function is called in the source code, so it's not clear to me as to where the tracing for the remote_function
is happening in this case.

```erlang
remote_function(Meta, Receiver, Name, Arity, E) ->
  check_deprecated(Meta, function, Receiver, Name, Arity, E),

  case elixir_rewrite:inline(Receiver, Name, Arity) of
    {AR, AN} -> {remote, AR, AN, Arity};
    false    -> {remote, Receiver, Name, Arity}
  end.
```

Any guidance would be appreciated!

This PR is in response to my proposal on the [mailing list](https://groups.google.com/g/elixir-lang-core/c/b7po6Ys0mlw).
