### PR TITLE
Update argument error message when matching with <>

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2082,8 +2082,9 @@ defmodule Kernel do
   defp invalid_concat_left_argument_error(arg) do
     :erlang.error(
       ArgumentError.exception(
-        "the left argument of <> operator inside a match should always be a literal " <>
-          "binary because its size can't be verified. Got: #{arg}"
+        "the left argument of <> operator inside a match should always be either a literal " <>
+          "binary or an existing variable matched with the pin operator (such as ^some_var) " <>
+          "because its size can't be verified. Got: #{arg}"
       )
     )
   end

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2082,9 +2082,9 @@ defmodule Kernel do
   defp invalid_concat_left_argument_error(arg) do
     :erlang.error(
       ArgumentError.exception(
-        "the left argument of <> operator inside a match should always be either a literal " <>
-          "binary or an existing variable matched with the pin operator (such as ^some_var) " <>
-          "because its size can't be verified. Got: #{arg}"
+        "cannot perform prefix match because the left operand of <> has unknown size. " <>
+          "The left operand of <> inside a match should either be a literal binary or " <>
+          "an existing variable with the pin operator (such as ^some_var). Got: #{arg}"
       )
     )
   end


### PR DESCRIPTION
The error message for `var <> "suffix" =` hasn't been updated following the [support of pinned variables on the left-handside operand](https://github.com/elixir-lang/elixir/pull/13106).

```elixir
** (ArgumentError) the left argument of <> operator inside a match should always be a literal binary because its size can't be verified. Got: var
```

Updated message:

```elixir
** (ArgumentError) the left argument of <> operator inside a match should always be either a literal binary or an existing variable matched with the pin operator (such as ^some_var) because its size can't be verified. Got: var
```

Based the phrasing on the similar error following `%{var => 1} = 1`

```elixir
error: cannot use variable var as map key inside a pattern. Map keys in patterns can only be literals (such as atoms, strings, tuples, and the like) or an existing variable matched with the pin operator (such as ^some_var)
```