### PR TITLE
Translate `:undefined` URI port to `nil`

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -659,14 +659,8 @@ defmodule URI do
           %{port: port} when is_integer(port) ->
             %{uri | scheme: scheme}
 
-          %{port: :undefined} ->
-            %{uri | scheme: scheme, port: default_port(scheme)}
-
           %{} ->
-            case default_port(scheme) do
-              nil -> %{uri | scheme: scheme}
-              port -> %{uri | scheme: scheme, port: port}
-            end
+            %{uri | scheme: scheme, port: default_port(scheme)}
         end
 
       %{port: :undefined} ->

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -656,8 +656,11 @@ defmodule URI do
         scheme = String.downcase(scheme, :ascii)
 
         case map do
-          %{port: port} when port != :undefined ->
+          %{port: port} when is_integer(port) ->
             %{uri | scheme: scheme}
+
+          %{port: :undefined} ->
+            %{uri | scheme: scheme, port: default_port(scheme)}
 
           %{} ->
             case default_port(scheme) do

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -666,6 +666,9 @@ defmodule URI do
             end
         end
 
+      %{port: :undefined} ->
+        %{uri | port: nil}
+
       %{} ->
         uri
     end

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -97,6 +97,20 @@ defmodule URITest do
       assert URI.new("") == {:ok, %URI{}}
     end
 
+    test "missing port part after host never resolves to :undefined" do
+      assert URI.new("//https://www.example.com") ==
+               {:ok,
+                %URI{
+                  scheme: nil,
+                  userinfo: nil,
+                  host: "https",
+                  port: nil,
+                  path: "//www.example.com",
+                  query: nil,
+                  fragment: nil
+                }}
+    end
+
     test "errors on bad URIs" do
       assert URI.new("/>") == {:error, ">"}
       assert URI.new(":https") == {:error, ":"}

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -97,20 +97,6 @@ defmodule URITest do
       assert URI.new("") == {:ok, %URI{}}
     end
 
-    test "missing port part after host never resolves to :undefined" do
-      assert URI.new("//https://www.example.com") ==
-               {:ok,
-                %URI{
-                  scheme: nil,
-                  userinfo: nil,
-                  host: "https",
-                  port: nil,
-                  path: "//www.example.com",
-                  query: nil,
-                  fragment: nil
-                }}
-    end
-
     test "errors on bad URIs" do
       assert URI.new("/>") == {:error, ">"}
       assert URI.new(":https") == {:error, ":"}
@@ -290,6 +276,32 @@ defmodule URITest do
 
     test "preserves an empty query" do
       assert URI.new!("http://foo.com/?").query == ""
+    end
+
+    test "without scheme, undefined port after host translates to nil" do
+      assert URI.new!("//https://www.example.com") ==
+               %URI{
+                 scheme: nil,
+                 userinfo: nil,
+                 host: "https",
+                 port: nil,
+                 path: "//www.example.com",
+                 query: nil,
+                 fragment: nil
+               }
+    end
+
+    test "with scheme, undefined port after host translates to nil" do
+      assert URI.new!("myscheme://myhost:/path/info") ==
+               %URI{
+                 scheme: "myscheme",
+                 userinfo: nil,
+                 host: "myhost",
+                 port: nil,
+                 path: "/path/info",
+                 query: nil,
+                 fragment: nil
+               }
     end
   end
 


### PR DESCRIPTION
Resolves #13462

When a url string is schema less and the host is followed by a colon without setting the actual port, `:uri_string.parse/1` returns the port to be `:undefined`. As long as the url string is parseable, we should translate `:undefiend` to `nil`, in order to ensure we return a valid URI struct.