### PR TITLE
Use System.otp_release/0 in tests for consistency

### DIFF
--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -572,7 +572,7 @@ defmodule Code.SyncTest do
 
   import PathHelpers
 
-  if :erlang.system_info(:otp_release) >= ~c"26" do
+  if System.otp_release() >= "26" do
     defp assert_cached(path) do
       assert find_path(path) != :nocache
     end

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -69,7 +69,7 @@ defmodule Kernel.CLITest do
     assert output =~ "hello_world123"
 
     # TODO: remove this once we bump CI to 26.3
-    unless windows?() and :erlang.system_info(:otp_release) == ~c"26" do
+    unless windows?() and System.otp_release() == "26" do
       {output, 0} =
         System.cmd(iex_executable(), ["--eval", "IO.puts :hello_world123; System.halt()"])
 

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -253,7 +253,7 @@ defmodule ExUnit.CaptureIOTest do
       capture_io("\"a", fn ->
         # TODO: Remove me when we require Erlang/OTP 27+
         expected_error =
-          if :erlang.system_info(:otp_release) >= ~c"27" do
+          if System.otp_release() >= "27" do
             {1, :erl_scan, {:unterminated, :string, ~c"a"}}
           else
             {1, :erl_scan, {:string, 34, ~c"a"}}


### PR DESCRIPTION
Following this [suggestion](https://github.com/elixir-lang/elixir/pull/13396#discussion_r1514005612) from @whatyouhide.

(I'm never sure which one to use and tend to check existing code for consistency, this will avoid me propagating the old pattern 😄)