### PR TITLE
ExUnit.Diff: Escape pinned values when computing diff

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -286,7 +286,7 @@ defmodule ExUnit.Diff do
   defp diff_pin({:^, _, [var]} = pin, right, %{pins: pins} = env) do
     identifier = var_context(var)
     %{^identifier => pin_value} = pins
-    {diff, post_env} = diff_value(pin_value, right, env)
+    {diff, post_env} = diff_value(Macro.escape(pin_value), right, env)
 
     diff_left = update_diff_meta(pin, not diff.equivalent?)
     {%{diff | left: diff_left}, post_env}

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -286,10 +286,10 @@ defmodule ExUnit.Diff do
   defp diff_pin({:^, _, [var]} = pin, right, %{pins: pins} = env) do
     identifier = var_context(var)
     %{^identifier => pin_value} = pins
-    {diff, post_env} = diff_value(Macro.escape(pin_value), right, env)
+    {diff, post_env} = diff_value(pin_value, right, %{env | context: :===})
 
     diff_left = update_diff_meta(pin, not diff.equivalent?)
-    {%{diff | left: diff_left}, post_env}
+    {%{diff | left: diff_left}, %{post_env | context: :match}}
   end
 
   # Vars

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -251,7 +251,12 @@ defmodule ExUnit.DiffTest do
     refute_diff([:a, [:c, :b]] = [:a, [:b, :c]], "[:a, [-:c-, :b]]", "[:a, [:b, +:c+]]")
     refute_diff(:a = [:a, [:b, :c]], "-:a-", "+[:a, [:b, :c]]+")
 
-    pins = %{{:a, nil} => :a, {:b, nil} => :b, {:list_ab, nil} => [:a, :b]}
+    pins = %{
+      {:a, nil} => :a,
+      {:b, nil} => :b,
+      {:list_ab, nil} => [:a, :b],
+      {:list_tuple, nil} => [{:foo}]
+    }
 
     assert_diff(x = [], [x: []], pins)
     assert_diff(x = [:a, :b], [x: [:a, :b]], pins)
@@ -282,6 +287,9 @@ defmodule ExUnit.DiffTest do
 
     refute_diff([:a, :b] = :a, "-[:a, :b]-", "+:a+")
     refute_diff([:foo] = [:foo, {:a, :b, :c}], "[:foo]", "[:foo, +{:a, :b, :c}+]")
+
+    refute_diff([{:foo}] = [{:bar}], "[{-:foo-}]", "[{+:bar+}]")
+    refute_diff(^list_tuple = [{:bar}], "-^list_tuple-", "[{+:bar+}]", pins)
   end
 
   test "improper lists" do


### PR DESCRIPTION
Take these two tests:

```elixir
  test "correctly colored" do
    assert [{:foo}] = [{:bar}]
  end

  test "incorrectly colored" do
    val = [{:foo}]
    assert ^val = [{:bar}]
  end
```

When diffing the match without a pin, `diff_value/3` would be passed the quoted version of `[{:foo}]` (`[{:{}, [], [:foo]}]`) as the left argument, allowing it to recurse deeper into the structure to find the correct diff.

When diffing the match with the pin, `diff_value/3` would be passed `[{:foo}]` instead, prohibiting it from recursively refining the diff, leading to overly broad diffs. The fix is to explicitly escape the pin value in the call to `diff_value/3` inside of `diff_pin/3`.

This fixes #13348