### PR TITLE
Make c/e/fprof clickable links in doc

### DIFF
--- a/lib/elixir/pages/getting-started/debugging.md
+++ b/lib/elixir/pages/getting-started/debugging.md
@@ -174,7 +174,7 @@ We have just scratched the surface of what the Erlang VM has to offer, for examp
 
   * [Microstate accounting](http://www.erlang.org/doc/man/msacc.html) measures how much time the runtime spends in several low-level tasks in a short time interval
 
-  * Mix ships with many tasks under the `profile` namespace, such as `mix cprof` and `mix fprof`
+  * Mix ships with many tasks under the `profile` namespace, such as `mix profile.cprof` and `mix profile.fprof`
 
   * For more advanced use cases, we recommend the excellent [Erlang in Anger](https://www.erlang-in-anger.com/), which is available as a free ebook
 

--- a/lib/elixir/pages/getting-started/debugging.md
+++ b/lib/elixir/pages/getting-started/debugging.md
@@ -174,7 +174,7 @@ We have just scratched the surface of what the Erlang VM has to offer, for examp
 
   * [Microstate accounting](http://www.erlang.org/doc/man/msacc.html) measures how much time the runtime spends in several low-level tasks in a short time interval
 
-  * Mix ships with many tasks under the `profile` namespace, such as `cprof` and `fprof`
+  * Mix ships with many tasks under the `profile` namespace, such as [`cprof`](`Mix.Tasks.Profile.Cprof`) and [`fprof`](`Mix.Tasks.Profile.Fprof`)
 
   * For more advanced use cases, we recommend the excellent [Erlang in Anger](https://www.erlang-in-anger.com/), which is available as a free ebook
 

--- a/lib/elixir/pages/getting-started/debugging.md
+++ b/lib/elixir/pages/getting-started/debugging.md
@@ -174,7 +174,7 @@ We have just scratched the surface of what the Erlang VM has to offer, for examp
 
   * [Microstate accounting](http://www.erlang.org/doc/man/msacc.html) measures how much time the runtime spends in several low-level tasks in a short time interval
 
-  * Mix ships with many tasks under the `profile` namespace, such as [`cprof`](`Mix.Tasks.Profile.Cprof`) and [`fprof`](`Mix.Tasks.Profile.Fprof`)
+  * Mix ships with many tasks under the `profile` namespace, such as `mix cprof` and `mix fprof`
 
   * For more advanced use cases, we recommend the excellent [Erlang in Anger](https://www.erlang-in-anger.com/), which is available as a free ebook
 

--- a/lib/mix/lib/mix/tasks/profile.cprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.cprof.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Profile.Cprof do
   @moduledoc """
   Profiles the given file or expression using Erlang's `cprof` tool.
 
-  `cprof` can be useful when you want to discover the bottlenecks related
+  [`:cprof`](`:cprof`) can be useful when you want to discover the bottlenecks related
   to function calls.
 
   Before running the code, it invokes the `app.start` task which compiles

--- a/lib/mix/lib/mix/tasks/profile.eprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.eprof.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Profile.Eprof do
   @moduledoc """
   Profiles the given file or expression using Erlang's `eprof` tool.
 
-  `:eprof` provides time information of each function call and can be useful
+  [`:eprof`](`:eprof`) provides time information of each function call and can be useful
   when you want to discover the bottlenecks related to this.
 
   Before running the code, it invokes the `app.start` task which compiles
@@ -94,7 +94,7 @@ defmodule Mix.Tasks.Profile.Eprof do
   some performance impact on the execution, but the impact is considerably lower than
   `Mix.Tasks.Profile.Fprof`. If you have a large system try to profile a limited
   scenario or focus on the main modules or processes. Another alternative is to use
-  `Mix.Tasks.Profile.Cprof` that uses `:cprof` and has a low performance degradation effect.
+  `Mix.Tasks.Profile.Cprof` that uses [`:cprof`](`:cprof`) and has a low performance degradation effect.
   """
 
   @switches [

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Profile.Fprof do
   @moduledoc """
   Profiles the given file or expression using Erlang's `fprof` tool.
 
-  `fprof` can be useful when you want to discover the bottlenecks of a
+  [`:fprof`](`:fprof`) can be useful when you want to discover the bottlenecks of a
   sequential code.
 
   Before running the code, it invokes the `app.start` task which compiles


### PR DESCRIPTION
Improve navigability of profile-related docs by adding clickable links to:
- https://hexdocs.pm/elixir/debugging.html#other-tools-and-community
- https://hexdocs.pm/mix/Mix.Tasks.Profile.Eprof.html
- https://hexdocs.pm/mix/Mix.Tasks.Profile.Cprof.html
- https://hexdocs.pm/mix/Mix.Tasks.Profile.Fprof.html

<img width="690" alt="Screenshot 2024-01-27 at 12 45 50" src="https://github.com/elixir-lang/elixir/assets/11598866/a8812214-007f-4dfa-a3e3-ee6654f66009">
<img width="706" alt="Screenshot 2024-01-27 at 12 45 55" src="https://github.com/elixir-lang/elixir/assets/11598866/2381410a-b1af-4210-8f0d-3e241e2352e9">
