### PR TITLE
Properly escape `\` in Path.wildcard docs

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -762,9 +762,9 @@ defmodule Path do
   You may call `Path.expand/1` to normalize the path before invoking
   this function.
 
-  A character preceded by \ loses its special meaning.
-  Note that \ must be written as \\ in a string literal.
-  For example, "\\?*" will match any filename starting with ?.
+  A character preceded by `\\` loses its special meaning.
+  Note that `\\` must be written as `\\\\` in a string literal.
+  For example, `"\\\\?*"` will match any filename starting with `?.`.
 
   By default, the patterns `*` and `?` do not match files starting
   with a dot `.`. See the `:match_dot` option in the "Options" section


### PR DESCRIPTION
Currently the documentation renders incorrectly in https://hexdocs.pm/elixir/Path.html#wildcard/2
<img width="817" alt="Screenshot 2023-11-22 at 17 10 39" src="https://github.com/elixir-lang/elixir/assets/1078186/91747726-50e4-4c24-99a5-fe92ebf9c2ae">
