### PR TITLE
Include from_brackets metadata in all cases

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -292,13 +292,13 @@ bracket_arg -> open_bracket container_expr close_bracket : build_access_arg('$1'
 bracket_arg -> open_bracket container_expr ',' close_bracket : build_access_arg('$1', '$2', '$4').
 bracket_arg -> open_bracket container_expr ',' container_args close_bracket : error_too_many_access_syntax('$3').
 
-bracket_expr -> dot_bracket_identifier bracket_arg : build_access(build_no_parens('$1', nil), '$2').
+bracket_expr -> dot_bracket_identifier bracket_arg : build_access(build_no_parens('$1', nil), meta_with_from_brackets('$2')).
 bracket_expr -> access_expr bracket_arg : build_access('$1', meta_with_from_brackets('$2')).
 
 bracket_at_expr -> at_op_eol dot_bracket_identifier bracket_arg :
-                     build_access(build_unary_op('$1', build_no_parens('$2', nil)), '$3').
+                     build_access(build_unary_op('$1', build_no_parens('$2', nil)), meta_with_from_brackets('$3')).
 bracket_at_expr -> at_op_eol access_expr bracket_arg :
-                     build_access(build_unary_op('$1', '$2'), '$3').
+                     build_access(build_unary_op('$1', '$2'), meta_with_from_brackets('$3')).
 
 %% Blocks
 

--- a/lib/elixir/test/elixir/kernel/tracers_test.exs
+++ b/lib/elixir/test/elixir/kernel/tracers_test.exs
@@ -217,6 +217,35 @@ defmodule Kernel.TracersTest do
     assert meta[:from_interpolation]
   end
 
+  test "traces bracket access" do
+    compile_string("""
+    foo = %{bar: 3}
+    foo[:bar]
+    """)
+
+    assert_receive {{:remote_function, meta, Access, :get, 2}, _env}
+    assert meta[:from_brackets]
+
+    compile_string("""
+    defmodule Foo do
+      @foo %{bar: 3}
+      def a() do
+        @foo[:bar]
+      end
+    end
+    """)
+
+    assert_receive {{:remote_function, meta, Access, :get, 2}, _env}
+    assert meta[:from_brackets]
+
+    compile_string("""
+    %{bar: 3}[:bar]
+    """)
+
+    assert_receive {{:remote_function, meta, Access, :get, 2}, _env}
+    assert meta[:from_brackets]
+  end
+
   """
   # Make sure this module is compiled with column information
   defmodule MacroWithColumn do


### PR DESCRIPTION
Currently, the `:from_brackets` metadata seems to only be populated when used against a literal map or keyword list or a function call (`Foo.bar()[:baz]`).

This populates it in all cases, which includes variables `foo[:bar]` and module attributes `@foo[:bar]`, as well as adding tests for tracing the hidden `Access.get/2` function, similar to the `Kernel.string/1` function as with interpolation.
