### PR TITLE
Code anti patterns typo fix

### DIFF
--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -370,7 +370,7 @@ iex> Graphics.plot(point_2d)
 {2, 3, nil}
 iex> Graphics.plot(bad_point)
 ** (KeyError) key :x not found in: %{y: 3, z: 4} # <= explicitly warns that
-  graphic.ex:4: Graphics.plot/1                  # <= the :z key does not exist!
+  graphic.ex:4: Graphics.plot/1                  # <= the :x key does not exist!
 ```
 
 Overall, the usage of `map.key` and `map[:key]` encode important information about your data structure, allowing developers to be clear about their intent. See both `Map` and `Access` module documentation for more information and examples.


### PR DESCRIPTION
I noticed a typo in an explanatory comment in one of the refactoring examples in the Code Anti-Patterns doc. This fixes that.