### PR TITLE
Add support for sigils containing integers

### DIFF
--- a/lib/elixir/pages/getting-started/sigils.md
+++ b/lib/elixir/pages/getting-started/sigils.md
@@ -235,6 +235,6 @@ iex> ~i(42)n
 -42
 ```
 
-Custom sigils may be either a single lowercase character or a uppercase letter followed by more uppercase letter and digits.
+Custom sigils may be either a single lowercase character or a uppercase character followed by more uppercase characters and digits.
 
 Sigils can also be used to do compile-time work with the help of macros. For example, regular expressions in Elixir are compiled into an efficient representation during compilation of the source code, therefore skipping this step at runtime. If you're interested in the subject, you can learn more about macros and check out how sigils are implemented in the `Kernel` module (where the `sigil_*` functions are defined).

--- a/lib/elixir/pages/getting-started/sigils.md
+++ b/lib/elixir/pages/getting-started/sigils.md
@@ -235,6 +235,6 @@ iex> ~i(42)n
 -42
 ```
 
-Custom sigils may be either a single lowercase character or several uppercase characters.
+Custom sigils may be either a single lowercase character or a uppercase letter followed by more uppercase letter and digits.
 
 Sigils can also be used to do compile-time work with the help of macros. For example, regular expressions in Elixir are compiled into an efficient representation during compilation of the source code, therefore skipping this step at runtime. If you're interested in the subject, you can learn more about macros and check out how sigils are implemented in the `Kernel` module (where the `sigil_*` functions are defined).

--- a/lib/elixir/pages/getting-started/sigils.md
+++ b/lib/elixir/pages/getting-started/sigils.md
@@ -235,6 +235,6 @@ iex> ~i(42)n
 -42
 ```
 
-Custom sigils may be either a single lowercase character or a uppercase character followed by more uppercase characters and digits.
+Custom sigils may be either a single lowercase character, or an uppercase character followed by more uppercase characters and digits.
 
 Sigils can also be used to do compile-time work with the help of macros. For example, regular expressions in Elixir are compiled into an efficient representation during compilation of the source code, therefore skipping this step at runtime. If you're interested in the subject, you can learn more about macros and check out how sigils are implemented in the `Kernel` module (where the `sigil_*` functions are defined).

--- a/lib/elixir/src/elixir_import.erl
+++ b/lib/elixir/src/elixir_import.erl
@@ -157,7 +157,7 @@ is_sigil({Name, 2}) ->
       case Letters of
         [L] when L >= $a, L =< $z -> true;
         [] -> false;
-        Letters -> lists:all(fun(L) -> L >= $A andalso L =< $Z end, Letters)
+        Letters -> lists:all(fun(L) -> L >= 0 andalso L =< $Z end, Letters)
       end;
     _ ->
       false

--- a/lib/elixir/src/elixir_import.erl
+++ b/lib/elixir/src/elixir_import.erl
@@ -157,7 +157,10 @@ is_sigil({Name, 2}) ->
       case Letters of
         [L] when L >= $a, L =< $z -> true;
         [] -> false;
-        Letters -> lists:all(fun(L) -> L >= 0 andalso L =< $Z end, Letters)
+        [H|T] when H >= $A, H =< $Z ->
+              lists:all(fun(L) -> (L >= $0 andalso L =< $9)
+                                  orelse (L>= $A andalso L =< $Z)
+                        end, T)
       end;
     _ ->
       false

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1564,10 +1564,15 @@ tokenize_sigil_name([S | T], [], Line, Column, Scope, Tokens) when ?is_upcase(S)
 % If we have an uppercase letter, we keep tokenizing the name.
 tokenize_sigil_name([S | T], NameAcc, Line, Column, Scope, Tokens) when ?is_upcase(S) ->
   tokenize_sigil_name(T, [S | NameAcc], Line, Column + 1, Scope, Tokens);
+% A digit is allowed but an upcase or digit must proceed it.
+tokenize_sigil_name([S | T], [P | _] = NameAcc, Line, Column, Scope, Tokens) when ?is_digit(S) andalso (?is_upcase(P)
+                                                                                                         orelse
+                                                                                                         ?is_digit(P)) ->
+    tokenize_sigil_name(T, [S | NameAcc], Line, Column + 1, Scope, Tokens);
 % With a lowercase letter and a non-empty NameAcc we return an error.
 tokenize_sigil_name([S | _T] = Original, [_ | _] = NameAcc, _Line, _Column, _Scope, _Tokens) when ?is_downcase(S) ->
   Message = "invalid sigil name, it should be either a one-letter lowercase letter or a" ++
-            " sequence of uppercase letters only, got: ",
+            " sequence of uppercase letters and digits, starting with uppercase letters only, got: ",
   {error, Message, [$~] ++ lists:reverse(NameAcc) ++ Original};
 % We finished the letters, so the name is over.
 tokenize_sigil_name(T, NameAcc, Line, Column, Scope, Tokens) ->

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1572,7 +1572,7 @@ tokenize_lower_sigil_name(T, NameAcc, Line, Column, Scope, Tokens) ->
 
 % If we have an uppercase letter, we keep tokenizing the name.
 % A digit is allowed but an uppercase letter or digit must proceed it.
-tokenize_upper_sigil_name([S | T], NameAcc, Line, Column, Scope, Tokens) when ?is_upcase(S) orelse ?is_digit(S) ->
+tokenize_upper_sigil_name([S | T], NameAcc, Line, Column, Scope, Tokens) when ?is_upcase(S); ?is_digit(S) ->
   tokenize_upper_sigil_name(T, [S | NameAcc], Line, Column + 1, Scope, Tokens);
 % With a lowercase letter and a non-empty NameAcc we return an error.
 tokenize_upper_sigil_name([S | _T] = Original, [_ | _] = NameAcc, _Line, _Column, _Scope, _Tokens) when ?is_downcase(S) ->

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1571,7 +1571,7 @@ tokenize_lower_sigil_name(T, NameAcc, Line, Column, Scope, Tokens) ->
   {ok, lists:reverse(NameAcc), T, Line, Column, Scope, Tokens}.
 
 % If we have an uppercase letter, we keep tokenizing the name.
-% A digit is allowed but an upcase or digit must proceed it.
+% A digit is allowed but an uppercase letter or digit must proceed it.
 tokenize_upper_sigil_name([S | T], NameAcc, Line, Column, Scope, Tokens) when ?is_upcase(S) orelse ?is_digit(S) ->
   tokenize_upper_sigil_name(T, [S | NameAcc], Line, Column + 1, Scope, Tokens);
 % With a lowercase letter and a non-empty NameAcc we return an error.

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1559,24 +1559,32 @@ tokenize_sigil([$~ | T], Line, Column, Scope, Tokens) ->
   end.
 
 % A one-letter sigil is ok both as upcase as well as downcase.
-tokenize_sigil_name([S | T], [], Line, Column, Scope, Tokens) when ?is_upcase(S) orelse ?is_downcase(S) ->
-  tokenize_sigil_name(T, [S], Line, Column + 1, Scope, Tokens);
-% If we have an uppercase letter, we keep tokenizing the name.
-tokenize_sigil_name([S | T], NameAcc, Line, Column, Scope, Tokens) when ?is_upcase(S) ->
-  tokenize_sigil_name(T, [S | NameAcc], Line, Column + 1, Scope, Tokens);
-% A digit is allowed but an upcase or digit must proceed it.
-tokenize_sigil_name([S | T], [P | _] = NameAcc, Line, Column, Scope, Tokens) when ?is_digit(S) andalso (?is_upcase(P)
-                                                                                                         orelse
-                                                                                                         ?is_digit(P)) ->
-    tokenize_sigil_name(T, [S | NameAcc], Line, Column + 1, Scope, Tokens);
-% With a lowercase letter and a non-empty NameAcc we return an error.
-tokenize_sigil_name([S | _T] = Original, [_ | _] = NameAcc, _Line, _Column, _Scope, _Tokens) when ?is_downcase(S) ->
-  Message = "invalid sigil name, it should be either a one-letter lowercase letter or a" ++
-            " uppercase letter optionally followed by uppercase letters and digits, got: ",
-  {error, Message, [$~] ++ lists:reverse(NameAcc) ++ Original};
-% We finished the letters, so the name is over.
-tokenize_sigil_name(T, NameAcc, Line, Column, Scope, Tokens) ->
+tokenize_sigil_name([S | T], [], Line, Column, Scope, Tokens) when ?is_downcase(S) ->
+  tokenize_lower_sigil_name(T, [S], Line, Column + 1, Scope, Tokens);
+tokenize_sigil_name([S | T], [], Line, Column, Scope, Tokens) when ?is_upcase(S) ->
+    tokenize_upper_sigil_name(T, [S], Line, Column + 1, Scope, Tokens).
+
+tokenize_lower_sigil_name([S | _T] = Original, [_ | _] = NameAcc, _Line, _Column, _Scope, _Tokens) when ?is_downcase(S) ->
+  SigilName = lists:reverse(NameAcc) ++ Original,
+  {error, sigil_name_error(), [$~] ++ SigilName};
+tokenize_lower_sigil_name(T, NameAcc, Line, Column, Scope, Tokens) ->
   {ok, lists:reverse(NameAcc), T, Line, Column, Scope, Tokens}.
+
+% If we have an uppercase letter, we keep tokenizing the name.
+% A digit is allowed but an upcase or digit must proceed it.
+tokenize_upper_sigil_name([S | T], NameAcc, Line, Column, Scope, Tokens) when ?is_upcase(S) orelse ?is_digit(S) ->
+  tokenize_upper_sigil_name(T, [S | NameAcc], Line, Column + 1, Scope, Tokens);
+% With a lowercase letter and a non-empty NameAcc we return an error.
+tokenize_upper_sigil_name([S | _T] = Original, [_ | _] = NameAcc, _Line, _Column, _Scope, _Tokens) when ?is_downcase(S) ->
+  SigilName = lists:reverse(NameAcc) ++ Original,
+  {error,  sigil_name_error(), [$~] ++ SigilName};
+% We finished the letters, so the name is over.
+tokenize_upper_sigil_name(T, NameAcc, Line, Column, Scope, Tokens) ->
+  {ok, lists:reverse(NameAcc), T, Line, Column, Scope, Tokens}.
+
+sigil_name_error() ->
+  "invalid sigil name, it should be either a one-letter lowercase letter or a" ++
+  " uppercase letter optionally followed by uppercase letters and digits, got: ".
 
 tokenize_sigil_contents([H, H, H | T] = Original, [S | _] = SigilName, Line, Column, Scope, Tokens)
     when ?is_quote(H) ->

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1583,8 +1583,8 @@ tokenize_upper_sigil_name(T, NameAcc, Line, Column, Scope, Tokens) ->
   {ok, lists:reverse(NameAcc), T, Line, Column, Scope, Tokens}.
 
 sigil_name_error() ->
-  "invalid sigil name, it should be either a one-letter lowercase letter or a" ++
-  " uppercase letter optionally followed by uppercase letters and digits, got: ".
+  "invalid sigil name, it should be either a one-letter lowercase letter or an " ++
+  "uppercase letter optionally followed by uppercase letters and digits, got: ".
 
 tokenize_sigil_contents([H, H, H | T] = Original, [S | _] = SigilName, Line, Column, Scope, Tokens)
     when ?is_quote(H) ->

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1572,7 +1572,7 @@ tokenize_sigil_name([S | T], [P | _] = NameAcc, Line, Column, Scope, Tokens) whe
 % With a lowercase letter and a non-empty NameAcc we return an error.
 tokenize_sigil_name([S | _T] = Original, [_ | _] = NameAcc, _Line, _Column, _Scope, _Tokens) when ?is_downcase(S) ->
   Message = "invalid sigil name, it should be either a one-letter lowercase letter or a" ++
-            " sequence of uppercase letters and digits, starting with uppercase letters only, got: ",
+            " uppercase letter optionally followed by uppercase letters and digits, got: ",
   {error, Message, [$~] ++ lists:reverse(NameAcc) ++ Original};
 % We finished the letters, so the name is over.
 tokenize_sigil_name(T, NameAcc, Line, Column, Scope, Tokens) ->

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -169,17 +169,22 @@ defmodule Kernel.ParserTest do
       args = {:sigil_FOO1, meta, [{:<<>>, [indentation: 0, line: 1], ["1,2,3\n"]}, []]}
       assert string_to_quoted.("~FOO1\"\"\"\n1,2,3\n\"\"\"") == args
 
+      args = {:sigil_BAR321, meta, [{:<<>>, [indentation: 0, line: 1], ["1,2,3\n"]}, []]}
+      assert string_to_quoted.("~BAR321\"\"\"\n1,2,3\n\"\"\"") == args
+
       args = {:sigil_I18N, meta, [{:<<>>, [indentation: 0, line: 1], ["1,2,3\n"]}, []]}
       assert string_to_quoted.("~I18N\"\"\"\n1,2,3\n\"\"\"") == args
     end
 
     test "invalid multi-letter sigils" do
       msg =
-        ~r/invalid sigil name, it should be either a one-letter lowercase letter or a sequence of uppercase letters only/
+        ~r/invalid sigil name, it should be either a one-letter lowercase letter or a uppercase letter optionally followed by uppercase letters and digits/
 
       assert_syntax_error(["nofile:1:1:", msg], "~Regex/foo/")
 
-      assert_syntax_error(["nofile:1:1:", msg], "~FOo1/bar/")
+      assert_syntax_error(["nofile:1:1:", msg], "~FOo1{bar]")
+
+      assert_syntax_error(["nofile:1:1:", msg], "~foo1{bar]")
     end
 
     test "sigil newlines" do

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -178,7 +178,7 @@ defmodule Kernel.ParserTest do
 
     test "invalid multi-letter sigils" do
       msg =
-        ~r/invalid sigil name, it should be either a one-letter lowercase letter or a uppercase letter optionally followed by uppercase letters and digits/
+        ~r/invalid sigil name, it should be either a one-letter lowercase letter or an uppercase letter optionally followed by uppercase letters and digits/
 
       assert_syntax_error(["nofile:1:1:", msg], "~Regex/foo/")
 

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -165,6 +165,12 @@ defmodule Kernel.ParserTest do
       meta = [delimiter: "\"\"\"", line: 1]
       args = {:sigil_MAT, meta, [{:<<>>, [indentation: 0, line: 1], ["1,2,3\n"]}, []]}
       assert string_to_quoted.("~MAT\"\"\"\n1,2,3\n\"\"\"") == args
+
+      args = {:sigil_FOO1, meta, [{:<<>>, [indentation: 0, line: 1], ["1,2,3\n"]}, []]}
+      assert string_to_quoted.("~FOO1\"\"\"\n1,2,3\n\"\"\"") == args
+
+      args = {:sigil_I18N, meta, [{:<<>>, [indentation: 0, line: 1], ["1,2,3\n"]}, []]}
+      assert string_to_quoted.("~I18N\"\"\"\n1,2,3\n\"\"\"") == args
     end
 
     test "invalid multi-letter sigils" do
@@ -172,6 +178,8 @@ defmodule Kernel.ParserTest do
         ~r/invalid sigil name, it should be either a one-letter lowercase letter or a sequence of uppercase letters only/
 
       assert_syntax_error(["nofile:1:1:", msg], "~Regex/foo/")
+
+      assert_syntax_error(["nofile:1:1:", msg], "~FOo1/bar/")
     end
 
     test "sigil newlines" do


### PR DESCRIPTION
This commit adds support for sigils containing integers. Integers must be proceeded by an upper case alpha, but can otherwise be mixed (e.g., `~A1B2C3`).