### PR TITLE
feat: supports setting lockfile via MIX_LOCKFILE env var

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -354,6 +354,8 @@ defmodule Mix do
 
     * `MIX_INSTALL_FORCE` - (since v1.13.0) runs `Mix.install/2` with empty install cache
 
+    * `MIX_LOCKFILE` - sets the path to the lockfile (default: `mix.lock`)
+
     * `MIX_PATH` - appends extra code paths
 
     * `MIX_PROFILE` - a list of comma-separated Mix tasks to profile the time spent on

--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -50,7 +50,7 @@ defmodule Mix.Dep.Lock do
   end
 
   defp lockfile do
-    Mix.Project.config()[:lockfile]
+    Mix.Project.lockfile()
   end
 
   defp assert_no_merge_conflicts_in_lockfile(lockfile, info) do

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -219,7 +219,7 @@ defmodule Mix.Project do
       consolidation_path: consolidation_path(config),
       deps_path: deps_path(config),
       deps_build_path: build_path(config),
-      lockfile: Path.expand(config[:lockfile])
+      lockfile: Path.expand(lockfile(config))
     ] ++ Keyword.take(config, [:build_embedded, :build_per_environment, :prune_code_paths])
   end
 
@@ -677,6 +677,11 @@ defmodule Mix.Project do
   @spec build_path(keyword) :: Path.t()
   def build_path(config \\ config()) do
     System.get_env("MIX_BUILD_PATH") || config[:deps_build_path] || do_build_path(config)
+  end
+
+  @doc false
+  def lockfile(config \\ config()) do
+    System.get_env("MIX_LOCKFILE") || config[:lockfile]
   end
 
   defp do_build_path(config) do

--- a/lib/mix/test/mix/project_test.exs
+++ b/lib/mix/test/mix/project_test.exs
@@ -62,6 +62,19 @@ defmodule Mix.ProjectTest do
     end
   end
 
+  describe "lockfile/1" do
+    test "defaults to mix.lock" do
+      assert Mix.Project.lockfile() == "mix.lock"
+    end
+
+    test "considers MIX_LOCKFILE" do
+      System.put_env("MIX_LOCKFILE", "another.lock")
+      assert Mix.Project.lockfile() == "another.lock"
+    after
+      System.delete_env("MIX_LOCKFILE")
+    end
+  end
+
   test "returns mix.exs path" do
     assert Mix.Project.project_file() == nil
     Mix.Project.push(SampleProject, "sample")


### PR DESCRIPTION
Hi,

I was exploring lately the feasibility of testing elixir packages against different lockfiles, and found an addition like this might help, despite already possible via the `:lockfile` project keyoword option.

Also considering that there's already a few `Project` options that have their corresponding env var overrides, like `:build_path`/`MIX_BUILD_PATH`, `:deps_path`/`MIX_DEPS_PATH`.
Also `MIX_EXS` already available.

Does this make sense?
Thanks in advance!