### PR TITLE
Improve Windows Installer

### DIFF
--- a/lib/elixir/scripts/windows_installer/installer.nsi
+++ b/lib/elixir/scripts/windows_installer/installer.nsi
@@ -165,7 +165,7 @@ Function FinishPageShow
   SendMessage $AddOTPToPathCheckbox ${BM_SETCHECK} ${BST_CHECKED} 0
   ${EndIf}
 
-  ${NSD_CreateLabel} 0 40u 100% 20u "Note: you need to restart your shell for the enviornment variable changes to take effect."
+  ${NSD_CreateLabel} 0 40u 100% 20u "Note: you need to restart your shell for the environment variable changes to take effect."
 
   nsDialogs::Show
 FunctionEnd

--- a/lib/elixir/scripts/windows_installer/installer.nsi
+++ b/lib/elixir/scripts/windows_installer/installer.nsi
@@ -52,11 +52,14 @@ Function CheckOTPPageShow
     ${If} $0 == 0
       StrCpy $InstalledOTPRelease $1
       ${If} $InstalledOTPRelease == ${OTP_RELEASE}
-        ${NSD_CreateLabel} 0 0 100% 20u "Found existing Erlang/OTP $InstalledOTPRelease installation at $OTPPath. Please proceed."
+        ${NSD_CreateLabel} 0 0 100% 60u "Found existing Erlang/OTP $InstalledOTPRelease installation at $OTPPath. Please proceed."
         StrCpy $OTPVerified "true"
       ${ElseIf} $2 < ${OTP_RELEASE}
-        ${NSD_CreateLabel} 0 0 100% 30u "Found existing Erlang/OTP $InstalledOTPRelease installation at $OTPPath but this Elixir installer was precompiled for Erlang/OTP ${OTP_RELEASE}. \
-        We recommend checking if there is an Elixir version precompiled for Erlang/OTP $InstalledOTPRelease. Otherwise, proceed."
+        ${NSD_CreateLabel} 0 0 100% 60u "Found existing Erlang/OTP $InstalledOTPRelease installation at $OTPPath but this Elixir installer was precompiled for Erlang/OTP ${OTP_RELEASE}. \
+        $\r$\n$\r$\nYou can either search for another Elixir installer precompiled for Erlang/OTP $InstalledOTPRelease or download Erlang/OTP ${OTP_RELEASE} and install before proceeding."
+        ${NSD_CreateLink}  0 60u 100% 20u "Download Erlang/OTP ${OTP_RELEASE}"
+        Pop $DownloadOTPLink
+        ${NSD_OnClick} $DownloadOTPLink OpenOTPDownloads
       ${Else}
         SetErrorlevel 5
         MessageBox MB_ICONSTOP "Found existing Erlang/OTP $InstalledOTPRelease installation at $OTPPath but this Elixir version was precompiled for Erlang/OTP ${OTP_RELEASE}. \

--- a/lib/elixir/scripts/windows_installer/installer.nsi
+++ b/lib/elixir/scripts/windows_installer/installer.nsi
@@ -103,7 +103,7 @@ Function VerifyOTP
         ${NSD_CreateLabel} 0 0 100% 60u "Found existing Erlang/OTP $InstalledOTPRelease installation at $OTPPath. Please proceed."
         StrCpy $OTPVerified "true"
 
-      ${ElseIf} $2 < ${OTP_RELEASE}
+      ${Else}
         ${If} $OTPMismatchLabelCreated != "true"
           StrCpy $OTPMismatchLabelCreated "true"
           ${NSD_CreateLabel} 0 0 100% 60u "Found existing Erlang/OTP $InstalledOTPRelease installation at $OTPPath but this Elixir installer was precompiled for Erlang/OTP ${OTP_RELEASE}. \
@@ -114,11 +114,6 @@ Function VerifyOTP
         ShowWindow $OTPMismatchLabel ${SW_SHOW}
         ShowWindow $DownloadOTPLink  ${SW_SHOW}
         ShowWindow $VerifyOTPButton  ${SW_SHOW}
-
-      ${Else}
-        SetErrorlevel 5
-        MessageBox MB_ICONSTOP "Found existing Erlang/OTP $InstalledOTPRelease installation at $OTPPath but this Elixir version was precompiled for Erlang/OTP ${OTP_RELEASE}. \
-        Please upgrade your Erlang/OTP version or choose an Elixir installer matching your Erlang/OTP version"
       ${EndIf}
     ${Else}
       SetErrorlevel 5
@@ -155,17 +150,20 @@ Function FinishPageShow
     Abort
   ${EndIf}
 
-  ${NSD_CreateCheckbox} 0 0 195u 10u "&Add $INSTDIR\bin to %PATH%"
-  Pop $AddElixirToPathCheckbox
-  SendMessage $AddElixirToPathCheckbox ${BM_SETCHECK} ${BST_CHECKED} 0
+  ; we add to PATH using erlang, so there must be an OTP installed to do so.
+  ${If} "$OTPPath" != ""
+    ${NSD_CreateCheckbox} 0 0 195u 10u "&Add $INSTDIR\bin to %PATH%"
+    Pop $AddElixirToPathCheckbox
+    SendMessage $AddElixirToPathCheckbox ${BM_SETCHECK} ${BST_CHECKED} 0
 
-  ${If} $OTPVerified == "true"
-  ${NSD_CreateCheckbox} 0 20u 195u 10u "&Add $OTPPath\bin to %PATH%"
-  Pop $AddOTPToPathCheckbox
-  SendMessage $AddOTPToPathCheckbox ${BM_SETCHECK} ${BST_CHECKED} 0
+    ${NSD_CreateCheckbox} 0 20u 195u 10u "&Add $OTPPath\bin to %PATH%"
+    Pop $AddOTPToPathCheckbox
+    ${If} $OTPVerified == "true"
+      SendMessage $AddOTPToPathCheckbox ${BM_SETCHECK} ${BST_CHECKED} 0
+    ${EndIf}
+
+    ${NSD_CreateLabel} 0 40u 100% 20u "Note: you need to restart your shell for the environment variable changes to take effect."
   ${EndIf}
-
-  ${NSD_CreateLabel} 0 40u 100% 20u "Note: you need to restart your shell for the environment variable changes to take effect."
 
   nsDialogs::Show
 FunctionEnd

--- a/lib/elixir/scripts/windows_installer/installer.nsi
+++ b/lib/elixir/scripts/windows_installer/installer.nsi
@@ -14,7 +14,6 @@ Page custom CheckOTPPageShow CheckOTPPageLeave
 
 var InstalledOTPRelease
 var OTPPath
-var OTPVerified
 
 var Dialog
 var NoOTPLabel
@@ -101,7 +100,6 @@ Function VerifyOTP
       StrCpy $InstalledOTPRelease $1
       ${If} $InstalledOTPRelease == ${OTP_RELEASE}
         ${NSD_CreateLabel} 0 0 100% 60u "Found existing Erlang/OTP $InstalledOTPRelease installation at $OTPPath. Please proceed."
-        StrCpy $OTPVerified "true"
 
       ${Else}
         ${If} $OTPMismatchLabelCreated != "true"
@@ -158,9 +156,7 @@ Function FinishPageShow
 
     ${NSD_CreateCheckbox} 0 20u 195u 10u "&Add $OTPPath\bin to %PATH%"
     Pop $AddOTPToPathCheckbox
-    ${If} $OTPVerified == "true"
-      SendMessage $AddOTPToPathCheckbox ${BM_SETCHECK} ${BST_CHECKED} 0
-    ${EndIf}
+    SendMessage $AddOTPToPathCheckbox ${BM_SETCHECK} ${BST_CHECKED} 0
 
     ${NSD_CreateLabel} 0 40u 100% 20u "Note: you need to restart your shell for the environment variable changes to take effect."
   ${EndIf}


### PR DESCRIPTION
1. If we couldn't verify installed OTP, don't quit but let user proceed with installing just Elixir

2. When checking installed OTPs, pick the recent most installed. Previously we were picking the first one which was basically guaranteed to be too old.

3. If we find an existing Elixir installation but it doesn't match the OTP version, offer to download the OTP version this Elixir installer was compiled against (which usually would be the newer version)

4. Add "Verify Erlang/OTP" button which re-checks for installed OTP.

Closes #12678.