### PR TITLE
Always use system certificates

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -656,9 +656,7 @@ defmodule Mix.Utils do
     request = {:binary.bin_to_list(path), headers}
 
     # Use the system certificates
-    # Currently we inline what `:httpc.ssl_verify_host_options/1` is doing, because it is not present
-    # on OTP < 25.1.
-    # TODO: just use `ssl_options = :httpc.ssl_verify_host_options(true)` once OTP >= 26.0 is required.
+    # TODO: use `ssl_options = :httpc.ssl_verify_host_options(true)` on Erlang/OTP 26+
     ssl_options = [
       verify: :verify_peer,
       cacerts: :public_key.cacerts_get(),

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -655,23 +655,8 @@ defmodule Mix.Utils do
     headers = [{~c"user-agent", ~c"Mix/#{System.version()}"}]
     request = {:binary.bin_to_list(path), headers}
 
-    # Use the system certificates if available, otherwise skip peer verification
-    # TODO: Always use system certificates when OTP >= 25.1 is required
-    ssl_options =
-      if Code.ensure_loaded?(:httpc) and function_exported?(:httpc, :ssl_verify_host_options, 1) do
-        try do
-          apply(:httpc, :ssl_verify_host_options, [true])
-        rescue
-          _ ->
-            Mix.shell().error(
-              "warning: failed to load system certificates. SSL peer verification will be skipped but downloads are still verified with a checksum"
-            )
-
-            [verify: :verify_none]
-        end
-      else
-        [verify: :verify_none]
-      end
+    # Use the system certificates
+    ssl_options = :httpc.ssl_verify_host_options(true)
 
     # We are using relaxed: true because some servers is returning a Location
     # header with relative paths, which does not follow the spec. This would

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -656,7 +656,14 @@ defmodule Mix.Utils do
     request = {:binary.bin_to_list(path), headers}
 
     # Use the system certificates
-    ssl_options = :httpc.ssl_verify_host_options(true)
+    # Currently we inline what `:httpc.ssl_verify_host_options/1` is doing, because it is not present
+    # on OTP < 25.1.
+    # TODO: just use `ssl_options = :httpc.ssl_verify_host_options(true)` once OTP >= 26.0 is required.
+    ssl_options = [
+      verify: :verify_peer,
+      cacerts: :public_key.cacerts_get(),
+      customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]
+    ]
 
     # We are using relaxed: true because some servers is returning a Location
     # header with relative paths, which does not follow the spec. This would


### PR DESCRIPTION
Relates to https://github.com/elixir-lang/elixir/issues/11220

Hope I didn't misunderstood "Use new system certificates" and the TODO, feel free to close if that's the case.

Note: [`:httpc.ssl_verify_host_options/1`](https://www.erlang.org/doc/man/httpc#ssl_verify_host_options-1) is available from 25.1, which would imply 1.17 compatibility is from OTP 25.1, not 25 (is this a showstopper?).