### PR TITLE
Use :erlang.float_to_binary/2 in Float.to_string/1

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -603,7 +603,7 @@ defmodule Float do
   """
   @spec to_string(float) :: String.t()
   def to_string(float) when is_float(float) do
-    IO.iodata_to_binary(:io_lib_format.fwrite_g(float))
+    :erlang.float_to_binary(float, [:short])
   end
 
   @doc false

--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -576,7 +576,7 @@ defmodule Float do
   """
   @spec to_charlist(float) :: charlist
   def to_charlist(float) when is_float(float) do
-    :io_lib_format.fwrite_g(float)
+    :erlang.float_to_list(float, [:short])
   end
 
   @doc """

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -387,7 +387,7 @@ defimpl Inspect, for: Float do
       if abs >= 1.0 and abs < 1.0e16 and trunc(float) == float do
         [Integer.to_string(trunc(float)), ?., ?0]
       else
-        :io_lib_format.fwrite_g(float)
+        :erlang.float_to_list(float, [:short])
       end
 
     color(IO.iodata_to_binary(formatted), :number, opts)

--- a/lib/elixir/lib/list/chars.ex
+++ b/lib/elixir/lib/list/chars.ex
@@ -58,6 +58,6 @@ end
 
 defimpl List.Chars, for: Float do
   def to_charlist(term) do
-    :io_lib_format.fwrite_g(term)
+    :erlang.float_to_list(term, [:short])
   end
 end

--- a/lib/elixir/lib/string/chars.ex
+++ b/lib/elixir/lib/string/chars.ex
@@ -57,6 +57,6 @@ end
 
 defimpl String.Chars, for: Float do
   def to_string(term) do
-    IO.iodata_to_binary(:io_lib_format.fwrite_g(term))
+    :erlang.float_to_binary(term, [:short])
   end
 end


### PR DESCRIPTION
Relates to #11220

Did a quick prop-based sanity check just to make sure there is no unexpected change in behavior / edge case:

```elixir
# hangs forever
iex> for f <- StreamData.float(), Float.to_string(f) != :erlang.float_to_binary(f, [:short]), do: throw f
```