### PR TITLE
Add span to unused/undefined variable diagnostics

### DIFF
--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -85,11 +85,11 @@ reset_unused_vars(#elixir_ex{unused={_Unused, Version}} = S) ->
   S#elixir_ex{unused={#{}, Version}}.
 
 check_unused_vars(#elixir_ex{unused={Unused, _Version}}, E) ->
-  [elixir_errors:file_warn(calculate_span(Name, Meta), E, ?MODULE, {unused_var, Name, Overridden}) ||
+  [elixir_errors:file_warn(calculate_span(Meta, Name), E, ?MODULE, {unused_var, Name, Overridden}) ||
     {{{Name, nil}, _}, {Meta, Overridden}} <- maps:to_list(Unused), is_unused_var(Name)],
   E.
 
-calculate_span(Name, Meta) ->
+calculate_span(Meta, Name) ->
   case lists:keyfind(column, 1, Meta) of
     {column, Column} ->
       [{span, {?line(Meta), Column + string:length(atom_to_binary(Name))}} | Meta];

--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -93,7 +93,7 @@ calculate_span(Name, Meta) ->
   Line = ?line(Meta),
   case lists:keyfind(column, 1, Meta) of
     {column, Column} ->
-      {span, {Line, Column + string:length(atom_to_list(Name))}};
+      {span, {Line, Column + string:length(atom_to_binary(Name))}};
 
     _ ->
       []

--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -90,10 +90,9 @@ check_unused_vars(#elixir_ex{unused={Unused, _Version}}, E) ->
   E.
 
 calculate_span(Name, Meta) ->
-  Line = ?line(Meta),
   case lists:keyfind(column, 1, Meta) of
     {column, Column} ->
-      [{span, {Line, Column + string:length(atom_to_binary(Name))}} | Meta];
+      [{span, {?line(Meta), Column + string:length(atom_to_binary(Name))}} | Meta];
 
     _ ->
       Meta

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -284,7 +284,7 @@ function_error(Meta, Env, Module, Desc) ->
 print_error(Meta, Env, Module, Desc) ->
   {EnvPosition, EnvFile, EnvStacktrace} = env_format(Meta, Env),
   Message = Module:format_error(Desc),
-  emit_diagnostic(error, EnvPosition, EnvFile, Message, EnvStacktrace, [{read_snippet, true}]),
+  emit_diagnostic(error, EnvPosition, EnvFile, Message, EnvStacktrace, [{read_snippet, true} | Meta]),
   ok.
 
 %% Compilation error.

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -251,7 +251,7 @@ file_warn(Meta, E, Module, Desc) when is_list(Meta) ->
     false ->
       {EnvPosition, EnvFile, EnvStacktrace} = env_format(Meta, E),
       Message = Module:format_error(Desc),
-      emit_diagnostic(warning, EnvPosition, EnvFile, Message, EnvStacktrace, [{read_snippet, true}])
+      emit_diagnostic(warning, EnvPosition, EnvFile, Message, EnvStacktrace, [{read_snippet, true} | Meta])
   end.
 
 -spec file_error(list(), binary() | #{file := binary(), _ => _}, module(), any()) -> no_return().

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -380,7 +380,8 @@ expand({Name, Meta, Kind}, S, E) when is_atom(Name), is_atom(Kind) ->
           {{Name, Meta, Kind}, S, E};
 
         _ ->
-          function_error(Meta, E, ?MODULE, {undefined_var, Name, Kind}),
+          SpanMeta = [calculate_span(Name, Meta) | Meta],
+          function_error(SpanMeta, E, ?MODULE, {undefined_var, Name, Kind}),
           {{Name, Meta, Kind}, S, E}
       end
   end;
@@ -462,6 +463,16 @@ expand(Other, _S, E) ->
   file_error([{line, 0}], ?key(E, file), ?MODULE, {invalid_quoted_expr, Other}).
 
 %% Helpers
+
+calculate_span(Name, Meta) ->
+  Line = ?line(Meta),
+  case lists:keyfind(column, 1, Meta) of
+    {column, Column} ->
+      {span, {Line, Column + string:length(atom_to_list(Name))}};
+
+    _ ->
+      []
+  end.
 
 escape_env_entries(Meta, #elixir_ex{vars={Read, _}}, Env0) ->
   Env1 = case Env0 of

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -380,7 +380,7 @@ expand({Name, Meta, Kind}, S, E) when is_atom(Name), is_atom(Kind) ->
           {{Name, Meta, Kind}, S, E};
 
         _ ->
-          SpanMeta =  elixir_env:calculate_span(Name, Meta),
+          SpanMeta =  elixir_env:calculate_span(Meta, Name),
           function_error(SpanMeta, E, ?MODULE, {undefined_var, Name, Kind}),
           {{Name, SpanMeta, Kind}, S, E}
       end

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -380,9 +380,9 @@ expand({Name, Meta, Kind}, S, E) when is_atom(Name), is_atom(Kind) ->
           {{Name, Meta, Kind}, S, E};
 
         _ ->
-          SpanMeta = [calculate_span(Name, Meta) | Meta],
+          SpanMeta =  elixir_env:calculate_span(Name, Meta),
           function_error(SpanMeta, E, ?MODULE, {undefined_var, Name, Kind}),
-          {{Name, Meta, Kind}, S, E}
+          {{Name, SpanMeta, Kind}, S, E}
       end
   end;
 
@@ -463,16 +463,6 @@ expand(Other, _S, E) ->
   file_error([{line, 0}], ?key(E, file), ?MODULE, {invalid_quoted_expr, Other}).
 
 %% Helpers
-
-calculate_span(Name, Meta) ->
-  Line = ?line(Meta),
-  case lists:keyfind(column, 1, Meta) of
-    {column, Column} ->
-      {span, {Line, Column + string:length(atom_to_binary(Name))}};
-
-    _ ->
-      []
-  end.
 
 escape_env_entries(Meta, #elixir_ex{vars={Read, _}}, Env0) ->
   Env1 = case Env0 of

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -468,7 +468,7 @@ calculate_span(Name, Meta) ->
   Line = ?line(Meta),
   case lists:keyfind(column, 1, Meta) of
     {column, Column} ->
-      {span, {Line, Column + string:length(atom_to_list(Name))}};
+      {span, {Line, Column + string:length(atom_to_binary(Name))}};
 
     _ ->
       []


### PR DESCRIPTION
This PR adds a span that highlights variables when showing printing errors/warnings.

![Screenshot from 2023-09-16 11-56-43](https://github.com/elixir-lang/elixir/assets/59743220/8ce8f6a8-9282-4e4a-9905-e56e41ee62e2)


Q: I think we'll have to set the `:columns` parser option to `true` by default, right? @josevalim
Otherwise there will be no columns for us to actually show errors like this

I haven't dived into the undefined local function call yet, but I believe if we get its AST the algorithm would be finding the token with the biggest line number and column and treat it as the ending, and then we use its position as the span. If the span ending line is greater than our current line, we just highlight from `start_column` to the end of line, wdyt?  