### PR TITLE
Improve protocol error message on atom when used instead of a struct

### DIFF
--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -121,6 +121,16 @@ defmodule ProtocolTest do
     end
   end
 
+  test "protocol not implemented for atom but for struct" do
+    message =
+      "protocol ProtocolTest.Sample not implemented for ProtocolTest.ImplStruct of type Atom (maybe you meant %ProtocolTest.ImplStruct{}, the struct)"
+
+    assert_raise Protocol.UndefinedError, message, fn ->
+      sample = Sample
+      sample.ok(ImplStruct)
+    end
+  end
+
   test "protocol documentation and deprecated" do
     import PathHelpers
 


### PR DESCRIPTION
A more specific error message when this common mistake happens:

```elixir
defprotocol Auditable do
  def to_log(_)
end

defmodule User do
  defstruct email: nil

  defimpl Auditable do
    def to_log(user), do: "User: #{user.email}"
  end
end
```

```elixir
Auditable.to_log(User)

# It often happens when the argument is a variable like this:

def do_something(schema) do
  Auditable.to_log(schema)
end
```

The error could be improved by pointing to the user that `User` is invalid but `%User{}` is expected instead.

The wording on `protocol ProtocolTest.Sample not implemented for ProtocolTest.ImplStruct of type Atom (maybe you meant %ProtocolTest.ImplStruct{}, the struct)` can be improved. I kept the original "Atom" but I don’t know if we should expose this detail in the error (that module are atom is unexpected for newcomers 😄 )