### PR TITLE
Fix typo in getting-started guide

### DIFF
--- a/lib/elixir/pages/getting-started/basic-types.md
+++ b/lib/elixir/pages/getting-started/basic-types.md
@@ -83,7 +83,7 @@ You can also use `is_float` or `is_number` to check, respectively, if an argumen
 
 ## Identifying functions and documentation
 
-Before we move on to the next data type, let's talk about how Elixir identity functions.
+Before we move on to the next data type, let's talk about how Elixir identifies functions.
 
 Functions in Elixir are identified by both their name and their arity. The arity of a function describes the number of arguments that the function takes. From this point on we will use both the function name and its arity to describe functions throughout the documentation. `trunc/1` identifies the function which is named `trunc` and takes `1` argument, whereas `trunc/2` identifies a different (nonexistent) function with the same name but with an arity of `2`.
 


### PR DESCRIPTION
Fixing a typo in [Getting Started – Identifying functions and documentation](https://hexdocs.pm/elixir/1.16/basic-types.html#identifying-functions-and-documentation).

`Before we move on to the next data type, let's talk about how Elixir identity functions.`

-->

`Before we move on to the next data type, let's talk about how Elixir identifies functions.`