### PR TITLE
Fix crash in surround_context

### DIFF
--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -489,7 +489,7 @@ defmodule Code.Fragment do
 
         cond do
           Code.Identifier.unary_op(op) == :error and Code.Identifier.binary_op(op) == :error ->
-            :none
+            {:none, 0}
 
           match?([?. | rest] when rest == [] or hd(rest) != ?., rest) ->
             dot(tl(rest), dot_count + 1, acc)


### PR DESCRIPTION
I don't know how to reproduce it but I've seen this stacktrace
```
an exception was raised:
    ** (CaseClauseError) no case clause matching: :none
        (elixir 1.15.6) <REDACTED: user-file-path>:408: Code.Fragment.dot_3
        (elixir 1.15.6) <REDACTED: user-file-path>:629: Code.Fragment.position_surround_context_4
        (elixir 1.15.6) <REDACTED: user-file-path>:604: Code.Fragment.surround_context_3
```
Looking at https://github.com/elixir-lang/elixir/blob/927b10df80ee1c1c7396e68efe00d06bc3e80420/lib/elixir/lib/code/fragment.ex#L408, only `operator` can return `:none` and it seems a mistake as other branches return `{:none, 0}`