### PR TITLE
docs: minor wording and typo fixes

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -258,8 +258,8 @@ defmodule Application do
       Application.stop(:ex_unit)
       #=> :ok
 
-  Stopping an application without a callback module is defined, but except for
-  some system tracing, it is in practice a no-op.
+  Stopping an application without a callback module defined, is in practice a
+  no-op, except for some system tracing.
 
   Stopping an application with a callback module has three steps:
 
@@ -277,7 +277,7 @@ defmodule Application do
   invoked only after termination of the whole supervision tree.
 
   Shutting down a live system cleanly can be done by calling `System.stop/1`. It
-  will shut down every application in the opposite order they had been started.
+  will shut down every application in the reverse order they were started.
 
   By default, a SIGTERM from the operating system will automatically translate to
   `System.stop/0`. You can also have more explicit control over operating system

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -760,7 +760,7 @@ defmodule Mix do
   it executes the code. This means that, by the time Elixir tries to expand
   the `%Decimal{}` struct, the dependency has not been installed yet.
 
-  Luckily this has a straightforward solution, which is move the code to
+  Luckily this has a straightforward solution, which is to move the code
   inside a module:
 
       Mix.install([:decimal])

--- a/lib/mix/lib/mix/state.ex
+++ b/lib/mix/lib/mix/state.ex
@@ -22,7 +22,7 @@ defmodule Mix.State do
     GenServer.call(@name, :builtin_apps, @timeout)
   end
 
-  ## ETS state storage (mutable, not cleared ion tests)
+  ## ETS state storage (mutable, not cleared in tests)
 
   def fetch(key) do
     case :ets.lookup(@name, key) do

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.Run do
       $ mix run -e "DbUtils.delete_old_records()" -- arg1 arg2 arg3
 
   In both cases, the command-line arguments for the script or expression
-  are available in `System.argv/0`. This mirror the command line interface
+  are available in `System.argv/0`. This mirrors the command line interface
   in the `elixir` executable.
 
   For starting long running systems, one typically passes the `--no-halt`


### PR DESCRIPTION
Spotted while reading code and docs.