### PR TITLE
Enrich option parser docs for unknown switches

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -205,6 +205,15 @@ defmodule OptionParser do
   only useful when you are building command-line applications that receive
   dynamically-named arguments and must be avoided in long-running systems.
 
+  Remember that, as it's difficult to know which atoms exist, the results of
+  parsing may be surprising. Compare the following two examples:
+
+      iex>  OptionParser.parse(["--name", "Foo"], switches: [])
+      {[name: "Foo"], [], []}
+
+      iex>  OptionParser.parse(["--surname", "Bar"], switches: [])
+      {[], [], []}
+
   ## Aliases
 
   A set of aliases can be specified in the `:aliases` option:

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -176,8 +176,9 @@ defmodule OptionParser do
       {[debug: true, ok: true], [], []}
 
   If you do want to parse unknown switches, remember that Elixir converts switches
-  to atoms. Since atoms are not garbage-collected, OptionParser will only parse
-  switches that translate to atoms used by the runtime to avoid leaking atoms.
+  to atoms. By default, since atoms are not garbage-collected, to avoid creating
+  new ones, OptionParser will only parse switches that translate to atoms already
+  used by the runtime.
   The code below discards the `--option-parser-example` switch
   because the `:option_parser_example` atom is never used anywhere:
 

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -152,21 +152,28 @@ defmodule OptionParser do
   ### Parsing unknown switches
 
   When the `:switches` option is given, `OptionParser` will attempt to parse
-  unknown switches:
+  unknown switches.
+
+  Switches without an argument will be set to `true`:
 
       iex> OptionParser.parse(["--debug"], switches: [key: :string])
       {[debug: true], [], []}
 
   Even though we haven't specified `--debug` in the list of switches, it is part
-  of the returned options. This would also work:
+  of the returned options.
+
+  Switches followed by a value will be assigned the value, as a string:
 
       iex> OptionParser.parse(["--debug", "value"], switches: [key: :string])
       {[debug: "value"], [], []}
 
-  Switches followed by a value will be assigned the value, as a string. Switches
-  without an argument will be set automatically to `true`. Since we cannot assert
-  the type of the switch value, it is preferred to use the `:strict` option that
-  accepts only known switches and always verify their types.
+  Since we cannot assert the type of the switch value, it is preferred to use the
+  `:strict` option that accepts only known switches and always verify their types.
+
+  Switches followed by another switch will be set to true:
+
+      iex> OptionParser.parse(["--debug", "--ok"], switches: [])
+      {[debug: true, ok: true], [], []}
 
   If you do want to parse unknown switches, remember that Elixir converts switches
   to atoms. Since atoms are not garbage-collected, OptionParser will only parse

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -185,14 +185,20 @@ defmodule OptionParser do
       iex> OptionParser.parse(["--option-parser-example"], switches: [])
       {[], [], []}
 
-  However, the code below would work as long as `:option_parser_example` atom is
-  used at some point later (or earlier) **in the same module**. For example:
+  However, if a switch corresponds to an existing Elixir atom, whether from your
+  code, a dependency or from Elixir itself, it will be accepted:
 
-      {opts, _, _} = OptionParser.parse(["--option-parser-example"], switches: [debug: :boolean])
-      # ... then somewhere in the same module you access it ...
-      opts[:option_parser_example]
+      iex> OptionParser.parse(["--shutdown"], switches: [])
+      ...> |> get_in([Access.elem(0), Access.at(0), Access.elem(0)]) |> to_string()
+      "shutdown"
 
-  In other words, Elixir will only parse options that are used by the runtime,
+  Note, the example above is contrived in such away as to **not** make explicit
+  use of the `:shutdown` atom, which would defeat the purpose!
+  The `parse/2` output is:
+
+      [{shutdown: true}, {}, {}]
+
+  So, Elixir will only parse options that are used by the runtime,
   ignoring all others. If you would like to parse all switches, regardless if
   they exist or not, you can force creation of atoms by passing
   `allow_nonexistent_atoms: true` as option. Use this option with care. It is

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -171,11 +171,11 @@ defmodule OptionParser do
   If you do want to parse unknown switches, remember that Elixir converts switches
   to atoms. Since atoms are not garbage-collected, OptionParser will only parse
   switches that translate to atoms used by the runtime to avoid leaking atoms.
-  For instance, the code below will discard the `--option-parser-example` switch
+  The code below discards the `--option-parser-example` switch
   because the `:option_parser_example` atom is never used anywhere:
 
-      OptionParser.parse(["--option-parser-example"], switches: [debug: :boolean])
-      # The :option_parser_example atom is not used anywhere below
+      iex> OptionParser.parse(["--option-parser-example"], switches: [])
+      {[], [], []}
 
   However, the code below would work as long as `:option_parser_example` atom is
   used at some point later (or earlier) **in the same module**. For example:


### PR DESCRIPTION
When handling unknown switches, results of `OptionParser.parse/2` depend on whether the supplied switches already exist as atoms.

This PR adds examples to aid developer expectations about this fact.

N.B. The PR is split into 5 commits to aid readability, but can be squashed before merging.