### PR TITLE
Include end_of_expression metadata in stabs of block

### DIFF
--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -396,6 +396,75 @@ defmodule Kernel.ParserTest do
 
       assert Code.string_to_quoted!(file, token_metadata: true, columns: true) ==
                {:__block__, [], args}
+
+      file = ~s'''
+      case :foo do
+        :foo ->
+          case get(:foo) do
+            :FOO ->
+              :bar
+            _ ->
+              :error
+            end
+
+        _ ->
+          :error
+      end
+      '''
+
+      expected = {
+        :case,
+        [do: [line: 1, column: 11], end: [line: 12, column: 1], line: 1, column: 1],
+        [
+          :foo,
+          [
+            do: [
+              {
+                :->,
+                [
+                  {:end_of_expression, [newlines: 2, line: 8, column: 10]},
+                  {:newlines, 1},
+                  {:line, 2},
+                  {:column, 8}
+                ],
+                [
+                  [:foo],
+                  {
+                    :case,
+                    [
+                      end_of_expression: [newlines: 2, line: 8, column: 10],
+                      do: [line: 3, column: 20],
+                      end: [line: 8, column: 7],
+                      line: 3,
+                      column: 5
+                    ],
+                    [
+                      {:get, [closing: [line: 3, column: 18], line: 3, column: 10], [:foo]},
+                      [
+                        do: [
+                          {:->,
+                           [
+                             end_of_expression: [newlines: 1, line: 5, column: 13],
+                             newlines: 1,
+                             line: 4,
+                             column: 12
+                           ], [[:FOO], :bar]},
+                          {:->, [newlines: 1, line: 6, column: 9],
+                           [[{:_, [line: 6, column: 7], nil}], :error]}
+                        ]
+                      ]
+                    ]
+                  }
+                ]
+              },
+              {:->, [newlines: 1, line: 10, column: 5],
+               [[{:_, [line: 10, column: 3], nil}], :error]}
+            ]
+          ]
+        ]
+      }
+
+      assert Code.string_to_quoted!(file, token_metadata: true, columns: true) == expected
     end
 
     test "adds pairing information" do


### PR DESCRIPTION
## Description

`:end_of_expression` metadata seems to be inconsistently to applied to arguments within blocks.

This PR adds a test to demonstrate this.

You can note that the 2 stab args of the outer case expression do not have any `:end_of_expression` metadata, but the firsts stab arg of the inner case expression correctly has the metadata.

I say "correctly" here to mean based on my understanding of how it currently works, which is from the documentation "denotes when the end of expression effectively happens. Available for all expressions except the last one inside a `__block__`"

Stabs are a little different in that really there is 1 expression, which is a list of stabs, rather than each stab being a "root" argument. This makes me not sure how the behavior needs to be.

If the current implementation is correct, please let me know the explanation so that I can code [Spitfire](https://github.com/elixir-tools/spitfire) to replicate it. Currently Spitfire produces the AST that is the "expected" in this test.

Thanks!

## Solution

TBD

## Notes

Screenshot of the failed assertion for ease of viewing since the CI needs approval

![CleanShot 2024-02-05 at 13 48 28@2x](https://github.com/elixir-lang/elixir/assets/5523984/5dc7a62a-80ec-4306-9de1-231c685fcfb9)
