### PR TITLE
Fix IEx doc printing for headings with newline characters

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -50,6 +50,10 @@ defmodule IO.ANSI.Docs do
   """
   @spec print_headings([String.t()], keyword) :: :ok
   def print_headings(headings, options \\ []) do
+    # It's possible for some of the headings to contain newline characters (`\n`), so in order to prevent it from
+    # breaking the output from `print_headings/2`, as `print_headings/2` tries to pad the whole heading, we first split
+    # any heading containgin newline characters into multiple headings, that way each one is padded on its own.
+    headings = Enum.flat_map(headings, fn heading -> String.split(heading, "\n") end)
     options = Keyword.merge(default_options(), options)
     newline_after_block(options)
     width = options[:width]

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -33,6 +33,14 @@ defmodule IO.ANSI.DocsTest do
       assert String.contains?(result, " foo ")
       assert String.contains?(result, " bar ")
     end
+
+    test "is correctly formatted when newline character is present" do
+      result = format_headings(["foo\nbar"])
+      assert :binary.matches(result, "\e[0m\n\e[7m\e[33m") |> length == 2
+      assert ["\e[0m", foo_line, bar_line, "\e[0m"] = String.split(result, "\n")
+      assert Regex.match?(~r/\e\[7m\e\[33m +foo +\e\[0m/, foo_line)
+      assert Regex.match?(~r/\e\[7m\e\[33m +bar +\e\[0m/, bar_line)
+    end
   end
 
   describe "metadata" do

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -808,6 +808,11 @@ defmodule IEx.Introspection do
   end
 
   defp print_doc(headings, types, format, doc, metadata) do
+    # It's possible for some of the headings to contain newline characters (`\n`), so in order to prevent it from
+    # breaking the output from `print_headings/2`, as `print_headings/2` tries to pad the whole heading, we first 
+    # split any heading containgin newline characters into multiple headings, that way each one is padded on its own.
+    headings = headings |> Enum.map(fn heading -> String.split(heading, "\n") end) |> List.flatten()
+
     doc = translate_doc(doc) || ""
     opts = IEx.Config.ansi_docs()
     IO.ANSI.Docs.print_headings(headings, opts)

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -808,11 +808,6 @@ defmodule IEx.Introspection do
   end
 
   defp print_doc(headings, types, format, doc, metadata) do
-    # It's possible for some of the headings to contain newline characters (`\n`), so in order to prevent it from
-    # breaking the output from `print_headings/2`, as `print_headings/2` tries to pad the whole heading, we first 
-    # split any heading containgin newline characters into multiple headings, that way each one is padded on its own.
-    headings = headings |> Enum.map(fn heading -> String.split(heading, "\n") end) |> List.flatten()
-
     doc = translate_doc(doc) || ""
     opts = IEx.Config.ansi_docs()
     IO.ANSI.Docs.print_headings(headings, opts)


### PR DESCRIPTION
Update `IEx.introspection.print_doc/5` to trasverse the list of headings and split each heading into multiple headings, in case the heading has any newline characters (`\n`). This fixes an issue where using the `h` macro with some functions ended up with a broken output for the function signature, as the padding done by `IO.ANSI.Docs.print_headings/2` does not take into consideration the fact the the headings can contain newline characters, and thus end up in multiple lines.

Here's a before and after comparison of running `h dbg` in `iex`:

#### Before

<img width="681" alt="image" src="https://github.com/elixir-lang/elixir/assets/6334322/398d9ce9-be64-4599-ac6b-8c8fb68d62ef">

#### After

<img width="676" alt="image" src="https://github.com/elixir-lang/elixir/assets/6334322/6128c4d7-0dcd-4888-93f2-425fbec121bd">

