### PR TITLE
Produce better error messages for non-binary mix git deps refspecs.

### DIFF
--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -201,18 +201,37 @@ defmodule Mix.SCM.Git do
   ## Helpers
 
   defp validate_git_options(opts) do
-    err =
-      "You should specify only one of branch, ref or tag, and only once. " <>
-        "Error on Git dependency: #{redact_uri(opts[:git])}"
-
-    validate_single_uniq(opts, [:branch, :ref, :tag], err)
+    opts
+    |> tap(&validate_single_refspec!/1)
+    |> tap(&validate_string_refspecs!/1)
   end
 
-  defp validate_single_uniq(opts, take, error) do
-    case Keyword.take(opts, take) do
-      [] -> opts
-      [_] -> opts
-      _ -> Mix.raise(error)
+  defp validate_single_refspec!(opts) do
+    case Keyword.take(opts, [:branch, :ref, :tag]) do
+      [] ->
+        opts
+
+      [_] ->
+        opts
+
+      _ ->
+        Mix.raise(
+          "You should specify only one of branch, ref or tag, and only once. " <>
+            "Error on Git dependency: #{redact_uri(opts[:git])}"
+        )
+    end
+  end
+
+  defp validate_string_refspecs!(opts) do
+    for {_kind, refspec} <- Keyword.take(opts, [:branch, :ref, :tag]) do
+      if is_binary(refspec) do
+        :ok
+      else
+        Mix.raise(
+          "A dependency's branch, ref or tag must be a string. " <>
+            "Error on Git dependency: #{redact_uri(opts[:git])}"
+        )
+      end
     end
   end
 

--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -201,37 +201,24 @@ defmodule Mix.SCM.Git do
   ## Helpers
 
   defp validate_git_options(opts) do
-    opts
-    |> tap(&validate_single_refspec!/1)
-    |> tap(&validate_string_refspecs!/1)
-  end
-
-  defp validate_single_refspec!(opts) do
     case Keyword.take(opts, [:branch, :ref, :tag]) do
       [] ->
         opts
 
-      [_] ->
+      [{_refspec, value}] when is_binary(value) ->
         opts
+
+      [{refspec, value}] ->
+        Mix.raise(
+          "A dependency's #{refspec} must be a string, got: #{inspect(value)}. " <>
+            "Error on Git dependency: #{redact_uri(opts[:git])}"
+        )
 
       _ ->
         Mix.raise(
           "You should specify only one of branch, ref or tag, and only once. " <>
             "Error on Git dependency: #{redact_uri(opts[:git])}"
         )
-    end
-  end
-
-  defp validate_string_refspecs!(opts) do
-    for {_kind, refspec} <- Keyword.take(opts, [:branch, :ref, :tag]) do
-      if is_binary(refspec) do
-        :ok
-      else
-        Mix.raise(
-          "A dependency's branch, ref or tag must be a string. " <>
-            "Error on Git dependency: #{redact_uri(opts[:git])}"
-        )
-      end
     end
   end
 

--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -61,15 +61,15 @@ defmodule Mix.SCM.GitTest do
   end
 
   test "raises about non-binary Git refspec options" do
-    assert_raise Mix.Error, ~r/branch, ref or tag must be a string/, fn ->
+    assert_raise Mix.Error, ~r/A dependency's branch must be a string/, fn ->
       Mix.SCM.Git.accepts_options(nil, git: "/repo", branch: :main)
     end
 
-    assert_raise Mix.Error, ~r/branch, ref or tag must be a string/, fn ->
+    assert_raise Mix.Error, ~r/A dependency's tag must be a string/, fn ->
       Mix.SCM.Git.accepts_options(nil, git: "/repo", tag: :stable)
     end
 
-    assert_raise Mix.Error, ~r/branch, ref or tag must be a string/, fn ->
+    assert_raise Mix.Error, ~r/A dependency's ref must be a string/, fn ->
       Mix.SCM.Git.accepts_options(nil, git: "/repo", ref: :abcdef0123456789)
     end
   end

--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -50,13 +50,27 @@ defmodule Mix.SCM.GitTest do
     end
   end
 
-  test "raises about conflicting Git checkout options" do
+  test "raises about conflicting Git refspec options" do
     assert_raise Mix.Error, ~r/You should specify only one of branch, ref or tag/, fn ->
       Mix.SCM.Git.accepts_options(nil, git: "/repo", branch: "main", tag: "0.1.0")
     end
 
     assert_raise Mix.Error, ~r/You should specify only one of branch, ref or tag/, fn ->
       Mix.SCM.Git.accepts_options(nil, git: "/repo", branch: "main", branch: "develop")
+    end
+  end
+
+  test "raises about non-binary Git refspec options" do
+    assert_raise Mix.Error, ~r/branch, ref or tag must be a string/, fn ->
+      Mix.SCM.Git.accepts_options(nil, git: "/repo", branch: :main)
+    end
+
+    assert_raise Mix.Error, ~r/branch, ref or tag must be a string/, fn ->
+      Mix.SCM.Git.accepts_options(nil, git: "/repo", tag: :stable)
+    end
+
+    assert_raise Mix.Error, ~r/branch, ref or tag must be a string/, fn ->
+      Mix.SCM.Git.accepts_options(nil, git: "/repo", ref: :abcdef0123456789)
     end
   end
 


### PR DESCRIPTION
When using git dependencies, a branch/ref/tag specifier is passed verbatim to `System.cmd/3`. This can lead to intimidating error messages when they are not provided as a binary (for instance, an atom like `tag: :stable`):

```
** (ArgumentError) all arguments for System.cmd/3 must be binaries
    (elixir 1.15.6) lib/system.ex:1083: System.cmd/3
    (mix 1.15.6) lib/mix/scm/git.ex:287: Mix.SCM.Git.git!/2
    (mix 1.15.6) lib/mix/scm/git.ex:136: Mix.SCM.Git.checkout/2
    (elixir 1.15.6) lib/file.ex:1624: File.cd!/2
    (mix 1.15.6) lib/mix/dep/fetcher.ex:64: Mix.Dep.Fetcher.do_fetch/3
    (mix 1.15.6) lib/mix/dep/converger.ex:229: Mix.Dep.Converger.all/8
    (mix 1.15.6) lib/mix/dep/converger.ex:162: Mix.Dep.Converger.init_all/8
    (mix 1.15.6) lib/mix/dep/converger.ex:110: Mix.Dep.Converger.all/4
```

This PR adds a check during git opts verification time to [provide better feedback](https://github.com/elixir-lang/elixir/blob/41e522da6460f89eefb48cf5b5c6c226b78e04ff/lib/mix/test/mix/scm/git_test.exs#L63-L75), earlier.