### PR TITLE
Mention the fixed regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Finally, we have started enriching our documentation with [Mermaid.js](https://m
   * [Macro] Address exception on `Macro.to_string/1` for certain ASTs
   * [Module] Make sure file and position information is included in several module warnings (regression)
   * [Path] Lazily evaluate `File.cwd!/0` in `Path.expand/1` and `Path.absname/1`
+  * [Compiler] Re-enabled compiler optimzations for top level functions in scripts, which has been a regression since 1.14.0 but shouldn't impact most programs
 
 #### IEx
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,10 +93,10 @@ Finally, we have started enriching our documentation with [Mermaid.js](https://m
 #### Elixir
 
   * [Code] Keep quotes for atom keys in formatter
+  * [Kernel] Re-enabled compiler optimzations for top level functions in scripts (enabled in v1.14.0 but shouldn't impact most programs)
   * [Macro] Address exception on `Macro.to_string/1` for certain ASTs
   * [Module] Make sure file and position information is included in several module warnings (regression)
   * [Path] Lazily evaluate `File.cwd!/0` in `Path.expand/1` and `Path.absname/1`
-  * [Compiler] Re-enabled compiler optimzations for top level functions in scripts, which has been a regression since 1.14.0 but shouldn't impact most programs
 
 #### IEx
 


### PR DESCRIPTION
:wave: Me again, but as always thanks for all your fantastic work! :green_heart: 

Kudos go to @sabiwara, full log/discussion at: https://github.com/bencheeorg/benchee/issues/406

As best as I learned this was introduced in #11420 and fixed in aabe465
It shouldn't affect almost anyone except for scripting usage of elixir and (probably most notably) benchee benchmarks that don't call functions in a module.

I think this warrants a Changelog entry. Not sure if [Compiler] is right and my entry is probably way too wordy - happy to adjust it.

I'll also write up a notice at benchee and potentially a blog post so that people can know to potentially redo benchmarks they ran on 1.14-1.15 by either wrapping the functions or the `Benchee.run` invocation in modules or running on an unaffected Elixir version.