### PR TITLE
Add more examples to the enum filter

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1096,6 +1096,13 @@ defmodule Enum do
 
       iex> Enum.filter([1, 2, 3], fn x -> rem(x, 2) == 0 end)
       [2]
+      iex> Enum.filter(["sally@example.com", "john@example.com"], fn x -> String.contains?(x, "example.com") end)
+      ["sally@example.com", "john@example.com"]
+      iex> Enum.filter([:error, :error, :error, :error], fn
+        :ok -> true
+        _anything_else -> false 
+      end)
+      []
 
   Keep in mind that `filter` is not capable of filtering and
   transforming an element at the same time. If you would like

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1096,12 +1096,9 @@ defmodule Enum do
 
       iex> Enum.filter([1, 2, 3], fn x -> rem(x, 2) == 0 end)
       [2]
-      iex> Enum.filter(["sally@example.com", "john@example.com"], fn x -> String.contains?(x, "example.com") end)
-      ["sally@example.com", "john@example.com"]
-      iex> Enum.filter([:error, :error, :error, :error], fn
-        :ok -> true
-        _anything_else -> false 
-      end)
+      iex> Enum.filter(["apple", "pear", "banana"], fn fruit -> String.contains?(fruit, "a") end)
+      ["apple", "pear", "banana"]
+      iex> Enum.filter([4, 21, 24, 904], fn seconds -> seconds > 1000 end)
       []
 
   Keep in mind that `filter` is not capable of filtering and


### PR DESCRIPTION
Had a student not really get the rem(x, 2) == 0 example and also not realize it could return none or all, or even that you could use the function pattern matching.