### PR TITLE
Document need of Tasks to trap exits for Task.Supervisor :shutdown to have effect

### DIFF
--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -162,6 +162,7 @@ defmodule Task.Supervisor do
 
     * `:shutdown` - `:brutal_kill` if the tasks must be killed directly on shutdown
       or an integer indicating the timeout value, defaults to 5000 milliseconds.
+      The tasks must trap exits for the timeout to have an effect.
 
   """
   @spec async(Supervisor.supervisor(), (-> any), Keyword.t()) :: Task.t()
@@ -183,6 +184,7 @@ defmodule Task.Supervisor do
 
     * `:shutdown` - `:brutal_kill` if the tasks must be killed directly on shutdown
       or an integer indicating the timeout value, defaults to 5000 milliseconds.
+      The tasks must trap exits for the timeout to have an effect.
 
   """
   @spec async(Supervisor.supervisor(), module, atom, [term], Keyword.t()) :: Task.t()
@@ -208,6 +210,7 @@ defmodule Task.Supervisor do
 
     * `:shutdown` - `:brutal_kill` if the tasks must be killed directly on shutdown
       or an integer indicating the timeout value, defaults to 5000 milliseconds.
+      The tasks must trap exits for the timeout to have an effect.
 
   ## Compatibility with OTP behaviours
 
@@ -342,6 +345,7 @@ defmodule Task.Supervisor do
 
     * `:shutdown` - `:brutal_kill` if the tasks must be killed directly on shutdown
       or an integer indicating the timeout value. Defaults to `5000` milliseconds.
+      The tasks must trap exits for the timeout to have an effect.
 
   ## Examples
 
@@ -460,6 +464,7 @@ defmodule Task.Supervisor do
 
     * `:shutdown` - `:brutal_kill` if the task must be killed directly on shutdown
       or an integer indicating the timeout value, defaults to 5000 milliseconds.
+      The task must trap exits for the timeout to have an effect.
 
   """
   @spec start_child(Supervisor.supervisor(), (-> any), keyword) ::


### PR DESCRIPTION
This pull request adds a note to Task.Supervisor documentation regarding the `:shutdown` option requiring any spawned tasks to be trapping exits for the timeout value to have an effect.

I have personally seen users be confused about this (myself included), as the current phrasing can make it sound like the Task.Supervisor would somehow be responsible for keeping the Tasks alive, while in reality the Tasks need to also trap the exits for the timeout value to have an observable effect.

Aside from my anecdotal evidence, I found at least https://elixirforum.com/t/task-supervisor-and-sigterm/49920 being puzzled about the same thing.

While it can be fair to say that knowledge of processes and exit signals would be prerequisite information to effectively use Task.Supervisor, I feel like this addition can be a simple way to be helpful for users who only read up on Task.Supervisor.