### PR TITLE
Update logger documentation

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -942,7 +942,7 @@ defmodule Logger do
 
   for level <- @levels do
     report = [something: :reported, this: level]
-    report_with_metadata = [user_id: 42, request_id: "xU32kFa"]
+    metadata = [user_id: 42, request_id: "xU32kFa"]
 
     extra =
       if translation = translations[level] do
@@ -977,10 +977,10 @@ defmodule Logger do
     Report message with metadata (maps or keywords):
 
         # as a keyword list
-        Logger.#{level}("this is a #{level} message", #{inspect(report_with_metadata)})
+        Logger.#{level}("this is a #{level} message", #{inspect(metadata)})
 
         # as map
-        Logger.#{level}("this is a #{level} message", #{inspect(Map.new(report_with_metadata))})
+        Logger.#{level}("this is a #{level} message", #{inspect(Map.new(metadata))})
     """
 
     # Only macros generated for the "new" Erlang levels are available since 1.11.0. Other

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -942,6 +942,7 @@ defmodule Logger do
 
   for level <- @levels do
     report = [something: :reported, this: level]
+    report_with_metadata = [user_id: 42, request_id: "xU32kFa"]
 
     extra =
       if translation = translations[level] do
@@ -973,6 +974,13 @@ defmodule Logger do
         # as map
         Logger.#{level}(#{inspect(Map.new(report))})
 
+    Report message with metadata (maps or keywords):
+
+        # as a keyword list
+        Logger.#{level}("this is a #{level} message", #{inspect(report_with_metadata)})
+
+        # as map
+        Logger.#{level}("this is a #{level} message", #{inspect(Map.new(report_with_metadata))})
     """
 
     # Only macros generated for the "new" Erlang levels are available since 1.11.0. Other


### PR DESCRIPTION
Hey there 👋🏾 

Logger metadata accepts also a map. It looks like it's not documented.

i.e.

```elixir
Logger.info("this is a info message", %{something: :reported, this: :info})
```

This PR tries to improve the documentation.

NOTE: If the map case is accidentally covered please let me know and I'll just close the PR. Thanks!