### PR TITLE
Expose getting process dictionary value for specific key in Process.info/2

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -826,6 +826,9 @@ defmodule Process do
   @spec flag(pid, :save_calls, 0..10000) :: 0..10000
   defdelegate flag(pid, flag, value), to: :erlang, as: :process_flag
 
+  @type process_info_item :: atom | {:dictionary, term}
+  @type process_info_result_item :: {process_info_item, term}
+
   @doc """
   Returns information about the process identified by `pid`, or returns `nil` if the process
   is not alive.
@@ -834,7 +837,7 @@ defmodule Process do
 
   See `:erlang.process_info/1` for more information.
   """
-  @spec info(pid) :: keyword | nil
+  @spec info(pid) :: [process_info_result_item] | nil
   def info(pid) do
     nilify(:erlang.process_info(pid))
   end
@@ -845,7 +848,8 @@ defmodule Process do
 
   See `:erlang.process_info/2` for more information.
   """
-  @spec info(pid, atom | [atom]) :: {atom, term} | [{atom, term}] | nil
+  @spec info(pid, process_info_item | [process_info_item]) ::
+          process_info_result_item | [process_info_result_item] | nil
   def info(pid, spec)
 
   def info(pid, :registered_name) do
@@ -854,6 +858,10 @@ defmodule Process do
       [] -> {:registered_name, []}
       other -> other
     end
+  end
+
+  def info(pid, {:dictionary, key}) do
+    nilify(:erlang.process_info(pid, {:dictionary, key}))
   end
 
   def info(pid, spec) when is_atom(spec) or is_list(spec) do

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -826,9 +826,6 @@ defmodule Process do
   @spec flag(pid, :save_calls, 0..10000) :: 0..10000
   defdelegate flag(pid, flag, value), to: :erlang, as: :process_flag
 
-  @type process_info_item :: atom | {:dictionary, term}
-  @type process_info_result_item :: {process_info_item, term}
-
   @doc """
   Returns information about the process identified by `pid`, or returns `nil` if the process
   is not alive.
@@ -837,10 +834,13 @@ defmodule Process do
 
   See `:erlang.process_info/1` for more information.
   """
-  @spec info(pid) :: [process_info_result_item] | nil
+  @spec info(pid) :: keyword | nil
   def info(pid) do
     nilify(:erlang.process_info(pid))
   end
+
+  @type process_info_item :: atom | {:dictionary, term}
+  @type process_info_result_item :: {process_info_item, term}
 
   @doc """
   Returns information about the process identified by `pid`,

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -860,11 +860,7 @@ defmodule Process do
     end
   end
 
-  def info(pid, {:dictionary, key}) do
-    nilify(:erlang.process_info(pid, {:dictionary, key}))
-  end
-
-  def info(pid, spec) when is_atom(spec) or is_list(spec) do
+  def info(pid, spec) do
     nilify(:erlang.process_info(pid, spec))
   end
 

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -848,8 +848,8 @@ defmodule Process do
 
   See `:erlang.process_info/2` for more information.
   """
-  @spec info(pid, process_info_item | [process_info_item]) ::
-          process_info_result_item | [process_info_result_item] | nil
+  @spec info(pid, process_info_item) :: process_info_result_item | nil
+  @spec info(pid, [process_info_item]) :: [process_info_result_item] | nil
   def info(pid, spec)
 
   def info(pid, :registered_name) do


### PR DESCRIPTION
This functionality is present since OTP 26.2:
https://github.com/erlang/otp/pull/7707

Discussed at https://github.com/elixir-lang/elixir/issues/12857#issuecomment-2068886344