### PR TITLE
Add doctest for absname with lazy path

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -64,6 +64,12 @@ defmodule Path do
       iex> Path.absname("../x", "bar")
       "bar/../x"
 
+      iex> Path.absname("foo", fn -> "lazy" end)
+      "lazy/foo"
+
+      iex> Path.absname("/foo", fn -> raise "unused!" end)
+      "/foo"
+
   """
   @spec absname(t, t | (-> t)) :: binary
   def absname(path, relative_to) do

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -67,9 +67,6 @@ defmodule Path do
       iex> Path.absname("foo", fn -> "lazy" end)
       "lazy/foo"
 
-      iex> Path.absname("/foo", fn -> raise "unused!" end)
-      "/foo"
-
   """
   @spec absname(t, t | (-> t)) :: binary
   def absname(path, relative_to) do


### PR DESCRIPTION
Add a doctest to `Path.absname/2` using the new lazy path signature introduced in https://github.com/elixir-lang/elixir/pull/13061.

I figured examples might be helpful for people who are not so familiar with specs.