### PR TITLE
Add GenServer.format_status/1 callback

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -1136,15 +1136,6 @@ defmodule DynamicSupervisor do
     ]
   end
 
-  @impl true
-  def format_status(:terminate, [_pdict, state]) do
-    state
-  end
-
-  def format_status(_, [_pdict, %{mod: mod} = state]) do
-    [data: [{~c"State", state}], supervisor: [{~c"Callback", mod}]]
-  end
-
   ## Helpers
 
   @compile {:inline, call: 2}

--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -507,6 +507,8 @@ defmodule GenEvent do
     {:ok, states, [name, handlers, hib]}
   end
 
+  # Keeping deprecated format_status/2 since the current implementation is not
+  # compatible with format_status/1 and GenEvent is deprecated anyway
   @doc false
   def format_status(opt, status_data) do
     [pdict, sys_state, parent, _debug, [name, handlers, _hib]] = status_data

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -759,6 +759,38 @@ defmodule GenServer do
             when old_vsn: term | {:down, term}
 
   @doc """
+  This function is called by a `GenServer` process in the following situations:
+
+    * `sys:get_status/1,2` is invoked to get the `GenServer` status.
+    * The `GenServer` process terminates abnormally and logs an error.
+
+  This callback is used to limit the status of the process returned by
+  `sys:get_status/1,2` or sent to logger.
+
+  The callback gets a map `status` describing the current status and shall return
+  a map `new_status` with the same keys, but it may transform some values.
+
+  Two possible use cases for this callback is to remove sensitive information
+  from the state to prevent it from being printed in log files, or to compact
+  large irrelevant status items that would only clutter the logs.
+
+  ## Example
+
+      @impl GenServer
+      def format_status(status) do
+        Map.new(status, fn
+          {:state, state} -> {:state, Map.delete(state, :private_key)}
+          {:message, {:password, _} -> {:message, {:password, "redacted"}}
+          key_value -> key_value
+        end)
+      end
+
+  """
+  @doc since: "1.17.0"
+  @callback format_status(status :: :gen_server.format_status()) ::
+              new_status :: :gen_server.format_status()
+
+  @doc """
   Invoked in some cases to retrieve a formatted version of the `GenServer` status:
 
     * one of `:sys.get_status/1` or `:sys.get_status/2` is invoked to get the
@@ -775,6 +807,7 @@ defmodule GenServer do
   list of `{key, value}` tuples representing the current process dictionary of
   the `GenServer` and `state` is the current state of the `GenServer`.
   """
+  @doc deprecated: "Use format_status/1 callback instead"
   @callback format_status(reason, pdict_and_state :: list) :: term
             when reason: :normal | :terminate
 
@@ -783,6 +816,7 @@ defmodule GenServer do
                       handle_info: 2,
                       handle_cast: 2,
                       handle_call: 3,
+                      format_status: 1,
                       format_status: 2,
                       handle_continue: 2
 

--- a/lib/elixir/pages/references/typespecs.md
+++ b/lib/elixir/pages/references/typespecs.md
@@ -371,7 +371,7 @@ Optional callbacks can be defined through the `@optional_callbacks` module attri
       @optional_callbacks non_vital_fun: 0, non_vital_macro: 1
     end
 
-One example of optional callback in Elixir's standard library is `c:GenServer.format_status/2`.
+One example of optional callback in Elixir's standard library is `c:GenServer.format_status/1`.
 
 ### Inspecting behaviours
 


### PR DESCRIPTION
https://github.com/elixir-lang/elixir/issues/11220

I'm not sure if something else has to be done, opening my progress so far for discussion.

- Existing implementations (`DynamicSupervisor`, `GenEvent`) are defining new keys like `supervisor` which don't seem possible anymore?
- `DynamicSupervisor` is adding a `supervisor: [{~c"Callback", ...` key, needed for the [`supervisor`](https://github.com/erlang/otp/blob/0c9f1f47edb408168141bea05828593043980d33/lib/stdlib/src/supervisor.erl#L840-L842) module. Unfortunately, I don't think there's a way to add something that will end up in the `Misc` part with `format_status/1`, so will probably need to revert this one to `format_status/2`?
- `GenEvent` has been deprecated for 6y, maybe it can stay on the deprecated callback? `:gen_event` itself seems to be defining its own `format_status/1` ([source](https://github.com/erlang/otp/blob/0c9f1f47edb408168141bea05828593043980d33/lib/stdlib/src/gen_event.erl#L393-L468)), but our docs encourage to use `:gen_event` directly so might be OK?