### PR TITLE
Update Mix.Task.preferred_cli_env/1 docs

### DIFF
--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -256,6 +256,9 @@ defmodule Mix.Task do
     Mix.ProjectStack.recursing() != nil
   end
 
+  @doc """
+  Available for backwards compatibility.
+  """
   @deprecated "Configure the environment in your mix.exs"
   defdelegate preferred_cli_env(task), to: Mix.CLI
 


### PR DESCRIPTION
ExDoc main emitted the following warning on Elixir main:

```
    warning: documentation references function "Mix.CLI.preferred_cli_env/1" but it is hidden
    │
  1 │ defmodule Mix.Task do
    │ ~~~~~~~~~~~~~~~~~~~~~
    │
    └─ (mix 1.17.0-dev) lib/mix/lib/mix/task.ex:1: Mix.Task.preferred_cli_env/1
```

and the warning was pointing to the wrong location. Not sure if it's worth addressing but here's what happened: `defdelegate` without explicit `@doc` adds the `@doc "See <delegating_to>"` however here we're delegating to a module with `@moduledoc false` hence the warning.

I decided to just update the docs. At some point I imagine this function would become a `@doc false` anyway.

Before:

<img width="869" alt="image" src="https://github.com/elixir-lang/elixir/assets/76071/f3f0c8cf-8eab-48df-aabc-bab2d332906c">

After:

<img width="869" alt="image" src="https://github.com/elixir-lang/elixir/assets/76071/57a66662-00f4-40c8-b6cc-7d08080c9a9f">
