### PR TITLE
Fix bit offset in Module.Types.Descr

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -10,19 +10,19 @@ defmodule Module.Types.Descr do
   # the dynamic type.
   import Bitwise
 
-  @bit_binary 1 <<< 1
-  @bit_empty_list 1 <<< 2
-  @bit_integer 1 <<< 3
-  @bit_float 1 <<< 4
-  @bit_pid 1 <<< 5
-  @bit_port 1 <<< 6
-  @bit_reference 1 <<< 7
+  @bit_binary 1 <<< 0
+  @bit_empty_list 1 <<< 1
+  @bit_integer 1 <<< 2
+  @bit_float 1 <<< 3
+  @bit_pid 1 <<< 4
+  @bit_port 1 <<< 5
+  @bit_reference 1 <<< 6
 
-  @bit_non_empty_list 1 <<< 8
-  @bit_map 1 <<< 9
-  @bit_tuple 1 <<< 10
-  @bit_fun 1 <<< 11
-  @bit_top (1 <<< 12) - 1
+  @bit_non_empty_list 1 <<< 7
+  @bit_map 1 <<< 8
+  @bit_tuple 1 <<< 9
+  @bit_fun 1 <<< 10
+  @bit_top (1 <<< 11) - 1
 
   @atom_top {:negation, :sets.new(version: 2)}
 

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -26,6 +26,25 @@ defmodule Module.Types.DescrTest do
       assert union(atom([:a]), negation(atom([:b]))) == negation(atom([:b]))
       assert union(negation(atom([:a, :b])), negation(atom([:b, :c]))) == negation(atom([:b]))
     end
+
+    test "all primitive types" do
+      all = [
+        atom(),
+        integer(),
+        float(),
+        binary(),
+        map(),
+        non_empty_list(),
+        empty_list(),
+        tuple(),
+        fun(),
+        pid(),
+        port(),
+        reference()
+      ]
+
+      assert Enum.reduce(all, &union/2) == term()
+    end
   end
 
   describe "intersection" do


### PR DESCRIPTION
The last bit was unused, and unless I misunderstood, is causing bugs:
- building types up by `union` would always generate even numbers like `4094`
- building types down by `difference` would lead to odd numbers like `4095`

```elixir
iex> Enum.reduce([integer(), float(), binary(), map(), non_empty_list(), empty_list(), tuple(), fun(), pid(), port(), reference()], &union/2)
%{bitmap: 4094}
iex> difference(term(), atom())
%{bitmap: 4095}
```

These would generate the same representations but wouldn't be `equal?`  in https://github.com/elixir-lang/elixir/pull/13330:

```elixir
iex> Descr.to_quoted_string(%{bitmap: 4094}) == Descr.to_quoted_string(%{bitmap: 4095})
true
```

After the fix:

```elixir
iex> Enum.reduce([integer(), float(), binary(), map(), non_empty_list(), empty_list(), tuple(), fun(), pid(), port(), reference()], &union/2)
%{bitmap: 2047}
iex> difference(term(), atom())
%{bitmap: 2047}
```