### PR TITLE
Log :$process_label in Task crash report

### DIFF
--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -149,17 +149,27 @@ defmodule Task.Supervised do
           starter: starter,
           function: fun,
           args: args,
-          reason: reason
+          reason: reason,
+          process_label: process_label
         }
       }) do
-    # TODO confirm if we need to add process_label
     message =
-      ~c"** Task ~p terminating~n" ++
-        ~c"** Started from ~p~n" ++
+      ~c"** Started from ~p~n" ++
         ~c"** When function  == ~p~n" ++
         ~c"**      arguments == ~p~n" ++ ~c"** Reason for termination == ~n" ++ ~c"** ~p~n"
 
-    {message, [starter, name, fun, args, get_reason(reason)]}
+    terms = [name, fun, args, get_reason(reason)]
+
+    {message, terms} =
+      case process_label do
+        :undefined -> {message, terms}
+        _ -> {~c"** Process Label == ~p~n" ++ message, [process_label | terms]}
+      end
+
+    message =
+      ~c"** Task ~p terminating~n" ++ message
+
+    {message, [starter | terms]}
   end
 
   defp get_from({node, pid_or_name, _pid}) when node == node(), do: pid_or_name

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -117,7 +117,9 @@ defmodule Task.Supervised do
               starter: get_from(owner),
               function: fun,
               args: args,
-              reason: {log_value(kind, value), __STACKTRACE__}
+              reason: {log_value(kind, value), __STACKTRACE__},
+              # TODO use Process.get_label/0 when we require Erlang/OTP 27+
+              process_label: Process.get(:"$process_label", :undefined)
             }
           },
           %{
@@ -150,6 +152,7 @@ defmodule Task.Supervised do
           reason: reason
         }
       }) do
+    # TODO confirm if we need to add process_label
     message =
       ~c"** Task ~p terminating~n" ++
         ~c"** Started from ~p~n" ++

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -1125,10 +1125,9 @@ defmodule TaskTest do
              """
     end
 
-    @tag skip: System.otp_release() < "27"
     test "logs a terminated task with a process label" do
       fun = fn ->
-        :proc_lib.set_label({:any, "term"})
+        Process.set_label({:any, "term"})
         raise "oops"
       end
 

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -99,7 +99,8 @@ defmodule Logger.Translator do
            starter: starter,
            function: function,
            args: args,
-           reason: reason
+           reason: reason,
+           process_label: process_label
          }}
       ) do
     opts = Application.get_env(:logger, :translator_inspect_opts)
@@ -108,9 +109,16 @@ defmodule Logger.Translator do
     metadata = [crash_reason: reason] ++ registered_name(name)
 
     msg =
-      ["Task #{inspect(name)} started from #{inspect(starter)} terminating"] ++
-        [formatted, "\nFunction: #{inspect(function, opts)}"] ++
+      ["\nFunction: #{inspect(function, opts)}"] ++
         ["\n    Args: #{inspect(args, opts)}"]
+
+    msg =
+      case process_label do
+        :undefined -> msg
+        _ -> ["\nProcess Label: #{inspect(process_label)}"] ++ msg
+      end
+
+    msg = ["Task #{inspect(name)} started from #{inspect(starter)} terminating", formatted] ++ msg
 
     {:ok, msg, metadata}
   end

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -431,7 +431,7 @@ defmodule Logger.TranslatorTest do
   @tag skip: System.otp_release() < "27"
   test "translates Task crashes with label" do
     fun = fn ->
-      :proc_lib.set_label({:any, "term"})
+      Process.set_label({:any, "term"})
       raise "oops"
     end
 

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -428,6 +428,36 @@ defmodule Logger.TranslatorTest do
     assert {:abnormal, [_ | _]} = task_metadata[:crash_reason]
   end
 
+  @tag skip: System.otp_release() < "27"
+  test "translates Task crashes with label" do
+    fun = fn ->
+      :proc_lib.set_label({:any, "term"})
+      raise "oops"
+    end
+
+    {:ok, pid} = Task.start_link(__MODULE__, :task, [self(), fun])
+    parent = self()
+
+    assert capture_log(fn ->
+             ref = Process.monitor(pid)
+             send(pid, :go)
+             receive do: ({:DOWN, ^ref, _, _, _} -> :ok)
+           end) =~
+             ~r"""
+             \[error\] Task #{inspect(pid)} started from #{inspect(self())} terminating
+             \*\* \(RuntimeError\) oops
+             .*
+             Process Label: {:any, \"term\"}
+             Function: &Logger.TranslatorTest.task\/2
+                 Args: \[#PID<\d+\.\d+\.\d+>\, .*]
+             """s
+
+    assert_receive {:event, {:string, ["Task " <> _ | _]}, task_metadata}
+    assert {%RuntimeError{message: "oops"}, [_ | _]} = task_metadata[:crash_reason]
+    assert [parent] == task_metadata[:callers]
+    refute Map.has_key?(task_metadata, :initial_call)
+  end
+
   test "translates application start" do
     assert capture_log(fn ->
              Application.start(:eex)


### PR DESCRIPTION
https://github.com/elixir-lang/elixir/pull/13394#issuecomment-1989602688

@josevalim is this the right approach?
If yes will handle other reports in a similar fashion (GenServer, gen_event...)