### PR TITLE
Update Windows installer to write Elixir install root to registry

### DIFF
--- a/lib/elixir/scripts/windows_installer/installer.nsi
+++ b/lib/elixir/scripts/windows_installer/installer.nsi
@@ -202,6 +202,8 @@ Section "Install Elixir" SectionElixir
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Elixir" "NoModify" 1
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Elixir" "NoRepair" 1
 
+  WriteRegStr   HKLM "Software\Elixir\Elixir" "InstallRoot" "$INSTDIR"
+
   WriteUninstaller "Uninstall.exe"
 SectionEnd
 
@@ -280,6 +282,8 @@ UninstPage custom un.FinishPageShow un.FinishPageLeave
 Section "Uninstall"
   RMDir /r "$INSTDIR"
   DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Elixir"
+  DeleteRegKey HKLM "Software\Elixir\Elixir"
+  DeleteRegKey /ifempty HKLM "Software\Elixir"
 SectionEnd
 
 !insertmacro MUI_LANGUAGE "English"


### PR DESCRIPTION
We don't need this right now but it could be useful in the future, if anything to detect if Elixir was installed using this installer.

Demo:

    iex> {:ok, r} = :win32reg.open([:read])
    iex> :win32reg.change_key(r, ~c"\\hklm\\software\\wow6432node\\elixir\\elixir")
    iex> :win32reg.value(r, ~c"installroot")
    {:ok, ~c"C:\\Program Files\\Elixir"}
