### PR TITLE
Fix typo in docs: `Keywoird` -> `Keyword`

### DIFF
--- a/lib/elixir/pages/anti-patterns/process-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/process-anti-patterns.md
@@ -263,7 +263,7 @@ defmodule Counter do
   @doc "Starts a counter process."
   def start_link(opts \\ []) do
     initial_valye = Keyword.get(opts, :initial_value, 0)
-    name = Keywoird.get(opts, :name, __MODULE__)
+    name = Keyword.get(opts, :name, __MODULE__)
     GenServer.start(__MODULE__, initial_value, name: name)
   end
 


### PR DESCRIPTION
While going through the new anti-patterns docs I found this small typo