### PR TITLE
Suggestion: to_quoted(term()) -> term()

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -90,6 +90,10 @@ defmodule Module.Types.Descr do
   @doc """
   Converts a descr to its quoted representation.
   """
+  def to_quoted(descr) when descr == %{bitmap: @top} do
+    {:term, [], []}
+  end
+
   def to_quoted(%{} = descr) do
     case Enum.flat_map(descr, fn {key, value} -> to_quoted(key, value) end) do
       [] -> {:none, [], []}

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -70,5 +70,9 @@ defmodule Module.Types.DescrTest do
     test "none" do
       assert none() |> to_quoted_string() == "none()"
     end
+
+    test "term" do
+      assert term() |> to_quoted_string() == "term()"
+    end
   end
 end


### PR DESCRIPTION
Hi!

Just a small suggestion on https://github.com/elixir-lang/elixir/pull/13230, feel free to close if not compatible with what you have in mind.

This would display `term()` as just

```elixir
term()
```

instead of

```elixir
atom() or binary() or empty_list() or float() or fun() or integer() or map() or non_empty_list() or pid() or port() or reference() or tuple()
```