### PR TITLE
Add gradual types to descr

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -284,6 +284,8 @@ defmodule Module.Types.Descr do
 
   @doc """
   Check if a type is equal to another.
+  
+  It is currently not optimized. Only to be used in tests.
   """
   def equal?(left, right), do: subtype?(left, right) and subtype?(right, left)
 

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -144,9 +144,11 @@ defmodule Module.Types.Descr do
     if gradual?(left) or gradual?(right) do
       {left_dynamic, left_static} = Map.pop(left, :dynamic, left)
       {right_dynamic, right_static} = Map.pop(right, :dynamic, right)
+      dynamic_part = difference_static(left_dynamic, right_static)
 
-      difference_static(left_static, right_dynamic)
-      |> Map.put(:dynamic, difference_static(left_dynamic, right_static))
+      if empty?(dynamic_part),
+        do: @none,
+        else: Map.put(difference_static(left_static, right_dynamic), :dynamic, dynamic_part)
     else
       difference_static(left, right)
     end
@@ -284,7 +286,7 @@ defmodule Module.Types.Descr do
 
   @doc """
   Check if a type is equal to another.
-  
+
   It is currently not optimized. Only to be used in tests.
   """
   def equal?(left, right), do: subtype?(left, right) and subtype?(right, left)

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -445,10 +445,9 @@ defmodule Module.Types.Descr do
 
   defp dynamic_to_quoted(%{} = descr) do
     if term?(descr) do
-      {:dynamic, [], []}
+      [{:dynamic, [], []}]
     else
-      {:and, [], [to_quoted(descr), {:dynamic, [], []}]}
+      [{:and, [], [to_quoted(descr), {:dynamic, [], []}]}]
     end
-    |> List.wrap()
   end
 end

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -251,8 +251,8 @@ defmodule Module.Types.Descr do
   @doc """
   Check if a type is a subtype of another.
 
-  If     `left  ~= (left_dyn  and dynamic()) or left_static`
-  and    `right ~= (right_dyn and dynamic()) or right_static`
+  If     `left  = (left_dyn  and dynamic()) or left_static`
+  and    `right = (right_dyn and dynamic()) or right_static`
 
   then the gradual subtyping relation defined in Definition 6.5 page 125 of
   the thesis https://vlanvin.fr/papers/thesis.pdf is:

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -30,10 +30,11 @@ defmodule Module.Types.Descr do
 
   @term %{bitmap: @bit_top, atom: @atom_top}
   @none %{}
+  @dynamic %{dynamic: @term}
 
   # Type definitions
 
-  def dynamic(), do: :dynamic
+  def dynamic(), do: @dynamic
   def term(), do: @term
   def none(), do: @none
 
@@ -60,11 +61,31 @@ defmodule Module.Types.Descr do
   Check type is empty.
   """
   def empty?(descr), do: descr == @none
+  def term?(descr), do: Map.delete(descr, :dynamic) == @term
+  def gradual?(descr), do: is_map_key(descr, :dynamic)
 
   @doc """
   Computes the union of two descrs.
   """
   def union(%{} = left, %{} = right) do
+    is_gradual_left = gradual?(left)
+    is_gradual_right = gradual?(right)
+
+    cond do
+      is_gradual_left and not is_gradual_right ->
+        right_with_dynamic = Map.put(right, :dynamic, right)
+        union_static(left, right_with_dynamic)
+
+      is_gradual_right and not is_gradual_left ->
+        left_with_dynamic = Map.put(left, :dynamic, left)
+        union_static(left_with_dynamic, right)
+
+      true ->
+        union_static(left, right)
+    end
+  end
+
+  defp union_static(left, right) do
     # Erlang maps:merge_with/3 has to preserve the order in combiner.
     # We don't care about the order, so we have a faster implementation.
     if map_size(left) > map_size(right) do
@@ -77,11 +98,30 @@ defmodule Module.Types.Descr do
   @compile {:inline, union: 3}
   defp union(:bitmap, v1, v2), do: bitmap_union(v1, v2)
   defp union(:atom, v1, v2), do: atom_union(v1, v2)
+  defp union(:dynamic, v1, v2), do: dynamic_union(v1, v2)
 
   @doc """
   Computes the intersection of two descrs.
   """
   def intersection(%{} = left, %{} = right) do
+    is_gradual_left = gradual?(left)
+    is_gradual_right = gradual?(right)
+
+    cond do
+      is_gradual_left and not is_gradual_right ->
+        right_with_dynamic = Map.put(right, :dynamic, right)
+        intersection_static(left, right_with_dynamic)
+
+      is_gradual_right and not is_gradual_left ->
+        left_with_dynamic = Map.put(left, :dynamic, left)
+        intersection_static(left_with_dynamic, right)
+
+      true ->
+        intersection_static(left, right)
+    end
+  end
+
+  defp intersection_static(left, right) do
     # Erlang maps:intersect_with/3 has to preserve the order in combiner.
     # We don't care about the order, so we have a faster implementation.
     if map_size(left) > map_size(right) do
@@ -95,11 +135,25 @@ defmodule Module.Types.Descr do
   @compile {:inline, intersection: 3}
   defp intersection(:bitmap, v1, v2), do: bitmap_intersection(v1, v2)
   defp intersection(:atom, v1, v2), do: atom_intersection(v1, v2)
+  defp intersection(:dynamic, v1, v2), do: dynamic_intersection(v1, v2)
 
   @doc """
   Computes the difference between two types.
   """
   def difference(left = %{}, right = %{}) do
+    if gradual?(left) or gradual?(right) do
+      {left_dynamic, left_static} = Map.pop(left, :dynamic, left)
+      {right_dynamic, right_static} = Map.pop(right, :dynamic, right)
+
+      difference_static(left_static, right_dynamic)
+      |> Map.put(:dynamic, difference_static(left_dynamic, right_static))
+    else
+      difference_static(left, right)
+    end
+  end
+
+  # For static types, the difference is component-wise.
+  defp difference_static(left, right) do
     iterator_difference(:maps.next(:maps.iterator(right)), left)
   end
 
@@ -107,6 +161,7 @@ defmodule Module.Types.Descr do
   @compile {:inline, difference: 3}
   defp difference(:bitmap, v1, v2), do: bitmap_difference(v1, v2)
   defp difference(:atom, v1, v2), do: atom_difference(v1, v2)
+  defp difference(:dynamic, v1, v2), do: dynamic_difference(v1, v2)
 
   @doc """
   Compute the negation of a type.
@@ -126,6 +181,7 @@ defmodule Module.Types.Descr do
   @compile {:inline, to_quoted: 2}
   defp to_quoted(:bitmap, val), do: bitmap_to_quoted(val)
   defp to_quoted(:atom, val), do: atom_to_quoted(val)
+  defp to_quoted(:dynamic, descr), do: dynamic_to_quoted(descr)
 
   @doc """
   Converts a descr to its quoted string representation.
@@ -188,6 +244,49 @@ defmodule Module.Types.Descr do
 
   defp iterator_difference(:none, map), do: map
 
+  ## Type relations
+
+  @doc """
+  Check if a type is a subtype of another.
+
+  If     `left  ~= (left_dyn  and dynamic()) or left_static`
+  and    `right ~= (right_dyn and dynamic()) or right_static`
+
+  then the gradual subtyping relation defined in Definition 6.5 page 125 of
+  the thesis https://vlanvin.fr/papers/thesis.pdf is:
+
+  `left <= right` if and only if
+    - `left_static <= right_static`
+    - `left_dyn <= right_dyn`
+
+  Because of the dynamic/static invariant in the `descr`, subtyping can be
+  simplified in several cases according to which type is gradual or not.
+  """
+  def subtype?(%{} = left, %{} = right) do
+    is_grad_left = gradual?(left)
+    is_grad_right = gradual?(right)
+
+    cond do
+      is_grad_left and not is_grad_right ->
+        left_dynamic = Map.get(left, :dynamic)
+        subtype_static(left_dynamic, right)
+
+      is_grad_right and not is_grad_left ->
+        right_static = Map.delete(right, :dynamic)
+        subtype_static(left, right_static)
+
+      true ->
+        subtype_static(left, right)
+    end
+  end
+
+  defp subtype_static(left, right), do: empty?(difference_static(left, right))
+
+  @doc """
+  Check if a type is equal to another.
+  """
+  def equal?(left, right), do: subtype?(left, right) and subtype?(right, left)
+
   ## Bitmaps
 
   defp bitmap_union(v1, v2), do: v1 ||| v2
@@ -228,6 +327,10 @@ defmodule Module.Types.Descr do
   #
   # `{:negation, :sets.new()}` is the `atom()` top type, as it is the difference
   # of `atom()` with an empty list.
+  #
+  # `{:union, :sets.new()}` is the empty type for atoms, as it is the union of
+  # an empty list of atoms. It is simplified to `0` in set operations, and the key
+  # is removed from the map.
 
   defp atom_new(as) when is_list(as), do: {:union, :sets.from_list(as, version: 2)}
 
@@ -240,7 +343,7 @@ defmodule Module.Types.Descr do
         {:negation, :union} -> {:union, :sets.subtract(s2, s1)}
       end
 
-    if :sets.size(s) == 0, do: 0, else: {tag, s}
+    if tag == :union and :sets.size(s) == 0, do: 0, else: {tag, s}
   end
 
   defp atom_union({:union, s1}, {:union, s2}), do: {:union, :sets.union(s1, s2)}
@@ -257,7 +360,7 @@ defmodule Module.Types.Descr do
         {:negation, :union} -> {:negation, :sets.union(s1, s2)}
       end
 
-    if :sets.size(s) == 0, do: 0, else: {tag, s}
+    if tag == :union and :sets.size(s) == 0, do: 0, else: {tag, s}
   end
 
   defp literal(lit), do: {:__block__, [], [lit]}
@@ -283,6 +386,68 @@ defmodule Module.Types.Descr do
     else
       atom_to_quoted({:union, a})
       |> Kernel.then(&{:and, [], [{:atom, [], []}, {:not, [], &1}]})
+    end
+    |> List.wrap()
+  end
+
+  # Dynamic
+  #
+  # A type with a dynamic component is a gradual type; without, it is a static
+  # type. The dynamic component itself is a static type; hence, any gradual type
+  # can be written using a pair of static types as the union:
+  #
+  # `type = (dynamic_component and dynamic()) or static_component`
+  #
+  # where the `static_component` is simply the rest of the `descr`, and `dynamic()`
+  # is the base type that can represent any value at runtime. The dynamic and
+  # static parts can be considered separately for a mixed-typed analysis. For
+  # example, the type
+  #
+  # `type = (dynamic() and integer()) or boolean()`
+  #
+  # denotes an expression that evaluates to booleans or integers; however, there is
+  # uncertainty about the source of these integers. In static mode, the
+  # type-checker refuses to apply a function of type `boolean() -> boolean()` to
+  # this argument (since the argument may turn out to be an integer()), but in
+  # dynamic mode, it considers the type obtained by replacing `dynamic()` with
+  # `none()` (that is, `boolean()`), accepts the application, but types it with a
+  # type that contains `dynamic()`.
+  #
+  # When pattern matching on an expression of type `type`, the static part (here,
+  # booleans) has to be handled exhaustively. In contrast, the dynamic part can
+  # produce potential warnings in specific user-induced conditions, such as asking
+  # for stronger enforcement of static types.
+  #
+  # During construction and through set operations, we maintain the invariant that
+  # the dynamic component is a supertype of the static one, formally
+  # `dynamic_component >= static_component`
+  #
+  # With this invariant, the dynamic component always represents every value that
+  # a given gradual type can take at runtime, allowing us to simplify set operations,
+  # compared, for example, to keeping only the extra dynamic type that can obtained
+  # on top of the static type. Though, the latter may be used for printing purposes.
+  #
+  # There are two ways for a descr to represent a static type: either the
+  # `:dynamic` field is unset, or it contains a type equal to the static component
+  # (that is, there are no extra dynamic values).
+
+  defp dynamic_intersection(left, right) do
+    inter = intersection_static(left, right)
+    if empty?(inter), do: 0, else: inter
+  end
+
+  defp dynamic_difference(left, right) do
+    diff = difference_static(left, right)
+    if empty?(diff), do: 0, else: diff
+  end
+
+  defp dynamic_union(left, right), do: union_static(left, right)
+
+  defp dynamic_to_quoted(%{} = descr) do
+    if term?(descr) do
+      {:dynamic, [], []}
+    else
+      {:and, [], [to_quoted(descr), {:dynamic, [], []}]}
     end
     |> List.wrap()
   end

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -26,6 +26,12 @@ defmodule Module.Types.DescrTest do
       assert union(atom([:a]), negation(atom([:b]))) == negation(atom([:b]))
       assert union(negation(atom([:a, :b])), negation(atom([:b, :c]))) == negation(atom([:b]))
     end
+
+    test "dynamic" do
+      assert equal?(union(dynamic(), dynamic()), dynamic())
+      assert equal?(union(dynamic(), term()), term())
+      assert equal?(union(intersection(dynamic(), atom()), atom()), atom())
+    end
   end
 
   describe "intersection" do
@@ -35,6 +41,7 @@ defmodule Module.Types.DescrTest do
     end
 
     test "term" do
+      assert intersection(term(), term()) == term()
       assert intersection(term(), float()) == float()
       assert intersection(term(), binary()) == binary()
     end
@@ -45,9 +52,15 @@ defmodule Module.Types.DescrTest do
     end
 
     test "atom" do
+      assert intersection(atom(), atom()) == atom()
       assert intersection(atom(), atom([:a])) == atom([:a])
       assert intersection(atom([:a]), atom([:b])) == none()
       assert intersection(atom([:a]), negation(atom([:b]))) == atom([:a])
+    end
+
+    test "dynamic" do
+      assert equal?(intersection(dynamic(), dynamic()), dynamic())
+      assert equal?(intersection(dynamic(), term()), dynamic())
     end
   end
 
@@ -74,6 +87,37 @@ defmodule Module.Types.DescrTest do
     test "atom" do
       assert difference(atom([:a]), atom()) == none()
       assert difference(atom([:a]), atom([:b])) == atom([:a])
+    end
+
+    test "dynamic" do
+      assert equal?(dynamic(), difference(dynamic(), dynamic()))
+    end
+  end
+
+  describe "subtype" do
+    test "bitmap" do
+      assert subtype?(integer(), union(integer(), float()))
+      assert subtype?(integer(), integer())
+      assert subtype?(integer(), term())
+      assert subtype?(none(), integer())
+      assert subtype?(integer(), negation(float()))
+    end
+
+    test "atom" do
+      assert subtype?(atom([:a]), atom())
+      assert subtype?(atom([:a]), atom([:a]))
+      assert subtype?(atom([:a]), term())
+      assert subtype?(none(), atom([:a]))
+      assert subtype?(atom([:a]), atom([:a, :b]))
+      assert subtype?(atom([:a]), negation(atom([:b])))
+    end
+
+    test "dynamic" do
+      assert subtype?(dynamic(), term())
+      assert subtype?(dynamic(), dynamic())
+      refute subtype?(term(), dynamic())
+      assert subtype?(intersection(dynamic(), integer()), integer())
+      assert subtype?(integer(), union(dynamic(), integer()))
     end
   end
 
@@ -104,6 +148,14 @@ defmodule Module.Types.DescrTest do
       assert atom([true, false, :a]) |> to_quoted_string() == "boolean() or :a"
       assert atom([true, :a]) |> to_quoted_string() == ":a or true"
       assert difference(atom(), boolean()) |> to_quoted_string() == "atom() and not boolean()"
+    end
+
+    test "dynamic" do
+      assert dynamic() |> to_quoted_string() == "dynamic()"
+      assert intersection(atom(), dynamic()) |> to_quoted_string() == "atom() and dynamic()"
+
+      assert union(atom([:foo, :bar]), dynamic()) |> to_quoted_string() ==
+               "dynamic() or (:bar or :foo)"
     end
   end
 end

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -30,6 +30,7 @@ defmodule Module.Types.DescrTest do
     test "dynamic" do
       assert equal?(union(dynamic(), dynamic()), dynamic())
       assert equal?(union(dynamic(), term()), term())
+      assert equal?(union(term(), dynamic()), term())
       assert equal?(union(intersection(dynamic(), atom()), atom()), atom())
     end
   end
@@ -61,6 +62,9 @@ defmodule Module.Types.DescrTest do
     test "dynamic" do
       assert equal?(intersection(dynamic(), dynamic()), dynamic())
       assert equal?(intersection(dynamic(), term()), dynamic())
+      assert equal?(intersection(term(), dynamic()), dynamic())
+      assert empty?(intersection(dynamic(), none()))
+      assert empty?(intersection(intersection(dynamic(), atom()), integer()))
     end
   end
 
@@ -91,6 +95,9 @@ defmodule Module.Types.DescrTest do
 
     test "dynamic" do
       assert equal?(dynamic(), difference(dynamic(), dynamic()))
+      assert equal?(dynamic(), difference(term(), dynamic()))
+      assert empty?(difference(dynamic(), term()))
+      assert empty?(difference(none(), dynamic()))
     end
   end
 


### PR DESCRIPTION
Implement the representation for set-theoretic gradual types, including `dynamic()`.

This is done by adding a field `:dynamic` to the descr. It points to another descr representing the "dynamic component" of the type, while the rest of the descr is the "static component". The set operations are modified to account for that.

`dynamic()` is the descr `%{dynamic: @term}`: it can hold for any type at runtime, but its static component is empty since there is no type it is guaranteed to produce.

More explanations are in the comments!