### PR TITLE
Add `c` alias to `IEx.Helpers`

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -986,6 +986,14 @@ defmodule IEx.Helpers do
   end
 
   @doc """
+  A shortcut for `continue/0`.
+  """
+  @doc since: "1.17.0"
+  def c do
+    continue()
+  end
+
+  @doc """
   Sets up a breakpoint in the AST of shape `Module.function/arity`
   with the given number of `stops`.
 


### PR DESCRIPTION
I thought it would be useful to bring over the `c` helper for debugging purposes.  We already have `n`, so I figured why not also have `c`.   This is my first contribution to Elixir, so please let me know if I missed anything.  Thanks!