### PR TITLE
ExUnit.Filters: change :location to :file

### DIFF
--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -6,8 +6,8 @@ defmodule ExUnit.Filters do
   """
 
   @type t :: list({atom, Regex.t() | String.Chars.t()} | atom)
-  @type location :: {:location, {String.t(), pos_integer | [pos_integer, ...]}}
-  @type ex_unit_opts :: [exclude: [:test], include: [location, ...]] | []
+  @type file_lines :: {:file, {String.t(), pos_integer | [pos_integer, ...]}}
+  @type ex_unit_opts :: [exclude: [:test], include: [file_lines, ...]] | []
 
   @doc """
   Parses filters out of a path.
@@ -34,7 +34,7 @@ defmodule ExUnit.Filters do
       Enum.map_reduce(file_paths, [], fn file_path, locations ->
         case extract_line_numbers(file_path) do
           {path, []} -> {path, locations}
-          {path, lines} -> {path, [{:location, {path, lines}} | locations]}
+          {path, lines} -> {path, [{:file, {path, lines}} | locations]}
         end
       end)
 
@@ -143,7 +143,7 @@ defmodule ExUnit.Filters do
   end
 
   defp parse_kv(:line, line) when is_binary(line), do: {:line, String.to_integer(line)}
-  defp parse_kv(:location, loc) when is_binary(loc), do: {:location, extract_line_numbers(loc)}
+  defp parse_kv(:file, loc) when is_binary(loc), do: {:file, extract_line_numbers(loc)}
   defp parse_kv(key, value), do: {key, value}
 
   @doc """
@@ -218,7 +218,7 @@ defmodule ExUnit.Filters do
     end
   end
 
-  defp has_tag({:location, {path, lines}}, %{line: _, describe_line: _} = tags, collection) do
+  defp has_tag({:file, {path, lines}}, %{line: _, describe_line: _} = tags, collection) do
     String.ends_with?(tags.file, path) and
       lines |> List.wrap() |> Enum.any?(&has_tag({:line, &1}, tags, collection))
   end

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -189,8 +189,8 @@ defmodule ExUnit.FiltersTest do
     assert ExUnit.Filters.parse(["run:true"]) == [run: "true"]
     assert ExUnit.Filters.parse(["run:test"]) == [run: "test"]
     assert ExUnit.Filters.parse(["line:9"]) == [line: 9]
-    assert ExUnit.Filters.parse(["location:foo.exs:9"]) == [location: {"foo.exs", 9}]
-    assert ExUnit.Filters.parse(["location:foo.exs:9:11"]) == [location: {"foo.exs", [9, 11]}]
+    assert ExUnit.Filters.parse(["file:foo.exs:9"]) == [file: {"foo.exs", 9}]
+    assert ExUnit.Filters.parse(["file:foo.exs:9:11"]) == [file: {"foo.exs", [9, 11]}]
   end
 
   test "file paths with line numbers" do
@@ -199,7 +199,7 @@ defmodule ExUnit.FiltersTest do
 
     for path <- [unix_path, windows_path] do
       assert ExUnit.Filters.parse_path("#{path}:123") ==
-               {path, [exclude: [:test], include: [location: {path, 123}]]}
+               {path, [exclude: [:test], include: [file: {path, 123}]]}
 
       assert ExUnit.Filters.parse_path(path) == {path, []}
 
@@ -207,19 +207,19 @@ defmodule ExUnit.FiltersTest do
                {"#{path}:123notreallyalinenumber123", []}
 
       assert ExUnit.Filters.parse_path("#{path}:123:456") ==
-               {path, [exclude: [:test], include: [location: {path, [123, 456]}]]}
+               {path, [exclude: [:test], include: [file: {path, [123, 456]}]]}
 
       assert ExUnit.Filters.parse_path("#{path}:123notalinenumber123:456") ==
                {"#{path}:123notalinenumber123",
-                [exclude: [:test], include: [location: {"#{path}:123notalinenumber123", 456}]]}
+                [exclude: [:test], include: [file: {"#{path}:123notalinenumber123", 456}]]}
 
       output =
         ExUnit.CaptureIO.capture_io(:stderr, fn ->
           assert ExUnit.Filters.parse_path("#{path}:123:456notalinenumber456") ==
-                   {path, [{:exclude, [:test]}, {:include, [location: {path, 123}]}]}
+                   {path, [{:exclude, [:test]}, {:include, [file: {path, 123}]}]}
 
           assert ExUnit.Filters.parse_path("#{path}:123:0:-789:456") ==
-                   {path, [exclude: [:test], include: [location: {path, [123, 456]}]]}
+                   {path, [exclude: [:test], include: [file: {path, [123, 456]}]]}
         end)
 
       assert output =~ "invalid line number given as ExUnit filter: 456notalinenumber456"
@@ -242,14 +242,14 @@ defmodule ExUnit.FiltersTest do
                {[path, other_path],
                 [
                   exclude: [:test],
-                  include: [location: {other_path, [456, 789]}]
+                  include: [file: {other_path, [456, 789]}]
                 ]}
 
       assert ExUnit.Filters.parse_paths(["#{path}:123", "#{other_path}:456"]) ==
                {[path, other_path],
                 [
                   exclude: [:test],
-                  include: [location: {path, 123}, location: {other_path, 456}]
+                  include: [file: {path, 123}, file: {other_path, 456}]
                 ]}
 
       output =
@@ -262,8 +262,8 @@ defmodule ExUnit.FiltersTest do
                     [
                       exclude: [:test],
                       include: [
-                        location: {path, [123, 456]},
-                        location: {other_path, [321, 654]}
+                        file: {path, [123, 456]},
+                        file: {other_path, [321, 654]}
                       ]
                     ]}
         end)

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -444,7 +444,7 @@ defmodule Mix.Tasks.TestTest do
           ["test/a_test_stale.exs:2", "test/b_test_stale.exs:4"],
           """
           Excluding tags: [:test]
-          Including tags: [location: {"test/a_test_stale.exs", 2}, location: {"test/b_test_stale.exs", 4}]
+          Including tags: [file: {"test/a_test_stale.exs", 2}, file: {"test/b_test_stale.exs", 4}]
           """
         )
       end)
@@ -501,7 +501,7 @@ defmodule Mix.Tasks.TestTest do
         assert output =~ """
                ==> bar
                Excluding tags: [:test]
-               Including tags: [location: {"test/bar_tests.exs", 10}]
+               Including tags: [file: {"test/bar_tests.exs", 10}]
 
                .
                """
@@ -513,12 +513,12 @@ defmodule Mix.Tasks.TestTest do
 
         assert output =~ """
                Excluding tags: [:test]
-               Including tags: [location: {"test/foo_tests.exs", 9}]
+               Including tags: [file: {"test/foo_tests.exs", 9}]
                """
 
         assert output =~ """
                Excluding tags: [:test]
-               Including tags: [location: {"test/bar_tests.exs", 5}]
+               Including tags: [file: {"test/bar_tests.exs", 5}]
                """
       end)
     end


### PR DESCRIPTION
I'm not sure but does `[file: {"test/bar_tests.exs", 10}]` read better and make more sense than `[location: {"test/bar_tests.exs", 10}]`?