### PR TITLE
Document the behavior of async_stream_nolink

### DIFF
--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -429,11 +429,11 @@ defmodule Task.Supervisor do
       end)
 
   If one task raises or times out:
-  
-    1. the second clause gets called,
-    2. an exception is raised,
-    3. the stream halts,
-    4. and all ongoing tasks will be shut down
+
+    1. the second clause gets called
+    2. an exception is raised
+    3. the stream halts
+    4. all ongoing tasks will be shut down
 
   Here is another example:
 

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -428,8 +428,12 @@ defmodule Task.Supervisor do
         {:exit, reason} -> raise "Task exited: #{Exception.format_exit(reason)}"
       end)
 
-  If one task raises or times out, the second clause gets called, an exception is raised,
-  the stream halts and all ongoing tasks will be shut down.
+  If one task raises or times out:
+  
+    1. the second clause gets called,
+    2. an exception is raised,
+    3. the stream halts,
+    4. and all ongoing tasks will be shut down
 
   Here is another example:
 
@@ -437,7 +441,7 @@ defmodule Task.Supervisor do
       |> Stream.filter(&match?({:ok, _}, &1))
       |> Enum.take(3)
 
-  This will return the 3 first tasks to succeed, ignoring timeouts and errors, and shutdown
+  This will return the three first tasks to succeed, ignoring timeouts and errors, and shut down
   every ongoing task.
 
   Just running the stream with `Stream.run/1` on the other hand would ignore errors and process the whole stream.


### PR DESCRIPTION
Hi!

I spent some time struggling trying to implement something relatively simple with `Task.async_stream`/  `Task.Supervisor.async_stream_nolink`, did many experiments, until I realized it was due to a misunderstanding and that I could actually solve it simply.

In my previous mental model, `Task.Supervisor.async_stream_nolink` meant "fire and forget" without a mean to cleanup dangling tasks if I wanted to bail on the first error. I didn't realize these tasks were cleaned up by an extra monitor when the stream halted, making it perfectly suited for my needs without any need to hack.

This PR is an attempt to clarify this behavior in the doc, and leave a couple of recipes which I think can be very useful for daily tasks and understanding.

<img width="854" alt="Screenshot 2024-01-26 at 9 00 20" src="https://github.com/elixir-lang/elixir/assets/11598866/e973d21d-2a5b-4e6f-9132-8efa1eefd51b">

Another idea could be to simplify this common use case by adding a `bail: true` option. For `async_stream`, we exit immediately so it is not an issue, but for `async_stream_nolink` it might be useful.