### PR TITLE
Coverage broken on OTP27 for protocols

### DIFF
--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -192,13 +192,18 @@ defmodule Mix.Tasks.TestTest do
 
                Percentage | Module
                -----------|--------------------------
+                   50.00% | Bar.Protocol
                   100.00% | Bar
                   100.00% | Bar.Ignore
-                  100.00% | Bar.Protocol
                   100.00% | Bar.Protocol.BitString
                   100.00% | Foo
                -----------|--------------------------
-                  100.00% | Total
+                   83.33% | Total
+
+               Coverage test failed, threshold not met:
+
+                   Coverage:   83.33%
+                   Threshold:  90.00%
                """
       end)
     end


### PR DESCRIPTION
Opening this for discussion and to report my findings so far:

The following test (protocol) breaks on OTP27 and reports an untested line for `defprotocol`.

<img width="506" alt="Screenshot 2024-02-16 at 14 54 28" src="https://github.com/elixir-lang/elixir/assets/11598866/8f8bf3b6-8b68-4866-8758-fbbe40fe52a5">

Relevant lines of `results` [here](https://github.com/elixir-lang/elixir/blob/v1.16/lib/mix/lib/mix/tasks/test.coverage.ex#L324):

In OTP26:
```elixir
  {{Bar.Protocol, 13}, {0, 1}},
  {{Bar.Protocol, 13}, {1, 0}},
  {{Bar.Protocol, 14}, {1, 0}}
```

In OTP27:
```elixir
  {{Bar.Protocol, 13}, {0, 1}},
  {{Bar.Protocol, 13}, {0, 1}},
  {{Bar.Protocol, 14}, {1, 0}}
```

Not sure if it is a bug upstream with `:cover` or something we need to handle.
I can look into it but I am yet unfamiliar with `:cover`, if somebody has an idea feel free to jump in.