### PR TITLE
Change the word "duplicated" to "duplicate"

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -815,11 +815,11 @@ defmodule Enum do
 
   @doc """
   Enumerates the `enumerable`, returning a list where all consecutive
-  duplicated elements are collapsed to a single element.
+  duplicate elements are collapsed to a single element.
 
   Elements are compared using `===/2`.
 
-  If you want to remove all duplicated elements, regardless of order,
+  If you want to remove all duplicate elements, regardless of order,
   see `uniq/1`.
 
   ## Examples
@@ -848,7 +848,7 @@ defmodule Enum do
 
   @doc """
   Enumerates the `enumerable`, returning a list where all consecutive
-  duplicated elements are collapsed to a single element.
+  duplicate elements are collapsed to a single element.
 
   The function `fun` maps every element to a term which is used to
   determine if two elements are duplicates.
@@ -3725,7 +3725,7 @@ defmodule Enum do
   def to_list(enumerable), do: reverse(enumerable) |> :lists.reverse()
 
   @doc """
-  Enumerates the `enumerable`, removing all duplicated elements.
+  Enumerates the `enumerable`, removing all duplicate elements.
 
   ## Examples
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2364,7 +2364,7 @@ defmodule Kernel do
 
   Keys in the `Enumerable` that don't exist in the struct are automatically
   discarded. Note that keys must be atoms, as only atoms are allowed when
-  defining a struct. If keys in the `Enumerable` are duplicated, the last
+  defining a struct. If there are duplicate keys in the `Enumerable`, the last
   entry will be taken (same behaviour as `Map.new/1`).
 
   This function is useful for dynamically creating and updating structs, as

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -14,7 +14,7 @@ defmodule Map do
   in the example above has a different order than the map that was created).
 
   Maps do not impose any restriction on the key type: anything can be a key in a
-  map. As a key-value structure, maps do not allow duplicated keys. Keys are
+  map. As a key-value structure, maps do not allow duplicate keys. Keys are
   compared using the exact-equality operator (`===/2`). If colliding keys are defined
   in a map literal, the last one prevails.
 

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -134,7 +134,7 @@ defmodule OptionParser do
   Switches can be specified with modifiers, which change how
   they behave. The following modifiers are supported:
 
-    * `:keep` - keeps duplicated elements instead of overriding them;
+    * `:keep` - keeps duplicate elements instead of overriding them;
       works with all types except `:count`. Specifying `switch_name: :keep`
       assumes the type of `:switch_name` will be `:string`.
 

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -194,7 +194,7 @@ defmodule Supervisor.Spec do
   defp assert_unique_ids([id | rest]) do
     if id in rest do
       raise ArgumentError,
-            "duplicated ID #{inspect(id)} found in the supervisor specification, " <>
+            "duplicate ID #{inspect(id)} found in the supervisor specification, " <>
               "please explicitly pass the :id option when defining this worker/supervisor"
     else
       assert_unique_ids(rest)

--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -382,7 +382,7 @@ format_error({bad_or_missing_clauses, Kind}) ->
   io_lib:format("expected -> clauses in \"~ts\"", [Kind]);
 
 format_error({duplicated_clauses, Kind, Key}) ->
-  io_lib:format("duplicated :~ts clauses given for \"~ts\"", [Key, Kind]);
+  io_lib:format("duplicate :~ts clauses given for \"~ts\"", [Key, Kind]);
 
 format_error({unexpected_option, Kind, Option}) ->
   io_lib:format("unexpected option ~ts in \"~ts\"", ['Elixir.Macro':to_string(Option), Kind]);

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1403,7 +1403,7 @@ defmodule Kernel.ExpansionTest do
         expand(quote(do: cond([])))
       end)
 
-      assert_compile_error(~r"duplicated :do clauses given for \"cond\"", fn ->
+      assert_compile_error(~r"duplicate :do clauses given for \"cond\"", fn ->
         expand(quote(do: cond(do: (x -> x), do: (y -> y))))
       end)
     end
@@ -1575,7 +1575,7 @@ defmodule Kernel.ExpansionTest do
         expand(quote(do: case(e, [])))
       end)
 
-      assert_compile_error(~r"duplicated :do clauses given for \"case\"", fn ->
+      assert_compile_error(~r"duplicate :do clauses given for \"case\"", fn ->
         expand(quote(do: case(e, do: (x -> x), do: (y -> y))))
       end)
     end
@@ -1775,11 +1775,11 @@ defmodule Kernel.ExpansionTest do
         expand(quote(do: receive([])))
       end)
 
-      assert_compile_error(~r"duplicated :do clauses given for \"receive\"", fn ->
+      assert_compile_error(~r"duplicate :do clauses given for \"receive\"", fn ->
         expand(quote(do: receive(do: (x -> x), do: (y -> y))))
       end)
 
-      assert_compile_error(~r"duplicated :after clauses given for \"receive\"", fn ->
+      assert_compile_error(~r"duplicate :after clauses given for \"receive\"", fn ->
         code =
           quote do
             receive do
@@ -2012,11 +2012,11 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects at most one clause" do
-      assert_compile_error(~r"duplicated :do clauses given for \"try\"", fn ->
+      assert_compile_error(~r"duplicate :do clauses given for \"try\"", fn ->
         expand(quote(do: try(do: e, do: f)))
       end)
 
-      assert_compile_error(~r"duplicated :rescue clauses given for \"try\"", fn ->
+      assert_compile_error(~r"duplicate :rescue clauses given for \"try\"", fn ->
         code =
           quote do
             try do
@@ -2031,7 +2031,7 @@ defmodule Kernel.ExpansionTest do
         expand(code)
       end)
 
-      assert_compile_error(~r"duplicated :after clauses given for \"try\"", fn ->
+      assert_compile_error(~r"duplicate :after clauses given for \"try\"", fn ->
         code =
           quote do
             try do
@@ -2046,7 +2046,7 @@ defmodule Kernel.ExpansionTest do
         expand(code)
       end)
 
-      assert_compile_error(~r"duplicated :else clauses given for \"try\"", fn ->
+      assert_compile_error(~r"duplicate :else clauses given for \"try\"", fn ->
         code =
           quote do
             try do
@@ -2061,7 +2061,7 @@ defmodule Kernel.ExpansionTest do
         expand(code)
       end)
 
-      assert_compile_error(~r"duplicated :catch clauses given for \"try\"", fn ->
+      assert_compile_error(~r"duplicate :catch clauses given for \"try\"", fn ->
         code =
           quote do
             try do


### PR DESCRIPTION
The word *duplicated* isn't wrong but *duplicate* sounds better in these cases. :+1: