### PR TITLE
Fix Exception.format_mfa spec again

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -700,7 +700,7 @@ defmodule Exception do
   where func is the name of the enclosing function. Convert to
   "anonymous fn in func/arity"
   """
-  @spec format_mfa(module, atom, arity) :: String.t()
+  @spec format_mfa(module, atom, arity_or_args) :: String.t()
   def format_mfa(module, fun, arity) when is_atom(module) and is_atom(fun) do
     case Code.Identifier.extract_anonymous_fun_parent(fun) do
       {outer_name, outer_arity} ->


### PR DESCRIPTION
From this function's documentation:

> The arity may also be a list of arguments.

Called with a list of args at https://github.com/elixir-lang/elixir/blob/a19140a479a3a263fa4769b58aa7c7bffd01da25/lib/elixir/lib/exception.ex#L447 and https://github.com/elixir-lang/elixir/blob/a19140a479a3a263fa4769b58aa7c7bffd01da25/lib/ex_unit/lib/ex_unit/formatter.ex#L223