### PR TITLE
Logger handles :process_label from OTP27

### DIFF
--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -406,11 +406,9 @@ defmodule Logger.Translator do
   end
 
   defp report_crash(min_level, crashed, extra, linked) do
-    [
-      {:pid, pid},
-      {:registered_name, name},
-      {:error_info, {kind, reason, stack}} | crashed
-    ] = crashed
+    {pid, crashed} = Keyword.pop_first(crashed, :pid)
+    {name, crashed} = Keyword.pop_first(crashed, :registered_name)
+    {{kind, reason, stack}, crashed} = Keyword.pop_first(crashed, :error_info)
 
     dictionary = crashed[:dictionary]
     reason = Exception.normalize(kind, reason, stack)
@@ -459,6 +457,10 @@ defmodule Logger.Translator do
 
   defp crash_info(min_level, [{:ancestors, ancestors} | debug], prefix) do
     [prefix, "Ancestors: ", inspect(ancestors) | crash_info(min_level, debug, prefix)]
+  end
+
+  defp crash_info(min_level, [{:process_label, _} | info], prefix) do
+    crash_info(min_level, info, prefix)
   end
 
   defp crash_info(:debug, debug, prefix) do


### PR DESCRIPTION
OTP27 introduces a new `:process_label` key between `:registered_name` and `:error_info` (https://github.com/erlang/otp/pull/7720), breaking the pattern-matching on the keyword-list:
<img width="571" alt="Screenshot 2024-03-05 at 20 34 29" src="https://github.com/elixir-lang/elixir/assets/11598866/651d9b43-5cd7-446b-a5fb-e9f25ccd0fa2">

This PR just fixes the CI, but doesn't do anything with the label. We could maybe display it if `!= :undefined`?