### PR TITLE
Fix string interpolation example in basic-types.md

### DIFF
--- a/lib/elixir/pages/getting-started/basic-types.md
+++ b/lib/elixir/pages/getting-started/basic-types.md
@@ -227,7 +227,7 @@ Elixir also supports string interpolation:
 ```elixir
 iex> string = "world"
 iex> "hello #{string}!"
-"hello world"
+"hello world!"
 ```
 
 String concatenation requires both sides to be strings but interpolation supports any data type that may be converted to a string:


### PR DESCRIPTION
There is a missing exclamation mark from the result of the `"hello #{string}!"` interpolation.