### PR TITLE
Use HEX_CACERTS_PATH environment variable to allow custom override of system defined CA certificates

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -337,7 +337,6 @@ defmodule Mix do
       written to. For example, "_build". If `MIX_BUILD_PATH` is set, this option
       is ignored.
 
-
     * `MIX_DEBUG` - outputs debug information about each task before running it
 
     * `MIX_DEPS_PATH` - sets the project `Mix.Project.deps_path/0` config for the

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -337,8 +337,6 @@ defmodule Mix do
       written to. For example, "_build". If `MIX_BUILD_PATH` is set, this option
       is ignored.
 
-    * `MIX_CACERTFILE` - use specified CA certificate file instead of default
-      system CA certificates. See [Erlang `ssl` module documentation](https://www.erlang.org/doc/man/ssl#type-client_cafile)
 
     * `MIX_DEBUG` - outputs debug information about each task before running it
 
@@ -373,6 +371,12 @@ defmodule Mix do
       than `MIX_XDG`. If none of the variables are set, the default directory
       `~/.mix` will be used
 
+  In addition, Mix also uses the following environment variables defined by other libraries
+
+    * `HEX_CACERTS_PATH` - use specified CA certificate file instead of default
+      system CA certificates. This configures how HTTPS calls are made via [Erlang `ssl` module](https://www.erlang.org/doc/man/ssl#type-client_cafile)
+      to fetch remote archives and packages. See [`mix hex.config`](https://hexdocs.pm/hex/Mix.Tasks.Hex.Config.html#module-config-keys)
+      for more details. 
   Environment variables that are not meant to hold a value (and act basically as
   flags) should be set to either `1` or `true`, for example:
 

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -337,6 +337,9 @@ defmodule Mix do
       written to. For example, "_build". If `MIX_BUILD_PATH` is set, this option
       is ignored.
 
+    * `MIX_CACERTFILE` - use specified CA certificate file instead of default
+      system CA certificates. See [Erlang `ssl` module documentation](https://www.erlang.org/doc/man/ssl#type-client_cafile)
+
     * `MIX_DEBUG` - outputs debug information about each task before running it
 
     * `MIX_DEPS_PATH` - sets the project `Mix.Project.deps_path/0` config for the

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -375,7 +375,8 @@ defmodule Mix do
     * `HEX_CACERTS_PATH` - use specified CA certificate file instead of default
       system CA certificates. This configures how HTTPS calls are made via [Erlang `ssl` module](https://www.erlang.org/doc/man/ssl#type-client_cafile)
       to fetch remote archives and packages. See [`mix hex.config`](https://hexdocs.pm/hex/Mix.Tasks.Hex.Config.html#module-config-keys)
-      for more details. 
+      for more details.
+
   Environment variables that are not meant to hold a value (and act basically as
   flags) should be set to either `1` or `true`, for example:
 

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -370,17 +370,17 @@ defmodule Mix do
       than `MIX_XDG`. If none of the variables are set, the default directory
       `~/.mix` will be used
 
+  Environment variables that are not meant to hold a value (and act basically as
+  flags) should be set to either `1` or `true`, for example:
+
+      $ MIX_DEBUG=1 mix compile
+
   In addition, Mix also uses the following environment variables defined by other libraries
 
     * `HEX_CACERTS_PATH` - use specified CA certificate file instead of default
       system CA certificates. This configures how HTTPS calls are made via [Erlang `ssl` module](https://www.erlang.org/doc/man/ssl#type-client_cafile)
       to fetch remote archives and packages. See [`mix hex.config`](https://hexdocs.pm/hex/Mix.Tasks.Hex.Config.html#module-config-keys)
       for more details.
-
-  Environment variables that are not meant to hold a value (and act basically as
-  flags) should be set to either `1` or `true`, for example:
-
-      $ MIX_DEBUG=1 mix compile
   """
 
   @mix_install_project __MODULE__.InstallProject

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -378,9 +378,10 @@ defmodule Mix do
   In addition, Mix also uses the following environment variables defined by other libraries
 
     * `HEX_CACERTS_PATH` - use specified CA certificate file instead of default
-      system CA certificates. This configures how HTTPS calls are made via [Erlang `ssl` module](https://www.erlang.org/doc/man/ssl#type-client_cafile)
-      to fetch remote archives and packages. See [`mix hex.config`](https://hexdocs.pm/hex/Mix.Tasks.Hex.Config.html#module-config-keys)
-      for more details.
+      system CA certificates. This configures how HTTPS calls are made via
+      [Erlang `ssl` module](https://www.erlang.org/doc/man/ssl#type-client_cafile)
+      to fetch remote archives and packages. For more details, see
+      [`mix hex.config`](https://hexdocs.pm/hex/Mix.Tasks.Hex.Config.html#module-config-keys).
   """
 
   @mix_install_project __MODULE__.InstallProject

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -655,11 +655,19 @@ defmodule Mix.Utils do
     headers = [{~c"user-agent", ~c"Mix/#{System.version()}"}]
     request = {:binary.bin_to_list(path), headers}
 
+    # allow override of system CA certs to support running on managed networks
+    # using an SSL proxy etc
+    cacert_opt =
+      case System.get_env("MIX_CACERTFILE") do
+        nil -> {:cacerts, :public_key.cacerts_get()}
+        file -> {:cacertfile, file}
+      end
+
     # Use the system certificates
     # TODO: use `ssl_options = :httpc.ssl_verify_host_options(true)` on Erlang/OTP 26+
     ssl_options = [
+      cacert_opt,
       verify: :verify_peer,
-      cacerts: :public_key.cacerts_get(),
       customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]
     ]
 

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -666,7 +666,6 @@ defmodule Mix.Utils do
       end
 
     # Use the system certificates
-    # TODO: use `ssl_options = :httpc.ssl_verify_host_options(true)` on Erlang/OTP 26+
     ssl_options = [
       cacert_opt,
       verify: :verify_peer,

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -656,9 +656,11 @@ defmodule Mix.Utils do
     request = {:binary.bin_to_list(path), headers}
 
     # allow override of system CA certs to support running on managed networks
-    # using an SSL proxy etc
+    # using an SSL proxy etc. Piggy back on Hex defined environment variable
+    # rather than creating a new one, as these are almost always going to be
+    # set and used together.
     cacert_opt =
-      case System.get_env("MIX_CACERTFILE") do
+      case System.get_env("HEX_CACERTS_PATH") do
         nil -> {:cacerts, :public_key.cacerts_get()}
         file -> {:cacertfile, file}
       end


### PR DESCRIPTION
Allow specifying a custom cacertfile for mix operations that need to make HTTPS requests. This allows mix operations to run in corporate environments that have a managed network with an SSL proxy that requires use of a custom cert file instead of the system default.

### On managed network with SSL proxy

Without environment variable on work laptop: 

```
> mix local.hex
** (Mix) httpc request failed with: {:failed_connect, [{:to_address, {~c"builds.hex.pm", 443}}, {:inet, [:inet], {:tls_alert, {:unknown_ca, ~c"TLS client: In state wait_cert_cr at ssl_handshake.erl:2125 generated CLIENT ALERT: Fatal - Unknown CA\n"}}}]}
 
Could not install Hex because Mix could not download metadata at https://builds.hex.pm/installs/hex-1.x.csv.
 
Alternatively, you can compile and install Hex directly with this command:
 
    $ mix archive.install github hexpm/hex branch latest
``` 
 
 With environment variable enabled on work laptop:

```
> HEX_CACERTS_PATH=~/.local/share/my_custom_cacert.crt mix local.hex
Found existing entry: /Users/jdoherty/src/opensource/elixir/.mix/archives/hex-2.0.6
Are you sure you want to replace it with https://builds.hex.pm/installs/1.16.0/hex-2.0.6.ez? [Yn] y
* creating /Users/jdoherty/src/opensource/elixir/.mix/archives/hex-2.0.6
```

### On regular connection

On personal laptop, without need for custom CA cert file

```
> mix local.hex
Are you sure you want to install "https://builds.hex.pm/installs/1.16.0/hex-2.0.6.ez"? [Yn] y
* creating .mix/archives/hex-2.0.6
```