### PR TITLE
Wrap :proc_lib label functionality

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -943,7 +943,13 @@ defmodule Process do
   @doc """
   Add a descriptive term to the current process.
 
-  The term does not need to be unique, and in Erlang/OTP 27+ will be shown in Observer.
+  The term does not need to be unique, and in Erlang/OTP 27+ will be shown in
+  Observer and in crash logs.
+  This label may be useful for identifying a process as one of multiple in a
+  given role, such as "database connection" or "queue worker".
+  Although any term may be used, concise display and memory efficiency should
+  be taken into account in the choice; a short atom would be ideal on both
+  counts.
 
   ## Examples
 

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -940,6 +940,23 @@ defmodule Process do
   @spec unalias(alias) :: boolean
   defdelegate unalias(alias), to: :erlang
 
+  @doc """
+  Add a descriptive term to the current process.
+  The term does not need to be unique, and in Erlang/OTP 27+ will be shown in Observer.
+
+  ## Examples
+
+      Process.set_label(:worker)
+      #=> :ok
+  """
+  @spec set_label(term()) :: nil
+  def set_label(label) do
+    # TODO: switch to `:proc_lib.set_label/2` when we require Erlang/OTP 27+
+    Process.put(:"$process_label", label)
+    # mimic return value of `:proc_lib.set_label/2`
+    :ok
+  end
+
   @compile {:inline, nilify: 1}
   defp nilify(:undefined), do: nil
   defp nilify(other), do: other

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -942,6 +942,7 @@ defmodule Process do
 
   @doc """
   Add a descriptive term to the current process.
+
   The term does not need to be unique, and in Erlang/OTP 27+ will be shown in Observer.
 
   ## Examples
@@ -949,6 +950,7 @@ defmodule Process do
       Process.set_label(:worker)
       #=> :ok
   """
+  @doc since: "1.17.0"
   @spec set_label(term()) :: :ok
   def set_label(label) do
     # TODO: switch to `:proc_lib.set_label/2` when we require Erlang/OTP 27+

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -949,7 +949,7 @@ defmodule Process do
       Process.set_label(:worker)
       #=> :ok
   """
-  @spec set_label(term()) :: nil
+  @spec set_label(term()) :: :ok
   def set_label(label) do
     # TODO: switch to `:proc_lib.set_label/2` when we require Erlang/OTP 27+
     Process.put(:"$process_label", label)

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -946,10 +946,7 @@ defmodule Process do
   The term does not need to be unique, and in Erlang/OTP 27+ will be shown in
   Observer and in crash logs.
   This label may be useful for identifying a process as one of multiple in a
-  given role, such as "database connection" or "queue worker".
-  Although any term may be used, concise display and memory efficiency should
-  be taken into account in the choice; a short atom would be ideal on both
-  counts.
+  given role, such as `:queue_worker` or `{:live_chat, user_id}`.
 
   ## Examples
 

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -949,6 +949,9 @@ defmodule Process do
 
       Process.set_label(:worker)
       #=> :ok
+      
+      Process.set_label({:any, "term"})
+      #=> :ok
   """
   @doc since: "1.17.0"
   @spec set_label(term()) :: :ok

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -170,7 +170,7 @@ defmodule ProcessTest do
     end
   end
 
-  describe "set_label/2" do
+  describe "set_label/1" do
     test "sets a process label, compatible with OTP 27+ `:proc_lib.get_label/1`" do
       label = {:some_label, :random.uniform(99999)}
       assert :ok = Process.set_label(label)

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -170,6 +170,17 @@ defmodule ProcessTest do
     end
   end
 
+  describe "set_label/2" do
+    test "sets a process label, compatible with OTP 27+ `:proc_lib.get_label/1`" do
+      label = {:some_label, :random.uniform(99999)}
+      assert :ok = Process.set_label(label)
+
+      if :erlang.system_info(:otp_release) == ~c"27" do
+        assert :proc_lib.get_label(self()) == label
+      end
+    end
+  end
+
   defp expand(expr, env) do
     {expr, _, _} = :elixir_expand.expand(expr, :elixir_env.env_to_ex(env), env)
     expr

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -175,7 +175,7 @@ defmodule ProcessTest do
       label = {:some_label, :random.uniform(99999)}
       assert :ok = Process.set_label(label)
 
-      if :erlang.system_info(:otp_release) == ~c"27" do
+      if System.otp_release() >= "27" do
         assert :proc_lib.get_label(self()) == label
       end
     end

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -175,7 +175,7 @@ defmodule ProcessTest do
       label = {:some_label, :random.uniform(99999)}
       assert :ok = Process.set_label(label)
 
-      if String.to_integer(System.otp_release()) >= 27 do
+      if System.otp_release() >= "27" do
         assert :proc_lib.get_label(self()) == label
       end
     end

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -175,6 +175,7 @@ defmodule ProcessTest do
       label = {:some_label, :random.uniform(99999)}
       assert :ok = Process.set_label(label)
 
+      # TODO: Remove this when we require Erlang/OTP 27+
       if System.otp_release() >= "27" do
         assert :proc_lib.get_label(self()) == label
       end

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -175,7 +175,7 @@ defmodule ProcessTest do
       label = {:some_label, :random.uniform(99999)}
       assert :ok = Process.set_label(label)
 
-      if System.otp_release() >= "27" do
+      if String.to_integer(System.otp_release()) >= 27 do
         assert :proc_lib.get_label(self()) == label
       end
     end


### PR DESCRIPTION
I'm open to reworking this completely, but I wanted to propose making the OTP 27.0 `:proc_lib.set_label/1` functionality easy to use.

I think we can make a lot of observability and error reporting clearer if we can start using these labels in a lot of places.

Example of effect: https://github.com/mtrudel/bandit/pull/319