### PR TITLE
Add error span for unknown local call

### DIFF
--- a/lib/elixir/lib/module/locals_tracker.ex
+++ b/lib/elixir/lib/module/locals_tracker.ex
@@ -105,9 +105,9 @@ defmodule Module.LocalsTracker do
   def collect_undefined_locals({set, bag}, all_defined) do
     undefined =
       for {pair, _, meta, _} <- all_defined,
-          {local, position, macro_dispatch?} <- out_neighbours(bag, {:local, pair}),
+          {{local_name, _} = local, position, macro_dispatch?} <-
+            out_neighbours(bag, {:local, pair}),
           error = undefined_local_error(set, local, macro_dispatch?),
-          {local_name, _arity} = local,
           do: {pair, build_meta(meta, position, local_name), local, error}
 
     :lists.usort(undefined)

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -890,6 +890,37 @@ defmodule Kernel.DiagnosticsTest do
     end
 
     @tag :tmp_dir
+    test "shows span for unknown local function calls", %{tmp_dir: tmp_dir} do
+      path = make_relative_tmp(tmp_dir, "unknown_local_function_call.ex")
+
+      source = """
+      defmodule Sample do
+        @file "#{path}"
+
+        def foo do
+          _result = unknown_func_call!(:hello!)
+        end
+      end
+      """
+
+      File.write!(path, source)
+
+      expected = """
+          error: undefined function unknown_func_call!/1 (expected Sample to define such a function or for it to be imported, but none are available)
+          │
+        5 │     _result = unknown_func_call!(:hello!)
+          │               ^^^^^^^^^^^^^^^^^^
+          │
+          └─ #{path}:5:15: Sample.foo/0
+
+      """
+
+      assert capture_compile(source) == expected
+    after
+      purge(Sample)
+    end
+
+    @tag :tmp_dir
     test "line + column", %{tmp_dir: tmp_dir} do
       path = make_relative_tmp(tmp_dir, "error_line_column.ex")
 

--- a/lib/elixir/test/elixir/module/locals_tracker_test.exs
+++ b/lib/elixir/test/elixir/module/locals_tracker_test.exs
@@ -51,7 +51,11 @@ defmodule Module.LocalsTrackerTest do
     D.add_local(config[:ref], {:public, 1}, {:private, 1}, [line: 1, column: 1], false)
 
     undefined = D.collect_undefined_locals(config[:ref], @used)
-    assert undefined == [{{:public, 1}, [line: 1, column: 1], {:private, 1}, :undefined_function}]
+
+    assert undefined == [
+             {{:public, 1}, [span: {1, 8}, line: 1, column: 1], {:private, 1},
+              :undefined_function}
+           ]
   end
 
   test "private definitions with unused default arguments", config do


### PR DESCRIPTION
Adds an error span to unknown local calls, only up to the end of the function name, since I couldn't find a reliable way to track whether the function call has parens or not.

Currently it works fine but the test I've added is failing, when I execute it normally using the compiler, we have the column information reported:

```ex
# unknown-local-call.ex
defmodule Mod do
  def func do
    _result = my_unknown_func_call(10, 20)
  end
end
```

`make && elixir unknown-local-call.ex`
```ex
    error: undefined function my_unknown_func_call/2 (expected Mod to define such a function or for it to be imported, but none are available)
    │
  3 │     _result = my_unknown_func_call(10, 20)
    │               ^^^^^^^^^^^^^^^^^^^^
    │
    └─ unknown-local-call.ex:3:15: Mod.func/0

** (CompileError) unknown-local-call.ex: cannot compile module Mod (errors have been logged)
``` 


When using a file annotation, we lose the column information:


```ex
# test.ex
source = """
defmodule Mod do
  @file "test.ex"
  def func do
    _result = my_unknown_func_call(10, 20)
  end
end
"""

ast = Code.string_to_quoted!(source, columns: true)
Code.eval_quoted(ast)
```

`make && elixir test.ex`
```ex
    error: undefined function my_unknown_func_call/2 (expected Mod to define such a function or for it to be imported, but none are available)
    │
  4 │   def func do
    │   ^^^^^^^^^^^
    │
    └─ test.ex:4: Mod.func/0

** (CompileError) nofile: cannot compile module Mod (errors have been logged)
    nofile:1: (file)
```

Showing the wrong line here is to be expected, but notice that if we add the `\@file` annotation to the function when we execute it using `Code.eval_quoted` we lose the column information in the process, even though the ast generated by `Code.string_to_quoted` has it.