### PR TITLE
Fix typo in Mix.Project docs

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -24,7 +24,7 @@ defmodule Mix.Project do
 
   ## Configuration
 
-  In order to configure Mix, the module that `use`s `Mix.Project` should export
+  In order to configure Mix, the module that uses `Mix.Project` should export
   a `project/0` function that returns a keyword list representing configuration
   for the project.
 


### PR DESCRIPTION
`use`s -> uses