### PR TITLE
Test: Reproduces a compilation error caused by the formatter

### DIFF
--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -296,6 +296,14 @@ defmodule Code.Formatter.GeneralTest do
       assert_same code, @short_length
     end
 
+    test "keeps parens if argument includes keyword list" do
+      assert_same """
+      fn (input: x) when is_integer(x) ->
+        x + 42
+      end
+      """
+    end
+
     test "with a single clause, followed by a newline, and can fit in one line" do
       assert_same """
       fn


### PR DESCRIPTION
The formatter removes the parens and they're needed because of the keyword list argument with the guard clause. Without parens the compilation fails.

This is valid code (note the needed function parens (`(input: x)` due to the keyword list arg):

```elixir
fn (input: x) when is_integer(x) ->
  x + 42
end
```

It becomes this after being formatted:

```elixir
fn input: x when is_integer(x) ->
  x + 42
end
```

And consequently the compilation fails with:

```bash
    error: undefined function when/2 (there is no such import)
    │
  1 │ fn input: x when is_integer(x) ->
    │             ^
    │
    └─ formatter_error.exs:1:13

** (CompileError) formatter_error.exs: cannot compile file (errors have been logged)
    (elixir 1.16.2) src/elixir_fn.erl:17: anonymous fn/4 in :elixir_fn.expand/4
```

I've looked at the `code/formatter.ex` to understand what's happening but I'm not yet sure what's causing this :sweat_smile:

Cheers!