### PR TITLE
Document supported OTP versions for 1.17

### DIFF
--- a/lib/elixir/pages/references/compatibility-and-deprecations.md
+++ b/lib/elixir/pages/references/compatibility-and-deprecations.md
@@ -43,6 +43,7 @@ Erlang/OTP versioning is independent from the versioning of Elixir. Erlang relea
 
 Elixir version | Supported Erlang/OTP versions
 :------------- | :-------------------------------
+1.17           | 25 - 27
 1.16           | 24 - 26
 1.15           | 24 - 26
 1.14           | 23 - 25 (and Erlang/OTP 26 from v1.14.5)


### PR DESCRIPTION
I thought we can already make it explicit so that people can find the information easily?