### PR TITLE
Update spec for `Regex.version/0`

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -304,7 +304,7 @@ defmodule Regex do
   Returns the version of the underlying Regex engine.
   """
   @doc since: "1.4.0"
-  @spec version :: term()
+  @spec version :: {binary, atom}
   def version do
     {:re.version(), :erlang.system_info(:endian)}
   end


### PR DESCRIPTION
Update type according to the returned value:

```elixir
iex(8)> Regex.version
{"8.44 2020-02-12", :little}
```