### PR TITLE
Fix `CaseClauseError` in `Code.fetch_docs`

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -2032,7 +2032,7 @@ defmodule Code do
              :module_not_found
              | :chunk_not_found
              | {:invalid_chunk, binary}
-             | :beam_lib.chnk_rsn()}
+             | :invalid_beam}
         when annotation: :erl_anno.anno(),
              beam_language: :elixir | :erlang | atom(),
              doc_content: %{optional(binary) => binary} | :none | :hidden,
@@ -2104,8 +2104,8 @@ defmodule Code do
       {:error, :beam_lib, {:file_error, _, :enoent}} ->
         {:error, :module_not_found}
 
-      {:error, :beam_lib, reason} ->
-        {:error, reason}
+      {:error, :beam_lib, _} ->
+        {:error, :invalid_beam}
     end
   end
 

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -2028,7 +2028,11 @@ defmodule Code do
   @spec fetch_docs(module | String.t()) ::
           {:docs_v1, annotation, beam_language, format, module_doc :: doc_content, metadata,
            docs :: [doc_element]}
-          | {:error, :module_not_found | :chunk_not_found | {:invalid_chunk, binary}}
+          | {:error,
+             :module_not_found
+             | :chunk_not_found
+             | {:invalid_chunk, binary}
+             | :beam_lib.chnk_rsn()}
         when annotation: :erl_anno.anno(),
              beam_language: :elixir | :erlang | atom(),
              doc_content: %{optional(binary) => binary} | :none | :hidden,
@@ -2099,6 +2103,9 @@ defmodule Code do
 
       {:error, :beam_lib, {:file_error, _, :enoent}} ->
         {:error, :module_not_found}
+
+      {:error, :beam_lib, reason} ->
+        {:error, reason}
     end
   end
 


### PR DESCRIPTION
`:beam_lib.chunks/2` can return more error codes, see https://www.erlang.org/doc/man/beam_lib#chunks-2
https://www.erlang.org/doc/man/beam_lib#type-chnk_rsn