### PR TITLE
Implement guard-safe `MapSet.is_member/2`

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -94,13 +94,11 @@ defmodule MapSet do
 
       false ->
         quote do
-          map_set = unquote(map_set)
           value = unquote(value)
 
-          if is_struct(map_set, unquote(__MODULE__)) do
-            is_map_key(map_set.map, value)
-          else
-            raise ArgumentError, message: "expected a MapSet, got: #{inspect(map_set)}"
+          case unquote(map_set) do
+            %MapSet{map: map} ->  is_map_key(map, value)
+            other -> raise ArgumentError, message: "expected a MapSet, got: #{inspect(other)}"
           end
         end
     end

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -83,6 +83,7 @@ defmodule MapSet do
       true
 
   """
+  @doc since: "1.17.0"
   defguard is_member(map_set, value)
            when is_struct(map_set, __MODULE__) and
                   is_map_key(map_set.map, value)

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -88,7 +88,7 @@ defmodule MapSet do
     case Macro.Env.in_guard?(__CALLER__) do
       true ->
         quote do
-          (is_struct(unquote(map_set), unquote(__MODULE__)) or :fail) and
+          is_struct(unquote(map_set), unquote(__MODULE__)) and
             is_map_key(unquote(map_set).map, unquote(value))
         end
 

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -98,7 +98,7 @@ defmodule MapSet do
 
           case unquote(map_set) do
             %MapSet{map: map} -> is_map_key(map, value)
-            other -> raise ArgumentError, message: "expected a MapSet, got: #{inspect(other)}"
+            other -> raise ArgumentError, "expected a MapSet, got: #{inspect(other)}"
           end
         end
     end

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -94,12 +94,7 @@ defmodule MapSet do
 
       false ->
         quote do
-          value = unquote(value)
-
-          case unquote(map_set) do
-            %MapSet{map: map} -> is_map_key(map, value)
-            other -> raise ArgumentError, "expected a MapSet, got: #{inspect(other)}"
-          end
+          MapSet.member?(unquote(map_set), unquote(value))
         end
     end
   end

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -88,7 +88,7 @@ defmodule MapSet do
     case Macro.Env.in_guard?(__CALLER__) do
       true ->
         quote do
-          (unquote(map_set).__struct__ == unquote(__MODULE__) or :fail) and
+          (is_struct(unquote(map_set), unquote(__MODULE__)) or :fail) and
             is_map_key(unquote(map_set).map, unquote(value))
         end
 

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -82,6 +82,20 @@ defmodule MapSet do
       ...> end
       true
 
+  ## Exceptions
+
+  Normally, if `map_set` is not a `MapSet`, `is_member/2` will raise (just like `member?/2`).
+  However, in guards, it will simply return false, allowing chaining.
+
+      iex> MapSet.is_member([1, 2, 3], :value)
+      ** (ArgumentError) expected a MapSet, got: [1, 2, 3]
+
+      iex> case [1, 2, 3] do
+      ...>   enumerable when MapSet.is_member(enumerable, 3) or length(enumerable) == 3 -> true
+      ...>   _ -> false
+      ...> end
+      true
+
   """
   @doc guard: true, since: "1.17.0"
   defmacro is_member(map_set, value) do
@@ -97,7 +111,7 @@ defmodule MapSet do
           value = unquote(value)
 
           case unquote(map_set) do
-            %MapSet{map: map} ->  is_map_key(map, value)
+            %MapSet{map: map} -> is_map_key(map, value)
             other -> raise ArgumentError, message: "expected a MapSet, got: #{inspect(other)}"
           end
         end

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -64,6 +64,30 @@ defmodule MapSet do
   defstruct map: :sets.new(version: 2)
 
   @doc """
+  Checks if `map_set` contains `value`. Allowed in guards.
+
+  Otherwise equivalent to `member?/2`.
+
+  ## Examples
+
+      iex> MapSet.is_member(MapSet.new([1, 2, 3]), 2)
+      true
+
+      iex> MapSet.is_member(MapSet.new([1, 2, 3]), 4)
+      false
+
+      iex> case MapSet.new([1, 2, 3]) do
+      ...>   map_set when MapSet.is_member(map_set, 3) -> true
+      ...>   _ -> false
+      ...> end
+      true
+
+  """
+  defguard is_member(map_set, value)
+           when is_struct(map_set, __MODULE__) and
+                  :erlang.is_map_key(value, map_set.map)
+
+  @doc """
   Returns a new set.
 
   ## Examples
@@ -242,6 +266,8 @@ defmodule MapSet do
       true
       iex> MapSet.member?(MapSet.new([1, 2, 3]), 4)
       false
+
+  See `is_member/2` for a guard-supported variant.
 
   """
   @spec member?(t, value) :: boolean

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -83,7 +83,7 @@ defmodule MapSet do
       true
 
   """
-  @doc since: "1.17.0"
+  @doc guard: true, since: "1.17.0"
   defguard is_member(map_set, value)
            when is_struct(map_set, __MODULE__) and
                   is_map_key(map_set.map, value)

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -82,27 +82,13 @@ defmodule MapSet do
       ...> end
       true
 
-  ## Exceptions
-
-  Normally, if `map_set` is not a `MapSet`, `is_member/2` will raise (just like `member?/2`).
-  However, in guards, it will simply return false, allowing chaining.
-
-      iex> MapSet.is_member([1, 2, 3], :value)
-      ** (ArgumentError) expected a MapSet, got: [1, 2, 3]
-
-      iex> case [1, 2, 3] do
-      ...>   enumerable when MapSet.is_member(enumerable, 3) or length(enumerable) == 3 -> true
-      ...>   _ -> false
-      ...> end
-      true
-
   """
   @doc guard: true, since: "1.17.0"
   defmacro is_member(map_set, value) do
     case Macro.Env.in_guard?(__CALLER__) do
       true ->
         quote do
-          is_struct(unquote(map_set), unquote(__MODULE__)) and
+          (unquote(map_set).__struct__ == unquote(__MODULE__) or :fail) and
             is_map_key(unquote(map_set).map, unquote(value))
         end
 

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -85,7 +85,7 @@ defmodule MapSet do
   """
   defguard is_member(map_set, value)
            when is_struct(map_set, __MODULE__) and
-                  :erlang.is_map_key(value, map_set.map)
+                  is_map_key(map_set.map, value)
 
   @doc """
   Returns a new set.

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -268,7 +268,6 @@ defmodule MapSet do
       false
 
   See `is_member/2` for a guard-supported variant.
-
   """
   @spec member?(t, value) :: boolean
   def member?(%MapSet{map: set}, value) do

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -12,7 +12,7 @@ defmodule MapSetTest do
     assert MapSet.is_member(map_set, 2)
     refute MapSet.is_member(map_set, 4)
 
-    assert_raise ArgumentError, ~r/expected a MapSet/, fn ->
+    assert_raise FunctionClauseError, fn ->
       MapSet.is_member(list, 2)
     end
 

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -17,10 +17,17 @@ defmodule MapSetTest do
     end
 
     guards = fn
-      input when MapSet.is_member(input, 4) or input == 4 -> :found_4
-      input when (is_struct(input, MapSet) and MapSet.is_member(input, 3)) or input == 3 -> :found_3
-      input when MapSet.is_member(input, 2) -> :found_2
-      _ -> :error
+      input when MapSet.is_member(input, 4) or input == 4 ->
+        :found_4
+
+      input when (is_struct(input, MapSet) and MapSet.is_member(input, 3)) or input == 3 ->
+        :found_3
+
+      input when MapSet.is_member(input, 2) ->
+        :found_2
+
+      _ ->
+        :error
     end
 
     assert guards.(MapSet.new(1..2)) == :found_2

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -5,6 +5,27 @@ defmodule MapSetTest do
 
   doctest MapSet
 
+  test "is_member/2" do
+    map_set = MapSet.new(1..3)
+    assert MapSet.is_member(map_set, 2)
+    refute MapSet.is_member(map_set, 4)
+
+    guards = fn
+      map_set when MapSet.is_member(map_set, 4) -> :found_4
+      map_set when MapSet.is_member(map_set, 2) -> :found_2
+      _ -> :error
+    end
+    assert guards.(map_set) == :found_2
+    assert guards.(MapSet.new(1..4)) == :found_4
+
+    list = [1, 2, 3]
+    assert guards.(list) == :error
+
+    assert_raise ArgumentError, ~r/expected a MapSet/, fn ->
+      MapSet.is_member(list, 2)
+    end
+  end
+
   test "new/1" do
     result = MapSet.new(1..5)
     assert MapSet.equal?(result, Enum.into(1..5, MapSet.new()))

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -18,13 +18,17 @@ defmodule MapSetTest do
 
     guards = fn
       input when MapSet.is_member(input, 4) or input == 4 -> :found_4
+      input when (is_struct(input, MapSet) and MapSet.is_member(input, 3)) or input == 3 -> :found_3
       input when MapSet.is_member(input, 2) -> :found_2
       _ -> :error
     end
 
-    assert guards.(map_set) == :found_2
+    assert guards.(MapSet.new(1..2)) == :found_2
+    assert guards.(MapSet.new(1..3)) == :found_3
     assert guards.(MapSet.new(1..4)) == :found_4
-    assert guards.(4) == :found_4
+    assert guards.(2) == :error
+    assert guards.(3) == :found_3
+    assert guards.(4) == :error
     assert guards.(list) == :error
   end
 

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -7,23 +7,25 @@ defmodule MapSetTest do
 
   test "is_member/2" do
     map_set = MapSet.new(1..3)
+    list = [1, 2, 3]
+
     assert MapSet.is_member(map_set, 2)
     refute MapSet.is_member(map_set, 4)
-
-    guards = fn
-      map_set when MapSet.is_member(map_set, 4) -> :found_4
-      map_set when MapSet.is_member(map_set, 2) -> :found_2
-      _ -> :error
-    end
-    assert guards.(map_set) == :found_2
-    assert guards.(MapSet.new(1..4)) == :found_4
-
-    list = [1, 2, 3]
-    assert guards.(list) == :error
 
     assert_raise ArgumentError, ~r/expected a MapSet/, fn ->
       MapSet.is_member(list, 2)
     end
+
+    guards = fn
+      input when MapSet.is_member(input, 4) or input == 4 -> :found_4
+      input when MapSet.is_member(input, 2) -> :found_2
+      _ -> :error
+    end
+
+    assert guards.(map_set) == :found_2
+    assert guards.(MapSet.new(1..4)) == :found_4
+    assert guards.(4) == :found_4
+    assert guards.(list) == :error
   end
 
   test "new/1" do


### PR DESCRIPTION
Per discussion on [elixir-lang-core](https://groups.google.com/g/elixir-lang-core/c/IRrfWoT55OM/m/QrGys8t_AQAJ), this provides a guard-safe membership check for `MapSet`s without modifying the existing `MapSet.member?/2`.