### PR TITLE
Do not error when File.rm_rf is called on unix domain socket on windows

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1363,6 +1363,11 @@ defmodule File do
       {:ok, _} ->
         {:ok, :regular}
 
+      {:error, :eio} when major == :win32 ->
+        # unix domain socket returns `{:error, :eio}`
+        # on other platforms the result is `{:ok, :regular}`
+        {:ok, :regular}
+
       {:error, reason} ->
         {:error, reason}
     end


### PR DESCRIPTION
Note that `File.rm` works correctly
Repro:
```
{:ok, socket} = :socket.open(:local, :stream)
:ok = :socket.bind(socket, %{family: :local, path: "socket"})
File.rm_rf("socket")
{:error, :eio, "socket"}
File.rm("socket")
:ok
```

