### PR TITLE
Add Logger.levels/0

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -446,6 +446,13 @@ defmodule Logger do
   @metadata :logger_level
 
   @doc ~S"""
+  Returns all the available levels.
+  """
+  @doc since: "1.16.0"
+  @spec levels() :: [level(), ...]
+  def levels(), do: @levels
+
+  @doc ~S"""
   Returns the default formatter used by Logger.
 
   It returns a `Logger.Formatter` built on the `:default_formatter` configuration:

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -16,6 +16,11 @@ defmodule LoggerTest do
     msg("module=LoggerTest #{text}")
   end
 
+  test "levels/0" do
+    assert [_ | _] = Logger.levels()
+    assert :info in Logger.levels()
+  end
+
   test "level/0" do
     assert Logger.level() == :debug
 


### PR DESCRIPTION
This PR adds `Logger.levels/0`, which returns all the available levels of Logger.

It's useful when checking the levels provided by a user.

---

Edit: Is it possible to backport it to 1.16? Or, we have to wait a few month to use it in a stable version. (1.16 is in the RC state, I'm not sure if merging new features is allowed.)