### PR TITLE
Fix unbounded growth in iex history

### DIFF
--- a/lib/iex/lib/iex/history.ex
+++ b/lib/iex/lib/iex/history.ex
@@ -91,7 +91,7 @@ defmodule IEx.History do
     {false, state}
   end
 
-  defp prune(%{size: size} = state, counter, limit, collect?) when size - counter < limit do
+  defp prune(%{size: size} = state, counter, limit, collect?) when size <= limit do
     {collect?, %{state | start: counter}}
   end
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1055,7 +1055,7 @@ defmodule IEx.HelpersTest do
              \n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n
              v(1)
              """) =~
-               "(RuntimeError) v(1) is out of bounds, the currently preserved history ranges from 2 to 22"
+               "(RuntimeError) v(1) is out of bounds, the currently preserved history ranges from 3 to 22"
     end
   end
 


### PR DESCRIPTION
My previous PR (#13333) caused a regression:

Since now `size` represents the actual size of the history, the condition in this prune clause would make the pruning stop too early, causing unbounded growth of the history.

Additionally, there was an off-by-one error, also fixed by adjusting the formula.