### PR TITLE
Ensure install-related functions do not crash when Mix is not started

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -1052,6 +1052,8 @@ defmodule Mix do
 
   @doc false
   def in_install_project(fun) do
+    Mix.start()
+
     case Mix.State.get(:installed) do
       {id, dynamic_config} ->
         config = install_project_config(dynamic_config)
@@ -1080,6 +1082,8 @@ defmodule Mix do
   @doc since: "1.16.2"
   @spec install_project_dir() :: Path.t() | nil
   def install_project_dir() do
+    Mix.start()
+
     case Mix.State.get(:installed) do
       {id, _dynamic_config} -> install_project_dir(id)
       nil -> nil
@@ -1092,6 +1096,8 @@ defmodule Mix do
   @doc since: "1.13.0"
   @spec installed?() :: boolean()
   def installed? do
+    Mix.start()
+
     Mix.State.get(:installed) != nil
   end
 

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -1052,9 +1052,7 @@ defmodule Mix do
 
   @doc false
   def in_install_project(fun) do
-    Mix.start()
-
-    case Mix.State.get(:installed) do
+    case safe_get_installed() do
       {id, dynamic_config} ->
         config = install_project_config(dynamic_config)
 
@@ -1082,9 +1080,7 @@ defmodule Mix do
   @doc since: "1.16.2"
   @spec install_project_dir() :: Path.t() | nil
   def install_project_dir() do
-    Mix.start()
-
-    case Mix.State.get(:installed) do
+    case safe_get_installed() do
       {id, _dynamic_config} -> install_project_dir(id)
       nil -> nil
     end
@@ -1096,9 +1092,17 @@ defmodule Mix do
   @doc since: "1.13.0"
   @spec installed?() :: boolean()
   def installed? do
-    Mix.start()
+    safe_get_installed() != nil
+  end
 
-    Mix.State.get(:installed) != nil
+  defp safe_get_installed() do
+    if mix_started?() do
+      Mix.State.get(:installed)
+    end
+  end
+
+  defp mix_started?() do
+    Process.whereis(Mix.State) != nil
   end
 
   defp stop_apps([]), do: :ok


### PR DESCRIPTION
Otherwise `Mix.State.get/1` raises.