### PR TITLE
Pretty print alias definition in mix help

### DIFF
--- a/lib/mix/lib/mix/tasks/help.ex
+++ b/lib/mix/lib/mix/tasks/help.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Help do
       $ mix help --search PATTERN - prints all tasks and aliases that contain PATTERN in the name
       $ mix help --names          - prints all task names and aliases
                                   (useful for autocompleting)
+      $ mix help --aliases        - prints all aliases
 
   ## Colors
 
@@ -67,6 +68,16 @@ defmodule Mix.Tasks.Help do
     for info <- Enum.sort(aliases ++ tasks) do
       Mix.shell().info(info)
     end
+  end
+
+  def run(["--aliases"]) do
+    loadpaths!()
+
+    aliases = load_aliases()
+
+    {docs, max} = build_doc_list([], aliases)
+
+    display_doc_list(docs, max)
   end
 
   def run(["--search", pattern]) do

--- a/lib/mix/lib/mix/tasks/help.ex
+++ b/lib/mix/lib/mix/tasks/help.ex
@@ -221,7 +221,18 @@ defmodule Mix.Tasks.Help do
   end
 
   defp alias_doc(task_name, note) do
-    {"Alias for " <> inspect(task_name), "mix.exs", note}
+    alias_doc = """
+    Alias for
+
+        #{format_alias(task_name)}
+    """
+
+    {alias_doc, "mix.exs", note}
+  end
+
+  defp format_alias(task) do
+    inspect(task, pretty: true, width: 0)
+    |> String.replace("\n", "\n    ")
   end
 
   defp task_doc(task) do

--- a/lib/mix/test/mix/tasks/help_test.exs
+++ b/lib/mix/test/mix/tasks/help_test.exs
@@ -199,6 +199,21 @@ defmodule Mix.Tasks.HelpTest do
     end)
   end
 
+  test "help --aliases", context do
+    in_tmp(context.test, fn ->
+      Mix.Project.push(Aliases)
+
+      Mix.Tasks.Help.run(["--aliases"])
+      assert_received {:mix_shell, :info, ["mix h" <> message]}
+      assert message =~ ~r/# Alias defined in mix.exs/
+
+      assert_received {:mix_shell, :info, ["mix c" <> message]}
+      assert message =~ ~r/# Alias defined in mix.exs/
+
+      refute_received {:mix_shell, :info, ["mix deps" <> _]}
+    end)
+  end
+
   test "bad arguments" do
     message = "Unexpected arguments, expected \"mix help\" or \"mix help TASK\""
 

--- a/lib/mix/test/mix/tasks/help_test.exs
+++ b/lib/mix/test/mix/tasks/help_test.exs
@@ -80,7 +80,8 @@ defmodule Mix.Tasks.HelpTest do
         end)
 
       assert output =~ "mix h\n\n"
-      assert output =~ "Alias for \"hello\"\n"
+      assert output =~ "Alias for\n\n"
+      assert output =~ "    \"hello\"\n"
       assert output =~ ~r/^Location: mix.exs/m
 
       output =
@@ -89,7 +90,8 @@ defmodule Mix.Tasks.HelpTest do
         end)
 
       assert output =~ "mix p\n\n"
-      assert output =~ "Alias for &Kernel.inspect/1\n"
+      assert output =~ "Alias for\n\n"
+      assert output =~ "    &Kernel.inspect/1\n"
       assert output =~ ~r/^Location: mix.exs/m
 
       output =
@@ -98,7 +100,9 @@ defmodule Mix.Tasks.HelpTest do
         end)
 
       assert output =~ "mix help\n\n"
-      assert output =~ "Alias for [\"help\", \"hello\"]\n"
+      assert output =~ "Alias for\n\n"
+      assert output =~ "    [\"help\",\n"
+      assert output =~ "    \"hello\"]\n"
       assert output =~ ~r/^Location: mix.exs/m
 
       output =
@@ -107,7 +111,8 @@ defmodule Mix.Tasks.HelpTest do
         end)
 
       assert output =~ "mix nested.h\n\n"
-      assert output =~ ~r/Alias for \[#Function/
+      assert output =~ "Alias for\n\n"
+      assert output =~ ~r/    \[#Function/
       assert output =~ ~r/^Location: mix.exs/m
     end)
   end
@@ -149,7 +154,8 @@ defmodule Mix.Tasks.HelpTest do
         end)
 
       assert output =~ "mix compile\n\n"
-      assert output =~ "Alias for \"compile\"\n"
+      assert output =~ "Alias for\n\n"
+      assert output =~ "\"compile\"\n"
       assert output =~ ~r/^Location: mix.exs/m
 
       assert output =~


### PR DESCRIPTION
This is an initial draft MR for discussing some details on the [proposal](https://groups.google.com/g/elixir-lang-core/c/_TC7KMJgajw)

This first commit pretty prints the output of `mix help ALIAS` (tests need to be updated)

Sample `mix.exs`:

```elixir
  defp aliases do
    [
       an_alias: [&hello/1, "deps.get --only #{Mix.env()}", "compile"],
       another_alias: [
        "format --check-formatted priv/hello1.exs",
        "cmd priv/world.sh",
        fn _ -> Mix.Task.reenable("format") end,
        "format --check-formatted priv/hello2.exs"
      ]
    ]
  end
```

**Current output** 

![image](https://github.com/elixir-lang/elixir/assets/1561963/f45328bb-1bcf-4dd0-91c0-ff09e3b89202)

**Formatted output**

![image](https://github.com/elixir-lang/elixir/assets/1561963/fdecb183-c43e-40c5-9a24-70601ca3b7b0)

We could also pretty print the alias in a single line but I personally don't like it for lengthy aliases.

![image](https://github.com/elixir-lang/elixir/assets/1561963/fd4925ea-41fc-40c5-88c5-b7b27afeed84)

How should we handle functions? Is the current way they are formatted ok?


