### PR TITLE
add --repeat-until-failure to mix test

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -217,7 +217,7 @@ defmodule ExUnit do
         0 ->
           time = ExUnit.Server.modules_loaded(false)
           options = persist_defaults(configuration())
-          %{failures: failures} = ExUnit.Runner.run(options, time)
+          %{failures: failures} = maybe_repeated_run(options, time)
 
           if failures > 0 do
             System.at_exit(fn _ -> exit({:shutdown, Keyword.fetch!(options, :exit_status)}) end)
@@ -408,7 +408,7 @@ defmodule ExUnit do
 
     _ = ExUnit.Server.modules_loaded(additional_modules != [])
     options = persist_defaults(configuration())
-    ExUnit.Runner.run(options, nil)
+    maybe_repeated_run(options)
   end
 
   @doc """
@@ -423,7 +423,7 @@ defmodule ExUnit do
     options = persist_defaults(configuration())
 
     Task.async(fn ->
-      ExUnit.Runner.run(options, nil)
+      maybe_repeated_run(options)
     end)
   end
 
@@ -486,8 +486,43 @@ defmodule ExUnit do
     config
   end
 
+  defp maybe_repeated_run(options, load_us \\ nil) do
+    repeat = Keyword.fetch!(options, :repeat_until_failure)
+
+    %{stats: stats} =
+      if repeat > 0 do
+        repeated_run(options, load_us, repeat)
+      else
+        ExUnit.Runner.run(options, load_us)
+      end
+
+    stats
+  end
+
+  defp repeated_run(options, load_us, repeat) do
+    result = ExUnit.Runner.run(options, load_us)
+    %{stats: stats, modules_to_restore: {async, sync}} = result
+
+    if repeat > 0 and stats.failures == 0 and (async != [] or sync != []) do
+      ExUnit.Server.restore_modules(async, sync)
+      # clear the seed if it was generated
+      if Keyword.get(options, :seed_generated, false) do
+        Application.delete_env(:ex_unit, :seed)
+      end
+
+      # re-run configuration
+      options = persist_defaults(configuration())
+      repeated_run(options, load_us, repeat - 1)
+    else
+      result
+    end
+  end
+
   defp put_seed(opts) do
     Keyword.put_new_lazy(opts, :seed, fn ->
+      # we want to change the seed when using with `repeat_until_failure`
+      Application.put_env(:ex_unit, :seed_generated, true)
+
       # We're using `rem System.system_time()` here
       # instead of directly using :os.timestamp or using the
       # :microsecond argument because the VM on Windows has odd

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -488,18 +488,11 @@ defmodule ExUnit do
 
   defp maybe_repeated_run(options, load_us \\ nil) do
     repeat = Keyword.fetch!(options, :repeat_until_failure)
-
-    %{stats: stats} =
-      if repeat > 0 do
-        repeated_run(options, load_us, repeat)
-      else
-        ExUnit.Runner.run(options, load_us)
-      end
-
+    %{stats: stats} = maybe_repeated_run(options, load_us, repeat)
     stats
   end
 
-  defp repeated_run(options, load_us, repeat) do
+  defp maybe_repeated_run(options, load_us, repeat) do
     result = ExUnit.Runner.run(options, load_us)
     %{stats: stats, modules_to_restore: {async, sync}} = result
 
@@ -512,7 +505,7 @@ defmodule ExUnit do
 
       # re-run configuration
       options = persist_defaults(configuration())
-      repeated_run(options, load_us, repeat - 1)
+      maybe_repeated_run(options, load_us, repeat - 1)
     else
       result
     end

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -61,7 +61,13 @@ defmodule ExUnit.Runner do
     EM.stop(config.manager)
     after_suite_callbacks = Application.fetch_env!(:ex_unit, :after_suite)
     Enum.each(after_suite_callbacks, fn callback -> callback.(stats) end)
-    stats
+
+    if Keyword.fetch!(opts, :repeat_until_failure) and stats.failures == 0 do
+      ExUnit.Server.restore_modules()
+      run_with_trap(opts, load_us)
+    else
+      stats
+    end
   end
 
   defp configure(opts, manager, runner_pid, stats_pid) do

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -116,12 +116,12 @@ defmodule ExUnit.Runner do
       # Slots are available, start with async modules
       modules = ExUnit.Server.take_async_modules(available) ->
         running = spawn_modules(config, modules, running)
-        modules_to_restore = maybe_store_modules(modules_to_restore, :async, modules)
+        modules_to_restore = maybe_store_modules(modules_to_restore, repeat, :async, modules)
         async_loop(config, running, true, repeat, modules_to_restore)
 
       true ->
         sync_modules = ExUnit.Server.take_sync_modules()
-        modules_to_restore = maybe_store_modules(modules_to_restore, :sync, sync_modules)
+        modules_to_restore = maybe_store_modules(modules_to_restore, repeat, :sync, sync_modules)
 
         # Wait for all async modules
         0 =
@@ -178,20 +178,14 @@ defmodule ExUnit.Runner do
     end
   end
 
-  defp maybe_store_modules({async, sync}, :async, modules) do
-    if Application.fetch_env!(:ex_unit, :repeat_until_failure) > 0 do
-      {async ++ modules, sync}
-    else
-      {async, sync}
-    end
+  defp maybe_store_modules(modules_to_restore, 0, _type, _modules), do: modules_to_restore
+
+  defp maybe_store_modules({async, sync}, _repeat, :async, modules) do
+    {async ++ modules, sync}
   end
 
-  defp maybe_store_modules({async, sync}, :sync, modules) do
-    if Application.fetch_env!(:ex_unit, :repeat_until_failure) > 0 do
-      {async, sync ++ modules}
-    else
-      {async, sync}
-    end
+  defp maybe_store_modules({async, sync}, _repeat, :sync, modules) do
+    {async, sync ++ modules}
   end
 
   ## Stacktrace

--- a/lib/ex_unit/mix.exs
+++ b/lib/ex_unit/mix.exs
@@ -34,7 +34,7 @@ defmodule ExUnit.MixProject do
         timeout: 60000,
         trace: false,
         after_suite: [],
-        repeat_until_failure: false
+        repeat_until_failure: 0
       ]
     ]
   end

--- a/lib/ex_unit/mix.exs
+++ b/lib/ex_unit/mix.exs
@@ -33,7 +33,8 @@ defmodule ExUnit.MixProject do
         stacktrace_depth: 20,
         timeout: 60000,
         trace: false,
-        after_suite: []
+        after_suite: [],
+        repeat_until_failure: false
       ]
     ]
   end

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -1009,7 +1009,7 @@ defmodule ExUnitTest do
       |> Keyword.merge(colors: [enabled: false])
 
     output = capture_io(fn -> Process.put(:capture_result, ExUnit.Runner.run(opts, nil)) end)
-    {Process.get(:capture_result), output}
+    {Process.get(:capture_result).stats, output}
   end
 
   defp next_message_in_mailbox() do

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -933,7 +933,8 @@ defmodule ExUnitTest do
     end
 
     test ":repeat_until_failure stops on failure" do
-      :persistent_term.put(:ex_unit_repeat_until_failure_count, 0)
+      {:ok, pid} = Agent.start_link(fn -> 0 end)
+      Process.register(pid, :ex_unit_repeat_until_failure_count)
 
       defmodule TestRepeatUntilFailureFailure do
         use ExUnit.Case
@@ -942,10 +943,10 @@ defmodule ExUnitTest do
         test "skipped #{__ENV__.line}", do: assert(true)
 
         test "maybe pass #{__ENV__.line}" do
-          count = :persistent_term.get(:ex_unit_repeat_until_failure_count)
+          count = Agent.get(:ex_unit_repeat_until_failure_count, & &1)
 
           if count < 3 do
-            :persistent_term.put(:ex_unit_repeat_until_failure_count, count + 1)
+            Agent.update(:ex_unit_repeat_until_failure_count, &(&1 + 1))
             assert(true)
           else
             assert(false)

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -173,6 +173,9 @@ defmodule Mix.Tasks.Test do
     * `--raise` - immediately raises if the test suite fails, instead of continuing
       the execution of other Mix tasks
 
+    * `--repeat-until-failure` - repeats the test suite until it fails. This is useful
+      for debugging flaky tests.
+
     * `--seed` - seeds the random number generator used to randomize the order of tests;
       `--seed 0` disables randomization so the tests in a single file will always be ran
       in the same order they were defined in
@@ -444,7 +447,8 @@ defmodule Mix.Tasks.Test do
     preload_modules: :boolean,
     warnings_as_errors: :boolean,
     profile_require: :string,
-    exit_status: :integer
+    exit_status: :integer,
+    repeat_until_failure: :boolean
   ]
 
   @cover [output: "cover", tool: Mix.Tasks.Test.Coverage]
@@ -676,7 +680,8 @@ defmodule Mix.Tasks.Test do
     :failures_manifest_file,
     :only_test_ids,
     :test_location_relative_path,
-    :exit_status
+    :exit_status,
+    :repeat_until_failure
   ]
 
   @doc false

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -173,8 +173,11 @@ defmodule Mix.Tasks.Test do
     * `--raise` - immediately raises if the test suite fails, instead of continuing
       the execution of other Mix tasks
 
-    * `--repeat-until-failure` - repeats the test suite until it fails. This is useful
-      for debugging flaky tests.
+    * `--repeat-until-failure` - sets the number of repetitions for running the test suite
+      until it fails. This is useful for debugging flaky tests;
+      `--repeat-until-failure 10000` repeats the test suite up to 10000 times until
+      the first failure. This can be combined with `--max-failures 1` to immediately stop
+      if one test fails. By default, the test suite is run completely.
 
     * `--seed` - seeds the random number generator used to randomize the order of tests;
       `--seed 0` disables randomization so the tests in a single file will always be ran
@@ -448,7 +451,7 @@ defmodule Mix.Tasks.Test do
     warnings_as_errors: :boolean,
     profile_require: :string,
     exit_status: :integer,
-    repeat_until_failure: :boolean
+    repeat_until_failure: :integer
   ]
 
   @cover [output: "cover", tool: Mix.Tasks.Test.Coverage]


### PR DESCRIPTION
The world isn't perfect and so are our tests. When debugging flaky tests I found myself wanting to run `mix test` repeatedly until a test fails. Of course you can do a loop in bash, fish, etc., but a lot of time is spent on starting the BEAM and the application.

This is where this PR comes in. It proposes a new flag `--repeat-until-failure` that re-runs all tests until at least one fails.