### PR TITLE
Handle empty string in System.shell

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -955,6 +955,12 @@ defmodule System do
   @doc since: "1.12.0"
   @spec shell(binary, keyword) :: {Collectable.t(), exit_status :: non_neg_integer}
   def shell(command, opts \\ []) when is_binary(command) do
+    command |> String.trim() |> do_shell(opts)
+  end
+
+  defp do_shell("", _opts), do: {"", 0}
+
+  defp do_shell(command, opts) do
     assert_no_null_byte!(command, "System.shell/2")
     {close_stdin?, opts} = Keyword.pop(opts, :close_stdin, false)
 

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -209,6 +209,11 @@ defmodule SystemTest do
       assert {"1\n2\n", 0} = System.shell("x=1; echo $x; echo '2'")
     end
 
+    test "shell/1 with empty string" do
+      assert {"", 0} = System.shell("")
+      assert {"", 0} = System.shell("  ")
+    end
+
     @tag timeout: 1_000
     test "shell/1 returns when command awaits input" do
       assert {"", 0} = System.shell("cat", close_stdin: true)


### PR DESCRIPTION
`System.shell` returns an error for an empty string:
```elixir
iex(3)> System.shell("")
/bin/sh: -c: line 1: syntax error near unexpected token `)'
                                                           /bin/sh: -c: line 1: `)'
                                                                                   {"", 2}
```
With the fix in this PR:
```elixir
iex(1)> System.shell("")
{"", 0}
iex(2)> System.shell("   ")
{"", 0}
```