### PR TITLE
Update indentantion on "HINT" labels

### DIFF
--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -413,14 +413,14 @@ defmodule Module.Types do
 
   defp format_message_hint(:inferred_dot) do
     """
-    HINT: "var.field" (without parentheses) implies "var" is a map() while \
+    #{hint()} "var.field" (without parentheses) implies "var" is a map() while \
     "var.fun()" (with parentheses) implies "var" is an atom()
     """
   end
 
   defp format_message_hint(:inferred_bitstring_spec) do
     """
-    HINT: all expressions given to binaries are assumed to be of type \
+    #{hint()} all expressions given to binaries are assumed to be of type \
     integer() unless said otherwise. For example, <<expr>> assumes "expr" \
     is an integer. Pass a modifier, such as <<expr::float>> or <<expr::binary>>, \
     to change the default behaviour.
@@ -429,10 +429,12 @@ defmodule Module.Types do
 
   defp format_message_hint({:sized_and_unsize_tuples, {size, var}}) do
     """
-    HINT: use pattern matching or "is_tuple(#{Macro.to_string(var)}) and \
+    #{hint()} use pattern matching or "is_tuple(#{Macro.to_string(var)}) and \
     tuple_size(#{Macro.to_string(var)}) == #{size}" to guard a sized tuple.
     """
   end
+
+  defp hint, do: :elixir_errors.prefix(:hint)
 
   defp format_type_hint(type, types, expr, hints) do
     case format_type_hint(type, types, expr) do

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -955,12 +955,6 @@ handle_space_sensitive_tokens(String, Line, Column, Scope, Tokens) ->
 
 %% Helpers
 
-blue(Message) ->
-  case application:get_env(elixir, ansi_enabled, false) of
-    true -> ["\e[34m", Message, "\e[0m"];
-    false -> Message
-  end.
-
 eol(_Line, _Column, [{',', {Line, Column, Count}} | Tokens]) ->
   [{',', {Line, Column, Count + 1}} | Tokens];
 eol(_Line, _Column, [{';', {Line, Column, Count}} | Tokens]) ->
@@ -1441,7 +1435,7 @@ check_terminator({'end', {Line, Column, _}}, [], #elixir_tokenizer{mismatch_hint
     case lists:keyfind('end', 1, Hints) of
       {'end', HintLine, _Identation} ->
         io_lib:format("\n~ts the \"end\" on line ~B may not have a matching \"do\" "
-                      "defined before it (based on indentation)", [blue("hint:"), HintLine]);
+                      "defined before it (based on indentation)", [elixir_errors:prefix(hint), HintLine]);
       false ->
         ""
     end,
@@ -1462,7 +1456,7 @@ missing_terminator_hint(Start, End, #elixir_tokenizer{mismatch_hints=Hints}) ->
   case lists:keyfind(Start, 1, Hints) of
     {Start, {HintLine, _, _}, _} ->
       io_lib:format("\n~ts it looks like the \"~ts\" on line ~B does not have a matching \"~ts\"",
-                    [blue("hint:"), Start, HintLine, End]);
+                    [elixir_errors:prefix(hint), Start, HintLine, End]);
     false ->
       ""
   end.

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -955,6 +955,12 @@ handle_space_sensitive_tokens(String, Line, Column, Scope, Tokens) ->
 
 %% Helpers
 
+blue(Message) ->
+  case application:get_env(elixir, ansi_enabled, false) of
+    true -> ["\e[34m", Message, "\e[0m"];
+    false -> Message
+  end.
+
 eol(_Line, _Column, [{',', {Line, Column, Count}} | Tokens]) ->
   [{',', {Line, Column, Count + 1}} | Tokens];
 eol(_Line, _Column, [{';', {Line, Column, Count}} | Tokens]) ->
@@ -1434,8 +1440,8 @@ check_terminator({'end', {Line, Column, _}}, [], #elixir_tokenizer{mismatch_hint
   Suffix =
     case lists:keyfind('end', 1, Hints) of
       {'end', HintLine, _Identation} ->
-        io_lib:format("\nHINT: the \"end\" on line ~B may not have a matching \"do\" "
-                      "defined before it (based on indentation)", [HintLine]);
+        io_lib:format("\n~ts the \"end\" on line ~B may not have a matching \"do\" "
+                      "defined before it (based on indentation)", [blue("hint:"), HintLine]);
       false ->
         ""
     end,
@@ -1455,8 +1461,8 @@ unexpected_token_or_reserved(_) -> "unexpected token: ".
 missing_terminator_hint(Start, End, #elixir_tokenizer{mismatch_hints=Hints}) ->
   case lists:keyfind(Start, 1, Hints) of
     {Start, {HintLine, _, _}, _} ->
-      io_lib:format("\nHINT: it looks like the \"~ts\" on line ~B does not have a matching \"~ts\"",
-                    [Start, HintLine, End]);
+      io_lib:format("\n~ts it looks like the \"~ts\" on line ~B does not have a matching \"~ts\"",
+                    [blue("hint:"), Start, HintLine, End]);
     false ->
       ""
   end.

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1434,7 +1434,7 @@ check_terminator({'end', {Line, Column, _}}, [], #elixir_tokenizer{mismatch_hint
   Suffix =
     case lists:keyfind('end', 1, Hints) of
       {'end', HintLine, _Identation} ->
-        io_lib:format("\n\n    HINT: the \"end\" on line ~B may not have a matching \"do\" "
+        io_lib:format("\nHINT: the \"end\" on line ~B may not have a matching \"do\" "
                       "defined before it (based on indentation)", [HintLine]);
       false ->
         ""
@@ -1455,7 +1455,7 @@ unexpected_token_or_reserved(_) -> "unexpected token: ".
 missing_terminator_hint(Start, End, #elixir_tokenizer{mismatch_hints=Hints}) ->
   case lists:keyfind(Start, 1, Hints) of
     {Start, {HintLine, _, _}, _} ->
-      io_lib:format("\n\n    HINT: it looks like the \"~ts\" on line ~B does not have a matching \"~ts\"",
+      io_lib:format("\nHINT: it looks like the \"~ts\" on line ~B does not have a matching \"~ts\"",
                     [Start, HintLine, End]);
     false ->
       ""

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -554,7 +554,7 @@ defmodule Kernel.ParserTest do
       )
 
       assert_token_missing(
-        [~s/HINT: it looks like the "do" on line 2 does not have a matching "end"/],
+        ["hint:", ~s/it looks like the "do" on line 2 does not have a matching "end"/],
         ~c"""
         defmodule MyApp do
           def one do
@@ -819,7 +819,8 @@ defmodule Kernel.ParserTest do
 
       assert_syntax_error(
         [
-          "HINT: the \"end\" on line 2 may not have a matching \"do\" defined before it (based on indentation)"
+          "hint:",
+          "the \"end\" on line 2 may not have a matching \"do\" defined before it (based on indentation)"
         ],
         ~c"""
         defmodule MyApp do
@@ -831,7 +832,8 @@ defmodule Kernel.ParserTest do
 
       assert_syntax_error(
         [
-          "HINT: the \"end\" on line 3 may not have a matching \"do\" defined before it (based on indentation)"
+          "hint:",
+          "the \"end\" on line 3 may not have a matching \"do\" defined before it (based on indentation)"
         ],
         ~c"""
         defmodule MyApp do
@@ -846,7 +848,8 @@ defmodule Kernel.ParserTest do
 
       assert_syntax_error(
         [
-          "HINT: the \"end\" on line 6 may not have a matching \"do\" defined before it (based on indentation)"
+          "hint:",
+          "the \"end\" on line 6 may not have a matching \"do\" defined before it (based on indentation)"
         ],
         ~c"""
         defmodule MyApp do

--- a/lib/elixir/test/elixir/module/types/types_test.exs
+++ b/lib/elixir/test/elixir/module/types/types_test.exs
@@ -5,6 +5,8 @@ defmodule Module.Types.TypesTest do
   alias Module.Types
   alias Module.Types.{Pattern, Expr}
 
+  @hint :elixir_errors.prefix(:hint)
+
   defmacro warning(patterns \\ [], guards \\ [], body) do
     min_line = min_line(patterns ++ guards ++ [body])
     patterns = reset_line(patterns, min_line)
@@ -261,7 +263,7 @@ defmodule Module.Types.TypesTest do
                  # types_test.ex:1
                  <<foo>>
 
-             HINT: all expressions given to binaries are assumed to be of type \
+             #{@hint} all expressions given to binaries are assumed to be of type \
              integer() unless said otherwise. For example, <<expr>> assumes "expr" \
              is an integer. Pass a modifier, such as <<expr::float>> or <<expr::binary>>, \
              to change the default behaviour.
@@ -314,7 +316,7 @@ defmodule Module.Types.TypesTest do
                  # types_test.ex:1
                  {_} = foo
 
-             HINT: use pattern matching or "is_tuple(foo) and tuple_size(foo) == 1" to guard a sized tuple.
+             #{@hint} use pattern matching or "is_tuple(foo) and tuple_size(foo) == 1" to guard a sized tuple.
              """
     end
 
@@ -454,7 +456,7 @@ defmodule Module.Types.TypesTest do
                  # types_test.ex:4
                  :atom = foo
 
-             HINT: "var.field" (without parentheses) implies "var" is a map() while \
+             #{@hint} "var.field" (without parentheses) implies "var" is a map() while \
              "var.fun()" (with parentheses) implies "var" is an atom()
              """
     end
@@ -489,7 +491,7 @@ defmodule Module.Types.TypesTest do
                  # types_test.ex:4
                  module.__struct__
 
-             HINT: "var.field" (without parentheses) implies "var" is a map() while \
+             #{@hint} "var.field" (without parentheses) implies "var" is a map() while \
              "var.fun()" (with parentheses) implies "var" is an atom()
              """
     end
@@ -517,7 +519,7 @@ defmodule Module.Types.TypesTest do
                  # types_test.ex:1
                  foo.__struct__()
 
-             HINT: "var.field" (without parentheses) implies "var" is a map() while \
+             #{@hint} "var.field" (without parentheses) implies "var" is a map() while \
              "var.fun()" (with parentheses) implies "var" is an atom()
              """
     end
@@ -632,7 +634,7 @@ defmodule Module.Types.TypesTest do
                  # types_test.ex:5
                  map2.subkey
 
-             HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()
+             #{@hint} "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()
              """
     end
   end

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -25,7 +25,7 @@ defmodule IEx.InteractionTest do
 
     expected = """
     ** (SyntaxError) invalid syntax found on iex:1:4:
-        \e[31merror: \e[0msyntax error before: '='
+        \e[31merror:\e[0m syntax error before: '='
         │
       1 │ a += 2
         │ \e[31m   ^\e[0m


### PR DESCRIPTION
Updates two error messages that were relying on the previous format to do some indentation
We shouldn't update the tests here because they already don't assert on the errors specific formatting.

## Before

```
** (SyntaxError) invalid syntax found on aaaaa.ex:7:1:
    error: unexpected reserved word: end

        HINT: the "end" on line 3 may not have a matching "do" defined before it (based on indentation)
    │
  7 │ end
    │ ^
    │
    └─ aaaaa.ex:7:1
    (elixir 1.16.0-dev) lib/code.ex:1463: Code.require_file/2

```

## This PR

```
** (SyntaxError) invalid syntax found on aaaaa.ex:7:1:
    error: unexpected reserved word: end
    HINT: the "end" on line 3 may not have a matching "do" defined before it (based on indentation)
    │
  7 │ end
    │ ^
    │
    └─ aaaaa.ex:7:1
    (elixir 1.16.0-dev) lib/code.ex:1463: Code.require_file/2

```