### PR TITLE
Only infer size in pinned variable when needed

### DIFF
--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -36,9 +36,9 @@ expand(BitstrMeta, Fun, [{'::', Meta, [Left, Right]} | T], Acc, S, E, Alignment,
   MatchOrRequireSize = RequireSize or is_match_size(T, EL),
   EType = expr_type(ELeft),
   ExpectSize = case ELeft of
+    _ when not MatchOrRequireSize -> optional;
     {'^', _, [{_, _, _}]} -> {infer, ELeft};
-    _ when MatchOrRequireSize -> required;
-    _ -> optional
+    _ -> required
   end,
   {ERight, EAlignment, SS, ES} = expand_specs(EType, Meta, Right, SL, OriginalS, EL, ExpectSize),
 

--- a/lib/elixir/test/elixir/kernel/binary_test.exs
+++ b/lib/elixir/test/elixir/kernel/binary_test.exs
@@ -255,6 +255,12 @@ defmodule Kernel.BinaryTest do
     assert <<1::size((^foo).bar)>> = <<1::5>>
   end
 
+  test "bitsyntax size with pinned integer" do
+    a = 1
+    b = <<2, 3>>
+    assert <<^a, ^b::binary>> = <<1, 2, 3>>
+  end
+
   test "automatic size computation of matched bitsyntax variable" do
     var = "foo"
     <<^var::binary, rest::binary>> = "foobar"


### PR DESCRIPTION
Close #13420

Even if the issue is caused by an Erlang bug, we don't need to infer the binary size in this case so we can just leave it.