### PR TITLE
"unrepl" for elixir

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -188,6 +188,17 @@ defmodule IEx.Evaluator do
         send(server, {:evaled, self(), status, parser_state})
         loop(state)
 
+      {:evalsocket, ^server, socket_client, code, counter, parser_state} ->
+        {status, parser_state, state} = parse_eval_inspect(code, counter, parser_state, state)
+
+        if status == :ok do
+          {[{_, result} | _], _} = state.history.queue
+          :gen_tcp.send(socket_client, inspect(result) <> "\n")
+        end
+
+        send(server, {:evaled, self(), status, parser_state})
+        loop(state)
+
       {:fields_from_env, ^server, ref, receiver, fields} ->
         send(receiver, {ref, Map.take(state.env, fields)})
         loop(state)


### PR DESCRIPTION
While tinkering around with Clojure, I came across the idea of [repl-driven development](https://clojure.org/guides/repl/enhancing_your_repl_workflow).
Though it is already possible to load files from a iex session, it would be really nice to just "send" a buffer/file into the repo with just a few shortcuts from the editor.
While researching the topic I came across Clojure's [unrepl](https://github.com/Unrepl/unrepl/blob/master/SPEC.md) and thought of implementing something similar for elixir.

The idea behind this is, that iex opens a socket where a client (e.g. an editor) can connect to and send snippets to the repl.

So this is not really a PR, more a question whether something like this has the chance to land in core and if you think this is something worth to explore :)