### PR TITLE
Fix bug in iex history

### DIFF
--- a/lib/iex/lib/iex/history.ex
+++ b/lib/iex/lib/iex/history.ex
@@ -55,7 +55,7 @@ defmodule IEx.History do
   end
 
   def nth(%History{size: size, start: start}, n) do
-    raise "v(#{n}) is out of bounds, the currently preserved history ranges from #{start} to #{start + size} " <>
+    raise "v(#{n}) is out of bounds, the currently preserved history ranges from #{start} to #{start + size - 1} " <>
             "(or use negative numbers to look from the end)"
   end
 
@@ -95,10 +95,10 @@ defmodule IEx.History do
     {collect?, %{state | start: counter}}
   end
 
-  defp prune(%{queue: q} = state, counter, limit, collect?) do
+  defp prune(%{queue: q, size: size} = state, counter, limit, collect?) do
     {{:value, entry}, q} = :queue.out(q)
     collect? = collect? || has_binary(entry)
-    prune(%{state | queue: q}, counter + 1, limit, collect?)
+    prune(%{state | queue: q, size: size - 1}, counter + 1, limit, collect?)
   end
 
   # Checks val and each of its elements (if it is a list or a tuple)

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1048,6 +1048,15 @@ defmodule IEx.HelpersTest do
       assert capture_iex("1\n2\nv(2)") == capture_iex("1\n2\nv(-1)")
       assert capture_iex("1\n2\nv(2)") == capture_iex("1\n2\nv()")
     end
+
+    test "returns proper error when trying to access history out of bounds" do
+      # We evaluate 22 statements as 20 is the current limit for iex history
+      assert capture_iex("""
+             \n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n
+             v(1)
+             """) =~
+               "(RuntimeError) v(1) is out of bounds, the currently preserved history ranges from 2 to 22"
+    end
   end
 
   describe "flush" do


### PR DESCRIPTION
Makes the pruning update the history size. Without this update, the size didn't reflect the actual length of the history, which caused the error message to return non-sensical values as the upper limit of the history.