### PR TITLE
Formatting fix for binary_part/3 documentation

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -397,7 +397,7 @@ defmodule Kernel do
       iex> binary_part("Hello", 5, -3)
       "llo"
 
-  An `ArgumentError` is raised when the size is outside of the binary:
+  An `ArgumentError` is raised when the `size` is outside of the binary:
 
       binary_part("Hello", 0, 10)
       ** (ArgumentError) argument error


### PR DESCRIPTION
Small fix for the `binary_part/3` function documentation where the argument `size` was shown as plain text instead of quoted. 