### PR TITLE
Improve mismatched delimiter message

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1041,8 +1041,12 @@ defmodule MismatchedDelimiterError do
     line = Enum.at(lines, end_line - 1)
     formatted_line = "#{line_padding(end_line, max_digits)}#{end_line} │ #{line}"
 
-    mismatched_closing_line = n_spaces(start_column - 1) <> red("│") <> mismatched_closing_delimiter(abs(end_column - start_column))
-         unclosed_delimiter_line = padding <> " │ " <> n_spaces(start_column - 1) <> unclosed_delimiter(start_column)
+    mismatched_closing_line =
+      n_spaces(start_column - 1) <>
+        red("│") <> mismatched_closing_delimiter(abs(end_column - start_column))
+
+    unclosed_delimiter_line =
+      padding <> " │ " <> n_spaces(start_column - 1) <> unclosed_delimiter(start_column)
 
     below_line = "#{padding} │ #{mismatched_closing_line}\n#{unclosed_delimiter_line}"
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -968,7 +968,7 @@ defmodule MismatchedDelimiterError do
   end
 
   defp format_snippet(
-         {start_line, start_column} = start_pos,
+         {start_line, _start_column} = start_pos,
          {end_line, end_column} = end_pos,
          description,
          file,
@@ -994,25 +994,6 @@ defmodule MismatchedDelimiterError do
      #{padding}└─ #{Path.relative_to_cwd(file)}:#{end_line}:#{end_column}\
     """
   end
-
-  defp line_padding(line_number, max_digits) do
-    line_digits = digits(line_number)
-
-    spacing =
-      if line_digits == 1 do
-        max(2, max_digits)
-      else
-        max_digits - line_digits + 1
-      end
-
-    n_spaces(spacing)
-  end
-
-  defp n_spaces(n), do: String.duplicate(" ", n)
-
-  defp digits(number, acc \\ 1)
-  defp digits(number, acc) when number < 10, do: acc
-  defp digits(number, acc), do: digits(div(number, 10), acc + 1)
 
   defp format_snippet(
          {start_line, start_column},
@@ -1050,6 +1031,25 @@ defmodule MismatchedDelimiterError do
      #{padding}└─ #{Path.relative_to_cwd(file)}:#{end_line}:#{end_column}\
     """
   end
+
+  defp line_padding(line_number, max_digits) do
+    line_digits = digits(line_number)
+
+    spacing =
+      if line_digits == 1 do
+        max(2, max_digits)
+      else
+        max_digits - line_digits + 1
+      end
+
+    n_spaces(spacing)
+  end
+
+  defp n_spaces(n), do: String.duplicate(" ", n)
+
+  defp digits(number, acc \\ 1)
+  defp digits(number, acc) when number < 10, do: acc
+  defp digits(number, acc), do: digits(div(number, 10), acc + 1)
 
   defp trimmed_inbetween_lines(lines, {start_line, start_column}, {end_line, end_column}, padding, max_digits) do
     start_padding = line_padding(start_line, max_digits)

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1088,14 +1088,26 @@ defmodule MismatchedDelimiterError do
       cond do
         line_number == start_line ->
           [
-            line_padding, to_string(line_number), " │ ", line, "\n",
-            padding, " │ ", unclosed_delimiter(start_column)
+            line_padding,
+            to_string(line_number),
+            " │ ",
+            line,
+            "\n",
+            padding,
+            " │ ",
+            unclosed_delimiter(start_column)
           ]
 
         line_number == end_line ->
           [
-            line_padding, to_string(line_number), " │ ", line, "\n",
-            padding, " │ ", mismatched_closing_delimiter(end_column)
+            line_padding,
+            to_string(line_number),
+            " │ ",
+            line,
+            "\n",
+            padding,
+            " │ ",
+            mismatched_closing_delimiter(end_column)
           ]
 
         true ->

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1051,7 +1051,13 @@ defmodule MismatchedDelimiterError do
   defp digits(number, acc) when number < 10, do: acc
   defp digits(number, acc), do: digits(div(number, 10), acc + 1)
 
-  defp trimmed_inbetween_lines(lines, {start_line, start_column}, {end_line, end_column}, padding, max_digits) do
+  defp trimmed_inbetween_lines(
+         lines,
+         {start_line, start_column},
+         {end_line, end_column},
+         padding,
+         max_digits
+       ) do
     start_padding = line_padding(start_line, max_digits)
     end_padding = line_padding(end_line, max_digits)
     first_line = Enum.fetch!(lines, start_line - 1)

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -983,17 +983,28 @@ defmodule MismatchedDelimiterError do
       if end_line - start_line < @max_lines_shown do
         line_range(lines, start_pos, end_pos, padding, max_digits)
       else
-        first_line = Enum.fetch!(lines, start_line - 1)
-        last_line = Enum.fetch!(lines, end_line - 1)
-
         start_padding = line_padding(start_line, max_digits)
-        end_padding = line_padding(end_line, max_digits)
+        first_line = Enum.fetch!(lines, start_line - 1)
+
+        range = (end_line - 2)..(end_line - 1)
+        last_lines = lines
+                     |> Enum.slice(range)
+                     |> Enum.zip_with(range, fn line, line_number ->
+                      line_number = line_number + 1
+                      line_padding = line_padding(line_number, max_digits)
+                      formatted_line = "#{line_padding}#{line_number} │ #{line}"
+                       if line_number == end_line do
+                         formatted_line
+                       else
+                         [formatted_line, "\n"]
+                       end
+                     end)
 
         """
         #{start_padding}#{start_line} │ #{first_line}
          #{padding}│ #{unclosed_delimiter(start_column)}
          #{padding}│ ...
-        #{end_padding}#{end_line} │ #{last_line}
+        #{last_lines}
          #{padding}│ #{mismatched_closing_delimiter(end_column)}\
         """
       end

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1087,19 +1087,19 @@ defmodule MismatchedDelimiterError do
 
       cond do
         line_number == start_line ->
-          """
-          #{line_padding}#{line_number} │ #{line}
-           #{padding}│ #{unclosed_delimiter(start_column)}\
-          """
+          [
+            line_padding, to_string(line_number), " │ ", line, "\n",
+            padding, " │ ", unclosed_delimiter(start_column)
+          ]
 
         line_number == end_line ->
-          """
-          #{line_padding}#{line_number} │ #{line}
-           #{padding}│ #{mismatched_closing_delimiter(end_column)}\
-          """
+          [
+            line_padding, to_string(line_number), " │ ", line, "\n",
+            padding, " │ ", mismatched_closing_delimiter(end_column)
+          ]
 
         true ->
-          "#{line_padding}#{line_number} │ #{line}"
+          [line_padding, to_string(line_number), " │ ", line]
       end
     end)
     |> Enum.intersperse("\n")

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1003,7 +1003,7 @@ defmodule MismatchedDelimiterError do
         """
         #{start_padding}#{start_line} │ #{first_line}
          #{padding}│ #{unclosed_delimiter(start_column)}
-         #{padding}│ ...
+         ...
         #{last_lines}
          #{padding}│ #{mismatched_closing_delimiter(end_column)}\
         """

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1142,7 +1142,7 @@ defmodule MismatchedDelimiterError do
   defp mismatched_closing_delimiter(end_column, expected_closing_delimiter),
     do: [
       n_spaces(end_column - 1),
-      red(~s/└ mismatched closing delimiter (expecting "#{expected_closing_delimiter}")/)
+      red(~s/└ mismatched closing delimiter (expected "#{expected_closing_delimiter}")/)
     ]
 
   defp unclosed_delimiter(start_column),

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -373,11 +373,8 @@ parse_error(Location, File, Error, <<"[", _/binary>> = Full, Input) when is_bina
 
 %% Given a string prefix and suffix to insert the token inside the error message rather than append it
 parse_error(Location, File, {ErrorPrefix, ErrorSuffix}, Token, Input) when is_binary(ErrorPrefix), is_binary(ErrorSuffix), is_binary(Token) ->
-  Message = <<ErrorPrefix/binary, Token/binary, ErrorSuffix/binary >>,
-  case lists:keytake(error_type, 1, Location) of
-    {value, {error_type, mismatched_delimiter}, Loc} -> raise_mismatched_delimiter(Loc, File, Input, Message);
-    _ -> raise_snippet(Location, File, Input, 'Elixir.SyntaxError', Message)
-  end;
+  Message = <<ErrorPrefix/binary, Token/binary, ErrorSuffix/binary>>,
+  raise_snippet(Location, File, Input, 'Elixir.SyntaxError', Message);
 
 %% Misplaced char tokens (for example, {char, _, 97}) are translated by Erlang into
 %% the char literal (i.e., the token in the previous example becomes $a),
@@ -391,7 +388,10 @@ parse_error(Location, File, <<"syntax error before: ">>, <<$$, Char/binary>>, In
 %% Everything else is fine as is
 parse_error(Location, File, Error, Token, Input) when is_binary(Error), is_binary(Token) ->
   Message = <<Error/binary, Token/binary>>,
-  raise_snippet(Location, File, Input, 'Elixir.SyntaxError', Message).
+  case lists:keytake(error_type, 1, Location) of
+    {value, {error_type, mismatched_delimiter}, Loc} -> raise_mismatched_delimiter(Loc, File, Input, Message);
+    _ -> raise_snippet(Location, File, Input, 'Elixir.SyntaxError', Message)
+  end.
 
 parse_erl_term(Term) ->
   {ok, Tokens, _} = erl_scan:string(binary_to_list(Term)),

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -399,11 +399,9 @@ parse_erl_term(Term) ->
   Parsed.
 
 raise_mismatched_delimiter(Location, File, Input, Message) ->
-  {end_line, EndLine} = lists:keyfind(end_line, 1, Location),
-  {end_column, EndCol} = lists:keyfind(end_column, 1, Location),
-  {InputString, InputStartLine, _} = Input,
-  Snippet = snippet_line(InputString, [{line, EndLine}, {column, EndCol}], InputStartLine),
-  raise('Elixir.MismatchedDelimiterError', Message,  [{file, File}, {snippet, Snippet} | Location]).
+  {InputString, _, _} = Input,
+  InputBinary = iolist_to_binary(InputString),
+  raise('Elixir.MismatchedDelimiterError', Message,  [{file, File}, {snippet, InputBinary} | Location]).
 
 raise_reserved(Location, File, Input, Keyword) ->
   raise_snippet(Location, File, Input, 'Elixir.SyntaxError',

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1416,10 +1416,18 @@ check_terminator({End, {EndLine, EndColumn, _}}, [{Start, {StartLine, StartColum
     End ->
       {ok, Scope#elixir_tokenizer{terminators=Terminators}};
 
-    _ExpectedEnd ->
-      StartLoc = ?LOC(StartLine, StartColumn),
-      EndLoc = [{end_line, EndLine}, {end_column, EndColumn}, {error_type, mismatched_delimiter}],
-      {error, {StartLoc ++ EndLoc, unexpected_token_or_reserved(End), [atom_to_list(End)]}}
+    ExpectedEnd ->
+      Meta = [
+        {line, StartLine},
+        {column, StartColumn},
+        {end_line, EndLine},
+        {end_column, EndColumn},
+        {error_type, mismatched_delimiter},
+        {opening_delimiter, Start},
+        {closing_delimiter, End},
+        {expected_closing_delimiter, ExpectedEnd}
+     ],
+     {error, {Meta, unexpected_token_or_reserved(End), [atom_to_list(End)]}}
   end;
 
 check_terminator({'end', {Line, Column, _}}, [], #elixir_tokenizer{mismatch_hints=Hints}) ->

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1416,15 +1416,10 @@ check_terminator({End, {EndLine, EndColumn, _}}, [{Start, {StartLine, StartColum
     End ->
       {ok, Scope#elixir_tokenizer{terminators=Terminators}};
 
-    ExpectedEnd ->
-      Suffix =
-        io_lib:format(
-          "\nHINT: the \"~ts\" on line ~B is missing terminator \"~ts\"",
-          [Start, StartLine, ExpectedEnd]
-        ),
+    _ExpectedEnd ->
       StartLoc = ?LOC(StartLine, StartColumn),
       EndLoc = [{end_line, EndLine}, {end_column, EndColumn}, {error_type, mismatched_delimiter}],
-      {error, {StartLoc ++ EndLoc, {unexpected_token_or_reserved(End), Suffix}, [atom_to_list(End)]}}
+      {error, {StartLoc ++ EndLoc, unexpected_token_or_reserved(End), [atom_to_list(End)]}}
   end;
 
 check_terminator({'end', {Line, Column, _}}, [], #elixir_tokenizer{mismatch_hints=Hints}) ->

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1419,7 +1419,7 @@ check_terminator({End, {EndLine, EndColumn, _}}, [{Start, {StartLine, StartColum
     ExpectedEnd ->
       Suffix =
         io_lib:format(
-          "\n\n    HINT: the \"~ts\" on line ~B is missing terminator \"~ts\"",
+          "\nHINT: the \"~ts\" on line ~B is missing terminator \"~ts\"",
           [Start, StartLine, ExpectedEnd]
         ),
       StartLoc = ?LOC(StartLine, StartColumn),

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1,7 +1,7 @@
 -module(elixir_tokenizer).
 -include("elixir.hrl").
 -include("elixir_tokenizer.hrl").
--export([tokenize/1, tokenize/3, tokenize/4, invalid_do_error/1]).
+-export([tokenize/1, tokenize/3, tokenize/4, invalid_do_error/1, terminator/1]).
 
 -define(at_op(T),
   T =:= $@).
@@ -1416,7 +1416,7 @@ check_terminator({End, {EndLine, EndColumn, _}}, [{Start, {StartLine, StartColum
     End ->
       {ok, Scope#elixir_tokenizer{terminators=Terminators}};
 
-    ExpectedEnd ->
+    _ExpectedEnd ->
       Meta = [
         {line, StartLine},
         {column, StartColumn},
@@ -1424,8 +1424,7 @@ check_terminator({End, {EndLine, EndColumn, _}}, [{Start, {StartLine, StartColum
         {end_column, EndColumn},
         {error_type, mismatched_delimiter},
         {opening_delimiter, Start},
-        {closing_delimiter, End},
-        {expected_closing_delimiter, ExpectedEnd}
+        {closing_delimiter, End}
      ],
      {error, {Meta, unexpected_token_or_reserved(End), [atom_to_list(End)]}}
   end;

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -156,7 +156,6 @@ defmodule Kernel.DiagnosticsTest do
                1 │ [ :a,
                  │ └ unclosed delimiter
               ...
-               8 │   :h
                9 │ )
                  │ └ mismatched closing delimiter
                  │
@@ -183,7 +182,6 @@ defmodule Kernel.DiagnosticsTest do
                1 │ [ a,
                  │ └ unclosed delimiter
               ...
-              12 │ 
               13 │   b )
                  │     └ mismatched closing delimiter
                  │
@@ -208,7 +206,6 @@ defmodule Kernel.DiagnosticsTest do
                 1 │ [ a,
                   │ └ unclosed delimiter
               ...
-              402 │ 
               403 │   b )
                   │     └ mismatched closing delimiter
                   │
@@ -234,7 +231,6 @@ defmodule Kernel.DiagnosticsTest do
                99 │ [ a,
                   │ └ unclosed delimiter
               ...
-              106 │ 
               107 │   b )
                   │     └ mismatched closing delimiter
                   │

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -12,18 +12,6 @@ defmodule Kernel.DiagnosticsTest do
 
   describe "mismatched delimiter" do
     test "trims start if distance exceeds threshold in same line" do
-      expected = """
-      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:1:77:
-          error: unexpected token: }
-          HINT: the "[" on line 1 is missing terminator "]"
-          │
-        1 │ ...long_long_name = [1, 2, 3}
-          │                     │       └ mismatched closing delimiter
-          │                     └ unclosed delimiter
-          │
-          └─ nofile:1:77\
-      """
-
       output =
         capture_raise(
           """
@@ -32,22 +20,20 @@ defmodule Kernel.DiagnosticsTest do
           MismatchedDelimiterError
         )
 
-      assert output == expected
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:1:77:
+                 error: unexpected token: }
+                 HINT: the "[" on line 1 is missing terminator "]"
+                 │
+               1 │ ...long_long_name = [1, 2, 3}
+                 │                     │       └ mismatched closing delimiter
+                 │                     └ unclosed delimiter
+                 │
+                 └─ nofile:1:77\
+             """
     end
 
     test "trims in between if distance exceeds threshold in same line" do
-      expected = """
-      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:1:91:
-          error: unexpected token: )
-          HINT: the "[" on line 1 is missing terminator "]"
-          │
-        1 │ [1, MyLong.ReallyLong...function(), 200)
-          │ │                                      └ mismatched closing delimiter
-          │ └ unclosed delimiter
-          │
-          └─ nofile:1:91\
-      """
-
       output =
         capture_raise(
           """
@@ -56,22 +42,20 @@ defmodule Kernel.DiagnosticsTest do
           MismatchedDelimiterError
         )
 
-      assert output == expected
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:1:91:
+                 error: unexpected token: )
+                 HINT: the "[" on line 1 is missing terminator "]"
+                 │
+               1 │ [1, MyLong.ReallyLong...function(), 200)
+                 │ │                                      └ mismatched closing delimiter
+                 │ └ unclosed delimiter
+                 │
+                 └─ nofile:1:91\
+             """
     end
 
     test "same line" do
-      expected = """
-      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:1:18:
-          error: unexpected token: )
-          HINT: the "[" on line 1 is missing terminator "]"
-          │
-        1 │ [1, 2, 3, 4, 5, 6)
-          │ │                └ mismatched closing delimiter
-          │ └ unclosed delimiter
-          │
-          └─ nofile:1:18\
-      """
-
       output =
         capture_raise(
           """
@@ -80,23 +64,20 @@ defmodule Kernel.DiagnosticsTest do
           MismatchedDelimiterError
         )
 
-      assert output == expected
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:1:18:
+                 error: unexpected token: )
+                 HINT: the "[" on line 1 is missing terminator "]"
+                 │
+               1 │ [1, 2, 3, 4, 5, 6)
+                 │ │                └ mismatched closing delimiter
+                 │ └ unclosed delimiter
+                 │
+                 └─ nofile:1:18\
+             """
     end
 
     test "two-line span" do
-      expected = """
-      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:2:9:
-          error: unexpected token: }
-          HINT: the "[" on line 1 is missing terminator "]"
-          │
-        1 │ [a, b, c
-          │ └ unclosed delimiter
-        2 │  d, f, g}
-          │         └ mismatched closing delimiter
-          │
-          └─ nofile:2:9\
-      """
-
       output =
         capture_raise(
           """
@@ -106,26 +87,21 @@ defmodule Kernel.DiagnosticsTest do
           MismatchedDelimiterError
         )
 
-      assert output == expected
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:2:9:
+                 error: unexpected token: }
+                 HINT: the "[" on line 1 is missing terminator "]"
+                 │
+               1 │ [a, b, c
+                 │ └ unclosed delimiter
+               2 │  d, f, g}
+                 │         └ mismatched closing delimiter
+                 │
+                 └─ nofile:2:9\
+             """
     end
 
     test "many-line span" do
-      expected = """
-      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:5:5:
-          error: unexpected token: )
-          HINT: the "[" on line 1 is missing terminator "]"
-          │
-        1 │ [ a,
-          │ └ unclosed delimiter
-        2 │   b,
-        3 │   c,
-        4 │   d
-        5 │   e )
-          │     └ mismatched closing delimiter
-          │
-          └─ nofile:5:5\
-      """
-
       output =
         capture_raise(
           """
@@ -138,58 +114,57 @@ defmodule Kernel.DiagnosticsTest do
           MismatchedDelimiterError
         )
 
-      assert output == expected
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:5:5:
+                 error: unexpected token: )
+                 HINT: the "[" on line 1 is missing terminator "]"
+                 │
+               1 │ [ a,
+                 │ └ unclosed delimiter
+               2 │   b,
+               3 │   c,
+               4 │   d
+               5 │   e )
+                 │     └ mismatched closing delimiter
+                 │
+                 └─ nofile:5:5\
+             """
     end
 
     test "trim inbetween lines if too many" do
-      expected = """
-      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:9:5:
-          error: unexpected token: )
-          HINT: the "[" on line 1 is missing terminator "]"
-          │
-        1 │ [ a,
-          │ └ unclosed delimiter
-          │ ...
-        9 │   i )
-          │     └ mismatched closing delimiter
-          │
-          └─ nofile:9:5\
-      """
-
       output =
         capture_raise(
           """
-          [ a,
-            b,
-            c,
-            d,
-            e,
-            f,
-            g,
-            h
-            i )
+          [ :a,
+            :b,
+            :c,
+            :d,
+            :e,
+            :f,
+            :g,
+            :h
+          )
           """,
           MismatchedDelimiterError
         )
 
-      assert output == expected
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:9:1:
+                 error: unexpected token: )
+                 HINT: the "[" on line 1 is missing terminator "]"
+                 │
+               1 │ [ :a,
+                 │ └ unclosed delimiter
+                 │ ...
+               8 │   :h
+               9 │ )
+                 │ └ mismatched closing delimiter
+                 │
+                 └─ nofile:9:1\
+             """
     end
 
     test "pads according to line number digits" do
-      expected = """
-      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:13:5:
-          error: unexpected token: )
-          HINT: the "[" on line 1 is missing terminator "]"
-          │
-        1 │ [ a,
-          │ └ unclosed delimiter
-          │ ...
-       13 │   b )
-          │     └ mismatched closing delimiter
-          │
-          └─ nofile:13:5\
-      """
-
       output =
         capture_raise(
           """
@@ -200,21 +175,19 @@ defmodule Kernel.DiagnosticsTest do
           MismatchedDelimiterError
         )
 
-      assert output == expected
-
-      expected = """
-      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:403:5:
-           error: unexpected token: )
-           HINT: the "[" on line 1 is missing terminator "]"
-           │
-         1 │ [ a,
-           │ └ unclosed delimiter
-           │ ...
-       403 │   b )
-           │     └ mismatched closing delimiter
-           │
-           └─ nofile:403:5\
-      """
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:13:5:
+                 error: unexpected token: )
+                 HINT: the "[" on line 1 is missing terminator "]"
+                 │
+               1 │ [ a,
+                 │ └ unclosed delimiter
+                 │ ...
+              13 │   b )
+                 │     └ mismatched closing delimiter
+                 │
+                 └─ nofile:13:5\
+             """
 
       output =
         capture_raise(
@@ -226,21 +199,19 @@ defmodule Kernel.DiagnosticsTest do
           MismatchedDelimiterError
         )
 
-      assert output == expected
-
-      expected = """
-      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:107:5:
-           error: unexpected token: )
-           HINT: the "[" on line 99 is missing terminator "]"
-           │
-        99 │ [ a,
-           │ └ unclosed delimiter
-           │ ...
-       107 │   b )
-           │     └ mismatched closing delimiter
-           │
-           └─ nofile:107:5\
-      """
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:403:5:
+                  error: unexpected token: )
+                  HINT: the "[" on line 1 is missing terminator "]"
+                  │
+                1 │ [ a,
+                  │ └ unclosed delimiter
+                  │ ...
+              403 │   b )
+                  │     └ mismatched closing delimiter
+                  │
+                  └─ nofile:403:5\
+             """
 
       output =
         capture_raise(
@@ -253,23 +224,22 @@ defmodule Kernel.DiagnosticsTest do
           MismatchedDelimiterError
         )
 
-      assert output == expected
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:107:5:
+                  error: unexpected token: )
+                  HINT: the "[" on line 99 is missing terminator "]"
+                  │
+               99 │ [ a,
+                  │ └ unclosed delimiter
+                  │ ...
+              107 │   b )
+                  │     └ mismatched closing delimiter
+                  │
+                  └─ nofile:107:5\
+             """
     end
 
     test "trims lines that are too long (> 60 chars)" do
-      expected = """
-      ** (MismatchedDelimiterError) invalid syntax found on nofile:1:17:
-          error: syntax error before: '*'
-          │
-        1 │ ...= { a,
-          │      └ unclosed delimiter
-        2 │ ...
-        3 │ ...    b )
-          │          └ mismatched closing delimiter
-          │
-          └─ nofile:1:17\
-      """
-
       output =
         capture_raise(
           """
@@ -280,20 +250,18 @@ defmodule Kernel.DiagnosticsTest do
           MismatchedDelimiterError
         )
 
-      assert output == expected
-
-      expected = """
-      ** (MismatchedDelimiterError) invalid syntax found on nofile:1:17:
-          error: syntax error before: '*'
-          │
-        1 │ ...aaaa = [ 1,
-          │           └ unclosed delimiter
-          │ ...
-        3 │ ...aaaa" )
-          │          └ mismatched closing delimiter
-          │
-          └─ nofile:1:17\
-      """
+      assert output == """
+             ** (MismatchedDelimiterError) invalid syntax found on nofile:1:17:
+                 error: syntax error before: '*'
+                 │
+               1 │ ...= { a,
+                 │      └ unclosed delimiter
+               2 │ ...
+               3 │ ...    b )
+                 │          └ mismatched closing delimiter
+                 │
+                 └─ nofile:1:17\
+             """
 
       output =
         capture_raise(
@@ -305,7 +273,18 @@ defmodule Kernel.DiagnosticsTest do
           MismatchedDelimiterError
         )
 
-      assert output == expected
+      assert output == """
+             ** (MismatchedDelimiterError) invalid syntax found on nofile:1:17:
+                 error: syntax error before: '*'
+                 │
+               1 │ ...aaaa = [ 1,
+                 │           └ unclosed delimiter
+                 │ ...
+               3 │ ...aaaa" )
+                 │          └ mismatched closing delimiter
+                 │
+                 └─ nofile:1:17\
+             """
     end
   end
 

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -183,6 +183,7 @@ defmodule Kernel.DiagnosticsTest do
                1 │ [ a,
                  │ └ unclosed delimiter
                  │ ...
+              12 │ 
               13 │   b )
                  │     └ mismatched closing delimiter
                  │
@@ -207,6 +208,7 @@ defmodule Kernel.DiagnosticsTest do
                 1 │ [ a,
                   │ └ unclosed delimiter
                   │ ...
+              402 │ 
               403 │   b )
                   │     └ mismatched closing delimiter
                   │
@@ -232,6 +234,7 @@ defmodule Kernel.DiagnosticsTest do
                99 │ [ a,
                   │ └ unclosed delimiter
                   │ ...
+              106 │ 
               107 │   b )
                   │     └ mismatched closing delimiter
                   │

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -25,7 +25,7 @@ defmodule Kernel.DiagnosticsTest do
                  error: unexpected token: )
                  │
                1 │ [1, 2, 3, 4, 5, 6)
-                 │ │                └ mismatched closing delimiter
+                 │ │                └ mismatched closing delimiter (expecting "]")
                  │ └ unclosed delimiter
                  │
                  └─ nofile:1:18\
@@ -49,7 +49,7 @@ defmodule Kernel.DiagnosticsTest do
                1 │ [a, b, c
                  │ └ unclosed delimiter
                2 │  d, f, g}
-                 │         └ mismatched closing delimiter
+                 │         └ mismatched closing delimiter (expecting "]")
                  │
                  └─ nofile:2:9\
              """
@@ -59,7 +59,7 @@ defmodule Kernel.DiagnosticsTest do
       output =
         capture_raise(
           """
-          [ a,
+              [ a,
             b,
             c,
             d
@@ -72,15 +72,38 @@ defmodule Kernel.DiagnosticsTest do
              ** (MismatchedDelimiterError) mismatched delimiter found on nofile:5:5:
                  error: unexpected token: )
                  │
-               1 │ [ a,
-                 │ └ unclosed delimiter
+               1 │     [ a,
+                 │     └ unclosed delimiter
                2 │   b,
                3 │   c,
                4 │   d
                5 │   e )
-                 │     └ mismatched closing delimiter
+                 │     └ mismatched closing delimiter (expecting "]")
                  │
                  └─ nofile:5:5\
+             """
+
+      output =
+        capture_raise(
+          """
+          fn always_forget_end ->
+            IO.inspect(2 + 2) + 2
+          )
+          """,
+          MismatchedDelimiterError
+        )
+
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:3:1:
+                 error: unexpected token: )
+                 │
+               1 │ fn always_forget_end ->
+                 │ └ unclosed delimiter
+               2 │   IO.inspect(2 + 2) + 2
+               3 │ )
+                 │ └ mismatched closing delimiter (expecting "end")
+                 │
+                 └─ nofile:3:1\
              """
     end
 
@@ -109,7 +132,7 @@ defmodule Kernel.DiagnosticsTest do
                  │ └ unclosed delimiter
               ...
                9 │ )
-                 │ └ mismatched closing delimiter
+                 │ └ mismatched closing delimiter (expecting "]")
                  │
                  └─ nofile:9:1\
              """
@@ -134,7 +157,7 @@ defmodule Kernel.DiagnosticsTest do
                  │ └ unclosed delimiter
               ...
               13 │   b )
-                 │     └ mismatched closing delimiter
+                 │     └ mismatched closing delimiter (expecting "]")
                  │
                  └─ nofile:13:5\
              """
@@ -157,7 +180,7 @@ defmodule Kernel.DiagnosticsTest do
                   │ └ unclosed delimiter
               ...
               403 │   b )
-                  │     └ mismatched closing delimiter
+                  │     └ mismatched closing delimiter (expecting "]")
                   │
                   └─ nofile:403:5\
              """
@@ -181,7 +204,7 @@ defmodule Kernel.DiagnosticsTest do
                   │ └ unclosed delimiter
               ...
               107 │   b )
-                  │     └ mismatched closing delimiter
+                  │     └ mismatched closing delimiter (expecting "]")
                   │
                   └─ nofile:107:5\
              """

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -11,6 +11,7 @@ defmodule Kernel.DiagnosticsTest do
   end
 
   describe "mismatched delimiter" do
+    # TODO: maybe trim middle of line if gap between start col and end col is too long
     # test "same line" do
     #   expected = """
     #   ** (SyntaxError) invalid syntax found on nofile:1:17:
@@ -128,35 +129,77 @@ defmodule Kernel.DiagnosticsTest do
 
     test "pads according to line number digits" do
       expected = """
-      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:11:5:
+      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:13:5:
           error: unexpected token: )
           HINT: the "[" on line 1 is missing terminator "]"
           │
-       10 │ [ a,
+        1 │ [ a,
           │ └ unclosed delimiter
           │ ...
-       11 │   b )
+       13 │   b )
           │     └ mismatched closing delimiter
           │
-          └─ nofile:11:5\
+          └─ nofile:13:5\
       """
 
       output =
         capture_raise(
           """
-
-
-
-
-
-
-
-
-
-
-
-
           [ a,
+          #{String.duplicate("\n", 10)}
+            b )
+          """,
+          MismatchedDelimiterError
+        )
+
+      assert output == expected
+
+      expected = """
+      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:403:5:
+           error: unexpected token: )
+           HINT: the "[" on line 1 is missing terminator "]"
+           │
+         1 │ [ a,
+           │ └ unclosed delimiter
+           │ ...
+       403 │   b )
+           │     └ mismatched closing delimiter
+           │
+           └─ nofile:403:5\
+      """
+
+      output =
+        capture_raise(
+          """
+          [ a,
+          #{String.duplicate("\n", 400)}
+            b )
+          """,
+          MismatchedDelimiterError
+        )
+
+      assert output == expected
+
+      expected = """
+      ** (MismatchedDelimiterError) mismatched delimiter found on nofile:107:5:
+           error: unexpected token: )
+           HINT: the "[" on line 99 is missing terminator "]"
+           │
+        99 │ [ a,
+           │ └ unclosed delimiter
+           │ ...
+       107 │   b )
+           │     └ mismatched closing delimiter
+           │
+           └─ nofile:107:5\
+      """
+
+      output =
+        capture_raise(
+          """
+          #{String.duplicate("\n", 97)}
+          [ a,
+          #{String.duplicate("\n", 6)}
             b )
           """,
           MismatchedDelimiterError

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -25,7 +25,7 @@ defmodule Kernel.DiagnosticsTest do
                  error: unexpected token: )
                  │
                1 │ [1, 2, 3, 4, 5, 6)
-                 │ │                └ mismatched closing delimiter (expecting "]")
+                 │ │                └ mismatched closing delimiter (expected "]")
                  │ └ unclosed delimiter
                  │
                  └─ nofile:1:18\
@@ -49,7 +49,7 @@ defmodule Kernel.DiagnosticsTest do
                1 │ [a, b, c
                  │ └ unclosed delimiter
                2 │  d, f, g}
-                 │         └ mismatched closing delimiter (expecting "]")
+                 │         └ mismatched closing delimiter (expected "]")
                  │
                  └─ nofile:2:9\
              """
@@ -78,7 +78,7 @@ defmodule Kernel.DiagnosticsTest do
                3 │   c,
                4 │   d
                5 │   e )
-                 │     └ mismatched closing delimiter (expecting "]")
+                 │     └ mismatched closing delimiter (expected "]")
                  │
                  └─ nofile:5:5\
              """
@@ -101,7 +101,7 @@ defmodule Kernel.DiagnosticsTest do
                  │ └ unclosed delimiter
                2 │   IO.inspect(2 + 2) + 2
                3 │ )
-                 │ └ mismatched closing delimiter (expecting "end")
+                 │ └ mismatched closing delimiter (expected "end")
                  │
                  └─ nofile:3:1\
              """
@@ -132,7 +132,7 @@ defmodule Kernel.DiagnosticsTest do
                  │ └ unclosed delimiter
               ...
                9 │ )
-                 │ └ mismatched closing delimiter (expecting "]")
+                 │ └ mismatched closing delimiter (expected "]")
                  │
                  └─ nofile:9:1\
              """
@@ -157,7 +157,7 @@ defmodule Kernel.DiagnosticsTest do
                  │ └ unclosed delimiter
               ...
               13 │   b )
-                 │     └ mismatched closing delimiter (expecting "]")
+                 │     └ mismatched closing delimiter (expected "]")
                  │
                  └─ nofile:13:5\
              """
@@ -180,7 +180,7 @@ defmodule Kernel.DiagnosticsTest do
                   │ └ unclosed delimiter
               ...
               403 │   b )
-                  │     └ mismatched closing delimiter (expecting "]")
+                  │     └ mismatched closing delimiter (expected "]")
                   │
                   └─ nofile:403:5\
              """
@@ -204,7 +204,7 @@ defmodule Kernel.DiagnosticsTest do
                   │ └ unclosed delimiter
               ...
               107 │   b )
-                  │     └ mismatched closing delimiter (expecting "]")
+                  │     └ mismatched closing delimiter (expected "]")
                   │
                   └─ nofile:107:5\
              """

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -11,50 +11,6 @@ defmodule Kernel.DiagnosticsTest do
   end
 
   describe "mismatched delimiter" do
-    test "trims start if distance exceeds threshold in same line" do
-      output =
-        capture_raise(
-          """
-          long_long_long_long_long_long_long_variable_with_a_long_long_name = [1, 2, 3}
-          """,
-          MismatchedDelimiterError
-        )
-
-      assert output == """
-             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:1:77:
-                 error: unexpected token: }
-                 HINT: the "[" on line 1 is missing terminator "]"
-                 │
-               1 │ ...long_long_name = [1, 2, 3}
-                 │                     │       └ mismatched closing delimiter
-                 │                     └ unclosed delimiter
-                 │
-                 └─ nofile:1:77\
-             """
-    end
-
-    test "trims in between if distance exceeds threshold in same line" do
-      output =
-        capture_raise(
-          """
-          [1, MyLong.ReallyLongModule.FromALongNamespace.calling_a_really_long_named_function(), 200)
-          """,
-          MismatchedDelimiterError
-        )
-
-      assert output == """
-             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:1:91:
-                 error: unexpected token: )
-                 HINT: the "[" on line 1 is missing terminator "]"
-                 │
-               1 │ [1, MyLong.ReallyLong...function(), 200)
-                 │ │                                      └ mismatched closing delimiter
-                 │ └ unclosed delimiter
-                 │
-                 └─ nofile:1:91\
-             """
-    end
-
     test "same line" do
       output =
         capture_raise(
@@ -235,56 +191,6 @@ defmodule Kernel.DiagnosticsTest do
                   │     └ mismatched closing delimiter
                   │
                   └─ nofile:107:5\
-             """
-    end
-
-    test "trims lines that are too long (> 60 chars)" do
-      output =
-        capture_raise(
-          """
-          a                                                           = { a,
-
-                                                                         b )
-          """,
-          MismatchedDelimiterError
-        )
-
-      assert output == """
-             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:3:66:
-                 error: unexpected token: )
-                 HINT: the "{" on line 1 is missing terminator "}"
-                 │
-               1 │ ...= { a,
-                 │      └ unclosed delimiter
-               2 │ ...
-               3 │ ...    b )
-                 │          └ mismatched closing delimiter
-                 │
-                 └─ nofile:3:66\
-             """
-
-      output =
-        capture_raise(
-          """
-          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = [ 1,
-
-          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )
-          """,
-          MismatchedDelimiterError
-        )
-
-      assert output == """
-             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:3:66:
-                 error: unexpected token: )
-                 HINT: the "[" on line 99 is missing terminator "]"
-                 │
-               1 │ ...aaaa = [ 1,
-                 │           └ unclosed delimiter
-                 │ ...
-               3 │ ...aaaa" )
-                 │          └ mismatched closing delimiter
-                 │
-                 └─ nofile:3:66\
              """
     end
   end

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -251,8 +251,9 @@ defmodule Kernel.DiagnosticsTest do
         )
 
       assert output == """
-             ** (MismatchedDelimiterError) invalid syntax found on nofile:1:17:
-                 error: syntax error before: '*'
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:3:66:
+                 error: unexpected token: )
+                 HINT: the "{" on line 1 is missing terminator "}"
                  │
                1 │ ...= { a,
                  │      └ unclosed delimiter
@@ -260,7 +261,7 @@ defmodule Kernel.DiagnosticsTest do
                3 │ ...    b )
                  │          └ mismatched closing delimiter
                  │
-                 └─ nofile:1:17\
+                 └─ nofile:3:66\
              """
 
       output =
@@ -274,8 +275,9 @@ defmodule Kernel.DiagnosticsTest do
         )
 
       assert output == """
-             ** (MismatchedDelimiterError) invalid syntax found on nofile:1:17:
-                 error: syntax error before: '*'
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:3:66:
+                 error: unexpected token: )
+                 HINT: the "[" on line 99 is missing terminator "]"
                  │
                1 │ ...aaaa = [ 1,
                  │           └ unclosed delimiter
@@ -283,7 +285,7 @@ defmodule Kernel.DiagnosticsTest do
                3 │ ...aaaa" )
                  │          └ mismatched closing delimiter
                  │
-                 └─ nofile:1:17\
+                 └─ nofile:3:66\
              """
     end
   end

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -23,7 +23,6 @@ defmodule Kernel.DiagnosticsTest do
       assert output == """
              ** (MismatchedDelimiterError) mismatched delimiter found on nofile:1:18:
                  error: unexpected token: )
-                 HINT: the "[" on line 1 is missing terminator "]"
                  │
                1 │ [1, 2, 3, 4, 5, 6)
                  │ │                └ mismatched closing delimiter
@@ -46,7 +45,6 @@ defmodule Kernel.DiagnosticsTest do
       assert output == """
              ** (MismatchedDelimiterError) mismatched delimiter found on nofile:2:9:
                  error: unexpected token: }
-                 HINT: the "[" on line 1 is missing terminator "]"
                  │
                1 │ [a, b, c
                  │ └ unclosed delimiter
@@ -73,7 +71,6 @@ defmodule Kernel.DiagnosticsTest do
       assert output == """
              ** (MismatchedDelimiterError) mismatched delimiter found on nofile:5:5:
                  error: unexpected token: )
-                 HINT: the "[" on line 1 is missing terminator "]"
                  │
                1 │ [ a,
                  │ └ unclosed delimiter
@@ -107,7 +104,6 @@ defmodule Kernel.DiagnosticsTest do
       assert output == """
              ** (MismatchedDelimiterError) mismatched delimiter found on nofile:9:1:
                  error: unexpected token: )
-                 HINT: the "[" on line 1 is missing terminator "]"
                  │
                1 │ [ :a,
                  │ └ unclosed delimiter
@@ -133,7 +129,6 @@ defmodule Kernel.DiagnosticsTest do
       assert output == """
              ** (MismatchedDelimiterError) mismatched delimiter found on nofile:13:5:
                  error: unexpected token: )
-                 HINT: the "[" on line 1 is missing terminator "]"
                  │
                1 │ [ a,
                  │ └ unclosed delimiter
@@ -157,7 +152,6 @@ defmodule Kernel.DiagnosticsTest do
       assert output == """
              ** (MismatchedDelimiterError) mismatched delimiter found on nofile:403:5:
                   error: unexpected token: )
-                  HINT: the "[" on line 1 is missing terminator "]"
                   │
                 1 │ [ a,
                   │ └ unclosed delimiter
@@ -182,7 +176,6 @@ defmodule Kernel.DiagnosticsTest do
       assert output == """
              ** (MismatchedDelimiterError) mismatched delimiter found on nofile:107:5:
                   error: unexpected token: )
-                  HINT: the "[" on line 99 is missing terminator "]"
                   │
                99 │ [ a,
                   │ └ unclosed delimiter

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -155,7 +155,7 @@ defmodule Kernel.DiagnosticsTest do
                  │
                1 │ [ :a,
                  │ └ unclosed delimiter
-                 │ ...
+              ...
                8 │   :h
                9 │ )
                  │ └ mismatched closing delimiter
@@ -182,7 +182,7 @@ defmodule Kernel.DiagnosticsTest do
                  │
                1 │ [ a,
                  │ └ unclosed delimiter
-                 │ ...
+              ...
               12 │ 
               13 │   b )
                  │     └ mismatched closing delimiter
@@ -207,7 +207,7 @@ defmodule Kernel.DiagnosticsTest do
                   │
                 1 │ [ a,
                   │ └ unclosed delimiter
-                  │ ...
+              ...
               402 │ 
               403 │   b )
                   │     └ mismatched closing delimiter
@@ -233,7 +233,7 @@ defmodule Kernel.DiagnosticsTest do
                   │
                99 │ [ a,
                   │ └ unclosed delimiter
-                  │ ...
+              ...
               106 │ 
               107 │   b )
                   │     └ mismatched closing delimiter

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -946,7 +946,8 @@ defmodule Kernel.ParserTest do
         [
           "nofile:1:9:",
           "unexpected token:",
-          "HINT: the \"fn\" on line 1 is missing terminator \"end\""
+          "└ unclosed delimiter",
+          "└ mismatched closing delimiter"
         ],
         ~c"fn a -> )"
       )
@@ -955,7 +956,8 @@ defmodule Kernel.ParserTest do
         [
           "nofile:1:16:",
           "unexpected token:",
-          "HINT: the \"do\" on line 1 is missing terminator \"end\""
+          "└ unclosed delimiter",
+          "└ mismatched closing delimiter"
         ],
         ~c"defmodule A do ]"
       )
@@ -964,7 +966,8 @@ defmodule Kernel.ParserTest do
         [
           "nofile:1:9:",
           "unexpected token:",
-          "HINT: the \"(\" on line 1 is missing terminator \")\""
+          "└ unclosed delimiter",
+          "└ mismatched closing delimiter"
         ],
         ~c"(1, 2, 3}"
       )
@@ -973,7 +976,8 @@ defmodule Kernel.ParserTest do
         [
           "nofile:1:14:",
           "unexpected reserved word:",
-          "HINT: the \"<<\" on line 1 is missing terminator \">>\""
+          "└ unclosed delimiter",
+          "└ mismatched closing delimiter"
         ],
         ~c"<<1, 2, 3, 4 end"
       )
@@ -984,7 +988,8 @@ defmodule Kernel.ParserTest do
         [
           "nofile:1:17:",
           "unexpected token:",
-          "HINT: the \"do\" on line 1 is missing terminator \"end\""
+          "└ unclosed delimiter",
+          "└ mismatched closing delimiter"
         ],
         ~c"\"foo\#{case 1 do )}bar\""
       )
@@ -993,7 +998,8 @@ defmodule Kernel.ParserTest do
         [
           "nofile:8:3:",
           "unexpected token: )",
-          "HINT: the \"do\" on line 3 is missing terminator \"end\""
+          "└ unclosed delimiter",
+          "└ mismatched closing delimiter"
         ],
         ~c"""
         defmodule MyApp do

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -49,7 +49,8 @@ defmodule IEx.InteractionTest do
     assert output =~ "unexpected token: )"
     assert output =~ "iex:1:12"
     assert output =~ "if true do ) false end"
-    assert output =~ ~s/HINT: the "do" on line 1 is missing terminator "end"/
+    assert output =~ "└ unclosed delimiter"
+    assert output =~ "└ mismatched closing delimiter"
   end
 
   test "multiple vars" do


### PR DESCRIPTION
This PR uses the `start` and `end` information contained in tokens to show a more precise message on mismatched delimiters error.

I'm opening it as a draft since there's still some tests missing implementations and I'll refactor the implementation a bit before fully opening for review.

@josevalim would you mind taking a look at the test cases and giving some feedback?

# Preview

![Screenshot from 2023-09-13 11-27-44](https://github.com/elixir-lang/elixir/assets/59743220/d09d63af-fc9d-4385-898b-364915f5dc23)

![Screenshot from 2023-09-13 11-28-38](https://github.com/elixir-lang/elixir/assets/59743220/be963c97-98a3-4a99-b04c-5591b44e4d7d)

![Screenshot from 2023-09-13 11-29-59](https://github.com/elixir-lang/elixir/assets/59743220/2ce0f4e4-b905-4492-a1e4-20f76a3bbc34)