### PR TITLE
Fix bug in negative lookups in v/1

### DIFF
--- a/lib/iex/lib/iex/history.ex
+++ b/lib/iex/lib/iex/history.ex
@@ -46,7 +46,7 @@ defmodule IEx.History do
 
   # Traverses the queue back-to-front if the index is negative.
   def nth(%History{queue: q, size: size, start: start}, n)
-      when n < 0 and size + n >= start - 1 do
+      when n < 0 and size + n >= 0 do
     get_nth(:queue.reverse(q), abs(n) - 1)
   end
 
@@ -54,7 +54,15 @@ defmodule IEx.History do
     raise "v(#{n}) is out of bounds, no entries were stored in history so far"
   end
 
-  def nth(%History{size: size, start: start}, n) do
+  def nth(%History{size: size, start: start} = h, n) do
+    # IO.inspect(h: h, n: n)
+
+    IO.inspect(
+      IO.inspect(size, label: :size) + IO.inspect(n, label: :n) >=
+        IO.inspect(start, label: :start) - 1,
+      label: :result
+    )
+
     raise "v(#{n}) is out of bounds, the currently preserved history ranges from #{start} to #{start + size - 1} " <>
             "(or use negative numbers to look from the end)"
   end

--- a/lib/iex/lib/iex/history.ex
+++ b/lib/iex/lib/iex/history.ex
@@ -45,7 +45,7 @@ defmodule IEx.History do
   end
 
   # Traverses the queue back-to-front if the index is negative.
-  def nth(%History{queue: q, size: size, start: start}, n)
+  def nth(%History{queue: q, size: size}, n)
       when n < 0 and size + n >= 0 do
     get_nth(:queue.reverse(q), abs(n) - 1)
   end

--- a/lib/iex/lib/iex/history.ex
+++ b/lib/iex/lib/iex/history.ex
@@ -55,14 +55,6 @@ defmodule IEx.History do
   end
 
   def nth(%History{size: size, start: start} = h, n) do
-    # IO.inspect(h: h, n: n)
-
-    IO.inspect(
-      IO.inspect(size, label: :size) + IO.inspect(n, label: :n) >=
-        IO.inspect(start, label: :start) - 1,
-      label: :result
-    )
-
     raise "v(#{n}) is out of bounds, the currently preserved history ranges from #{start} to #{start + size - 1} " <>
             "(or use negative numbers to look from the end)"
   end

--- a/lib/iex/lib/iex/history.ex
+++ b/lib/iex/lib/iex/history.ex
@@ -54,7 +54,7 @@ defmodule IEx.History do
     raise "v(#{n}) is out of bounds, no entries were stored in history so far"
   end
 
-  def nth(%History{size: size, start: start} = h, n) do
+  def nth(%History{size: size, start: start}, n) do
     raise "v(#{n}) is out of bounds, the currently preserved history ranges from #{start} to #{start + size - 1} " <>
             "(or use negative numbers to look from the end)"
   end

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1057,6 +1057,20 @@ defmodule IEx.HelpersTest do
              """) =~
                "(RuntimeError) v(1) is out of bounds, the currently preserved history ranges from 3 to 22"
     end
+
+    test "negative lookup works properly after crashes" do
+      capture =
+        capture_iex("""
+            \n
+            \n
+            \n
+            Process.exit(self(), :some_reason)\n
+            :target_value
+            v(-1)
+        """)
+
+      assert capture |> String.split("\n") |> List.last() == ":target_value"
+    end
   end
 
   describe "flush" do


### PR DESCRIPTION
This is not related to #13333 or #13336, but to a bug that already existed for a while and was reported in Elixir's slack by @axelson.

Existing behaviour:
```
v0idpwn:~/oss/elixir$ iex
Erlang/OTP 26 [erts-14.0.2] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [jit:ns]

Interactive Elixir (1.15.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> 1
1
iex(2)> 2
2
iex(3)> 3
3
iex(4)> Process.exit(self(), :hi)
** (EXIT from #PID<0.110.0>) shell process exited with reason: :hi

Interactive Elixir (1.15.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(4)> 4
4
iex(5)> v(-1)
** (RuntimeError) v(-1) is out of bounds, the currently preserved history ranges from 4 to 5 (or use negative numbers to look from the end)
    (iex 1.15.4) lib/iex/history.ex:58: IEx.History.nth/2
    (iex 1.15.4) lib/iex/helpers.ex:380: IEx.Helpers.v/1
    iex:5: (file)
iex(5)>
```

After the fix:
```
v0idpwn:~/oss/elixir$ ./bin/iex
Erlang/OTP 26 [erts-14.0.2] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [jit:ns]

Interactive Elixir (1.17.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> 1
1
iex(2)> 2
2
iex(3)> 3
3
iex(4)> Process.exit(self(), :hi)
** (EXIT from #PID<0.110.0>) shell process exited with reason: :hi

Interactive Elixir (1.17.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(4)> 4
4
iex(5)> v(-1)
4
```