### PR TITLE
Add documentation to `Exception` callbacks

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -31,7 +31,21 @@ defmodule Exception do
   @type arity_or_args :: non_neg_integer | list
   @type location :: keyword
 
+  @doc """
+  Receives the arguments given to `raise/2` and returns the exception struct.
+
+  The default implementation accepts either a set of keyword arguments
+  that is merged into the struct or a string to be used as the exception's message.
+  """
   @callback exception(term) :: t
+
+  @doc """
+  Receives the exception struct and must return its message.
+
+  Most commonly exceptions have a message field which by default is accessed
+  by this function. However, if an exception does not have a message field,
+  this function must be explicitly implemented.
+  """
   @callback message(t) :: String.t()
 
   @doc """

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -805,7 +805,7 @@ defmodule IEx.HelpersTest do
 
       assert capture_io(fn -> b(NoMix.run()) end) == "Could not load module NoMix, got: nofile\n"
 
-      assert capture_io(fn -> b(Exception.message() / 1) end) ==
+      assert capture_io(fn -> b(Exception.message() / 1) end) =~
                "@callback message(t()) :: String.t()\n\n"
 
       assert capture_io(fn -> b(:gen_server.handle_cast() / 2) end) =~


### PR DESCRIPTION
I noticed the required callbacks of `Exception` behaviour were not documented with `@doc`. The relevant documentation was only on `defexception` which made it inaccessible via `Code.fetch_docs(Exception)`