### PR TITLE
Improve diagnostics for unclosed heredocs

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -795,6 +795,15 @@ defmodule Exception do
   end
 
   @doc false
+  def format_expected_delimiter(opening_delimiter) do
+    terminator = :elixir_tokenizer.terminator(opening_delimiter)
+
+    if terminator |> Atom.to_string() |> String.contains?("\""),
+      do: terminator,
+      else: ~s("#{terminator}")
+  end
+
+  @doc false
   def format_snippet(
         {start_line, _start_column} = start_pos,
         {end_line, end_column} = end_pos,
@@ -1145,10 +1154,10 @@ defmodule MismatchedDelimiterError do
     start_pos = {start_line, start_column}
     end_pos = {end_line, end_column}
     lines = String.split(snippet, "\n")
-    expected_delimiter = :elixir_tokenizer.terminator(opening_delimiter)
+    expected_delimiter = Exception.format_expected_delimiter(opening_delimiter)
 
     start_message = "└ unclosed delimiter"
-    end_message = ~s/└ mismatched closing delimiter (expected "#{expected_delimiter}")/
+    end_message = ~s/└ mismatched closing delimiter (expected #{expected_delimiter})/
 
     snippet =
       Exception.format_snippet(
@@ -1268,10 +1277,10 @@ defmodule TokenMissingError do
 
     start_pos = {line, column}
     end_pos = {end_line, end_column}
-    expected_delimiter = :elixir_tokenizer.terminator(opening_delimiter)
+    expected_delimiter = Exception.format_expected_delimiter(opening_delimiter)
 
     start_message = ~s/└ unclosed delimiter/
-    end_message = ~s/└ missing closing delimiter (expected "#{expected_delimiter}")/
+    end_message = ~s/└ missing closing delimiter (expected #{expected_delimiter})/
 
     snippet =
       Exception.format_snippet(

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -798,7 +798,7 @@ defmodule Exception do
   def format_expected_delimiter(opening_delimiter) do
     terminator = :elixir_tokenizer.terminator(opening_delimiter)
 
-    if terminator |> Atom.to_string() |> String.contains?("\""),
+    if terminator |> Atom.to_string() |> String.contains?(["\"", "'"]),
       do: terminator,
       else: ~s("#{terminator}")
   end

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1036,7 +1036,7 @@ extract_heredoc_with_interpolation(Line, Column, Scope, Interpol, T, H) ->
           {line, EndLine} = lists:keyfind(line, 1, Position),
            Meta = [
              {error_type, unclosed_delimiter},
-             {opening_delimiter, '\"\"\"'},
+             {opening_delimiter, '"""'},
              {line, Line},
              {column, Column},
              {end_line, EndLine}

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1032,7 +1032,16 @@ extract_heredoc_with_interpolation(Line, Column, Scope, Interpol, T, H) ->
           {ok, NewLine, NewColumn, tokens_to_binary(Parts2), Rest, NewScope};
 
         {error, Reason} ->
-          {error, interpolation_format(Reason, " (for heredoc starting at line ~B)", [Line])}
+          {Position, Message, List} = interpolation_format(Reason, " (for heredoc starting at line ~B)", [Line]),
+          {line, EndLine} = lists:keyfind(line, 1, Position),
+           Meta = [
+             {error_type, unclosed_delimiter},
+             {opening_delimiter, '\"\"\"'},
+             {line, Line},
+             {column, Column},
+             {end_line, EndLine}
+          ],
+          {error, {Meta, Message, List}}
       end;
 
     error ->
@@ -1483,6 +1492,7 @@ terminator('do') -> 'end';
 terminator('(')  -> ')';
 terminator('[')  -> ']';
 terminator('{')  -> '}';
+terminator('"""') -> '"""';
 terminator('<<') -> '>>'.
 
 %% Keywords checking

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -382,7 +382,7 @@ defmodule Kernel.DiagnosticsTest do
                2 │ test string
                3 │ 
                4 │ IO.inspect(10 + 20)
-                 │                    └ missing closing delimiter (expected \""""")
+                 │                    └ missing closing delimiter (expected \""")
                  │
                  └─ nofile:4:20\
              """

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -361,6 +361,33 @@ defmodule Kernel.DiagnosticsTest do
              """
     end
 
+    test "missing heredoc terminator" do
+      output =
+        capture_raise(
+          """
+          a = \"""
+          test string
+
+          IO.inspect(10 + 20)
+          """,
+          TokenMissingError
+        )
+
+      assert output == """
+             ** (TokenMissingError) token missing on nofile:4:20:
+                 error: missing terminator: \""" (for heredoc starting at line 1)
+                 │
+               1 │ a = \"""
+                 │     └ unclosed delimiter
+               2 │ test string
+               3 │ 
+               4 │ IO.inspect(10 + 20)
+                 │                    └ missing closing delimiter (expected \""""")
+                 │
+                 └─ nofile:4:20\
+             """
+    end
+
     test "shows in between lines if EOL is not far below" do
       output =
         capture_raise(

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -528,7 +528,7 @@ defmodule Kernel.ParserTest do
     test "heredoc with incomplete interpolation" do
       assert_token_missing(
         [
-          "nofile:2:1:",
+          "nofile:1:4:",
           ~s/missing interpolation terminator: "}" (for heredoc starting at line 1)/
         ],
         ~c"\"\"\"\n\#{\n"


### PR DESCRIPTION
![image](https://github.com/elixir-lang/elixir/assets/59743220/60fec3d6-b1e1-45b7-b143-3066ba5e55a4)

'expected """"" ' looks a bit odd, but I'm open to ideas on how we handle it (if needed)
perhaps using single quotes or only 'expected """ ' like at the top