### PR TITLE
Fix warnings on conflicting callbacks

### DIFF
--- a/lib/elixir/lib/module/types/behaviour.ex
+++ b/lib/elixir/lib/module/types/behaviour.ex
@@ -302,9 +302,9 @@ defmodule Module.Types.Behaviour do
 
   def format_warning({:duplicate_behaviour, module, behaviour, conflict, kind, callback}) do
     [
-      "conflicting behaviours found. ",
+      "conflicting behaviours found. Callback ",
       format_definition(kind, callback),
-      " is required by ",
+      " is defined by both ",
       inspect(conflict),
       " and ",
       inspect(behaviour),

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1379,7 +1379,7 @@ defmodule Kernel.WarningTest do
     assert_warn_eval(
       [
         "nofile:9: ",
-        "conflicting behaviours found. function foo/0 is required by Sample1 and Sample2 (in module Sample3)"
+        "conflicting behaviours found. Callback function foo/0 is defined by both Sample1 and Sample2 (in module Sample3)"
       ],
       """
       defmodule Sample1 do


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/12841

The first commit improves the [message for the remaining warning](https://github.com/elixir-lang/elixir/pull/13006/commits/eeb5652d128d291178aaefa55dec9528e3be2f03#diff-d617989cbb2ccf2d27a606096a66a4d23c05640a477f3b835f287c442353f83bR1382)