### PR TITLE
Change how CI jobs are canceled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ permissions:
 
 concurrency:
   group: ci-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 
 jobs:
   test_linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test_linux:
     name: Ubuntu 20.04, Erlang/OTP ${{ matrix.otp_version }}
@@ -74,6 +78,7 @@ jobs:
   test_windows:
     name: Windows Server 2019, Erlang/OTP ${{ matrix.otp_version }}
     strategy:
+      fail-fast: false
       matrix:
         otp_version: ["25.3", "26.0"]
     runs-on: windows-2019

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ci-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
   test_windows:
     name: Windows Server 2019, Erlang/OTP ${{ matrix.otp_version }}
     strategy:
-      fail-fast: false
       matrix:
         otp_version: ["25.3", "26.0"]
     runs-on: windows-2019


### PR DESCRIPTION
This PR adds two changes:
1. It introduces `concurrency:` flag to the workflow, to cancel older jobs for the same branch. It is really helpful for PRs, so no stale jobs will continue to operate when new commits are pushed to the same branch
2. I've added `fail-fast: false` to Windows jobs to be in sync with other jobs