### PR TITLE
Test against OTP 26.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - otp_version: "26.0"
+          - otp_version: "26.1"
             otp_latest: true
+          - otp_version: "26.0"
           - otp_version: "25.3"
           - otp_version: "25.0"
           - otp_version: master


### PR DESCRIPTION
Thanks for elixir :green_heart: 

I kept OTP 26.0 around because the testing strategy seemed to be test against lowest and highest minor version (or so I interpreted the OTP 25.0 and 25.3)