### PR TITLE
Add explicit clarification that values like 0 and "" are truthy in Elixir

### DIFF
--- a/lib/elixir/pages/getting-started/basic-types.md
+++ b/lib/elixir/pages/getting-started/basic-types.md
@@ -167,6 +167,8 @@ iex> !nil
 true
 ```
 
+Since only `false` and `nil` are considered "falsy", values like `0` and `""` that some other programming languages consider to also be "falsy" are in fact "truthy" in Elixir.
+
 ## Atoms
 
 An atom is a constant whose value is its own name. Some other languages call these symbols. They are often useful to enumerate over distinct values, such as:

--- a/lib/elixir/pages/getting-started/basic-types.md
+++ b/lib/elixir/pages/getting-started/basic-types.md
@@ -167,7 +167,7 @@ iex> !nil
 true
 ```
 
-Since only `false` and `nil` are considered "falsy", values like `0` and `""` that some other programming languages consider to also be "falsy" are in fact "truthy" in Elixir.
+Similarly, values like `0` and `""`, which some other programming languages consider to be "falsy", are also "truthy" in Elixir.
 
 ## Atoms
 


### PR DESCRIPTION
I thought that it might be useful to explicitly call out this difference between Elixir and some other programming languages. The difference caught me off guard when I started writing a few simple functions in Elixir.