### PR TITLE
Support --sparse in archive.install and escript.install

### DIFF
--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -47,6 +47,9 @@ defmodule Mix.Tasks.Archive.Install do
     * `--submodules` - fetches repository submodules before building archive from
       Git or GitHub
 
+    * `--sparse` - checkout a single directory inside the Git repository and use
+      it as the archive root directory
+
     * `--app` - specifies a custom app name to be used for building the archive
       from Git, GitHub, or Hex
 
@@ -63,6 +66,7 @@ defmodule Mix.Tasks.Archive.Install do
     force: :boolean,
     sha512: :string,
     submodules: :boolean,
+    sparse: :string,
     app: :string,
     organization: :string,
     repo: :string,

--- a/lib/mix/lib/mix/tasks/escript.install.ex
+++ b/lib/mix/lib/mix/tasks/escript.install.ex
@@ -47,6 +47,9 @@ defmodule Mix.Tasks.Escript.Install do
     * `--submodules` - fetches repository submodules before building escript from
       Git or GitHub
 
+    * `--sparse` - checkout a single directory inside the Git repository and use
+      it as the escript project directory
+
     * `--app` - specifies a custom app name to be used for building the escript
       from Git, GitHub, or Hex
 
@@ -66,6 +69,7 @@ defmodule Mix.Tasks.Escript.Install do
     force: :boolean,
     sha512: :string,
     submodules: :boolean,
+    sparse: :string,
     app: :string,
     organization: :string,
     repo: :string,

--- a/lib/mix/test/mix/local/installer_test.exs
+++ b/lib/mix/test/mix/local/installer_test.exs
@@ -30,50 +30,76 @@ defmodule Mix.Local.InstallerTest do
 
   test "parse_args Git" do
     args = ["git", "https://example.com/user/repo.git"]
-    opts = [git: "https://example.com/user/repo.git", submodules: nil]
+    opts = [git: "https://example.com/user/repo.git", submodules: nil, sparse: nil]
 
     assert Mix.Local.Installer.parse_args(args, []) == {:fetcher, {:"new package", opts}}
   end
 
   test "parse_args Git branch" do
     args = ["git", "https://example.com/user/repo.git", "branch", "not_main"]
-    opts = [branch: "not_main", git: "https://example.com/user/repo.git", submodules: nil]
+
+    opts = [
+      branch: "not_main",
+      git: "https://example.com/user/repo.git",
+      submodules: nil,
+      sparse: nil
+    ]
 
     assert Mix.Local.Installer.parse_args(args, []) == {:fetcher, {:"new package", opts}}
   end
 
   test "parse_args Git ref" do
     args = ["git", "https://example.com/user/repo.git", "ref", "not_main"]
-    opts = [ref: "not_main", git: "https://example.com/user/repo.git", submodules: nil]
+
+    opts = [
+      ref: "not_main",
+      git: "https://example.com/user/repo.git",
+      submodules: nil,
+      sparse: nil
+    ]
 
     assert Mix.Local.Installer.parse_args(args, []) == {:fetcher, {:"new package", opts}}
   end
 
   test "parse_args Git tag" do
     args = ["git", "https://example.com/user/repo.git", "tag", "not_main"]
-    opts = [tag: "not_main", git: "https://example.com/user/repo.git", submodules: nil]
+
+    opts = [
+      tag: "not_main",
+      git: "https://example.com/user/repo.git",
+      submodules: nil,
+      sparse: nil
+    ]
 
     assert Mix.Local.Installer.parse_args(args, []) == {:fetcher, {:"new package", opts}}
   end
 
   test "parse_args Git submodules" do
     args = ["git", "https://example.com/user/repo.git"]
-    opts = [git: "https://example.com/user/repo.git", submodules: true]
+    opts = [git: "https://example.com/user/repo.git", submodules: true, sparse: nil]
 
     assert Mix.Local.Installer.parse_args(args, submodules: true) ==
              {:fetcher, {:"new package", opts}}
   end
 
+  test "parse_args Git sparse" do
+    args = ["git", "https://example.com/user/repo.git"]
+    opts = [git: "https://example.com/user/repo.git", submodules: nil, sparse: "foo"]
+
+    assert Mix.Local.Installer.parse_args(args, sparse: "foo") ==
+             {:fetcher, {:"new package", opts}}
+  end
+
   test "parse_args Git app" do
     args = ["git", "https://example.com/user/repo.git"]
-    opts = [git: "https://example.com/user/repo.git", submodules: nil]
+    opts = [git: "https://example.com/user/repo.git", submodules: nil, sparse: nil]
 
     assert Mix.Local.Installer.parse_args(args, app: "my_app") == {:fetcher, {:my_app, opts}}
   end
 
   test "parse_args GitHub" do
     args = ["github", "user/repo"]
-    opts = [git: "https://github.com/user/repo.git", submodules: nil]
+    opts = [git: "https://github.com/user/repo.git", submodules: nil, sparse: nil]
 
     assert Mix.Local.Installer.parse_args(args, []) == {:fetcher, {:"new package", opts}}
   end


### PR DESCRIPTION
```
mix archive.install github phoenixframework/phoenix --sparse installer
```

Didn't test escript but it should be identical to archive install
