### PR TITLE
Print valid duration units in `Duration.new!/1` validation error

### DIFF
--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -87,14 +87,13 @@ defmodule Duration do
 
   defp validate_duration_unit!({:microsecond, microsecond}) do
     raise ArgumentError,
-          "expected a tuple {ms, precision} for microsecond where precision is an integer from 0 to 6, got #{inspect(microsecond)}"
+          "unsupported value #{inspect(microsecond)} for :microsecond. Expected a tuple {ms, precision} where precision is an integer from 0 to 6"
   end
 
   defp validate_duration_unit!({unit, _value})
        when unit not in [:year, :month, :week, :day, :hour, :minute, :second] do
     raise ArgumentError,
-          "unexpected unit #{inspect(unit)}" <>
-            did_you_mean(unit, [:year, :month, :week, :day, :hour, :minute, :second, :microsecond])
+          "unsupported unit #{inspect(unit)}. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond"
   end
 
   defp validate_duration_unit!({_unit, value}) when is_integer(value) do
@@ -102,7 +101,8 @@ defmodule Duration do
   end
 
   defp validate_duration_unit!({unit, value}) do
-    raise ArgumentError, "expected an integer for #{inspect(unit)}, got #{inspect(value)}"
+    raise ArgumentError,
+          "unsupported value #{inspect(value)} for #{inspect(unit)}. Expected an integer"
   end
 
   @doc """
@@ -213,24 +213,5 @@ defmodule Duration do
       second: -duration.second,
       microsecond: {-ms, p}
     }
-  end
-
-  defp did_you_mean(key, valid) when is_atom(key) and is_list(valid) do
-    case did_you_mean(Atom.to_string(key), Enum.map(valid, &Atom.to_string/1)) do
-      {similar, score} when score > 0.8 ->
-        "\n\nDid you mean :#{similar}?\n"
-
-      _ ->
-        ""
-    end
-  end
-
-  defp did_you_mean(option, valid) do
-    Enum.reduce(valid, {nil, 0}, &max_similar(&1, option, &2))
-  end
-
-  defp max_similar(option, valid, {_, current} = best) do
-    score = String.jaro_distance(option, valid)
-    if score < current, do: best, else: {option, score}
   end
 end

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -194,13 +194,13 @@ defmodule DateTest do
     assert Date.shift(~D[2000-01-01], month: 12) == ~D[2001-01-01]
     assert Date.shift(~D[0000-01-01], day: 2, year: 1, month: 37) == ~D[0004-02-03]
 
-    assert_raise ArgumentError, "cannot shift date by time units", fn ->
-      Date.shift(~D[2012-02-29], second: 86400)
-    end
+    assert_raise ArgumentError,
+                 "cannot shift date by time units",
+                 fn -> Date.shift(~D[2012-02-29], second: 86400) end
 
-    assert_raise ArgumentError, "unexpected unit :months", fn ->
-      Date.shift(~D[2012-01-01], months: 12)
-    end
+    assert_raise ArgumentError,
+                 "unexpected unit :months\n\nDid you mean :month?\n",
+                 fn -> Date.shift(~D[2012-01-01], months: 12) end
 
     # Implements calendar callback
     assert_raise RuntimeError, "shift_date/4 not implemented", fn ->

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -199,7 +199,7 @@ defmodule DateTest do
                  fn -> Date.shift(~D[2012-02-29], second: 86400) end
 
     assert_raise ArgumentError,
-                 "unexpected unit :months\n\nDid you mean :month?\n",
+                 "unsupported unit :months. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
                  fn -> Date.shift(~D[2012-01-01], months: 12) end
 
     # Implements calendar callback

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -1152,7 +1152,7 @@ defmodule DateTimeTest do
              }
 
     assert_raise ArgumentError,
-                 "unexpected unit :months\n\nDid you mean :month?\n",
+                 "unsupported unit :months. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
                  fn -> DateTime.shift(~U[2012-01-01 00:00:00Z], months: 12) end
   end
 end

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -1151,8 +1151,8 @@ defmodule DateTimeTest do
                zone_abbr: "CEST"
              }
 
-    assert_raise ArgumentError, "unexpected unit :months", fn ->
-      DateTime.shift(~U[2012-01-01 00:00:00Z], months: 12)
-    end
+    assert_raise ArgumentError,
+                 "unexpected unit :months\n\nDid you mean :month?\n",
+                 fn -> DateTime.shift(~U[2012-01-01 00:00:00Z], months: 12) end
   end
 end

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -16,8 +16,12 @@ defmodule DurationTest do
                  fn -> Duration.new!(month: nil) end
 
     assert_raise ArgumentError,
-                 "unexpected unit :years",
+                 "unexpected unit :years\n\nDid you mean :year?\n",
                  fn -> Duration.new!(years: 1) end
+
+    assert_raise ArgumentError,
+                 "unexpected unit :foo",
+                 fn -> Duration.new!(foo: 1) end
 
     assert_raise ArgumentError,
                  ~s/expected a tuple {ms, precision} for microsecond where precision is an integer from 0 to 6, got {1, 2, 3}/,

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -12,23 +12,19 @@ defmodule DurationTest do
     assert ^duration = Duration.new!(duration)
 
     assert_raise ArgumentError,
-                 "expected an integer for :month, got nil",
+                 "unsupported value nil for :month. Expected an integer",
                  fn -> Duration.new!(month: nil) end
 
     assert_raise ArgumentError,
-                 "unexpected unit :years\n\nDid you mean :year?\n",
+                 "unsupported unit :years. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
                  fn -> Duration.new!(years: 1) end
 
     assert_raise ArgumentError,
-                 "unexpected unit :foo",
-                 fn -> Duration.new!(foo: 1) end
-
-    assert_raise ArgumentError,
-                 ~s/expected a tuple {ms, precision} for microsecond where precision is an integer from 0 to 6, got {1, 2, 3}/,
+                 "unsupported value {1, 2, 3} for :microsecond. Expected a tuple {ms, precision} where precision is an integer from 0 to 6",
                  fn -> Duration.new!(microsecond: {1, 2, 3}) end
 
     assert_raise ArgumentError,
-                 ~s/expected a tuple {ms, precision} for microsecond where precision is an integer from 0 to 6, got {100, 7}/,
+                 "unsupported value {100, 7} for :microsecond. Expected a tuple {ms, precision} where precision is an integer from 0 to 6",
                  fn -> Duration.new!(microsecond: {100, 7}) end
   end
 

--- a/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
@@ -392,7 +392,7 @@ defmodule NaiveDateTimeTest do
     end
   end
 
-  describe "shift/2" do
+  test "shift/2" do
     naive_datetime = ~N[2000-01-01 00:00:00]
     assert NaiveDateTime.shift(naive_datetime, year: 1) == ~N[2001-01-01 00:00:00]
     assert NaiveDateTime.shift(naive_datetime, month: 1) == ~N[2000-02-01 00:00:00]

--- a/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
@@ -393,66 +393,62 @@ defmodule NaiveDateTimeTest do
   end
 
   describe "shift/2" do
-    test "shifts with valid arguments" do
-      naive_datetime = ~N[2000-01-01 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, year: 1) == ~N[2001-01-01 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, month: 1) == ~N[2000-02-01 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, week: 3) == ~N[2000-01-22 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, day: 2) == ~N[2000-01-03 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, hour: 6) == ~N[2000-01-01 06:00:00]
-      assert NaiveDateTime.shift(naive_datetime, minute: 30) == ~N[2000-01-01 00:30:00]
-      assert NaiveDateTime.shift(naive_datetime, second: 45) == ~N[2000-01-01 00:00:45]
-      assert NaiveDateTime.shift(naive_datetime, year: -1) == ~N[1999-01-01 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, month: -1) == ~N[1999-12-01 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, week: -1) == ~N[1999-12-25 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, day: -1) == ~N[1999-12-31 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, hour: -12) == ~N[1999-12-31 12:00:00]
-      assert NaiveDateTime.shift(naive_datetime, minute: -45) == ~N[1999-12-31 23:15:00]
-      assert NaiveDateTime.shift(naive_datetime, second: -30) == ~N[1999-12-31 23:59:30]
-      assert NaiveDateTime.shift(naive_datetime, year: 1, month: 2) == ~N[2001-03-01 00:00:00]
+    naive_datetime = ~N[2000-01-01 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, year: 1) == ~N[2001-01-01 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, month: 1) == ~N[2000-02-01 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, week: 3) == ~N[2000-01-22 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, day: 2) == ~N[2000-01-03 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, hour: 6) == ~N[2000-01-01 06:00:00]
+    assert NaiveDateTime.shift(naive_datetime, minute: 30) == ~N[2000-01-01 00:30:00]
+    assert NaiveDateTime.shift(naive_datetime, second: 45) == ~N[2000-01-01 00:00:45]
+    assert NaiveDateTime.shift(naive_datetime, year: -1) == ~N[1999-01-01 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, month: -1) == ~N[1999-12-01 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, week: -1) == ~N[1999-12-25 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, day: -1) == ~N[1999-12-31 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, hour: -12) == ~N[1999-12-31 12:00:00]
+    assert NaiveDateTime.shift(naive_datetime, minute: -45) == ~N[1999-12-31 23:15:00]
+    assert NaiveDateTime.shift(naive_datetime, second: -30) == ~N[1999-12-31 23:59:30]
+    assert NaiveDateTime.shift(naive_datetime, year: 1, month: 2) == ~N[2001-03-01 00:00:00]
 
-      assert NaiveDateTime.shift(naive_datetime, microsecond: {-500, 6}) ==
-               ~N[1999-12-31 23:59:59.999500]
+    assert NaiveDateTime.shift(naive_datetime, microsecond: {-500, 6}) ==
+             ~N[1999-12-31 23:59:59.999500]
 
-      assert NaiveDateTime.shift(naive_datetime, microsecond: {500, 6}) ==
-               ~N[2000-01-01 00:00:00.000500]
+    assert NaiveDateTime.shift(naive_datetime, microsecond: {500, 6}) ==
+             ~N[2000-01-01 00:00:00.000500]
 
-      assert NaiveDateTime.shift(naive_datetime, microsecond: {100, 6}) ==
-               ~N[2000-01-01 00:00:00.000100]
+    assert NaiveDateTime.shift(naive_datetime, microsecond: {100, 6}) ==
+             ~N[2000-01-01 00:00:00.000100]
 
-      assert NaiveDateTime.shift(naive_datetime, microsecond: {100, 4}) ==
-               ~N[2000-01-01 00:00:00.0001]
+    assert NaiveDateTime.shift(naive_datetime, microsecond: {100, 4}) ==
+             ~N[2000-01-01 00:00:00.0001]
 
-      assert NaiveDateTime.shift(naive_datetime, month: 2, day: 3, hour: 6, minute: 15) ==
-               ~N[2000-03-04 06:15:00]
+    assert NaiveDateTime.shift(naive_datetime, month: 2, day: 3, hour: 6, minute: 15) ==
+             ~N[2000-03-04 06:15:00]
 
-      assert NaiveDateTime.shift(naive_datetime,
-               year: 1,
-               month: 2,
-               week: 3,
-               day: 4,
-               hour: 5,
-               minute: 6,
-               second: 7,
-               microsecond: {8, 6}
-             ) == ~N[2001-03-26 05:06:07.000008]
+    assert NaiveDateTime.shift(naive_datetime,
+             year: 1,
+             month: 2,
+             week: 3,
+             day: 4,
+             hour: 5,
+             minute: 6,
+             second: 7,
+             microsecond: {8, 6}
+           ) == ~N[2001-03-26 05:06:07.000008]
 
-      assert NaiveDateTime.shift(naive_datetime,
-               year: -1,
-               month: -2,
-               week: -3,
-               day: -4,
-               hour: -5,
-               minute: -6,
-               second: -7,
-               microsecond: {-8, 6}
-             ) == ~N[1998-10-06 18:53:52.999992]
-    end
+    assert NaiveDateTime.shift(naive_datetime,
+             year: -1,
+             month: -2,
+             week: -3,
+             day: -4,
+             hour: -5,
+             minute: -6,
+             second: -7,
+             microsecond: {-8, 6}
+           ) == ~N[1998-10-06 18:53:52.999992]
 
-    test "fails with invalid unit" do
-      assert_raise ArgumentError, "unexpected unit :months", fn ->
-        NaiveDateTime.shift(~N[2000-01-01 00:00:00], months: 12)
-      end
-    end
+    assert_raise ArgumentError,
+                 "unexpected unit :months\n\nDid you mean :month?\n",
+                 fn -> NaiveDateTime.shift(~N[2000-01-01 00:00:00], months: 12) end
   end
 end

--- a/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
@@ -448,7 +448,7 @@ defmodule NaiveDateTimeTest do
            ) == ~N[1998-10-06 18:53:52.999992]
 
     assert_raise ArgumentError,
-                 "unexpected unit :months\n\nDid you mean :month?\n",
+                 "unsupported unit :months. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
                  fn -> NaiveDateTime.shift(~N[2000-01-01 00:00:00], months: 12) end
   end
 end

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -113,12 +113,12 @@ defmodule TimeTest do
     assert Time.shift(time, microsecond: {1000, 4}) == ~T[00:00:00.0010]
     assert Time.shift(time, hour: 2, minute: 65, second: 5) == ~T[03:05:05.0]
 
-    assert_raise ArgumentError, "cannot shift time by date units", fn ->
-      Time.shift(time, day: 1)
-    end
+    assert_raise ArgumentError,
+                 "cannot shift time by date units",
+                 fn -> Time.shift(time, day: 1) end
 
-    assert_raise ArgumentError, "unexpected unit :hours", fn ->
-      Time.shift(time, hours: 12)
-    end
+    assert_raise ArgumentError,
+                 "unexpected unit :hours\n\nDid you mean :hour?\n",
+                 fn -> Time.shift(time, hours: 12) end
   end
 end

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -118,7 +118,7 @@ defmodule TimeTest do
                  fn -> Time.shift(time, day: 1) end
 
     assert_raise ArgumentError,
-                 "unexpected unit :hours\n\nDid you mean :hour?\n",
+                 "unsupported unit :hours. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
                  fn -> Time.shift(time, hours: 12) end
   end
 end


### PR DESCRIPTION
Produces the following error message:

```
iex(1)> Duration.new!(montth: 1)
** (ArgumentError) unexpected unit :montth

Did you mean :month?

    (elixir 1.17.0-dev) lib/calendar/duration.ex:95: Duration.validate_duration_unit!/1
    (elixir 1.17.0-dev) lib/enum.ex:987: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir 1.17.0-dev) lib/calendar/duration.ex:79: Duration.new!/1
    iex:1: (file)
```

/cc @sabiwara @wojtekmach 