### PR TITLE
Fix Project docs Markdown - incorrect backticks

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -24,7 +24,7 @@ defmodule Mix.Project do
 
   ## Configuration
 
-  In order to configure Mix, the module that `use`s `Mix.Project` should export
+  In order to configure Mix, the module that uses `Mix.Project` should export
   a `project/0` function that returns a keyword list representing configuration
   for the project.
 

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -24,7 +24,7 @@ defmodule Mix.Project do
 
   ## Configuration
 
-  In order to configure Mix, the module that uses `Mix.Project` should export
+  In order to configure Mix, the module that calls `use Mix.Project` should export
   a `project/0` function that returns a keyword list representing configuration
   for the project.
 


### PR DESCRIPTION
<img width="845" alt="image" src="https://github.com/elixir-lang/elixir/assets/584394/a0c45d40-2547-431d-b97b-5471fbf2dc62">
Believe the backticks on `use`s, should just be uses.