### PR TITLE
Fix a broken link to the "Guards" section

### DIFF
--- a/lib/elixir/pages/getting-started/case-cond-and-if.md
+++ b/lib/elixir/pages/getting-started/case-cond-and-if.md
@@ -65,7 +65,7 @@ iex> case :ok do
 ** (CaseClauseError) no case clause matching: :ok
 ```
 
-The documentation for the `Kernel` module lists all available guards in its sidebar. You can also consult the complete [Patterns and Guards](../references/patterns-and-guards.html#guards) reference for in-depth documentation.
+The documentation for the `Kernel` module lists all available guards in its sidebar. You can also consult the complete [Patterns and Guards](../references/patterns-and-guards.md#guards) reference for in-depth documentation.
 
 ## cond
 


### PR DESCRIPTION
Fix a broken link to the "Guards" section of the "Patterns and Guards" references page.
The link is from the "Case, Cond and If" getting-started page.