### PR TITLE
Add info that Regex.scan/3 is only matching non-overlapping matches and corresponding doctests

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -471,8 +471,7 @@ defmodule Regex do
   end
 
   @doc ~S"""
-  Same as `run/3`, but scans the target several times collecting all
-  non-overlapping matches of the regular expression.
+  Same as `run/3` but returns all non-overlapping matches of the regular expression.
 
   A list of lists is returned, where each entry in the primary list represents a
   match and each entry in the secondary list represents the captured contents.


### PR DESCRIPTION
During the first day of this year's Advent of Code I discovered that Regex.scan docs can be improved: they claim that the function is matching *all* matches, but in truth it only matches non-overlapping matches. Corrected the docs and added corresponding doctests. 

Not sure about the positioning for the doctests, thought it makes more sense to add them after the "non-matching" case, but looking forward to feedback :)