### PR TITLE
Fix IEx tests on OTP27: fix assertions

### DIFF
--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -339,10 +339,10 @@ defmodule IEx.HelpersTest do
     end
 
     @tag :erlang_doc
-    test "prints Erlang module function specs" do
+    test "prints Erlang module function docs" do
       captured = capture_io(fn -> h(:timer.sleep() / 1) end)
       assert captured =~ ":timer.sleep/1"
-      assert captured =~ "-spec sleep(Time) -> ok when Time :: timeout()."
+      assert captured =~ "sleep(Time)"
     end
 
     @tag :erlang_doc
@@ -1014,18 +1014,18 @@ defmodule IEx.HelpersTest do
     @tag :erlang_doc
     test "prints all types in Erlang module" do
       captured = capture_io(fn -> t(:queue) end)
-      assert captured =~ "-type queue() :: queue(_)"
-      assert captured =~ "-opaque queue(Item)"
+      assert captured =~ "queue()"
+      assert captured =~ "queue(Item)"
     end
 
     @tag :erlang_doc
     test "prints single type from Erlang module" do
       captured = capture_io(fn -> t(:erlang.iovec()) end)
-      assert captured =~ "-type iovec() :: [binary()]"
+      assert captured =~ "iovec()"
       assert captured =~ "A list of binaries."
 
       captured = capture_io(fn -> t(:erlang.iovec() / 0) end)
-      assert captured =~ "-type iovec() :: [binary()]"
+      assert captured =~ "iovec()"
       assert captured =~ "A list of binaries."
     end
 


### PR DESCRIPTION
Opening this PR for discussion.

We migrated IEx introspection to use `:shell_docs` in https://github.com/elixir-lang/elixir/pull/12803, but OTP27 stops returning specs, which would be a regression for us.

**Before** (type)

<img width="653" alt="Screenshot 2024-02-16 at 13 43 22" src="https://github.com/elixir-lang/elixir/assets/11598866/35936141-2182-443f-8716-d97d78c7fb5e">

**After** (type)

<img width="497" alt="Screenshot 2024-02-16 at 13 43 41" src="https://github.com/elixir-lang/elixir/assets/11598866/d9276ce5-c88b-4e33-ab46-e44aa1148384">

(The `opaque` information got lost as well, not great)

**Before** (spec)

<img width="596" alt="Screenshot 2024-02-16 at 13 45 35" src="https://github.com/elixir-lang/elixir/assets/11598866/4105d79b-db79-43e6-83fd-32e82a1cf441">

**After** (spec)

<img width="627" alt="Screenshot 2024-02-16 at 13 45 58" src="https://github.com/elixir-lang/elixir/assets/11598866/aa12fa05-5c12-4180-b138-5b32af982f3f">

It might be fine given we're aiming at replacing typespecs with set-theoretic types, but I wanted to confirm.
Or should we open an issue upstream?