### PR TITLE
Add `Tuple.ok/1` and `Tuple.error/1` to the standard library

### DIFF
--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -184,4 +184,28 @@ defmodule Tuple do
   def to_list(tuple) do
     :erlang.tuple_to_list(tuple)
   end
+
+  @doc """
+  Wraps a term in a tuple tagged with `:ok`.
+
+  ## Examples
+
+      iex> Tuple.ok(:foo)
+      {:ok, :foo}
+
+  """
+  @spec ok(term) :: {:ok, term}
+  def ok(term), do: {:ok, term}
+
+  @doc """
+  Wraps a term in a tuple tagged with `:error`.
+
+  ## Examples
+
+      iex> Tuple.error(:foo)
+      {:error, :foo}
+
+  """
+  @spec error(term) :: {:error, term}
+  def error(term), do: {:error, term}
 end

--- a/lib/elixir/test/elixir/tuple_test.exs
+++ b/lib/elixir/test/elixir/tuple_test.exs
@@ -62,4 +62,18 @@ defmodule TupleTest do
     mod = Tuple
     assert mod.delete_at({:foo, :bar, :baz}, 0) == {:bar, :baz}
   end
+
+  test "ok/1" do
+    assert Tuple.ok(:foo) == {:ok, :foo}
+
+    mod = Tuple
+    assert mod.ok(:foo) == {:ok, :foo}
+  end
+
+  test "error/1" do
+    assert Tuple.error(:foo) == {:error, :foo}
+
+    mod = Tuple
+    assert mod.error(:foo) == {:error, :foo}
+  end
 end


### PR DESCRIPTION
`Tuple.ok/1` and `Tuple.error/1` allow the creation of more readable code when piping a term and desiring one of the two conventionally used tagged tuples as the output. For example:

Before:

```elixir
entity = fetch_entity(entity_id)
if entity do
  transform_entity(entity)
  |> add_to_entity(entity)
  |> then(&{:ok, &1})
else
  {:error, :not_found}
end
```

After:

```elixir
entity = fetch_entity(entity_id)
if entity do
  transform_entity(entity)
  |> add_to_entity(entity)
  |> Tuple.ok
else
  {:error, :not_found}
end
```

This embodies the convention of using `{:ok, term}` and `{:error, term}` as part of Elixir's standard library.
