### PR TITLE
Add default type to Keyword module

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -101,6 +101,8 @@ defmodule Keyword do
 
   @type key :: atom
   @type value :: any
+
+  @typedoc since: "1.17.0"
   @type default :: any
 
   @type t :: [{key, value}]

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -389,7 +389,7 @@ defmodule Keyword do
       3
 
   """
-  @spec get(t, key, value) :: value | default
+  @spec get(t, key, default) :: value | default
   def get(keywords, key, default \\ nil) when is_list(keywords) and is_atom(key) do
     case :lists.keyfind(key, 1, keywords) do
       {^key, value} -> value
@@ -1290,7 +1290,7 @@ defmodule Keyword do
       {1, []}
 
   """
-  @spec pop(t, key, value) :: {value | default, t}
+  @spec pop(t, key, default) :: {value | default, t}
   def pop(keywords, key, default \\ nil) when is_list(keywords) and is_atom(key) do
     case fetch(keywords, key) do
       {:ok, value} -> {value, delete(keywords, key)}
@@ -1406,7 +1406,7 @@ defmodule Keyword do
       {1, [a: 2]}
 
   """
-  @spec pop_first(t, key, value) :: {value | default, t}
+  @spec pop_first(t, key, default) :: {value | default, t}
   def pop_first(keywords, key, default \\ nil) when is_list(keywords) and is_atom(key) do
     case :lists.keytake(key, 1, keywords) do
       {:value, {^key, value}, rest} -> {value, rest}

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -101,6 +101,7 @@ defmodule Keyword do
 
   @type key :: atom
   @type value :: any
+  @type default :: any
 
   @type t :: [{key, value}]
   @type t(value) :: [{key, value}]
@@ -388,7 +389,7 @@ defmodule Keyword do
       3
 
   """
-  @spec get(t, key, value) :: value
+  @spec get(t, key, value) :: value | default
   def get(keywords, key, default \\ nil) when is_list(keywords) and is_atom(key) do
     case :lists.keyfind(key, 1, keywords) do
       {^key, value} -> value
@@ -1289,7 +1290,7 @@ defmodule Keyword do
       {1, []}
 
   """
-  @spec pop(t, key, value) :: {value, t}
+  @spec pop(t, key, value) :: {value | default, t}
   def pop(keywords, key, default \\ nil) when is_list(keywords) and is_atom(key) do
     case fetch(keywords, key) do
       {:ok, value} -> {value, delete(keywords, key)}
@@ -1405,7 +1406,7 @@ defmodule Keyword do
       {1, [a: 2]}
 
   """
-  @spec pop_first(t, key, value) :: {value, t}
+  @spec pop_first(t, key, value) :: {value | default, t}
   def pop_first(keywords, key, default \\ nil) when is_list(keywords) and is_atom(key) do
     case :lists.keytake(key, 1, keywords) do
       {:value, {^key, value}, rest} -> {value, rest}


### PR DESCRIPTION
Since [Enum module has this type](https://hexdocs.pm/elixir/1.16.2/Enum.html#t:default/0) and Keyword module has more than two functions which operates default values.