### PR TITLE
Fix typo in charlists documentation

### DIFF
--- a/lib/elixir/pages/getting-started/binaries-strings-and-charlists.md
+++ b/lib/elixir/pages/getting-started/binaries-strings-and-charlists.md
@@ -257,7 +257,7 @@ iex> heartbeats_per_minute = [99, 97, 116]
 ~c"cat"
 ```
 
-You can always for charlists to be printed in their list representation by calling the `inspect/2` function:
+You can always force charlists to be printed in their list representation by calling the `inspect/2` function:
 
 ```elixir
 iex> inspect(heartbeats_per_minute, charlists: :as_list)


### PR DESCRIPTION
I was reading the docs, and I found something odd. By checking this [commit](https://github.com/elixir-lang/elixir/pull/12850/commits/3c3e3d3f12dd2a5763520738578dd8145345f9b0), I believe the author wanted to say _force_ istead of _for_.
