### PR TITLE
Fix assertion for ex_unit test in OTP27

### DIFF
--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -216,7 +216,15 @@ defmodule ExUnit.CaptureIOTest do
       end)
 
       capture_io("\"a", fn ->
-        assert :io.scan_erl_form(~c">") == {:error, {1, :erl_scan, {:string, 34, ~c"a"}}, 1}
+        # TODO: Remove me when we require Erlang/OTP 27+
+        expected_error =
+          if :erlang.system_info(:otp_release) >= ~c"27" do
+            {1, :erl_scan, {:unterminated, :string, ~c"a"}}
+          else
+            {1, :erl_scan, {:string, 34, ~c"a"}}
+          end
+
+        assert :io.scan_erl_form(~c">") == {:error, expected_error, 1}
         assert :io.scan_erl_form(~c">") == {:eof, 1}
       end)
 


### PR DESCRIPTION
Most likely due to this change
https://github.com/erlang/otp/commit/be9c343f7188f5845c8e2f31a614e4d257452abf