### PR TITLE
Translate `:gen_statem` termination reports

### DIFF
--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -297,7 +297,7 @@ defmodule Logger.Translator do
     %{
       client_info: client,
       name: name,
-      reason: {:error, maybe_exception, maybe_stacktrace},
+      reason: {kind, reason, stack},
       state: {state, data},
       queue: queue,
       postponed: postponed,
@@ -305,7 +305,8 @@ defmodule Logger.Translator do
       state_enter: state_enter?,
     } = report
 
-    {formatted, reason} = format_reason({maybe_exception, maybe_stacktrace})
+    {reason, stack} = exit_reason(kind, reason, stack)
+    {formatted, reason} = format_reason({reason, stack})
     metadata = [crash_reason: reason] ++ registered_name(name)
 
     msg =

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -302,7 +302,7 @@ defmodule Logger.Translator do
       queue: queue,
       postponed: postponed,
       callback_mode: callback_mode,
-      state_enter: state_enter?,
+      state_enter: state_enter?
     } = report
 
     {reason, stack} = exit_reason(kind, reason, stack)
@@ -317,11 +317,15 @@ defmodule Logger.Translator do
     if min_level == :debug do
       msg = [
         msg,
-        "\nState: ", inspect(state, inspect_opts),
-        "\nData: ", inspect(data, inspect_opts),
-        "\nCallback mode: ", "#{inspect(callback_mode, inspect_opts)}, state_enter: #{state_enter?}"
+        "\nState: ",
+        inspect(state, inspect_opts),
+        "\nData: ",
+        inspect(data, inspect_opts),
+        "\nCallback mode: ",
+        "#{inspect(callback_mode, inspect_opts)}, state_enter: #{state_enter?}"
         | format_client_info(client)
       ]
+
       {:ok, msg, metadata}
     else
       {:ok, msg, metadata}

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -309,8 +309,17 @@ defmodule Logger.Translator do
     {formatted, reason} = format_reason({reason, stack})
     metadata = [crash_reason: reason] ++ registered_name(name)
 
+    label_msg =
+      case report do
+        %{process_label: process_label} when process_label != :undefined ->
+          ["\nProcess Label: ", inspect(process_label, inspect_opts)]
+
+        _ ->
+          []
+      end
+
     msg =
-      [":gen_statem ", inspect(name), " terminating", formatted] ++
+      [":gen_statem ", inspect(name), " terminating", formatted, label_msg] ++
         ["\nQueue: #{inspect(queue, inspect_opts)}"] ++
         ["\nPostponed: #{inspect(postponed, inspect_opts)}"]
 

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -423,8 +423,10 @@ defmodule Logger.TranslatorTest do
 
   @tag skip: System.otp_release() < "27"
   test "translates :gen_statem crashes with process label" do
-    {:ok, pid} = :gen_statem.start(MyGenStatem, :ok)
-    :ok = :gen_statem.call(pid, {:execute, fn -> Process.set_label({:any, "term"}) end})
+    {:ok, pid} = :gen_statem.start(MyGenStatem, :ok, [])
+
+    {:started, :ok} =
+      :gen_statem.call(pid, {:execute, fn -> Process.set_label({:any, "term"}) end})
 
     assert capture_log(:info, fn -> catch_exit(:gen_statem.call(pid, :error)) end) =~ ~r"""
            \[error\] :gen_statem #PID<\d+\.\d+\.\d+> terminating


### PR DESCRIPTION
This PR addresses an issue where `:gen_statem` modules terminate silently in Elixir, as their termination reports aren't translated. This is particularly troublesome in cases where mix dependencies use `:gen_statem` internally, and may fail silently.

I've made a small repo for reproducing the issue [here](https://github.com/Moosieus/a-sad-state-machine).

I haven't exhaustively evaluated all possible errors or diagnostics that could be included, but I think what's here is a reasonable starting point.