### PR TITLE
Add compatibility relation for gradual typechecking

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -299,28 +299,27 @@ defmodule Module.Types.Descr do
   @doc """
   Checks if a type is a compatible subtype of another.
 
-  If `left` has a static part (i.e., values that are known to appear), then it
-  should be a subtype of `right`'s dynamic part (i.e., the largest type that can
-  appear at runtime).
+  If `input_type` has a static part (i.e., values that are known to appear and
+  need to be handled), then to be compatible it should be a subtype of the
+  the dynamic part of `expected_type` (that is, the largest allowed type at
+  runtime).
 
-  If `left` has no static part, then it is a purely dynamic type, and we check
-  that it intersects with `right`, that is, they can produce similar values at
-  runtime.
+  If `input_type` is a dynamic type, then we check that the two can intersect
+  at runtime, i.e. it is possible to get valid inputs at runtime.
 
-  This function is used in gradual mode, to type an operator that expects a given
-  type. For instance, `+` expects `integer()` or `float()`, which will be given
-  as the `right` argument. Compatible `left` arguments could then be: `dynamic()`,
-  `integer()`, but also `dynamic() and (integer() or atom())`. Incompatible subtypes
-  include `atom()`, `dynamic() and atom()`.
+  The function is used, in gradual mode, to type an operator that expects a given
+  type. For instance, `+` expects `integer() or float()` inputs. Compatible inputs
+  include `dynamic()`, `integer()`, but also `dynamic() and (integer() or atom())`.
+  Incompatible subtypes include `integer() or list()`, `dynamic() and atom()`.
   """
-  def compatible?(left, right) do
-    {left_dynamic, left_static} = Map.pop(left, :dynamic, left)
-    right_dynamic = Map.get(right, :dynamic, right)
+  def compatible?(input_type, expected_type) do
+    {input_dynamic, input_static} = Map.pop(input_type, :dynamic, input_type)
+    expected_dynamic = Map.get(expected_type, :dynamic, expected_type)
 
-    if not empty?(left_static) do
-      subtype_static(left_static, right_dynamic)
+    if not empty?(input_static) do
+      subtype_static(input_static, expected_dynamic)
     else
-      intersect?(left_dynamic, right_dynamic)
+      intersect?(input_dynamic, expected_dynamic)
     end
   end
 

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -114,9 +114,7 @@ defmodule Module.Types.Of do
       # will already have checked the type, so we skip the check here
       # as an optimization.
       # TODO: properly handle dynamic. Do we need materialization?
-      if actual_type == dynamic() or
-           (kind == :pattern and is_var(left)) or
-           empty?(difference(actual_type, expected_type)) do
+      if (kind == :pattern and is_var(left)) or compatible?(actual_type, expected_type) do
         {:ok, context}
       else
         hints = if meta[:inferred_bitstring_spec], do: [:inferred_bitstring_spec], else: []

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -147,6 +147,31 @@ defmodule Module.Types.DescrTest do
     end
   end
 
+  describe "compatible" do
+    test "intersection" do
+      assert compatible?(integer(), intersection(dynamic(), integer()))
+      refute compatible?(intersection(dynamic(), integer()), atom())
+      refute compatible?(atom(), intersection(dynamic(), integer()))
+      refute compatible?(atom(), intersection(dynamic(), atom([:foo, :bar])))
+      assert compatible?(intersection(dynamic(), atom()), atom([:foo, :bar]))
+      assert compatible?(atom([:foo, :bar]), intersection(dynamic(), atom()))
+    end
+
+    test "static" do
+      refute compatible?(atom(), atom([:foo, :bar]))
+      refute compatible?(union(integer(), atom()), integer())
+      refute compatible?(none(), integer())
+      refute compatible?(union(atom(), dynamic()), integer())
+    end
+
+    test "dynamic" do
+      assert compatible?(dynamic(), term())
+      assert compatible?(term(), dynamic())
+      assert compatible?(dynamic(), integer())
+      assert compatible?(integer(), dynamic())
+    end
+  end
+
   describe "to_quoted" do
     test "bitmap" do
       assert union(integer(), union(float(), binary())) |> to_quoted_string() ==


### PR DESCRIPTION
This relation checks if the input given to a function/operator is a compatible subtype of its expected type, that is, if they coincide at runtime and there are no static values in the input that cannot be covered by the expected type at runtime.

If this relation is not validated, then a warning should be produced as either:
- the input type is statically known to produce values that will never be covered in the expected type

e.g., `integer() or tuple()` is not a consistent subtype of `dynamic() and tuple()`, and we can blame the input type for containing integers

- OR none of the unknown values that may be given as inputs at runtime will ever be covered in the expected type 

e.g., `dynamic() and atom()` is not a consistent subtype of `dynamic() and tuple()` 

More examples:
`dynamic() and (integer() or boolean())` is a compatible subtype of `integer()` 
`integer() or boolean()` is not a compatible subtype of `integer()`
`dynamic()` is a compatible subtype of every type
Every type is a compatible subtype of `dynamic()`

This is the relation used in the dynamic mode of the typechecker. By contrast, in static mode, subtyping should be used as it does check that all values in the input are covered in the expected type.

Hence, to typecheck in gradual mode the `+` operator with two expressions of types `t1` and `t2`, the condition is:
```compatible?(t1, @integer_or_float) and compatible?(t2, @integer_or_float)```