### PR TITLE
Clean up unreachable function clause in  ex_unit/filters.ex

### DIFF
--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -142,7 +142,6 @@ defmodule ExUnit.Filters do
     end)
   end
 
-  defp parse_kv(:line, line) when is_integer(line), do: {:line, line}
   defp parse_kv(:line, line) when is_binary(line), do: {:line, String.to_integer(line)}
   defp parse_kv(:location, loc) when is_binary(loc), do: {:location, extract_line_numbers(loc)}
   defp parse_kv(key, value), do: {key, value}


### PR DESCRIPTION
The parse_kv function always gets called with a binary second argument, from line 139.
This function clause was kept after refactoring in https://github.com/elixir-lang/elixir/commit/4971af9fc9848b3c8e081a62f586014eda23f446