### PR TITLE
Fix crashes when :beam_lib.info(beam) returns error

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -2057,7 +2057,8 @@ defmodule Code do
 
   defp get_beam_and_path(module) do
     with {^module, beam, filename} <- :code.get_object_code(module),
-         {:ok, ^module} <- beam |> :beam_lib.info() |> Keyword.fetch(:module) do
+         info_pairs when is_list(info_pairs) <- :beam_lib.info(beam),
+         {:ok, ^module} <- Keyword.fetch(info_pairs, :module) do
       {beam, filename}
     else
       _ -> :error

--- a/lib/elixir/lib/code/typespec.ex
+++ b/lib/elixir/lib/code/typespec.ex
@@ -175,7 +175,8 @@ defmodule Code.Typespec do
 
   defp get_module_and_beam(module) when is_atom(module) do
     with {^module, beam, _filename} <- :code.get_object_code(module),
-         {:ok, ^module} <- beam |> :beam_lib.info() |> Keyword.fetch(:module) do
+         info_pairs when is_list(info_pairs) <- :beam_lib.info(beam),
+         {:ok, ^module} <- Keyword.fetch(info_pairs, :module) do
       {module, beam}
     else
       _ -> :error

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -1476,7 +1476,8 @@ defmodule IEx.Helpers do
 
   defp get_beam_and_path(module) do
     with {^module, beam, filename} <- :code.get_object_code(module),
-         {:ok, ^module} <- beam |> :beam_lib.info() |> Keyword.fetch(:module) do
+         info_pairs when is_list(info_pairs) <- :beam_lib.info(beam),
+         {:ok, ^module} <- Keyword.fetch(info_pairs, :module) do
       {beam, filename}
     else
       _ -> :error

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -89,7 +89,7 @@ defimpl IEx.Info, for: Atom do
 
       {^atom, beam, _path} ->
         info = :beam_lib.info(beam)
-        Keyword.fetch(info, :module) == {:ok, atom}
+        is_list(info) and Keyword.fetch(info, :module) == {:ok, atom}
     end
   end
 


### PR DESCRIPTION
`:beam_lib.info/1` returns `{:error, :beam_lib, info_rsn()}` on error

```
an exception was raised:
    ** (FunctionClauseError) no function clause matching in Keyword.fetch/2
        (elixir 1.15.4) <REDACTED: user-file-path>:571: Keyword.fetch({:error, :beam_lib, {:not_a_beam_file, ""}}, :module)
        (elixir 1.15.4) <REDACTED: user-file-path>:2032: Code.get_beam_and_path/1
        (elixir 1.15.4) <REDACTED: user-file-path>:1994: Code.fetch_docs/1
```