### PR TITLE
Always rewrite signed numbers during expansion

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -894,6 +894,9 @@ attach_context_module(Receiver, Meta, #{context_modules := ContextModules}) ->
     false -> Meta
   end.
 
+% Signed numbers can be rewritten no matter the context
+rewrite(_, erlang, _, '+', _, [Arg], _S) when is_number(Arg) -> {ok, Arg};
+rewrite(_, erlang, _, '-', _, [Arg], _S) when is_number(Arg) -> {ok, -Arg};
 rewrite(match, Receiver, DotMeta, Right, Meta, EArgs, _S) ->
   elixir_rewrite:match_rewrite(Receiver, DotMeta, Right, Meta, EArgs);
 rewrite(guard, Receiver, DotMeta, Right, Meta, EArgs, S) ->

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -302,8 +302,6 @@ increment(Meta, Other) ->
 %% The allowed operations are very limited.
 %% The Kernel operators are already inlined by now, we only need to
 %% care about Erlang ones.
-match_rewrite(erlang, _, '+', _, [Arg]) when is_number(Arg) -> {ok, Arg};
-match_rewrite(erlang, _, '-', _, [Arg]) when is_number(Arg) -> {ok, -Arg};
 match_rewrite(erlang, _, '++', Meta, [Left, Right]) ->
   try {ok, static_append(Left, Right, Meta)}
   catch impossible -> {error, {invalid_match_append, Left}}

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -725,10 +725,10 @@ defmodule Kernel.ExpansionTest do
         expand(quote(do: [1] ++ 2 ++ [3] = [1, 2, 3]))
       end)
 
-      assert {:=, _, [-1, {{:., _, [:erlang, :-]}, _, [1]}]} =
+      assert {:=, _, [-1, -1]} =
                expand(quote(do: -1 = -1))
 
-      assert {:=, _, [1, {{:., _, [:erlang, :+]}, _, [1]}]} =
+      assert {:=, _, [1, 1]} =
                expand(quote(do: +1 = +1))
 
       assert {:=, _, [[{:|, _, [1, [{:|, _, [2, 3]}]]}], [1, 2, 3]]} =


### PR DESCRIPTION
Simplify emitted erlang AST for signed numbers following discussions in https://github.com/elixir-lang/elixir/pull/12949.

Before, `-1` would be:
- `{:integer, _, -1}` in matches
- `{:op, _, :-, {:integer, _, 1}}` otherwise

With this PR:
- `{:integer, _, -1}`, always