### PR TITLE
Raise in Time.add/3 for non-positive integer

### DIFF
--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -519,7 +519,7 @@ defmodule Time do
          unit not in ~w(second millisecond microsecond nanosecond)a do
       raise ArgumentError,
             "unsupported time unit. Expected :hour, :minute, :second, :millisecond, " <>
-            ":microsecond, :nanosecond, or a positive integer, got #{inspect(unit)}"
+              ":microsecond, :nanosecond, or a positive integer, got #{inspect(unit)}"
     end
 
     amount_to_add = System.convert_time_unit(amount_to_add, unit, :microsecond)

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -515,10 +515,11 @@ defmodule Time do
 
   def add(%{calendar: calendar, microsecond: {_, precision}} = time, amount_to_add, unit)
       when is_integer(amount_to_add) do
-    if not is_integer(unit) and
+    if (is_integer(unit) and unit < 1) or
          unit not in ~w(second millisecond microsecond nanosecond)a do
       raise ArgumentError,
-            "unsupported time unit. Expected :hour, :minute, :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got #{inspect(unit)}"
+            "unsupported time unit. Expected :hour, :minute, :second, :millisecond, " <>
+            ":microsecond, :nanosecond, or a positive integer, got #{inspect(unit)}"
     end
 
     amount_to_add = System.convert_time_unit(amount_to_add, unit, :microsecond)

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -97,7 +97,7 @@ defmodule TimeTest do
     assert Time.add(time, 1, :hour) == ~T[01:00:00.0]
 
     assert_raise ArgumentError, ~r/Expected :hour, :minute, :second/, fn ->
-      assert Time.add(time, 1, 0)
+      Time.add(time, 1, 0)
     end
   end
 end

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -91,7 +91,7 @@ defmodule TimeTest do
     assert Time.truncate(~T[01:01:01.123456], :second) == ~T[01:01:01]
   end
 
-  test "add/2" do
+  test "add/3" do
     time = ~T[00:00:00.0]
 
     assert Time.add(time, 1, :hour) == ~T[01:00:00.0]

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -90,4 +90,14 @@ defmodule TimeTest do
 
     assert Time.truncate(~T[01:01:01.123456], :second) == ~T[01:01:01]
   end
+
+  test "add/2" do
+    time = ~T[00:00:00.0]
+
+    assert Time.add(time, 1, :hour) == ~T[01:00:00.0]
+
+    assert_raise ArgumentError, ~r/Expected :hour, :minute, :second/, fn ->
+      assert Time.add(time, 1, 0)
+    end
+  end
 end


### PR DESCRIPTION
Before this fix the test fails because the code runs through `System.convert_time_unit/3` into `System.normalize_time_unit/1`.

```sh
  1) test add/2 (TimeTest)
     lib/elixir/test/elixir/calendar/time_test.exs:94
     Wrong message for ArgumentError
     expected:
       ~r/Expected :hour, :minute, :second/
     actual:
       "unsupported time unit. Expected :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got 0"
     code: assert_raise ArgumentError, ~r/Expected :hour, :minute, :second/, fn ->
     stacktrace:
       lib/elixir/test/elixir/calendar/time_test.exs:99: (test)
```