### PR TITLE
Map types representation

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -947,8 +947,8 @@ defmodule Module.Types.Descr do
       empty_s1_diff = empty?(s1_diff)
 
       cond do
-        # if fst is a subtype of s1, the disjointness invariant
-        # ensures we can safely add those two pairs and end the recursion
+        # if fst is a subtype of s1, the disjointness invariant ensures we can
+        # add those two pairs and end the recursion
         empty_fst_diff and empty_s1_diff ->
           [{x, union(snd, s2)} | pairs ++ acc]
 
@@ -959,6 +959,9 @@ defmodule Module.Types.Descr do
           add_pair_to_disjoint_list(pairs, fst_diff, snd, [{x, union(snd, s2)} | acc])
 
         true ->
+          # case where, when comparing {fst, snd} and {s1, s2}, both (fst and not s1)
+          # and (s1 and not fst) are non empty. that is, there is something in fst
+          # that is not in s1, and something in s1 that is not in fst
           add_pair_to_disjoint_list(pairs, fst_diff, snd, [
             {s1_diff, s2},
             {x, union(snd, s2)} | acc

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -281,6 +281,21 @@ defmodule Module.Types.DescrTest do
              |> difference(map(a: atom([:bar])))
              |> map_get!(:a)
              |> equal?(intersection(atom(), negation(atom([:foo, :bar]))))
+
+      assert map(a: union(atom(), pid()), b: integer(), c: tuple())
+             |> difference(map([a: atom(), b: integer()], :open))
+             |> difference(map([a: atom(), c: tuple()], :open))
+             |> map_get!(:a) == pid()
+
+      assert map(a: union(atom([:foo]), pid()), b: integer(), c: tuple())
+             |> difference(map([a: atom([:foo]), b: integer()], :open))
+             |> difference(map([a: atom(), c: tuple()], :open))
+             |> map_get!(:a) == pid()
+
+      assert map(a: union(atom([:foo, :bar, :baz]), integer()))
+             |> difference(map([a: atom([:foo, :bar])], :open))
+             |> difference(map([a: atom([:foo, :baz])], :open))
+             |> map_get!(:a) == integer()
     end
 
     test "key presence" do

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -238,19 +238,32 @@ defmodule Module.Types.DescrTest do
       assert map_get!(map(a: integer()), :a) == integer()
       assert map_get!(dynamic(), :a) == dynamic()
 
-      assert map_get!(intersection(dynamic(), map([a: integer()], :open)), :a) ==
-               intersection(integer(), dynamic())
+      assert intersection(dynamic(), map([a: integer()], :open))
+             |> map_get!(:a) == intersection(integer(), dynamic())
 
-      assert intersection(
-               map([my_map: map([foo: integer()], :open)], :open),
-               map([my_map: map([bar: boolean()], :open)], :open)
-             )
+      assert map([my_map: map([foo: integer()], :open)], :open)
+             |> intersection(map([my_map: map([bar: boolean()], :open)], :open))
              |> map_get!(:my_map)
              |> equal?(map([foo: integer(), bar: boolean()], :open))
 
       assert map_get!(union(map(a: integer()), map(a: atom())), :a) == union(integer(), atom())
       assert map_get!(union(map(a: integer()), map(b: atom())), :a) == integer()
       assert map_get!(term(), :a) == term()
+
+      assert map(a: union(integer(), atom()))
+             |> difference(map([a: integer()], :open))
+             |> map_get!(:a)
+             |> equal?(atom())
+
+      assert map(a: integer(), b: atom())
+             |> difference(map(a: integer(), b: atom([:foo])))
+             |> map_get!(:a)
+             |> equal?(integer())
+
+      assert map(a: integer())
+             |> difference(map(a: atom()))
+             |> map_get!(:a)
+             |> equal?(integer())
     end
 
     test "key presence" do

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -233,6 +233,12 @@ defmodule Module.Types.DescrTest do
     end
   end
 
+  describe "empty" do
+    test "map" do
+      assert intersection(map(b: atom()), map([a: integer()], :open)) |> empty?
+    end
+  end
+
   describe "map operations" do
     test "get field" do
       assert map_get!(map(a: integer()), :a) == integer()
@@ -264,6 +270,17 @@ defmodule Module.Types.DescrTest do
              |> difference(map(a: atom()))
              |> map_get!(:a)
              |> equal?(integer())
+
+      assert map([a: integer(), b: atom()], :open)
+             |> union(map(a: tuple()))
+             |> map_get!(:a)
+             |> equal?(union(integer(), tuple()))
+
+      assert map(a: atom())
+             |> difference(map(a: atom([:foo, :bar])))
+             |> difference(map(a: atom([:bar])))
+             |> map_get!(:a)
+             |> equal?(intersection(atom(), negation(atom([:foo, :bar]))))
     end
 
     test "key presence" do


### PR DESCRIPTION
Introducing a representation for map types, closed or open, with required or optional atom keys.

The representation is by disjunctive normal forms, that is, lists of pairs `{positive_map, negative_maps}`. A map type is the union of each element of the list, and each element is the difference of the `positive_map` with the `negative_maps`.

For instance, `%{a: integer()} and not %{..., b: atom()}` is stored as the pair with a positive `{:closed, %{a: integer()}}` and a negative `{:open, %{b: atom()}}`.

Set-theoretic operations constitute in distributing `or`, `and`, `and not` along those lists. 

To handle optional fields, bit 10 of the bitmap is used to represent the `not_set()` special type. A key may be absent if and only if its value type contains `not_set()`.

TODO, after that 
- add domain types (`%{atom() => if_set(integer())}`)
- if needed, stronger normalization for pretty-printing