### PR TITLE
Fix mix xref order across OTP versions (OTP 27)

### DIFF
--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -1004,11 +1004,11 @@ defmodule Mix.Tasks.Xref do
 
   defp cycles(graph, opts) do
     # Vertices order in cyclic_strong_components/1 return is arbitrary and changes between
-    # OTP versions, :desc sorting is necessary to make the output stable across versions.
+    # OTP versions, sorting is necessary to make the output stable across versions.
     cycles =
       graph
       |> :digraph_utils.cyclic_strong_components()
-      |> Enum.reduce([], &inner_cycles(graph, Enum.sort(&1, :desc), &2))
+      |> Enum.reduce([], &inner_cycles(graph, Enum.sort(&1), &2))
       |> Enum.map(&{length(&1), &1})
 
     if min = opts[:min_cycle_size], do: Enum.filter(cycles, &(elem(&1, 0) > min)), else: cycles

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -1003,10 +1003,12 @@ defmodule Mix.Tasks.Xref do
   end
 
   defp cycles(graph, opts) do
+    # Vertices order in cyclic_strong_components/1 return is arbitrary and changes between
+    # OTP versions, :desc sorting is necessary to make the output stable across versions.
     cycles =
       graph
       |> :digraph_utils.cyclic_strong_components()
-      |> Enum.reduce([], &inner_cycles(graph, &1, &2))
+      |> Enum.reduce([], &inner_cycles(graph, Enum.sort(&1, :desc), &2))
       |> Enum.map(&{length(&1), &1})
 
     if min = opts[:min_cycle_size], do: Enum.filter(cycles, &(elem(&1, 0) > min)), else: cycles

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -445,9 +445,9 @@ defmodule Mix.Tasks.XrefTest do
 
       Cycle of length 3:
 
-          lib/b.ex
           lib/a.ex
           lib/b.ex
+          lib/a.ex
 
       """)
     end

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -1085,7 +1085,7 @@ defmodule Mix.Tasks.XrefTest do
                  ^first_line | ["Generated sample app" | result]
                ] = receive_until_no_messages([]) |> String.split("\n")
 
-        assert normalize_graph_output(result |> Enum.join("\n")) == expected
+        assert result |> Enum.join("\n") |> normalize_graph_output() == expected
       end)
     end
 


### PR DESCRIPTION
I think it is the same issue as https://github.com/elixir-lang/elixir/pull/13351/files#r1491807968

Arbitrary order mentioned in [doc](https://erlang.org/documentation/doc-15.0-rc1/lib/stdlib-6.0/doc/html/digraph_utils.html#cyclic_strong_components/1).

Fixes a failing test on OTP27.

<img width="951" alt="Screenshot 2024-03-21 at 22 20 58" src="https://github.com/elixir-lang/elixir/assets/11598866/d8be10e0-2301-469a-8179-bdb33bfcf79f">
