### PR TITLE
Warn when using @tag outside of describe

### DIFF
--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -766,7 +766,7 @@ defmodule ExUnit.Callbacks do
     end
 
     if Module.get_attribute(module, :tag) != [] do
-      IO.warn("@tag only affects the next test, did you mean to use @describetag?")
+      IO.warn("found unused @tag before \"describe\", did you mean to use @describetag?")
     end
 
     setup = Module.get_attribute(module, :ex_unit_setup)

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -541,7 +541,7 @@ defmodule ExUnit.Callbacks do
   its process dictionary with all of its ancestors, which will include the test
   process. Additionally, `start_supervised/2` will also store the test process
   in the `$callers` key of the started process, allowing tools that perform
-  either ancestor or caller tracking to reach the test process. You can learn 
+  either ancestor or caller tracking to reach the test process. You can learn
   more about these keys in
   [the `Task` module](`Task#module-ancestor-and-caller-tracking`).
   """
@@ -763,6 +763,10 @@ defmodule ExUnit.Callbacks do
 
     if Module.get_attribute(module, :describetag) != [] do
       raise "@describetag must be set inside describe/2 blocks"
+    end
+
+    if Module.get_attribute(module, :tag) != [] do
+      IO.warn("@tag only affects the next test, did you mean to use @describetag?")
     end
 
     setup = Module.get_attribute(module, :ex_unit_setup)

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -147,7 +147,7 @@ defmodule ExUnit.CaseTest do
     stderr =
       ExUnit.CaptureIO.capture_io(:stderr, fn ->
         defmodule TagOutsideOfDescribe do
-          use ExUnit.Case
+          use ExUnit.Case, register: false
 
           @tag :foo
           describe "bar" do

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -142,6 +142,23 @@ defmodule ExUnit.CaseTest do
                    end
                  end
   end
+
+  test "warns when using @tag outside of describe" do
+    stderr =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defmodule TagOutsideOfDescribe do
+          use ExUnit.Case
+
+          @tag :foo
+          describe "bar" do
+            test "baz" do
+            end
+          end
+        end
+      end)
+
+    assert stderr =~ "@tag only affects the next test, did you mean to use @describetag?"
+  end
 end
 
 defmodule ExUnit.DoubleCaseTest1 do

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -157,7 +157,7 @@ defmodule ExUnit.CaseTest do
         end
       end)
 
-    assert stderr =~ "@tag only affects the next test, did you mean to use @describetag?"
+    assert stderr =~ "found unused @tag before \"describe\", did you mean to use @describetag?"
   end
 end
 


### PR DESCRIPTION
This is a proposal following https://github.com/elixir-lang/elixir/issues/13414 to improve the discoverability.

~~Note: the suite is flaky right now as the test seems to be interfering with other exunit tests, this is just a draft to discuss the proposal.~~