### PR TITLE
New anti-pattern

### DIFF
--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -375,7 +375,7 @@ There are few known exceptions to this anti-pattern:
 
 #### Problem
 
-Overall, Elixir systems are composed of many supervised processes, so the effects of an error are localized to a single process, not propagating to the entire application. A supervisor will detect the failing process, report it, and possibly restart it. This means Elixir developers can write code in an assertive style, instead of programming defensively and returning incorrect values which were not planned for.
+Overall, Elixir systems are composed of many supervised processes, so the effects of an error are localized to a single process, not propagating to the entire application. A supervisor will detect the failing process, report it, and possibly restart it. This anti-pattern arises when developers write defensive or imprecise code, capable of returning incorrect values which were not planned for, instead of programming in an assertive style through pattern matching and guards.
 
 #### Example
 
@@ -487,18 +487,7 @@ else
 end
 ```
 
-A more assertive version of the code may also replace `if/2` by `case/2`, applying similar concepts to the ones presented in [Non-assertive patterns](#non-assertive-patterns):
-
-```elixir
-case is_binary(name) or is_integer(age) do
-  true -> # ...
-  false -> # ...
-end
-```
-
-These techniques may be particularly important when working with Erlang code. Erlang does not have the concept of truthiness. It never returns `nil`, instead its functions may return `:error` or `:undefined` in places an Elixir developer would return `nil`.
-
-Therefore, to avoid accidentally interpreting `:undefined` or `:error` as a truthy value, it may be preferrable to use `and/2`, `or/2`, `not/1`, and `case/2` exclusively when interfacing with Erlang APIs.
+This technique may be particularly important when working with Erlang code. Erlang does not have the concept of truthiness. It never returns `nil`, instead its functions may return `:error` or `:undefined` in places an Elixir developer would return `nil`. Therefore, to avoid accidentally interpreting `:undefined` or `:error` as a truthy value, you may prefer to use `and/2`, `or/2`, and `not/1` exclusively when interfacing with Erlang APIs.
 
 ## Non-existent map keys
 

--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -598,3 +598,6 @@ iex> point.z   # <= trying to access a non-existent key
 iex> point[:x] # <= by default, struct does not support dynamic access
 ** (UndefinedFunctionError) ... (Point does not implement the Access behaviour)
 ```
+
+#### Additional remarks
+This anti-pattern was formerly known as [Accessing non-existent map/struct fields](https://github.com/lucasvegi/Elixir-Code-Smells#accessing-non-existent-mapstruct-fields).

--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -463,7 +463,7 @@ Elixir provides the concept of truthiness: where `nil` and `false` are considere
 
 #### Example
 
-The simplest scenario this anti-pattern manifest is conditions, such as:
+The simplest scenario where this anti-pattern manifests is in conditionals, such as:
 
 ```elixir
 if is_binary(name) && is_integer(age) do

--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -371,11 +371,11 @@ There are few known exceptions to this anti-pattern:
 
   * If you are the maintainer for both `plug` and `plug_auth`, then you may allow `plug_auth` to define modules with the `Plug` namespace, such as `Plug.Auth`. However, you are responsible for avoiding or managing any conflicts that may arise in the future
 
-## Non-assertive patterns
+## Non-assertive pattern matching
 
 #### Problem
 
-Overall, Elixir systems are composed of many supervised processes, so the effects of an error are localized to a single process, not propagating to the entire application. A supervisor will detect the failing process, report it, and possibly restart it. This anti-pattern arises when developers write defensive or imprecise code, capable of returning incorrect values which were not planned for, instead of programming in an assertive style through pattern matching and guards.
+Overall, Elixir systems are composed of many supervised processes, so the effects of an error are localized to a single process, and don't propagate to the entire application. A supervisor detects the failing process, reports it, and possibly restarts it. This anti-pattern arises when developers write defensive or imprecise code, capable of returning incorrect values which were not planned for, instead of programming in an assertive style through pattern matching and guards.
 
 #### Example
 
@@ -407,7 +407,7 @@ iex> Extract.get_value("name=Lucas&university=institution=UFMG&lab=ASERG", "univ
 
 #### Refactoring
 
-To remove this anti-pattern, `get_value/2` can be refactored through the use of pattern matching. So, if an unexpected URL query string format is used, the function will crash instead of returning an invalid value. This behaviour, shown below, will allow clients to decide how to handle these errors and will not give a false impression that the code is working correctly when unexpected values are extracted:
+To remove this anti-pattern, `get_value/2` can be refactored through the use of pattern matching. So, if an unexpected URL query string format is used, the function will crash instead of returning an invalid value. This behaviour, shown below, allows clients to decide how to handle these errors and doesn't give a false impression that the code is working correctly when unexpected values are extracted:
 
 ```elixir
 defmodule Extract do
@@ -437,7 +437,7 @@ iex> Extract.get_value("name=Lucas&university&lab=ASERG", "university")
 
 Elixir and pattern matching promote an assertive style of programming where you handle the known cases. Once an unexpected scenario arises, you can decide to address it accordingly based on practical examples, or conclude the scenario is indeed invalid and the exception is the desired choice.
 
-`case/2` is another important construct in Elixir that help us write assertive code, by matching on specific patterns. For exmaple, if a function returns `{:ok, ...}` or `{:error, ...}`, prefer to explicitly match on both patterns:
+`case/2` is another important construct in Elixir that help us write assertive code, by matching on specific patterns. For example, if a function returns `{:ok, ...}` or `{:error, ...}`, prefer to explicitly match on both patterns:
 
 ```elixir
 case some_function(arg) do

--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -493,7 +493,7 @@ This technique may be particularly important when working with Erlang code. Erla
 
 #### Problem
 
-In Elixir, it is possible to access values from `Map`s, which are key-value data structures, either statically or dynamically. When the keys are known upfront, they must be accessed using the `map.key` notation, instead of `map[:key]`. When the latter is used, if the informed key does not exist, `nil` is returned. This return can be confusing and does not allow developers to conclude whether the key is non-existent in the map or just has no bound value. In this way, this anti-pattern may cause bugs in the code.
+In Elixir, it is possible to access values from `Map`s, which are key-value data structures, either statically or dynamically. When the keys are known upfront, they must be accessed using the `map.key` notation, which asserts the key exists. If `map[:key]` is used and the informed key does not exist, `nil` is returned. This return can be confusing and does not allow developers to conclude whether the key is non-existent in the map or just has a bound `nil` value. In this way, this anti-pattern may cause bugs in the code.
 
 #### Example
 

--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -477,7 +477,7 @@ Given both operands of `&&/2` are booleans, the code is more generic than necess
 
 #### Refactoring
 
-To remove this anti-pattern, we can replace `&&/2`, `||/2`, and `!/1` by `and/2`, `or/2`, and `not/1` respectively. The new operators assert at least their first argument is a boolean:
+To remove this anti-pattern, we can replace `&&/2`, `||/2`, and `!/1` by `and/2`, `or/2`, and `not/1` respectively. These operators assert at least their first argument is a boolean:
 
 ```elixir
 if is_binary(name) or is_integer(age) do
@@ -489,7 +489,7 @@ end
 
 This technique may be particularly important when working with Erlang code. Erlang does not have the concept of truthiness. It never returns `nil`, instead its functions may return `:error` or `:undefined` in places an Elixir developer would return `nil`. Therefore, to avoid accidentally interpreting `:undefined` or `:error` as a truthy value, you may prefer to use `and/2`, `or/2`, and `not/1` exclusively when interfacing with Erlang APIs.
 
-## Non-existent map keys
+## Non-assertive map access
 
 #### Problem
 

--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -455,11 +455,15 @@ case some_function(arg) do
 end
 ```
 
+#### Additional remarks
+
+This anti-pattern was formerly known as [Speculative assumptions](https://github.com/lucasvegi/Elixir-Code-Smells#speculative-assumptions).
+
 ## Non-assertive truthiness
 
 #### Problem
 
-Elixir provides the concept of truthiness: where `nil` and `false` are considered "falsy" and all other values are "truthy". Many constructs in the language, such as `&&/2`, `||/2`, and `!/1` handle truthy and falsy values. Using those operators is not an anti-pattern. However, using those operators when all operands are expected to be booleans, may be an anti-pattern.
+Elixir provides the concept of truthiness: `nil` and `false` are considered "falsy" and all other values are "truthy". Many constructs in the language, such as `&&/2`, `||/2`, and `!/1` handle truthy and falsy values. Using those operators is not an anti-pattern. However, using those operators when all operands are expected to be booleans, may be an anti-pattern.
 
 #### Example
 


### PR DESCRIPTION
I was prompted to add a new anti-pattern, which I see as a specialization of "speculative assumptions". However, I was already not the biggest fan of speculative assumptions, because I don't think the "speculative assumption" is the intent of the developer. Most of the times, it is rather that the developer writes a code in a non-assertive style, which becomes an anti-pattern. So I have renamed "speculative assumptions" to "non-assertive patterns". We could also call it "Broad patterns" or "Loose patterns". The new anti-pattern is called "non-assertive truthiness", but it may be called "Broad truthiness" or "Loose truthiness".

Thoughts?

/cc @lucasvegi @whatyouhide 