### PR TITLE
Add environment variable for reusing Mix.install/2 installation

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -105,6 +105,14 @@ defmodule IEx.Helpers do
 
       Mix.installed?() ->
         Mix.in_install_project(fn ->
+          # TODO: remove this once Mix requires Hex with the fix from
+          # https://github.com/hexpm/hex/pull/1015
+          # Context: Mix.install/1 starts :hex if necessary and stops
+          # it afterwards. Calling compile here may require hex to be
+          # started and that should happen automatically, but because
+          # of a bug it is not (fixed in the linked PR).
+          _ = Application.ensure_all_started(:hex)
+
           do_recompile(options)
           # Just as with Mix.install/2 we clear all task invocations,
           # so that we can recompile the dependencies again next time

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -881,7 +881,7 @@ defmodule Mix do
           restore_dir = System.get_env("MIX_INSTALL_RESTORE_PROJECT_DIR")
 
           if first_build? and restore_dir != nil and not force? do
-            File.cp_r!(restore_dir, install_dir)
+            File.cp_r(restore_dir, install_dir)
           end
 
           File.mkdir_p!(install_dir)
@@ -1002,9 +1002,9 @@ defmodule Mix do
 
     for dep <- leftover_deps do
       build_path = Path.join(build_lib_dir, dep)
-      File.rm_rf!(build_path)
+      File.rm_rf(build_path)
       dep_path = Path.join(deps_dir, dep)
-      File.rm_rf!(dep_path)
+      File.rm_rf(dep_path)
     end
   end
 

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -1060,11 +1060,8 @@ defmodule Mix do
   @spec install_project_dir() :: Path.t()
   def install_project_dir() do
     case Mix.State.get(:installed) do
-      {id, _dynamic_config} ->
-        install_dir(id)
-
-      nil ->
-        nil
+      {id, _dynamic_config} -> install_dir(id)
+      nil -> nil
     end
   end
 

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -1067,7 +1067,7 @@ defmodule Mix do
         install_dir(id)
 
       nil ->
-        Mix.raise("trying to call Mix.install_project_dir/0, but Mix.install/2 was never called")
+        nil
     end
   end
 

--- a/lib/mix/test/mix_test.exs
+++ b/lib/mix/test/mix_test.exs
@@ -263,27 +263,25 @@ defmodule MixTest do
         [
           {:git_repo, git: fixture_path("git_repo")}
         ],
-        lockfile: lockfile,
-        verbose: true
+        lockfile: lockfile
       )
 
       assert_received {:mix_shell, :info, ["* Getting git_repo " <> _]}
-      assert_received {:mix_shell, :info, ["Mix.install/2 using " <> install_dir]}
+
+      install_dir = Mix.install_project_dir()
       assert File.read!(Path.join(install_dir, "mix.lock")) =~ rev
     end
 
     test ":lockfile merging", %{tmp_dir: tmp_dir} do
       [rev1, rev2 | _] = get_git_repo_revs("git_repo")
 
-      Mix.install(
-        [
-          {:git_repo, git: fixture_path("git_repo")}
-        ],
-        verbose: true
-      )
+      Mix.install([
+        {:git_repo, git: fixture_path("git_repo")}
+      ])
 
       assert_received {:mix_shell, :info, ["* Getting git_repo " <> _]}
-      assert_received {:mix_shell, :info, ["Mix.install/2 using " <> install_dir]}
+
+      install_dir = Mix.install_project_dir()
       assert File.read!(Path.join(install_dir, "mix.lock")) =~ rev1
 
       Mix.Project.push(GitApp)
@@ -314,12 +312,11 @@ defmodule MixTest do
           {:install_test, path: Path.join(tmp_dir, "install_test")},
           {:git_repo, git: fixture_path("git_repo")}
         ],
-        lockfile: :install_test,
-        verbose: true
+        lockfile: :install_test
       )
 
       assert_received {:mix_shell, :info, ["* Getting git_repo " <> _]}
-      assert_received {:mix_shell, :info, ["Mix.install/2 using " <> install_dir]}
+      install_dir = Mix.install_project_dir()
       assert File.read!(Path.join(install_dir, "mix.lock")) =~ rev
     end
 

--- a/lib/mix/test/mix_test.exs
+++ b/lib/mix/test/mix_test.exs
@@ -270,8 +270,6 @@ defmodule MixTest do
       assert_received {:mix_shell, :info, ["* Getting git_repo " <> _]}
       assert_received {:mix_shell, :info, ["Mix.install/2 using " <> install_dir]}
       assert File.read!(Path.join(install_dir, "mix.lock")) =~ rev
-    after
-      purge([GitRepo, GitRepo.MixProject])
     end
 
     test ":lockfile merging", %{tmp_dir: tmp_dir} do
@@ -301,8 +299,6 @@ defmodule MixTest do
       )
 
       assert File.read!(Path.join(install_dir, "mix.lock")) =~ rev1
-    after
-      purge([GitRepo, GitRepo.MixProject])
     end
 
     test ":lockfile with application name", %{tmp_dir: tmp_dir} do
@@ -325,14 +321,79 @@ defmodule MixTest do
       assert_received {:mix_shell, :info, ["* Getting git_repo " <> _]}
       assert_received {:mix_shell, :info, ["Mix.install/2 using " <> install_dir]}
       assert File.read!(Path.join(install_dir, "mix.lock")) =~ rev
-    after
-      purge([GitRepo, GitRepo.MixProject])
     end
 
     test ":lockfile that does not exist" do
       assert_raise File.Error, ~r/bad": no such file or directory/, fn ->
         Mix.install([], lockfile: "bad")
       end
+    end
+
+    test "restore dir", %{tmp_dir: tmp_dir} do
+      with_cleanup(fn ->
+        Mix.install([
+          {:git_repo, git: fixture_path("git_repo")}
+        ])
+
+        assert_received {:mix_shell, :info, ["* Getting git_repo " <> _]}
+        assert_received {:mix_shell, :info, ["==> git_repo"]}
+        assert_received {:mix_shell, :info, ["Compiling 1 file (.ex)"]}
+        assert_received {:mix_shell, :info, ["Generated git_repo app"]}
+        refute_received _
+
+        install_dir = Mix.install_project_dir()
+        build_lib_path = Path.join([install_dir, "_build", "dev", "lib"])
+        deps_path = Path.join([install_dir, "deps"])
+
+        assert File.ls!(build_lib_path) |> Enum.sort() == ["git_repo", "mix_install"]
+        assert File.ls!(deps_path) == ["git_repo"]
+
+        System.put_env("MIX_INSTALL_RESTORE_PROJECT_DIR", install_dir)
+      end)
+
+      # Adding a dependency
+
+      with_cleanup(fn ->
+        Mix.install([
+          {:git_repo, git: fixture_path("git_repo")},
+          {:install_test, path: Path.join(tmp_dir, "install_test")}
+        ])
+
+        assert_received {:mix_shell, :info, ["==> install_test"]}
+        assert_received {:mix_shell, :info, ["Compiling 2 files (.ex)"]}
+        assert_received {:mix_shell, :info, ["Generated install_test app"]}
+        refute_received _
+
+        install_dir = Mix.install_project_dir()
+        build_lib_path = Path.join([install_dir, "_build", "dev", "lib"])
+        deps_path = Path.join([install_dir, "deps"])
+
+        assert File.ls!(build_lib_path) |> Enum.sort() ==
+                 ["git_repo", "install_test", "mix_install"]
+
+        assert File.ls!(deps_path) == ["git_repo"]
+
+        System.put_env("MIX_INSTALL_RESTORE_PROJECT_DIR", install_dir)
+      end)
+
+      # Removing a dependency
+
+      with_cleanup(fn ->
+        Mix.install([
+          {:install_test, path: Path.join(tmp_dir, "install_test")}
+        ])
+
+        refute_received _
+
+        install_dir = Mix.install_project_dir()
+        build_lib_path = Path.join([install_dir, "_build", "dev", "lib"])
+        deps_path = Path.join([install_dir, "deps"])
+
+        assert File.ls!(build_lib_path) |> Enum.sort() == ["install_test", "mix_install"]
+        assert File.ls!(deps_path) == []
+      end)
+    after
+      System.delete_env("MIX_INSTALL_RESTORE_PROJECT_DIR")
     end
 
     test "installed?", %{tmp_dir: tmp_dir} do
@@ -380,15 +441,7 @@ defmodule MixTest do
 
       on_exit(fn ->
         :code.set_path(path)
-        purge([InstallTest, InstallTest.MixProject, InstallTest.Protocol])
-
-        ExUnit.CaptureLog.capture_log(fn ->
-          Application.stop(:git_repo)
-          Application.unload(:git_repo)
-
-          Application.stop(:install_test)
-          Application.unload(:install_test)
-        end)
+        cleanup_deps()
       end)
 
       Mix.State.put(:installed, nil)
@@ -423,6 +476,38 @@ defmodule MixTest do
       """)
 
       [tmp_dir: tmp_dir]
+    end
+
+    defp with_cleanup(fun) do
+      path = :code.get_path()
+
+      try do
+        fun.()
+      after
+        :code.set_path(path)
+        cleanup_deps()
+
+        Mix.State.clear_cache()
+        Mix.State.put(:installed, nil)
+      end
+    end
+
+    defp cleanup_deps() do
+      purge([
+        GitRepo,
+        GitRepo.MixProject,
+        InstallTest,
+        InstallTest.MixProject,
+        InstallTest.Protocol
+      ])
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        Application.stop(:git_repo)
+        Application.unload(:git_repo)
+
+        Application.stop(:install_test)
+        Application.unload(:install_test)
+      end)
     end
   end
 end

--- a/lib/mix/test/mix_test.exs
+++ b/lib/mix/test/mix_test.exs
@@ -268,8 +268,8 @@ defmodule MixTest do
 
       assert_received {:mix_shell, :info, ["* Getting git_repo " <> _]}
 
-      install_dir = Mix.install_project_dir()
-      assert File.read!(Path.join(install_dir, "mix.lock")) =~ rev
+      install_project_dir = Mix.install_project_dir()
+      assert File.read!(Path.join(install_project_dir, "mix.lock")) =~ rev
     end
 
     test ":lockfile merging", %{tmp_dir: tmp_dir} do
@@ -281,8 +281,8 @@ defmodule MixTest do
 
       assert_received {:mix_shell, :info, ["* Getting git_repo " <> _]}
 
-      install_dir = Mix.install_project_dir()
-      assert File.read!(Path.join(install_dir, "mix.lock")) =~ rev1
+      install_project_dir = Mix.install_project_dir()
+      assert File.read!(Path.join(install_project_dir, "mix.lock")) =~ rev1
 
       Mix.Project.push(GitApp)
       lockfile = Path.join(tmp_dir, "lock")
@@ -296,7 +296,7 @@ defmodule MixTest do
         lockfile: lockfile
       )
 
-      assert File.read!(Path.join(install_dir, "mix.lock")) =~ rev1
+      assert File.read!(Path.join(install_project_dir, "mix.lock")) =~ rev1
     end
 
     test ":lockfile with application name", %{tmp_dir: tmp_dir} do
@@ -316,8 +316,8 @@ defmodule MixTest do
       )
 
       assert_received {:mix_shell, :info, ["* Getting git_repo " <> _]}
-      install_dir = Mix.install_project_dir()
-      assert File.read!(Path.join(install_dir, "mix.lock")) =~ rev
+      install_project_dir = Mix.install_project_dir()
+      assert File.read!(Path.join(install_project_dir, "mix.lock")) =~ rev
     end
 
     test ":lockfile that does not exist" do
@@ -338,14 +338,14 @@ defmodule MixTest do
         assert_received {:mix_shell, :info, ["Generated git_repo app"]}
         refute_received _
 
-        install_dir = Mix.install_project_dir()
-        build_lib_path = Path.join([install_dir, "_build", "dev", "lib"])
-        deps_path = Path.join([install_dir, "deps"])
+        install_project_dir = Mix.install_project_dir()
+        build_lib_path = Path.join([install_project_dir, "_build", "dev", "lib"])
+        deps_path = Path.join([install_project_dir, "deps"])
 
         assert File.ls!(build_lib_path) |> Enum.sort() == ["git_repo", "mix_install"]
         assert File.ls!(deps_path) == ["git_repo"]
 
-        System.put_env("MIX_INSTALL_RESTORE_PROJECT_DIR", install_dir)
+        System.put_env("MIX_INSTALL_RESTORE_PROJECT_DIR", install_project_dir)
       end)
 
       # Adding a dependency
@@ -361,16 +361,16 @@ defmodule MixTest do
         assert_received {:mix_shell, :info, ["Generated install_test app"]}
         refute_received _
 
-        install_dir = Mix.install_project_dir()
-        build_lib_path = Path.join([install_dir, "_build", "dev", "lib"])
-        deps_path = Path.join([install_dir, "deps"])
+        install_project_dir = Mix.install_project_dir()
+        build_lib_path = Path.join([install_project_dir, "_build", "dev", "lib"])
+        deps_path = Path.join([install_project_dir, "deps"])
 
         assert File.ls!(build_lib_path) |> Enum.sort() ==
                  ["git_repo", "install_test", "mix_install"]
 
         assert File.ls!(deps_path) == ["git_repo"]
 
-        System.put_env("MIX_INSTALL_RESTORE_PROJECT_DIR", install_dir)
+        System.put_env("MIX_INSTALL_RESTORE_PROJECT_DIR", install_project_dir)
       end)
 
       # Removing a dependency
@@ -382,9 +382,9 @@ defmodule MixTest do
 
         refute_received _
 
-        install_dir = Mix.install_project_dir()
-        build_lib_path = Path.join([install_dir, "_build", "dev", "lib"])
-        deps_path = Path.join([install_dir, "deps"])
+        install_project_dir = Mix.install_project_dir()
+        build_lib_path = Path.join([install_project_dir, "_build", "dev", "lib"])
+        deps_path = Path.join([install_project_dir, "deps"])
 
         assert File.ls!(build_lib_path) |> Enum.sort() == ["install_test", "mix_install"]
         assert File.ls!(deps_path) == []


### PR DESCRIPTION
After calling `Mix.install/2`, one may retrieve the installation directory with `Mix.install_project_dir/0` and then use the MIX_INSTALL_RESTORE_PROJECT_DIR environment variable in another session as a starting point for a different `Mix.install/2`.

Implementation-wise we copy the restore dir contents, do the installation, then remove files for the dependencies that are not used.