### PR TITLE
Validate options in async_stream* functions

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -717,7 +717,7 @@ defmodule Task do
   end
 
   defp build_stream(enumerable, fun, options) do
-    options = Task.Supervised.validate_stream_options!(options)
+    options = Task.Supervised.validate_stream_options(options)
 
     fn acc, acc_fun ->
       owner = get_owner(self())

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -717,6 +717,8 @@ defmodule Task do
   end
 
   defp build_stream(enumerable, fun, options) do
+    options = Task.Supervised.validate_stream_options!(options)
+
     fn acc, acc_fun ->
       owner = get_owner(self())
 

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -195,7 +195,6 @@ defmodule Task.Supervised do
     timeout = Keyword.get(options, :timeout, 5000)
     ordered = Keyword.get(options, :ordered, true)
     zip_input_on_exit = Keyword.get(options, :zip_input_on_exit, false)
-    shutdown = Keyword.get(options, :shutdown, 5000)
 
     unless is_integer(max_concurrency) and max_concurrency > 0 do
       raise ArgumentError, ":max_concurrency must be an integer greater than zero"
@@ -209,17 +208,12 @@ defmodule Task.Supervised do
       raise ArgumentError, ":timeout must be either a positive integer or :infinity"
     end
 
-    unless (is_integer(shutdown) and shutdown >= 0) or shutdown == :brutal_kill do
-      raise ArgumentError, ":shutdown must be either a positive integer or :brutal_kill"
-    end
-
     %{
       max_concurrency: max_concurrency,
       on_timeout: on_timeout,
       timeout: timeout,
       ordered: ordered,
-      zip_input_on_exit: zip_input_on_exit,
-      shutdown: shutdown
+      zip_input_on_exit: zip_input_on_exit
     }
   end
 

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -592,10 +592,15 @@ defmodule Task.Supervisor do
   end
 
   defp build_stream(supervisor, link_type, enumerable, fun, options) do
+    shutdown = Keyword.get(options, :shutdown, 5000)
+
+    unless (is_integer(shutdown) and shutdown >= 0) or shutdown == :brutal_kill do
+      raise ArgumentError, ":shutdown must be either a positive integer or :brutal_kill"
+    end
+
     options = Task.Supervised.validate_stream_options(options)
 
     fn acc, acc_fun ->
-      shutdown = options.shutdown
       owner = get_owner(self())
 
       Task.Supervised.stream(enumerable, acc, acc_fun, get_callers(self()), fun, options, fn ->

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -592,10 +592,10 @@ defmodule Task.Supervisor do
   end
 
   defp build_stream(supervisor, link_type, enumerable, fun, options) do
-    options = Task.Supervised.validate_stream_options!(options)
+    options = Task.Supervised.validate_stream_options(options)
 
     fn acc, acc_fun ->
-      shutdown = options[:shutdown]
+      shutdown = options.shutdown
       owner = get_owner(self())
 
       Task.Supervised.stream(enumerable, acc, acc_fun, get_callers(self()), fun, options, fn ->

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -592,6 +592,8 @@ defmodule Task.Supervisor do
   end
 
   defp build_stream(supervisor, link_type, enumerable, fun, options) do
+    options = Task.Supervised.validate_stream_options!(options)
+
     fn acc, acc_fun ->
       shutdown = options[:shutdown]
       owner = get_owner(self())

--- a/lib/elixir/test/elixir/task/supervisor_test.exs
+++ b/lib/elixir/test/elixir/task/supervisor_test.exs
@@ -477,6 +477,14 @@ defmodule Task.SupervisorTest do
              |> Task.Supervisor.async_stream(1..8, &exit/1, opts)
              |> Enum.take(4) == [exit: {1, 1}, exit: {2, 2}, exit: {3, 3}, exit: {4, 4}]
     end
+
+    test "does not allow streaming with invalid :shutdown", %{supervisor: supervisor} do
+      message = ":shutdown must be either a positive integer or :brutal_kill"
+
+      assert_raise ArgumentError, message, fn ->
+        Task.Supervisor.async_stream(supervisor, [], fn _ -> :ok end, shutdown: :unknown)
+      end
+    end
   end
 
   describe "async_stream_nolink" do

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -869,8 +869,28 @@ defmodule TaskTest do
 
     test "does not allow streaming with max_concurrency = 0" do
       assert_raise ArgumentError, ":max_concurrency must be an integer greater than zero", fn ->
-        Task.async_stream([1], fn _ -> :ok end, max_concurrency: 0) |> Enum.to_list()
+        Task.async_stream([1], fn _ -> :ok end, max_concurrency: 0)
       end
+    end
+
+    test "does not allow streaming with invalid :on_timeout" do
+      assert_raise ArgumentError, ":on_timeout must be either :exit or :kill_task", fn ->
+        Task.async_stream([1], fn _ -> :ok end, on_timeout: :unknown)
+      end
+    end
+
+    test "does not allow streaming with invalid :timeout" do
+      assert_raise ArgumentError, ":timeout must be either a positive integer or :infinity", fn ->
+        Task.async_stream([1], fn _ -> :ok end, timeout: :unknown)
+      end
+    end
+
+    test "does not allow streaming with invalid :shutdown" do
+      assert_raise ArgumentError,
+                   ":shutdown must be either a positive integer or :brutal_kill",
+                   fn ->
+                     Task.async_stream([1], fn _ -> :ok end, shutdown: :unknown)
+                   end
     end
 
     test "streams with fake down messages on the inbox" do

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -885,14 +885,6 @@ defmodule TaskTest do
       end
     end
 
-    test "does not allow streaming with invalid :shutdown" do
-      assert_raise ArgumentError,
-                   ":shutdown must be either a positive integer or :brutal_kill",
-                   fn ->
-                     Task.async_stream([1], fn _ -> :ok end, shutdown: :unknown)
-                   end
-    end
-
     test "streams with fake down messages on the inbox" do
       parent = self()
 


### PR DESCRIPTION
This is a proposal for discussion.

Working with `async_stream*` functions can be a bit error prone and requires to constantly double check the doc (which often needs to jump to a separate function), since any typo in an option would fail either silently or much later down the lane when a timeout/exception happens.

The proposal is to validate these upfront instead of lazily, and with helpful error messages.

I also plan to add a dedicated type `t:Task.async_stream_options/1` following [this pattern](https://hexdocs.pm/elixir/1.16.0/GenServer.html#t:option/0), which could help check the spec in the IDE more easily. Thoughts?