### PR TITLE
Protocol consolidation consolidates type `t`

### DIFF
--- a/lib/elixir/test/elixir/fixtures/consolidation/with_declared_types.ex
+++ b/lib/elixir/test/elixir/fixtures/consolidation/with_declared_types.ex
@@ -1,0 +1,30 @@
+defprotocol Protocol.ConsolidationTest.WithDeclaredTypes do
+  @type tuple_type :: tuple()
+  @type atom_type :: atom()
+  @type list_type :: list()
+  @type bitstring_type :: bitstring()
+  @type integer_type :: integer()
+  @type float_type :: float()
+  @type function_type :: function()
+  @type pid_type :: pid()
+  @type map_type :: map()
+  @type port_type :: port()
+  @type reference_type :: reference()
+  @type implstruct_type :: %{__struct__: Protocol.ConsolidationTest.ImplStruct}
+
+  @type impl_types ::
+          tuple()
+          | atom()
+          | list()
+          | bitstring()
+          | integer()
+          | float()
+          | function()
+          | pid()
+          | map()
+          | port()
+          | reference()
+          | %{__struct__: Protocol.ConsolidationTest.ImplStruct}
+
+  def ok(impl)
+end

--- a/lib/elixir/test/elixir/fixtures/consolidation/with_explicit_type_t.ex
+++ b/lib/elixir/test/elixir/fixtures/consolidation/with_explicit_type_t.ex
@@ -1,0 +1,5 @@
+defprotocol Protocol.ConsolidationTest.WithExplicitTypeT do
+  @type t :: atom()
+
+  def ok(_impl)
+end


### PR DESCRIPTION
When a protocol is consolidated, its known implementation types are consolidated into the automatically-defined type `t`, replacing the original, hardcoded type `:term`.

Type `t` is consolidated only when warranted. The original type `t` is left unchanged under any of these circumstances:

- The protocol definition explicitly declares a type `t`
- The protocol has no implementations
- `Any` is an implementing type of the protocol (as when used with `@fallback_to_any true`)

If the protocol has only one implementation, `t` represents the single, scalar type of that implementation. When there are multiple implementations, the consolidated `t` is a `:union` type whose members are each of the protocol's implementing types.

I understand from [this discussion](https://github.com/elixir-lang/elixir/issues/7541) that additional work on protocol typespecs has been set aside in favor of focus on the Elixir type system. That said, I thought the changes in this PR were worth considering, given:

- Although the Elixir type system appears to have very strong momentum, there's still a degree of official caution around its eventual prospects
- The (gradual) release schedule for Elixir type system is unknown/uknowable. In the meantime, we use typespecs.
- Even after "completion" of the Elixir type system, some Elixir projects will continue to use typespecs, possibly forever

I considered a couple slightly-different approaches for testing these changes and landed on the approach in this PR. Happy to adjust as desired.

Thank you very much!