### PR TITLE
Fix Code.Normalizer for keyword operand with :do key

### DIFF
--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -353,6 +353,10 @@ defmodule Code.Normalizer do
     last = List.last(args)
 
     cond do
+      not allow_keyword?(form, arity) ->
+        args = normalize_args(args, %{state | parent_meta: meta})
+        {form, meta, args}
+
       Keyword.has_key?(meta, :do) or match?([{{:__block__, _, [:do]}, _} | _], last) ->
         # def foo do :ok end
         # def foo, do: :ok
@@ -364,7 +368,7 @@ defmodule Code.Normalizer do
         meta = meta ++ [do: [line: line], end: [line: line]]
         normalize_kw_blocks(form, meta, args, state)
 
-      allow_keyword?(form, arity) ->
+      true ->
         args = normalize_args(args, %{state | parent_meta: meta})
         {last_arg, leading_args} = List.pop_at(args, -1, [])
 
@@ -385,10 +389,6 @@ defmodule Code.Normalizer do
           end
 
         {form, meta, leading_args ++ last_args}
-
-      true ->
-        args = normalize_args(args, %{state | parent_meta: meta})
-        {form, meta, args}
     end
   end
 

--- a/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
@@ -539,6 +539,10 @@ defmodule Code.Normalizer.QuotedASTTest do
                "\e[34m[\e[0m\e[32ma:\e[0m \e[33m1\e[0m, \e[32mb:\e[0m \e[33m2\e[0m\e[34m]\e[0m"
     end
 
+    test "keyword list with :do as operand" do
+      assert quoted_to_string(quote(do: a = [do: 1])) == "a = [do: 1]"
+    end
+
     test "interpolation" do
       assert quoted_to_string(quote(do: "foo#{bar}baz")) == ~S["foo#{bar}baz"]
     end


### PR DESCRIPTION
Closes https://github.com/elixir-lang/elixir/issues/13248

I'm not 100% confident with the fix, it might have unwanted side effects in cases I didn't consider.
The idea is to prevent entering the special cases for `:do` keys if we're inside an operand, so I moved the `allow_keyword?` check up.