### PR TITLE
pattern matching syntax fix

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -831,7 +831,7 @@ defmodule Calendar do
          "s" <> rest,
          _width,
          _pad,
-         datetime = %{utc_offset: _utc_offset, std_offset: _std_offset},
+         %{utc_offset: _utc_offset, std_offset: _std_offset} = datetime,
          format_options,
          acc
        ) do
@@ -859,7 +859,7 @@ defmodule Calendar do
          "z" <> rest,
          width,
          pad,
-         datetime = %{utc_offset: utc_offset, std_offset: std_offset},
+         %{utc_offset: utc_offset, std_offset: std_offset} = datetime,
          format_options,
          acc
        ) do

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -2412,7 +2412,7 @@ defmodule Code.Formatter do
     {left, right}
   end
 
-  defp get_charlist_quotes(_heredoc = false, state) do
+  defp get_charlist_quotes(false = _heredoc, state) do
     if state.normalize_charlists_as_sigils do
       {@sigil_c, @double_quote}
     else
@@ -2420,7 +2420,7 @@ defmodule Code.Formatter do
     end
   end
 
-  defp get_charlist_quotes(_heredoc = true, state) do
+  defp get_charlist_quotes(true = _heredoc, state) do
     if state.normalize_charlists_as_sigils do
       {@sigil_c_heredoc, @double_heredoc}
     else

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1837,10 +1837,10 @@ defmodule Enum do
   end
 
   @doc false
-  def max(list = [_ | _]), do: :lists.max(list)
+  def max([_ | _] = list), do: :lists.max(list)
 
   @doc false
-  def max(list = [_ | _], empty_fallback) when is_function(empty_fallback, 0) do
+  def max([_ | _] = list, empty_fallback) when is_function(empty_fallback, 0) do
     :lists.max(list)
   end
 
@@ -2017,10 +2017,10 @@ defmodule Enum do
   end
 
   @doc false
-  def min(list = [_ | _]), do: :lists.min(list)
+  def min([_ | _] = list), do: :lists.min(list)
 
   @doc false
-  def min(list = [_ | _], empty_fallback) when is_function(empty_fallback, 0) do
+  def min([_ | _] = list, empty_fallback) when is_function(empty_fallback, 0) do
     :lists.min(list)
   end
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -362,7 +362,7 @@ defmodule Exception do
     _ -> false
   end
 
-  defp evaluate_guard(kernel_op, meta, guards = [_, _]) do
+  defp evaluate_guard(kernel_op, meta, [_, _] = guards) do
     [x, y] = Enum.map(guards, &evaluate_guard/1)
 
     logic_value =
@@ -2016,7 +2016,7 @@ defmodule KeyError do
   defexception [:key, :term, :message]
 
   @impl true
-  def message(exception = %{message: nil}), do: message(exception.key, exception.term)
+  def message(%{message: nil} = exception), do: message(exception.key, exception.term)
   def message(%{message: message}), do: message
 
   defp message(key, term) do

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1931,5 +1931,5 @@ defmodule File do
   defp normalize_path_or_io_device(path) when is_list(path), do: IO.chardata_to_string(path)
   defp normalize_path_or_io_device(path) when is_binary(path), do: path
   defp normalize_path_or_io_device(io_device) when is_pid(io_device), do: io_device
-  defp normalize_path_or_io_device(io_device = {:file_descriptor, _, _}), do: io_device
+  defp normalize_path_or_io_device({:file_descriptor, _, _} = io_device), do: io_device
 end

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -188,7 +188,7 @@ defmodule IO.ANSI.Docs do
     process(drop_comment([line | rest]), text, indent, options)
   end
 
-  defp process(all = [line | rest], text, indent, options) do
+  defp process([line | rest] = all, text, indent, options) do
     {stripped, count} = strip_spaces(line, 0, :infinity)
 
     cond do

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -252,8 +252,8 @@ defmodule Regex do
     end
   end
 
-  defp format_doc_opts(_doc_opts = "", _opts = []), do: ""
-  defp format_doc_opts(_doc_opts = "", opts), do: opts
+  defp format_doc_opts("" = _doc_opts, [] = _opts), do: ""
+  defp format_doc_opts("" = _doc_opts, opts), do: opts
   defp format_doc_opts(doc_opts, _opts), do: doc_opts
 
   @doc """

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -461,7 +461,7 @@ defmodule URI do
     unpercent(string, "", true)
   end
 
-  defp unpercent(<<?+, tail::binary>>, acc, spaces = true) do
+  defp unpercent(<<?+, tail::binary>>, acc, true = spaces) do
     unpercent(tail, <<acc::binary, ?\s>>, spaces)
   end
 


### PR DESCRIPTION
This pull request addresses an issue with reverse pattern matching found in several files. 


Testing:
I ran `make test` and everything passed that passed before. One test failed and 13 excluded
```

 1) test blaming annotates undefined function error with module suggestions (ExceptionTest)
     test/elixir/exception_test.exs:589
     ** (ExUnit.TimeoutError) test timed out after 60000ms. You can change the timeout:

       1. per test by setting "@tag timeout: x" (accepts :infinity)
       2. per test module by setting "@moduletag timeout: x" (accepts :infinity)
       3. globally via "ExUnit.start(timeout: x)" configuration
       4. by running "mix test --timeout x" which sets timeout
       5. or by running "mix test --trace" which sets timeout to infinity
          (useful when using IEx.pry/0)

     where "x" is the timeout given as integer in milliseconds (defaults to 60_000).
     
     code: assert blame_message(ENUM, & &1.not_a_function(&1, 1)) ==
     stacktrace:
       (kernel 9.2) code_server.erl:150: :code_server.call/1
       (kernel 9.2) code.erl:190: :code.ensure_loaded/1
       (kernel 9.2) error_handler.erl:40: :error_handler.undefined_function/3
       test/elixir/exception_test.exs:804: ExceptionTest.blame_message/2
       test/elixir/exception_test.exs:615: (test)
       (ex_unit 1.17.0-dev) lib/ex_unit/runner.ex:472: ExUnit.Runner.exec_test/2
       (stdlib 5.2) timer.erl:270: :timer.tc/2
       (ex_unit 1.17.0-dev) lib/ex_unit/runner.ex:394: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4

```