### PR TITLE
Fix spec in `Code.Typespec.fetch_types/1` and `fetch_callbacks/1`

### DIFF
--- a/lib/elixir/lib/code/typespec.ex
+++ b/lib/elixir/lib/code/typespec.ex
@@ -121,7 +121,7 @@ defmodule Code.Typespec do
   located by the runtime system. The types will be in the Erlang
   Abstract Format.
   """
-  @spec fetch_specs(module) :: {:ok, [tuple]} | :error
+  @spec fetch_specs(module | binary) :: {:ok, [tuple]} | :error
   def fetch_specs(module) when is_atom(module) or is_binary(module) do
     case typespecs_abstract_code(module) do
       {:ok, abstract_code} ->
@@ -142,7 +142,7 @@ defmodule Code.Typespec do
   which can be located by the runtime system. The types will be
   in the Erlang Abstract Format.
   """
-  @spec fetch_callbacks(module) :: {:ok, [tuple]} | :error
+  @spec fetch_callbacks(module | binary) :: {:ok, [tuple]} | :error
   def fetch_callbacks(module) when is_atom(module) or is_binary(module) do
     case typespecs_abstract_code(module) do
       {:ok, abstract_code} ->


### PR DESCRIPTION
The guards for these functions were already allowing binaries, which allows either a file name or a binary containing the BEAM object code to be passed in. The specs, however, only specified `module`. (Note that `fetch_types/1` already specified `module | binary`.)