### PR TITLE
Mention dangers around `Task` and sending a lot of data along

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -17,27 +17,6 @@ defmodule Task do
   They are implemented by spawning a process that sends a message
   to the caller once the given computation is performed.
 
-  Be wary though that tasks are still processes and so data
-  will need to be completely copied to them which will result
-  in more memory usage and depending on the data and work,
-  even longer run times.
-  For example if your code was:
-
-      large_data = fetch_large_data()
-      task = Task.async(fn -> do_some_work(large_data) end)
-      res = do_some_other_work()
-      res + Task.await(task)
-
-  Then we'd need to copy over all of `large_data` which can be
-  very resource intensive. So, if possible try to avoid using
-  huge pieces of data in tasks. Instead, if possible, you
-  could fetch them inside the task itself:
-
-      task = Task.async(fn ->
-        large_data = fetch_large_data()
-        do_some_work(large_data)
-      end)
-
   Compared to plain processes, started with `spawn/1`, tasks
   include monitoring metadata and logging in case of errors.
 
@@ -65,10 +44,38 @@ defmodule Task do
        means that, if the caller crashes, the task will crash
        too and vice-versa. This is on purpose: if the process
        meant to receive the result no longer exists, there is
-       no purpose in completing the computation.
+       no purpose in completing the computation. If this is not
+       desired, you will want to use supervised tasks, described
+       in a subsequent section.
 
-       If this is not desired, you will want to use supervised
-       tasks, described next.
+  ## Tasks are processes
+
+  Tasks are processes and so data will need to be completely copied
+  to them. Take the following code as an example:
+
+      large_data = fetch_large_data()
+      task = Task.async(fn -> do_some_work(large_data) end)
+      res = do_some_other_work()
+      res + Task.await(task)
+
+  The code above copies over all of `large_data`, which can be
+  resource intensive depending on the size of the data.
+  There are two ways to address this.
+
+  First, if you need to access only part of `large_data`,
+  consider extracting it before the task:
+
+      large_data = fetch_large_data()
+      subset_data = large_data.some_field
+      task = Task.async(fn -> do_some_work(subset_data) end)
+
+  Alternatively, if you can move the data loading altogether
+  to the task, it may be even better:
+
+      task = Task.async(fn ->
+        large_data = fetch_large_data()
+        do_some_work(large_data)
+      end)
 
   ## Dynamically supervised tasks
 

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -17,6 +17,27 @@ defmodule Task do
   They are implemented by spawning a process that sends a message
   to the caller once the given computation is performed.
 
+  Be wary though that tasks are still processes and so data
+  will need to be completely copied to them which will result
+  in more memory usage and depending on the data and work,
+  even longer run times.
+  For example if your code was:
+
+      large_data = fetch_large_data()
+      task = Task.async(fn -> do_some_work(large_data) end)
+      res = do_some_other_work()
+      res + Task.await(task)
+
+  Then we'd need to copy over all of `large_data` which can be
+  very resource intensive. So, if possible try to avoid using
+  huge pieces of data in tasks. Instead, if possible, you
+  could fetch them inside the task itself:
+
+      task = Task.async(fn ->
+        large_data = fetch_large_data()
+        do_some_work(large_data)
+      end)
+
   Compared to plain processes, started with `spawn/1`, tasks
   include monitoring metadata and logging in case of errors.
 


### PR DESCRIPTION
First, as always, thanks to y'all for elixir and all your great work on it :green_heart: I'm truly happy to be a part of this community where discussion & contributions are always welcome, where we (well, more y'all) push the boundaries of what was previously thought possible and somehow it all happens without breaking things all the time :rocket: 

The `Task` module is one of the coolest modules in elixir and is probably the first contact and experience of a lot of beginners with parallelism in elixir. I hence find it worthwhile to warn about the memory copying and its impacts here as it might easily lead to unwelcome results, so it's worth pointing out.

This is only a first draft, not sure if this is the best place to put it - feedback very welcome.

Honestly `Task.async`/`Task.await` may be too magical/too much of a nice high level magical abstraction. I'm somewhat ashamed to admit that while I knew that sending a message would copy the data I never made the connection to `Task.async` myself and I had an "oh shit" moment just yesterday :sweat-smile: Which, totally should have occurred to me before as I knew they were processes and wouldn't magically change the rules on how processes work. I also asked some elixir friends and saw similiar reactions in some of them.

I think it's also fair to assume that the BEAM wouldn't need to copy immutable data (cos it's immutable anyhow), I know why it does but it's not obvious. We might want to/need to work on making it more obvious in other parts of the documentation as well but I thought this was the best starting point.

-------------------------------------------

To show my own pile of shame where I'm coming from with this: Benchee works mostly on a big `Suite` struct that over the different stages acummulates more data. It's fine, works well with piping. However, it also holds the benchmarking function and the inputs used. Which means if you benchmark with a ton of data and Benchee goes off to calculate the statistics in parallel or run the formatters in parallel memory consumption explodes and it also takes _forever_. That all was a big :man_facepalming: moment that I'm honestly a bit ashamed about :sweat_smile: I want to help others to avoid making the same mistake (will also probably blog soon).

Fixes in benchee should be easy - be more selective about the data to put into tasks/not just pass the whole Suite along (so no need to reach for ETS/persistent terms). Fix version hopefully dropping this week :)

Just, as background :see_no_evil: :see_no_evil: :see_no_evil: 

Again, happy to have feedback and ideas about other/better places to put this or also word it better et. al.

Go have a bunny picture.

Thanks! :green_heart: 

![IMG20230429191639](https://github.com/elixir-lang/elixir/assets/606517/99c0e5ee-5573-4d65-950d-e124f50d8fd7)


