### PR TITLE
Fix typespec for Stream.with_index/2

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1200,7 +1200,9 @@ defmodule Stream do
       [1, 3, 5]
 
   """
-  @spec with_index(Enumerable.t(), integer) :: Enumerable.t()
+  @spec with_index(Enumerable.t(), integer) :: Enumerable.t({element, integer})
+  @spec with_index(Enumerable.t(), (element, index -> return_value)) :: Enumerable.t(return_value)
+        when return_value: term
   def with_index(enum, fun_or_offset \\ 0)
 
   def with_index(enum, offset) when is_integer(offset) do


### PR DESCRIPTION
SInce https://github.com/elixir-lang/elixir/pull/13486/files#diff-11ced97f76da97ec34bfa29d332bf443d59bb797a59312f6a5d94392978aedeaR1210 we now support an offset or a function, but the spec didn't reflect that.