### PR TITLE
Unicode support for mismatched delimiter errors

### DIFF
--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -400,7 +400,7 @@ parse_erl_term(Term) ->
 
 raise_mismatched_delimiter(Location, File, Input, Message) ->
   {InputString, _, _} = Input,
-  InputBinary = iolist_to_binary(InputString),
+  InputBinary = elixir_utils:characters_to_binary(InputString),
   raise('Elixir.MismatchedDelimiterError', Message,  [{file, File}, {snippet, InputBinary} | Location]).
 
 raise_reserved(Location, File, Input, Keyword) ->

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -11,6 +11,27 @@ defmodule Kernel.DiagnosticsTest do
   end
 
   describe "mismatched delimiter" do
+    test "same line - handles unicode input" do
+      output =
+        capture_raise(
+          """
+          [1, 2, 3, 4, 5, 6) <- 😎
+          """,
+          MismatchedDelimiterError
+        )
+
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:1:18:
+                 error: unexpected token: )
+                 │
+               1 │ [1, 2, 3, 4, 5, 6) <- 😎
+                 │ │                └ mismatched closing delimiter (expected "]")
+                 │ └ unclosed delimiter
+                 │
+                 └─ nofile:1:18\
+             """
+    end
+
     test "same line" do
       output =
         capture_raise(
@@ -107,6 +128,31 @@ defmodule Kernel.DiagnosticsTest do
              """
     end
 
+    test "line range - handles unicode input" do
+      output =
+        capture_raise(
+          """
+          defmodule A do
+            IO.inspect(2 + 2)
+          ) <- 😎
+          """,
+          MismatchedDelimiterError
+        )
+
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:3:1:
+                 error: unexpected token: )
+                 │
+               1 │ defmodule A do
+                 │             └ unclosed delimiter
+               2 │   IO.inspect(2 + 2)
+               3 │ ) <- 😎
+                 │ └ mismatched closing delimiter (expected "end")
+                 │
+                 └─ nofile:3:1\
+             """
+    end
+
     test "trim inbetween lines if too many" do
       output =
         capture_raise(
@@ -132,6 +178,37 @@ defmodule Kernel.DiagnosticsTest do
                  │ └ unclosed delimiter
               ...
                9 │ )
+                 │ └ mismatched closing delimiter (expected "]")
+                 │
+                 └─ nofile:9:1\
+             """
+    end
+
+    test "trimmed line range - handles unicode input" do
+      output =
+        capture_raise(
+          """
+          [ :a,
+            :b,
+            :c,
+            :d,
+            :e,
+            :f,
+            :g,
+            :h
+          ) <- 😎
+          """,
+          MismatchedDelimiterError
+        )
+
+      assert output == """
+             ** (MismatchedDelimiterError) mismatched delimiter found on nofile:9:1:
+                 error: unexpected token: )
+                 │
+               1 │ [ :a,
+                 │ └ unclosed delimiter
+              ...
+               9 │ ) <- 😎
                  │ └ mismatched closing delimiter (expected "]")
                  │
                  └─ nofile:9:1\


### PR DESCRIPTION
Fixes crash in `iolist_to_binary` if source code contains unicode char, now treats it as unicode