### PR TITLE
Fix OTP 26.1 warning in tests

### DIFF
--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -14,8 +14,8 @@ cond_line_test() ->
 
 float_match_test() ->
   {'case', _, _,
-    [{clause, _, [{op, _, '+', {float, _, 0.0}}], [], [{atom, _, pos}]},
-     {clause, _, [{op, _, '-', {float, _, 0.0}}], [], [{atom, _, neg}]}]
+    [{clause, _, [{op, _, '+', {float, _, +0.0}}], [], [{atom, _, pos}]},
+     {clause, _, [{op, _, '-', {float, _, +0.0}}], [], [{atom, _, neg}]}]
   } = to_erl("case X do\n  +0.0 -> :pos\n  -0.0 -> :neg\nend").
 
 % Optimized


### PR DESCRIPTION
```sh
lib/elixir/test/erlang/control_test.erl:17:43: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
%   17|     [{clause, _, [{op, _, '+', {float, _, 0.0}}], [], [{atom, _, pos}]},
%     |                                           ^

lib/elixir/test/erlang/control_test.erl:18:43: Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
%   18|      {clause, _, [{op, _, '-', {float, _, 0.0}}], [], [{atom, _, neg}]}]
%     |
```