### PR TITLE
Separate Duration date and time unit specs

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -794,10 +794,10 @@ defmodule Date do
 
   """
   @doc since: "1.17.0"
-  @spec shift(Calendar.date(), Duration.duration()) :: t
+  @spec shift(Calendar.date(), Duration.t() | [Duration.date_unit_pair()]) :: t
   def shift(%{calendar: calendar} = date, duration) do
     %{year: year, month: month, day: day} = date
-    {year, month, day} = calendar.shift_date(year, month, day, Duration.new!(duration))
+    {year, month, day} = calendar.shift_date(year, month, day, Duration.new_date_units!(duration))
     %Date{calendar: calendar, year: year, month: month, day: day}
   end
 

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -797,7 +797,7 @@ defmodule Date do
   @spec shift(Calendar.date(), Duration.t() | [Duration.date_unit_pair()]) :: t
   def shift(%{calendar: calendar} = date, duration) do
     %{year: year, month: month, day: day} = date
-    {year, month, day} = calendar.shift_date(year, month, day, Duration.new_date_units!(duration))
+    {year, month, day} = calendar.shift_date(year, month, day, Duration.new!(duration))
     %Date{calendar: calendar, year: year, month: month, day: day}
   end
 

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -802,31 +802,8 @@ defmodule Date do
     %Date{calendar: calendar, year: year, month: month, day: day}
   end
 
-  @doc false
-  def to_iso_days(%{calendar: Calendar.ISO, year: year, month: month, day: day}) do
-    {Calendar.ISO.date_to_iso_days(year, month, day), {0, 86_400_000_000}}
-  end
-
-  def to_iso_days(%{calendar: calendar, year: year, month: month, day: day}) do
-    calendar.naive_datetime_to_iso_days(year, month, day, 0, 0, 0, {0, 0})
-  end
-
-  defp from_iso_days({days, _}, Calendar.ISO) do
-    {year, month, day} = Calendar.ISO.date_from_iso_days(days)
-    %Date{year: year, month: month, day: day, calendar: Calendar.ISO}
-  end
-
-  defp from_iso_days(iso_days, target_calendar) do
-    {year, month, day, _, _, _, _} = target_calendar.naive_datetime_from_iso_days(iso_days)
-    %Date{year: year, month: month, day: day, calendar: target_calendar}
-  end
-
-  defp new_duration!(%Duration{hour: 0, minute: 0, second: 0, microsecond: {0, 0}} = duration) do
+  defp new_duration!(%Duration{} = duration) do
     duration
-  end
-
-  defp new_duration!(%Duration{}) do
-    raise ArgumentError, "duration may not contain time scale units"
   end
 
   defp new_duration!(unit_pairs) do
@@ -850,6 +827,25 @@ defmodule Date do
   defp validate_duration_unit!({unit, value}) do
     raise ArgumentError,
           "unsupported value #{inspect(value)} for #{inspect(unit)}. Expected an integer"
+  end
+
+  @doc false
+  def to_iso_days(%{calendar: Calendar.ISO, year: year, month: month, day: day}) do
+    {Calendar.ISO.date_to_iso_days(year, month, day), {0, 86_400_000_000}}
+  end
+
+  def to_iso_days(%{calendar: calendar, year: year, month: month, day: day}) do
+    calendar.naive_datetime_to_iso_days(year, month, day, 0, 0, 0, {0, 0})
+  end
+
+  defp from_iso_days({days, _}, Calendar.ISO) do
+    {year, month, day} = Calendar.ISO.date_from_iso_days(days)
+    %Date{year: year, month: month, day: day, calendar: Calendar.ISO}
+  end
+
+  defp from_iso_days(iso_days, target_calendar) do
+    {year, month, day, _, _, _, _} = target_calendar.naive_datetime_from_iso_days(iso_days)
+    %Date{year: year, month: month, day: day, calendar: target_calendar}
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -794,7 +794,8 @@ defmodule Date do
 
   """
   @doc since: "1.17.0"
-  @spec shift(Calendar.date(), Duration.t() | [Duration.date_unit_pair()]) :: t
+  @spec shift(Calendar.date(), Duration.t() | [unit_pair]) :: t
+        when unit_pair: {:year, integer} | {:month, integer} | {:week, integer} | {:day, integer}
   def shift(%{calendar: calendar} = date, duration) do
     %{year: year, month: month, day: day} = date
     {year, month, day} = calendar.shift_date(year, month, day, new_duration!(duration))

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -38,27 +38,17 @@ defmodule Duration do
         }
 
   @typedoc """
-  The time unit pair type specifies a pair of a valid time duration unit key and value.
+  The unit pair type specifies a pair of a valid duration unit key and value.
   """
-  @type time_unit_pair ::
-          {:hour, integer}
-          | {:minute, integer}
-          | {:second, integer}
-          | {:microsecond, {integer, 0..6}}
-
-  @typedoc """
-  The date unit pair type specifies a pair of a valid date duration unit key and value.
-  """
-  @type date_unit_pair ::
+  @type unit_pair ::
           {:year, integer}
           | {:month, integer}
           | {:week, integer}
           | {:day, integer}
-
-  @typedoc """
-  The unit pair type specifies a pair of a valid duration unit key and value.
-  """
-  @type unit_pair :: date_unit_pair | time_unit_pair
+          | {:hour, integer}
+          | {:minute, integer}
+          | {:second, integer}
+          | {:microsecond, {integer, 0..6}}
 
   @typedoc """
   The duration type specifies a `%Duration{}` struct or a keyword list of valid duration unit pairs.

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -90,82 +90,27 @@ defmodule Duration do
     struct!(Duration, unit_pairs)
   end
 
-  @doc false
-  @spec new_date_units!(t | [date_unit_pair]) :: t
-  def new_date_units!(%Duration{hour: 0, minute: 0, second: 0, microsecond: {0, 0}} = duration) do
-    duration
-  end
-
-  def new_date_units!(%Duration{}) do
-    raise ArgumentError, "duration may not contain time scale units in `new_date_units!/1`"
-  end
-
-  def new_date_units!(unit_pairs) do
-    Enum.each(unit_pairs, &validate_date_unit!/1)
-    struct!(Duration, unit_pairs)
-  end
-
-  @doc false
-  @spec new_time_units!(t | [time_unit_pair]) :: t
-  def new_time_units!(%Duration{year: 0, month: 0, week: 0, day: 0} = duration) do
-    duration
-  end
-
-  def new_time_units!(%Duration{}) do
-    raise ArgumentError, "duration may not contain date scale units in `new_time_units!/1`"
-  end
-
-  def new_time_units!(unit_pairs) do
-    Enum.each(unit_pairs, &validate_time_unit!/1)
-    struct!(Duration, unit_pairs)
-  end
-
-  defp validate_unit!({unit, value}) when unit in [:year, :month, :week, :day] do
-    validate_date_unit!({unit, value})
-  end
-
-  defp validate_unit!({unit, value}) when unit in [:hour, :minute, :second, :microsecond] do
-    validate_time_unit!({unit, value})
-  end
-
-  defp validate_unit!({unit, _value}) do
-    raise ArgumentError,
-          "unsupported unit #{inspect(unit)}. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond"
-  end
-
-  defp validate_date_unit!({unit, _value}) when unit not in [:year, :month, :week, :day] do
-    raise ArgumentError, "unsupported unit #{inspect(unit)}. Expected :year, :month, :week, :day"
-  end
-
-  defp validate_date_unit!({_unit, value}) when is_integer(value) do
-    :ok
-  end
-
-  defp validate_date_unit!({unit, value}) do
-    raise ArgumentError,
-          "unsupported value #{inspect(value)} for #{inspect(unit)}. Expected an integer"
-  end
-
-  defp validate_time_unit!({:microsecond, {ms, precision}})
+  defp validate_unit!({:microsecond, {ms, precision}})
        when is_integer(ms) and precision in 0..6 do
     :ok
   end
 
-  defp validate_time_unit!({:microsecond, microsecond}) do
+  defp validate_unit!({:microsecond, microsecond}) do
     raise ArgumentError,
           "unsupported value #{inspect(microsecond)} for :microsecond. Expected a tuple {ms, precision} where precision is an integer from 0 to 6"
   end
 
-  defp validate_time_unit!({unit, _value}) when unit not in [:hour, :minute, :second] do
+  defp validate_unit!({unit, _value})
+       when unit not in [:year, :month, :week, :day, :hour, :minute, :second] do
     raise ArgumentError,
-          "unsupported unit #{inspect(unit)}. Expected :hour, :minute, :second, :microsecond"
+          "unknown unit #{inspect(unit)}. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond"
   end
 
-  defp validate_time_unit!({_unit, value}) when is_integer(value) do
+  defp validate_unit!({_unit, value}) when is_integer(value) do
     :ok
   end
 
-  defp validate_time_unit!({unit, value}) do
+  defp validate_unit!({unit, value}) do
     raise ArgumentError,
           "unsupported value #{inspect(value)} for #{inspect(unit)}. Expected an integer"
   end

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1637,7 +1637,8 @@ defmodule Calendar.ISO do
   end
 
   defp shift_date_options(_duration) do
-    raise ArgumentError, "cannot shift date by time units"
+    raise ArgumentError,
+          "cannot shift date by time scale unit. Expected :year, :month, :week, :day"
   end
 
   defp shift_datetime_options(%Duration{
@@ -1674,7 +1675,8 @@ defmodule Calendar.ISO do
   end
 
   defp shift_time_options(_duration) do
-    raise ArgumentError, "cannot shift time by date units"
+    raise ArgumentError,
+          "cannot shift time by date scale unit. Expected :hour, :minute, :second, :microsecond"
   end
 
   ## Helpers

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -571,12 +571,12 @@ defmodule Time do
 
   """
   @doc since: "1.17.0"
-  @spec shift(Calendar.time(), Duration.duration()) :: t
+  @spec shift(Calendar.time(), Duration.t() | [Duration.time_unit_pair()]) :: t
   def shift(%{calendar: calendar} = time, duration) do
     %{hour: hour, minute: minute, second: second, microsecond: microsecond} = time
 
     {hour, minute, second, microsecond} =
-      calendar.shift_time(hour, minute, second, microsecond, Duration.new!(duration))
+      calendar.shift_time(hour, minute, second, microsecond, Duration.new_time_units!(duration))
 
     %Time{
       calendar: calendar,

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -592,12 +592,8 @@ defmodule Time do
     }
   end
 
-  defp new_duration!(%Duration{year: 0, month: 0, week: 0, day: 0} = duration) do
+  defp new_duration!(%Duration{} = duration) do
     duration
-  end
-
-  defp new_duration!(%Duration{}) do
-    raise ArgumentError, "duration may not contain date scale units"
   end
 
   defp new_duration!(unit_pairs) do

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -571,7 +571,12 @@ defmodule Time do
 
   """
   @doc since: "1.17.0"
-  @spec shift(Calendar.time(), Duration.t() | [Duration.time_unit_pair()]) :: t
+  @spec shift(Calendar.time(), Duration.t() | [unit_pair]) :: t
+        when unit_pair:
+               {:hour, integer}
+               | {:minute, integer}
+               | {:second, integer}
+               | {:microsecond, {integer, 0..6}}
   def shift(%{calendar: calendar} = time, duration) do
     %{hour: hour, minute: minute, second: second, microsecond: microsecond} = time
 

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -576,7 +576,7 @@ defmodule Time do
     %{hour: hour, minute: minute, second: second, microsecond: microsecond} = time
 
     {hour, minute, second, microsecond} =
-      calendar.shift_time(hour, minute, second, microsecond, Duration.new_time_units!(duration))
+      calendar.shift_time(hour, minute, second, microsecond, Duration.new!(duration))
 
     %Time{
       calendar: calendar,

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -194,13 +194,17 @@ defmodule DateTest do
     assert Date.shift(~D[2000-01-01], month: 12) == ~D[2001-01-01]
     assert Date.shift(~D[0000-01-01], day: 2, year: 1, month: 37) == ~D[0004-02-03]
 
-    assert_raise ArgumentError, "cannot shift date by time units", fn ->
-      Date.shift(~D[2012-02-29], second: 86400)
-    end
+    assert_raise ArgumentError,
+                 "unsupported unit :second. Expected :year, :month, :week, :day",
+                 fn -> Date.shift(~D[2012-02-29], second: 86400) end
 
-    assert_raise ArgumentError, "unexpected unit :months", fn ->
-      Date.shift(~D[2012-01-01], months: 12)
-    end
+    assert_raise ArgumentError,
+                 "unsupported unit :months. Expected :year, :month, :week, :day",
+                 fn -> Date.shift(~D[2012-01-01], months: 12) end
+
+    assert_raise ArgumentError,
+                 "duration may not contain time scale units in `new_date_units!/1`",
+                 fn -> Date.shift(~D[2012-02-29], %Duration{second: 86400}) end
 
     # Implements calendar callback
     assert_raise RuntimeError, "shift_date/4 not implemented", fn ->

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -203,7 +203,7 @@ defmodule DateTest do
                  fn -> Date.shift(~D[2012-01-01], months: 12) end
 
     assert_raise ArgumentError,
-                 "duration may not contain time scale units",
+                 "cannot shift date by time scale unit. Expected :year, :month, :week, :day",
                  fn -> Date.shift(~D[2012-02-29], %Duration{second: 86400}) end
 
     # Implements calendar callback

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -195,15 +195,15 @@ defmodule DateTest do
     assert Date.shift(~D[0000-01-01], day: 2, year: 1, month: 37) == ~D[0004-02-03]
 
     assert_raise ArgumentError,
-                 "cannot shift date by time scale unit. Expected :year, :month, :week, :day",
+                 "unsupported unit :second. Expected :year, :month, :week, :day",
                  fn -> Date.shift(~D[2012-02-29], second: 86400) end
 
     assert_raise ArgumentError,
-                 "unknown unit :months. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
+                 "unknown unit :months. Expected :year, :month, :week, :day",
                  fn -> Date.shift(~D[2012-01-01], months: 12) end
 
     assert_raise ArgumentError,
-                 "cannot shift date by time scale unit. Expected :year, :month, :week, :day",
+                 "duration may not contain time scale units",
                  fn -> Date.shift(~D[2012-02-29], %Duration{second: 86400}) end
 
     # Implements calendar callback

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -195,15 +195,15 @@ defmodule DateTest do
     assert Date.shift(~D[0000-01-01], day: 2, year: 1, month: 37) == ~D[0004-02-03]
 
     assert_raise ArgumentError,
-                 "unsupported unit :second. Expected :year, :month, :week, :day",
+                 "cannot shift date by time scale unit. Expected :year, :month, :week, :day",
                  fn -> Date.shift(~D[2012-02-29], second: 86400) end
 
     assert_raise ArgumentError,
-                 "unsupported unit :months. Expected :year, :month, :week, :day",
+                 "unknown unit :months. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
                  fn -> Date.shift(~D[2012-01-01], months: 12) end
 
     assert_raise ArgumentError,
-                 "duration may not contain time scale units in `new_date_units!/1`",
+                 "cannot shift date by time scale unit. Expected :year, :month, :week, :day",
                  fn -> Date.shift(~D[2012-02-29], %Duration{second: 86400}) end
 
     # Implements calendar callback

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -1151,8 +1151,8 @@ defmodule DateTimeTest do
                zone_abbr: "CEST"
              }
 
-    assert_raise ArgumentError, "unexpected unit :months", fn ->
-      DateTime.shift(~U[2012-01-01 00:00:00Z], months: 12)
-    end
+    assert_raise ArgumentError,
+                 "unsupported unit :months. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
+                 fn -> DateTime.shift(~U[2012-01-01 00:00:00Z], months: 12) end
   end
 end

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -1152,7 +1152,7 @@ defmodule DateTimeTest do
              }
 
     assert_raise ArgumentError,
-                 "unsupported unit :months. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
+                 "unknown unit :months. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
                  fn -> DateTime.shift(~U[2012-01-01 00:00:00Z], months: 12) end
   end
 end

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -12,19 +12,19 @@ defmodule DurationTest do
     assert ^duration = Duration.new!(duration)
 
     assert_raise ArgumentError,
-                 "expected an integer for :month, got nil",
+                 "unsupported value nil for :month. Expected an integer",
                  fn -> Duration.new!(month: nil) end
 
     assert_raise ArgumentError,
-                 "unexpected unit :years",
+                 "unsupported unit :years. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
                  fn -> Duration.new!(years: 1) end
 
     assert_raise ArgumentError,
-                 ~s/expected a tuple {ms, precision} for microsecond where precision is an integer from 0 to 6, got {1, 2, 3}/,
+                 "unsupported value {1, 2, 3} for :microsecond. Expected a tuple {ms, precision} where precision is an integer from 0 to 6",
                  fn -> Duration.new!(microsecond: {1, 2, 3}) end
 
     assert_raise ArgumentError,
-                 ~s/expected a tuple {ms, precision} for microsecond where precision is an integer from 0 to 6, got {100, 7}/,
+                 "unsupported value {100, 7} for :microsecond. Expected a tuple {ms, precision} where precision is an integer from 0 to 6",
                  fn -> Duration.new!(microsecond: {100, 7}) end
   end
 

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -16,7 +16,7 @@ defmodule DurationTest do
                  fn -> Duration.new!(month: nil) end
 
     assert_raise ArgumentError,
-                 "unsupported unit :years. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
+                 "unknown unit :years. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
                  fn -> Duration.new!(years: 1) end
 
     assert_raise ArgumentError,

--- a/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
@@ -392,67 +392,63 @@ defmodule NaiveDateTimeTest do
     end
   end
 
-  describe "shift/2" do
-    test "shifts with valid arguments" do
-      naive_datetime = ~N[2000-01-01 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, year: 1) == ~N[2001-01-01 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, month: 1) == ~N[2000-02-01 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, week: 3) == ~N[2000-01-22 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, day: 2) == ~N[2000-01-03 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, hour: 6) == ~N[2000-01-01 06:00:00]
-      assert NaiveDateTime.shift(naive_datetime, minute: 30) == ~N[2000-01-01 00:30:00]
-      assert NaiveDateTime.shift(naive_datetime, second: 45) == ~N[2000-01-01 00:00:45]
-      assert NaiveDateTime.shift(naive_datetime, year: -1) == ~N[1999-01-01 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, month: -1) == ~N[1999-12-01 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, week: -1) == ~N[1999-12-25 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, day: -1) == ~N[1999-12-31 00:00:00]
-      assert NaiveDateTime.shift(naive_datetime, hour: -12) == ~N[1999-12-31 12:00:00]
-      assert NaiveDateTime.shift(naive_datetime, minute: -45) == ~N[1999-12-31 23:15:00]
-      assert NaiveDateTime.shift(naive_datetime, second: -30) == ~N[1999-12-31 23:59:30]
-      assert NaiveDateTime.shift(naive_datetime, year: 1, month: 2) == ~N[2001-03-01 00:00:00]
+  test "shift/2" do
+    naive_datetime = ~N[2000-01-01 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, year: 1) == ~N[2001-01-01 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, month: 1) == ~N[2000-02-01 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, week: 3) == ~N[2000-01-22 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, day: 2) == ~N[2000-01-03 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, hour: 6) == ~N[2000-01-01 06:00:00]
+    assert NaiveDateTime.shift(naive_datetime, minute: 30) == ~N[2000-01-01 00:30:00]
+    assert NaiveDateTime.shift(naive_datetime, second: 45) == ~N[2000-01-01 00:00:45]
+    assert NaiveDateTime.shift(naive_datetime, year: -1) == ~N[1999-01-01 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, month: -1) == ~N[1999-12-01 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, week: -1) == ~N[1999-12-25 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, day: -1) == ~N[1999-12-31 00:00:00]
+    assert NaiveDateTime.shift(naive_datetime, hour: -12) == ~N[1999-12-31 12:00:00]
+    assert NaiveDateTime.shift(naive_datetime, minute: -45) == ~N[1999-12-31 23:15:00]
+    assert NaiveDateTime.shift(naive_datetime, second: -30) == ~N[1999-12-31 23:59:30]
+    assert NaiveDateTime.shift(naive_datetime, year: 1, month: 2) == ~N[2001-03-01 00:00:00]
 
-      assert NaiveDateTime.shift(naive_datetime, microsecond: {-500, 6}) ==
-               ~N[1999-12-31 23:59:59.999500]
+    assert NaiveDateTime.shift(naive_datetime, microsecond: {-500, 6}) ==
+             ~N[1999-12-31 23:59:59.999500]
 
-      assert NaiveDateTime.shift(naive_datetime, microsecond: {500, 6}) ==
-               ~N[2000-01-01 00:00:00.000500]
+    assert NaiveDateTime.shift(naive_datetime, microsecond: {500, 6}) ==
+             ~N[2000-01-01 00:00:00.000500]
 
-      assert NaiveDateTime.shift(naive_datetime, microsecond: {100, 6}) ==
-               ~N[2000-01-01 00:00:00.000100]
+    assert NaiveDateTime.shift(naive_datetime, microsecond: {100, 6}) ==
+             ~N[2000-01-01 00:00:00.000100]
 
-      assert NaiveDateTime.shift(naive_datetime, microsecond: {100, 4}) ==
-               ~N[2000-01-01 00:00:00.0001]
+    assert NaiveDateTime.shift(naive_datetime, microsecond: {100, 4}) ==
+             ~N[2000-01-01 00:00:00.0001]
 
-      assert NaiveDateTime.shift(naive_datetime, month: 2, day: 3, hour: 6, minute: 15) ==
-               ~N[2000-03-04 06:15:00]
+    assert NaiveDateTime.shift(naive_datetime, month: 2, day: 3, hour: 6, minute: 15) ==
+             ~N[2000-03-04 06:15:00]
 
-      assert NaiveDateTime.shift(naive_datetime,
-               year: 1,
-               month: 2,
-               week: 3,
-               day: 4,
-               hour: 5,
-               minute: 6,
-               second: 7,
-               microsecond: {8, 6}
-             ) == ~N[2001-03-26 05:06:07.000008]
+    assert NaiveDateTime.shift(naive_datetime,
+             year: 1,
+             month: 2,
+             week: 3,
+             day: 4,
+             hour: 5,
+             minute: 6,
+             second: 7,
+             microsecond: {8, 6}
+           ) == ~N[2001-03-26 05:06:07.000008]
 
-      assert NaiveDateTime.shift(naive_datetime,
-               year: -1,
-               month: -2,
-               week: -3,
-               day: -4,
-               hour: -5,
-               minute: -6,
-               second: -7,
-               microsecond: {-8, 6}
-             ) == ~N[1998-10-06 18:53:52.999992]
-    end
+    assert NaiveDateTime.shift(naive_datetime,
+             year: -1,
+             month: -2,
+             week: -3,
+             day: -4,
+             hour: -5,
+             minute: -6,
+             second: -7,
+             microsecond: {-8, 6}
+           ) == ~N[1998-10-06 18:53:52.999992]
 
-    test "fails with invalid unit" do
-      assert_raise ArgumentError, "unexpected unit :months", fn ->
-        NaiveDateTime.shift(~N[2000-01-01 00:00:00], months: 12)
-      end
-    end
+    assert_raise ArgumentError,
+                 "unsupported unit :months. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
+                 fn -> NaiveDateTime.shift(~N[2000-01-01 00:00:00], months: 12) end
   end
 end

--- a/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
@@ -448,7 +448,7 @@ defmodule NaiveDateTimeTest do
            ) == ~N[1998-10-06 18:53:52.999992]
 
     assert_raise ArgumentError,
-                 "unsupported unit :months. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
+                 "unknown unit :months. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
                  fn -> NaiveDateTime.shift(~N[2000-01-01 00:00:00], months: 12) end
   end
 end

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -113,12 +113,16 @@ defmodule TimeTest do
     assert Time.shift(time, microsecond: {1000, 4}) == ~T[00:00:00.0010]
     assert Time.shift(time, hour: 2, minute: 65, second: 5) == ~T[03:05:05.0]
 
-    assert_raise ArgumentError, "cannot shift time by date units", fn ->
-      Time.shift(time, day: 1)
-    end
+    assert_raise ArgumentError,
+                 "unsupported unit :day. Expected :hour, :minute, :second, :microsecond",
+                 fn -> Time.shift(time, day: 1) end
 
-    assert_raise ArgumentError, "unexpected unit :hours", fn ->
-      Time.shift(time, hours: 12)
-    end
+    assert_raise ArgumentError,
+                 "duration may not contain date scale units in `new_time_units!/1`",
+                 fn -> Time.shift(time, %Duration{day: 1}) end
+
+    assert_raise ArgumentError,
+                 "unsupported unit :hours. Expected :hour, :minute, :second, :microsecond",
+                 fn -> Time.shift(time, hours: 12) end
   end
 end

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -114,15 +114,15 @@ defmodule TimeTest do
     assert Time.shift(time, hour: 2, minute: 65, second: 5) == ~T[03:05:05.0]
 
     assert_raise ArgumentError,
-                 "cannot shift time by date scale unit. Expected :hour, :minute, :second, :microsecond",
+                 "unsupported unit :day. Expected :hour, :minute, :second, :microsecond",
                  fn -> Time.shift(time, day: 1) end
 
     assert_raise ArgumentError,
-                 "unknown unit :hours. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
+                 "unknown unit :hours. Expected :hour, :minute, :second, :microsecond",
                  fn -> Time.shift(time, hours: 12) end
 
     assert_raise ArgumentError,
-                 "cannot shift time by date scale unit. Expected :hour, :minute, :second, :microsecond",
+                 "duration may not contain date scale units",
                  fn -> Time.shift(time, %Duration{day: 1}) end
   end
 end

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -122,7 +122,7 @@ defmodule TimeTest do
                  fn -> Time.shift(time, hours: 12) end
 
     assert_raise ArgumentError,
-                 "duration may not contain date scale units",
+                 "cannot shift time by date scale unit. Expected :hour, :minute, :second, :microsecond",
                  fn -> Time.shift(time, %Duration{day: 1}) end
   end
 end

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -114,15 +114,15 @@ defmodule TimeTest do
     assert Time.shift(time, hour: 2, minute: 65, second: 5) == ~T[03:05:05.0]
 
     assert_raise ArgumentError,
-                 "unsupported unit :day. Expected :hour, :minute, :second, :microsecond",
+                 "cannot shift time by date scale unit. Expected :hour, :minute, :second, :microsecond",
                  fn -> Time.shift(time, day: 1) end
 
     assert_raise ArgumentError,
-                 "duration may not contain date scale units in `new_time_units!/1`",
-                 fn -> Time.shift(time, %Duration{day: 1}) end
+                 "unknown unit :hours. Expected :year, :month, :week, :day, :hour, :minute, :second, :microsecond",
+                 fn -> Time.shift(time, hours: 12) end
 
     assert_raise ArgumentError,
-                 "unsupported unit :hours. Expected :hour, :minute, :second, :microsecond",
-                 fn -> Time.shift(time, hours: 12) end
+                 "cannot shift time by date scale unit. Expected :hour, :minute, :second, :microsecond",
+                 fn -> Time.shift(time, %Duration{day: 1}) end
   end
 end


### PR DESCRIPTION
This PR introduces new Duration types: `t:Duration.date_unit_pair/0` and `t:Duration.time_unit_pair/0` to be used in `{Date, Time}.shift/2`. This corrects the spec of the two functions.

It also introduces two new Duration constructors: `Duration.new_date_units!/1` and `Duration.new_time_units!/1` with separate validators to return useful error messages. These are based on the existing validation for `Duration.new!/1`, making sure that we share as much code as possible.

---

I find the names for the new Duration constructors not ideal, happy about suggestions!