### PR TITLE
fix(spec): add :all and :none for Logger.level/0

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -604,7 +604,7 @@ defmodule Logger do
 
   The `Logger` level can be changed via `configure/1`.
   """
-  @spec level() :: level()
+  @spec level() :: level() | :all | :none
   def level() do
     %{level: level} = :logger.get_primary_config()
 


### PR DESCRIPTION
👋 

I think that the spec for `Logger.level/0` is invalid: `:all` and `:none` may be missing.

According to https://www.erlang.org/doc/man/logger#get_primary_config-0 and https://www.erlang.org/doc/man/logger#type-primary_config,
returned type for `:logger.get_primary_config` is:

```erlang
 #{level => level() | all | none,
   metadata => metadata(),
   filter_default => log | stop,
   filters => [{filter_id(), filter()}]}
```

Thus, inside `Logger.level/0` fun, `level` could also be `all` and `none` when calling:

```elixir
%{level: level} = :logger.get_primary_config()
```