### PR TITLE
Update File.Stat.t type definition to mirror :file.file_info type.

### DIFF
--- a/lib/elixir/lib/file/stat.ex
+++ b/lib/elixir/lib/file/stat.ex
@@ -60,19 +60,19 @@ defmodule File.Stat do
   defstruct keys
 
   @type t :: %__MODULE__{
-          size: non_neg_integer(),
-          type: :device | :directory | :regular | :other | :symlink,
-          access: :read | :write | :read_write | :none,
-          atime: :calendar.datetime() | integer(),
-          mtime: :calendar.datetime() | integer(),
-          ctime: :calendar.datetime() | integer(),
-          mode: non_neg_integer(),
-          links: non_neg_integer(),
-          major_device: non_neg_integer(),
-          minor_device: non_neg_integer(),
-          inode: non_neg_integer(),
-          uid: non_neg_integer(),
-          gid: non_neg_integer()
+          size: non_neg_integer() | :undefined,
+          type: :device | :directory | :regular | :other | :symlink | :undefined,
+          access: :read | :write | :read_write | :none | :undefined,
+          atime: :calendar.datetime() | integer() | :undefined,
+          mtime: :calendar.datetime() | integer() | :undefined,
+          ctime: :calendar.datetime() | integer() | :undefined,
+          mode: non_neg_integer() | :undefined,
+          links: non_neg_integer() | :undefined,
+          major_device: non_neg_integer() | :undefined,
+          minor_device: non_neg_integer() | :undefined,
+          inode: non_neg_integer() | :undefined,
+          uid: non_neg_integer() | :undefined,
+          gid: non_neg_integer() | :undefined
         }
 
   @doc """


### PR DESCRIPTION
Example code for which Dialyzer emitted warning:
```elixir
channel_pid = :ssh_sftp.start_channel(ssh_connection)

{:ok, record} = :ssh_sftp.read_file_info(channel_pid, "/home/dummy/test.file")
stat = File.Stat.from_record(record)

case stat.mtime do
  :undefined -> nil
  modification_time -> modification_time
end
```

Fixes #13497