### PR TITLE
Add callout to full bitstring reference in the getting started guide.

### DIFF
--- a/lib/elixir/pages/getting-started/binaries-strings-and-charlists.md
+++ b/lib/elixir/pages/getting-started/binaries-strings-and-charlists.md
@@ -94,7 +94,7 @@ We are getting a little bit ahead of ourselves. Let's talk about bitstrings to l
 
 ## Bitstrings
 
-Although we have covered code points and UTF-8 encoding, we still need to go a bit deeper into how exactly we store the encoded bytes, and this is where we introduce the **bitstring**. A bitstring is a fundamental data type in Elixir, denoted with the `<<>>/1` syntax. **A bitstring is a contiguous sequence of bits in memory.**
+Although we have covered code points and UTF-8 encoding, we still need to go a bit deeper into how exactly we store the encoded bytes, and this is where we introduce the **bitstring**. A bitstring is a fundamental data type in Elixir, denoted with the [`<<>>`](`<<>>/1`) syntax. **A bitstring is a contiguous sequence of bits in memory.**
 
 By default, 8 bits (i.e. 1 byte) is used to store each number in a bitstring, but you can manually specify the number of bits via a `::n` modifier to denote the size in `n` bits, or you can use the more verbose declaration `::size(n)`:
 
@@ -120,6 +120,8 @@ true
 ```
 
 Here, 257 in base 2 would be represented as `100000001`, but since we have reserved only 8 bits for its representation (by default), the left-most bit is ignored and the value becomes truncated to `00000001`, or simply `1` in decimal.
+
+**A complete reference for the bitstring constructor can be found in the [`SpecialForms`](`<<>>/1`) documentation.**
 
 ## Binaries
 

--- a/lib/elixir/pages/getting-started/binaries-strings-and-charlists.md
+++ b/lib/elixir/pages/getting-started/binaries-strings-and-charlists.md
@@ -121,7 +121,7 @@ true
 
 Here, 257 in base 2 would be represented as `100000001`, but since we have reserved only 8 bits for its representation (by default), the left-most bit is ignored and the value becomes truncated to `00000001`, or simply `1` in decimal.
 
-**A complete reference for the bitstring constructor can be found in the [`SpecialForms`](`<<>>/1`) documentation.**
+A complete reference for the bitstring constructor can be found in [`<<>>`](`<<>>/1`)'s documentation.
 
 ## Binaries
 


### PR DESCRIPTION
The bitstring constructor syntax reference [`<<>>`](https://hexdocs.pm/elixir/1.16.1/Kernel.SpecialForms.html#%3C%3C%3E%3E/1) isn't easy for newcomers to discover. It's not SEO friendly and the [getting started guide for bitstrings](https://hexdocs.pm/elixir/binaries-strings-and-charlists.html#bitstrings) doesn't indicate that subtle link's the full reference.

The old getting started guide on [elixir-lang.org](http://web.archive.org/web/20230216152522/https://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html#bitstrings) called out to it in plain English, and I think it's worth adding back in some form.

I've added it back in this PR at the bottom of the bitstring section in bold, in addition to removing the `/1` from the `<<>>/1` link at the top.

_My impetus for this is,_ I saw a new person asking questions about bitstrings. They'd already been working with them a fair bit, going off blog posts and the getting started guide. They weren't aware the full syntax reference was available. Purely an anecdotal case, but I thought this worth proposing nonetheless.