### PR TITLE
Pull requests need approval of one committer?

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ case you are looking for some examples:
 Once a pull request is sent, the Elixir team will review your changes.
 We outline our process below to clarify the roles of everyone involved.
 
-All pull requests must be approved by two committers before being merged into
+All pull requests must be approved by at least one committer before being merged into
 the repository. If any changes are necessary, the team will leave appropriate
 comments requesting changes to the code. Unfortunately, we cannot guarantee a
 pull request will be merged, even when modifications are requested, as the Elixir


### PR DESCRIPTION
Browsing through the contributing docs earlier I noticed it mentioned needing approval from 2 committers. However, recent changes I've seen were fine to go from 1 committer so I assume the guidelines is outdated and updated it.

Of course, if that's only temporary or has some more nuance happy for this to be closed :grin: