### PR TITLE
Replace deprecated :code.lib_dir/2 usages

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -448,7 +448,7 @@ defmodule Protocol do
   ## Examples
 
       # Get Elixir's ebin directory path and retrieve all protocols
-      iex> path = Path.join(:code.lib_dir(:elixir), "ebin")
+      iex> path = Application.app_dir(:elixir, "ebin")
       iex> mods = Protocol.extract_protocols([path])
       iex> Enumerable in mods
       true
@@ -477,7 +477,7 @@ defmodule Protocol do
   ## Examples
 
       # Get Elixir's ebin directory path and retrieve all protocols
-      iex> path = Path.join(:code.lib_dir(:elixir), "ebin")
+      iex> path = Application.app_dir(:elixir, "ebin")
       iex> mods = Protocol.extract_impls(Enumerable, [path])
       iex> List in mods
       true

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -448,7 +448,7 @@ defmodule Protocol do
   ## Examples
 
       # Get Elixir's ebin directory path and retrieve all protocols
-      iex> path = :code.lib_dir(:elixir, :ebin)
+      iex> path = Path.join(:code.lib_dir(:elixir), "ebin")
       iex> mods = Protocol.extract_protocols([path])
       iex> Enumerable in mods
       true
@@ -477,7 +477,7 @@ defmodule Protocol do
   ## Examples
 
       # Get Elixir's ebin directory path and retrieve all protocols
-      iex> path = :code.lib_dir(:elixir, :ebin)
+      iex> path = Path.join(:code.lib_dir(:elixir), "ebin")
       iex> mods = Protocol.extract_impls(Enumerable, [path])
       iex> List in mods
       true

--- a/lib/elixir/test/elixir/protocol/consolidation_test.exs
+++ b/lib/elixir/test/elixir/protocol/consolidation_test.exs
@@ -161,13 +161,13 @@ defmodule Protocol.ConsolidationTest do
   end
 
   test "consolidation extracts protocols" do
-    protos = Protocol.extract_protocols([:code.lib_dir(:elixir, :ebin)])
+    protos = Protocol.extract_protocols([Path.join(:code.lib_dir(:elixir), "ebin")])
     assert Enumerable in protos
     assert Inspect in protos
   end
 
   test "consolidation extracts implementations with charlist path" do
-    protos = Protocol.extract_impls(Enumerable, [:code.lib_dir(:elixir, :ebin)])
+    protos = Protocol.extract_impls(Enumerable, [Path.join(:code.lib_dir(:elixir), "ebin")])
     assert List in protos
     assert Function in protos
   end

--- a/lib/elixir/test/elixir/protocol/consolidation_test.exs
+++ b/lib/elixir/test/elixir/protocol/consolidation_test.exs
@@ -161,13 +161,15 @@ defmodule Protocol.ConsolidationTest do
   end
 
   test "consolidation extracts protocols" do
-    protos = Protocol.extract_protocols([Path.join(:code.lib_dir(:elixir), "ebin")])
+    protos = Protocol.extract_protocols([Application.app_dir(:elixir, "ebin")])
     assert Enumerable in protos
     assert Inspect in protos
   end
 
   test "consolidation extracts implementations with charlist path" do
-    protos = Protocol.extract_impls(Enumerable, [Path.join(:code.lib_dir(:elixir), "ebin")])
+    protos =
+      Protocol.extract_impls(Enumerable, [to_charlist(Application.app_dir(:elixir, "ebin"))])
+
     assert List in protos
     assert Function in protos
   end

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -144,7 +144,7 @@ defmodule IEx.HelpersTest do
   describe "open" do
     @iex_helpers "iex/lib/iex/helpers.ex"
     @elixir_erl "elixir/src/elixir.erl"
-    @lists_erl "#{:code.lib_dir(:stdlib)}/src/lists.erl"
+    @lists_erl Application.app_dir(:stdlib, "src/lists.erl")
     @httpc_erl "src/http_client/httpc.erl"
     @editor System.get_env("ELIXIR_EDITOR")
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -144,7 +144,7 @@ defmodule IEx.HelpersTest do
   describe "open" do
     @iex_helpers "iex/lib/iex/helpers.ex"
     @elixir_erl "elixir/src/elixir.erl"
-    @lists_erl "#{:code.lib_dir(:stdlib, :src)}/lists.erl"
+    @lists_erl "#{:code.lib_dir(:stdlib)}/src/lists.erl"
     @httpc_erl "src/http_client/httpc.erl"
     @editor System.get_env("ELIXIR_EDITOR")
 


### PR DESCRIPTION
Not 100% sure, should we do this replacement following https://github.com/erlang/otp/pull/8091?
