### PR TITLE
Fix top level functions changelog (enabled --> disabled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ Finally, we have started enriching our documentation with [Mermaid.js](https://m
 #### Elixir
 
   * [Code] Keep quotes for atom keys in formatter
-  * [Kernel] Re-enabled compiler optimzations for top level functions in scripts (enabled in v1.14.0 but shouldn't impact most programs)
+  * [Kernel] Re-enabled compiler optimzations for top level functions in scripts (disabled in v1.14.0 but shouldn't impact most programs)
   * [Macro] Address exception on `Macro.to_string/1` for certain ASTs
   * [Module] Make sure file and position information is included in several module warnings (regression)
   * [Path] Lazily evaluate `File.cwd!/0` in `Path.expand/1` and `Path.absname/1`


### PR DESCRIPTION
Log said enabled twice, best to my understanding it was disabled in 1.14 and re-enabled now... right? :eyes:

Relation to/follow up to: https://github.com/elixir-lang/elixir/pull/13176