### PR TITLE
Fix typo in the Enum cheatsheet

### DIFF
--- a/lib/elixir/pages/cheatsheets/enum-cheat.cheatmd
+++ b/lib/elixir/pages/cheatsheets/enum-cheat.cheatmd
@@ -636,7 +636,7 @@ iex> Enum.group_by(cart, &String.last(&1.fruit), & &1.fruit)
 }
 ```
 
-## Joining & interpersing
+## Joining & interspersing
 {: .col-2}
 
 ### [join(enum, joiner \\\\ "")](`Enum.join/2`)


### PR DESCRIPTION
Been reading the docs and came across a minor typo - this PR fixes it.