### PR TITLE
Support IO capture from an already-started process

### DIFF
--- a/lib/ex_unit/lib/ex_unit/capture_io.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_io.ex
@@ -72,6 +72,9 @@ defmodule ExUnit.CaptureIO do
     * `:encoding` (since v1.10.0) - encoding of the IO device. Allowed
       values are `:unicode` (default) and `:latin1`.
 
+    * `:pid` (since v1.17.0) - a process identifier. This option can be
+      used to capture IO from an already-started process.
+
   ## Examples
 
   To capture the standard io:
@@ -236,15 +239,16 @@ defmodule ExUnit.CaptureIO do
     prompt_config = Keyword.get(options, :capture_prompt, true)
     encoding = Keyword.get(options, :encoding, :unicode)
     input = Keyword.get(options, :input, "")
+    pid = Keyword.get(options, :pid, self())
 
     original_gl = Process.group_leader()
     {:ok, capture_gl} = StringIO.open(input, capture_prompt: prompt_config, encoding: encoding)
 
     try do
-      Process.group_leader(self(), capture_gl)
+      Process.group_leader(pid, capture_gl)
       do_capture_gl(capture_gl, fun)
     after
-      Process.group_leader(self(), original_gl)
+      Process.group_leader(pid, original_gl)
     end
   end
 

--- a/lib/ex_unit/lib/ex_unit/capture_io.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_io.ex
@@ -29,15 +29,15 @@ defmodule ExUnit.CaptureIO do
 
   Returns the binary which is the captured output.
 
-  By default, `capture_io` replaces the `group_leader` (`:stdio`)
-  for the current process. Capturing the group leader is done per
-  process and therefore can be done concurrently.
+  By default, `capture_io` replaces the `Process.group_leader/0` of the current
+  process, which is the process used by default for all IO operations. Capturing
+  the group leader of the current process is safe to run concurrently, under
+  `async: true` tests. You may also explicitly capture the group leader of
+  another process, however that is not safe to do concurrently.
 
-  However, the capturing of any other named device, such as `:stderr`,
-  happens globally and persists until the function has ended. While this means
-  it is safe to run your tests with `async: true` in many cases, captured output
-  may include output from a different test and care must be taken when using
-  `capture_io` with a named process asynchronously.
+  You may also capture any other named IO device, such as `:stderr`. This is
+  also safe to run concurrently but, if several tests are writting to the same
+  device at once, captured output may include output from a different test.
 
   A developer can set a string as an input. The default input is an empty
   string. If capturing a named device asynchronously, an input can only be given
@@ -51,15 +51,28 @@ defmodule ExUnit.CaptureIO do
 
   ## IO devices
 
-  You may capture the IO from any registered IO device. The device name given
-  must be an atom representing the name of a registered process. In addition,
-  Elixir provides two shortcuts:
+  You may capture the IO of the group leader of any process, by passing a `pid`
+  as argument, or from any registered IO device given as an `atom`. Here are
+  some example values:
 
-    * `:stdio` - a shortcut for `:standard_io`, which maps to
-      the current `Process.group_leader/0` in Erlang
+    * `:stdio`, `:standard_io` - a shortcut for capturing the group leader
+      of the current process. It is equivalent to passing `self()` as the
+      first argument. This is safe to run concurrently and captures only
+      the of the current process or any child process spawned inside the
+      given function
 
-    * `:stderr` - a shortcut for the named process `:standard_error`
-      provided in Erlang
+    * `:stderr`, `:standard_error` - captures all IO to standard error
+      (represented internally by an Erlang process named `:standard_error`).
+      This is safe to run concurrently but it will capture the output
+      of any other test writing to the same named device
+
+    * any other atom - captures all IO to the given device given by the
+      atom. This is safe to run concurrently but it will capture the output
+      of any other test writing to the same named device
+
+    * any other pid (since v1.17.0) - captures all IO to the group leader
+      of the given process. This option is not safe to run concurrently
+      if the pid is not `self()`. Tests using this value must set `async: true`
 
   ## Options
 
@@ -71,9 +84,6 @@ defmodule ExUnit.CaptureIO do
 
     * `:encoding` (since v1.10.0) - encoding of the IO device. Allowed
       values are `:unicode` (default) and `:latin1`.
-
-    * `:pid` (since v1.17.0) - a process identifier. This option can be
-      used to capture IO from an already-started process.
 
   ## Examples
 
@@ -94,10 +104,10 @@ defmodule ExUnit.CaptureIO do
       ...> end) == "this is input"
       true
 
-  Note it is fine to use `==` with standard IO, because the content is captured
-  per test process. However, `:stderr` is shared across all tests, so you will
-  want to use `=~` instead of `==` for assertions on `:stderr` if your tests
-  are async:
+  Note it is fine to use `==` with `:stdio` (the default IO device), because
+  the content is captured per test process. However, `:stderr` is shared
+  across all tests, so you will want to use `=~` instead of `==` for assertions
+  on `:stderr` if your tests are async:
 
       iex> capture_io(:stderr, fn -> IO.write(:stderr, "john") end) =~ "john"
       true
@@ -112,6 +122,14 @@ defmodule ExUnit.CaptureIO do
 
   Otherwise, if the standard error of any other test is captured, the test will
   fail.
+
+  To capture the IO from another process, you can pass a `pid`:
+
+      capture_io(GenServer.whereis(MyServer), fn ->
+        GenServer.call(MyServer, :do_something)
+      end)
+
+  Tests that directly capture a PID cannot run concurrently.
 
   ## Returning values
 

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -39,9 +39,24 @@ defmodule ExUnit.CaptureIOTest do
     def init(_), do: {:ok, nil}
 
     @impl GenServer
-    def handle_call({device, message}, _from, state) do
-      IO.puts(device, message)
-      {:reply, device, state}
+    def handle_call({:stdio, message}, _from, state) do
+      IO.puts(message)
+      {:reply, :ok, state}
+    end
+
+    @impl GenServer
+    def handle_call({:prompt, prompt}, _from, state) do
+      prompt
+      |> IO.gets()
+      |> IO.puts()
+
+      {:reply, :ok, state}
+    end
+
+    @impl GenServer
+    def handle_call({:stderr, message}, _from, state) do
+      IO.puts(:stderr, message)
+      {:reply, :ok, state}
     end
   end
 
@@ -486,16 +501,28 @@ defmodule ExUnit.CaptureIOTest do
     end
   end
 
-  test "capture_io with pid in options" do
+  test "capture_io with a separate process" do
     {:ok, pid} = MockProc.start_link()
 
-    assert capture_io([pid: pid], fn ->
+    assert capture_io(pid, fn ->
              GenServer.call(pid, {:stdio, "a"})
            end) == "a\n"
 
-    assert capture_io(:stderr, [pid: pid], fn ->
-             GenServer.call(pid, {:stderr, "b"})
-           end) == "b\n"
+    assert capture_io(pid, [input: "b"], fn ->
+             GenServer.call(pid, {:prompt, "> "})
+           end) == "> b\n"
+
+    assert capture_io(pid, "c", fn ->
+             GenServer.call(pid, {:prompt, "> "})
+           end) == "> c\n"
+
+    assert capture_io(pid, [input: "d", capture_prompt: false], fn ->
+             GenServer.call(pid, {:prompt, "> "})
+           end) == "d\n"
+
+    assert capture_io(:stderr, fn ->
+             GenServer.call(pid, {:stderr, "uhoh"})
+           end) == "uhoh\n"
 
     GenServer.stop(pid)
   end


### PR DESCRIPTION
`capture_io/1,2,3` does not capture IO from a process that was already started. This change allows someone to pass a `:pid` option so that `Process.group_leader/2` is called on the target process rather than the calling process.