### PR TITLE
Restore GenServer introduction mermaid graph

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -8,6 +8,13 @@ defmodule GenServer do
   will have a standard set of interface functions and include functionality for
   tracing and error reporting. It will also fit into a supervision tree.
 
+  ```mermaid
+  graph BT
+      C(Client #3) ~~~ B(Client #2) ~~~ A(Client #1)
+      A & B & C -->|request| GenServer
+      GenServer -.->|reply| A & B & C
+  ```
+
   ## Example
 
   The GenServer behaviour abstracts the common client-server interaction.


### PR DESCRIPTION
Restores graph removed in f5a61d1, with correct request -> reply arrow ordering.

Jose mentioned fixing it on the forum thread (https://elixirforum.com/t/elixir-v1-16-0-rc-0-released/59386/8), but after building it I noticed the removal commit. Not sure if it was removed due to the "bug" or because the graph was not wanted any more.

I do not believe its possible to get the client nodes on the same "level", so this may not be appropriate to merge anyway.

  ```mermaid
  graph BT
      C(Client #3) ~~~ B(Client #2) ~~~ A(Client #1)
      A & B & C -->|request| GenServer
      GenServer -.->|reply| A & B & C
  ```

I actually think this would be better read in the inverse also, but again, the different "levels" for the clients is problematic.

  ```mermaid
  graph TB
      C(Client #3) ~~~ B(Client #2) ~~~ A(Client #1)
      A & B & C -->|request| GenServer
      GenServer -.->|reply| A & B & C
  ```