### PR TITLE
Keep variable names consistent in example

### DIFF
--- a/lib/elixir/pages/cheatsheets/enum-cheat.cheatmd
+++ b/lib/elixir/pages/cheatsheets/enum-cheat.cheatmd
@@ -431,8 +431,8 @@ iex> for item <- cart,
 ### [`into(enum, collectable)`](`Enum.into/2`)
 
 ```elixir
-iex> pairs = [{"apple", 3}, {"banana", 1}, {"orange", 6}]
-iex> Enum.into(pairs, %{})
+iex> cart = [{"apple", 3}, {"banana", 1}, {"orange", 6}]
+iex> Enum.into(cart, %{})
 %{"apple" => 3, "banana" => 1, "orange" => 6}
 ```
 


### PR DESCRIPTION
This change makes the variable name match the naming in follow-up examples.