### PR TITLE
Remove calling_self clause in GenServer

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -1106,10 +1106,6 @@ defmodule GenServer do
       nil ->
         exit({:noproc, {__MODULE__, :call, [server, request, timeout]}})
 
-      # TODO: remove this clause when we require Erlang/OTP 25+
-      pid when pid == self() ->
-        exit({:calling_self, {__MODULE__, :call, [server, request, timeout]}})
-
       pid ->
         try do
           :gen.call(pid, :"$gen_call", request, timeout)


### PR DESCRIPTION
This check is now done in OTP directly: https://github.com/erlang/otp/pull/5008

Relates to https://github.com/elixir-lang/elixir/issues/11220

Note: I wasn't sure about the clause in stop/3, but I fear this would make it a breaking change (cf this [branch](https://github.com/elixir-lang/elixir/compare/main...sabiwara:remove-call-self-2?expand=1))