### PR TITLE
adds more expected naming conventions to the list

### DIFF
--- a/lib/elixir/pages/references/naming-conventions.md
+++ b/lib/elixir/pages/references/naming-conventions.md
@@ -129,9 +129,9 @@ In other words, functions using the word "size" in its name will take the same a
 
 When you see the functions `get`, `fetch`, and `fetch!` for key-value data structures, you can expect the following behaviours:
 
-- `get` returns `nil` if the key is not present, or the requested value.
-- `fetch` returns `:error` if the key is not present, `{:ok, value}` if it is.
-- `fetch!` *raises* if the key is not present, or the requested value.
+- `get` returns a default value (which itself defaults to `nil`) if the key is not present, or returns the requested value.
+- `fetch` returns `:error` if the key is not present, or returns `{:ok, value}` if it is.
+- `fetch!` *raises* if the key is not present, or returns the requested value.
 
 Examples: `Map.get/2`, `Map.fetch/2`, `Map.fetch!/2`, `Keyword.get/2`, `Keyword.fetch/2`, `Keyword.fetch!/2`
 
@@ -142,4 +142,4 @@ terms compare as equivalent, or `:gt` if the first term is greater than the seco
 
 Examples: `DateTime.compare/2`
 
-Note that this specific behaviour is important due to the expectations of `Enum.sort/2`
+Note that this specific convention is important due to the expectations of `Enum.sort/2`

--- a/lib/elixir/pages/references/naming-conventions.md
+++ b/lib/elixir/pages/references/naming-conventions.md
@@ -127,11 +127,11 @@ In other words, functions using the word "size" in its name will take the same a
 
 ### get, fetch, fetch!
 
-When you see the functions `get`, `fetch`, and `fetch!` for collections, you can expect the following behaviours:
+When you see the functions `get`, `fetch`, and `fetch!` for key-value data structures, you can expect the following behaviours:
 
-- `get` returns `nil` if the item is not present in the collection, or the requested item.
-- `fetch` returns `:error` if the item is not present in the collection, `{:ok, item}` if it is.
-- `fetch!` *raises* if the item is not present in the collection, or the requested item.
+- `get` returns `nil` if the key is not present, or the requested value.
+- `fetch` returns `:error` if the key is not present, `{:ok, value}` if it is.
+- `fetch!` *raises* if the key is not present, or the requested value.
 
 Examples: `Map.get/2`, `Map.fetch/2`, `Map.fetch!/2`, `Keyword.get/2`, `Keyword.fetch/2`, `Keyword.fetch!/2`
 

--- a/lib/elixir/pages/references/naming-conventions.md
+++ b/lib/elixir/pages/references/naming-conventions.md
@@ -124,3 +124,22 @@ When you see `length`, the operation runs in linear time ("O(n) time") because t
 Examples: `length/1`, `String.length/1`
 
 In other words, functions using the word "size" in its name will take the same amount of time whether the data structure is tiny or huge. Conversely, functions having "length" in its name will take more time as the data structure grows in size.
+
+### get, fetch, fetch!
+
+When you see the functions `get`, `fetch`, and `fetch!` for collections, you can expect the following behaviours:
+
+- `get` returns `nil` if the item is not present in the collection, or the requested item.
+- `fetch` returns `:error` if the item is not present in the collection, `{:ok, item}` if it is.
+- `fetch!` *raises* if the item is not present in the collection, or the requested item.
+
+Examples: `Map.get/2`, `Map.fetch/2`, `Map.fetch!/2`, `Keyword.get/2`, `Keyword.fetch/2`, `Keyword.fetch!/2`
+
+### compare
+
+The function `compare/2` should return `:lt` if the first term is less than the second, `:eq` if the two
+terms compare as equivalent, or `:gt` if the first term is greater than the second.
+
+Examples: `DateTime.compare/2`
+
+Note that this specific behaviour is important due to the expectations of `Enum.sort/2`


### PR DESCRIPTION
let's official-ize the following conventions:

- get, fetch, fetch!

- compare/2