### PR TITLE
Add some signposting to the String docs for pattern matching

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -201,6 +201,9 @@ defmodule String do
       iex> eacute
       233
 
+  See the documentation for [`<<>>`](`<<>>/1`) or the Patterns and Guards
+  guide for more information on binary pattern matching
+
   You can also fully convert a string into a list of integer code points,
   known as "charlists" in Elixir, by calling `String.to_charlist/1`:
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -201,8 +201,8 @@ defmodule String do
       iex> eacute
       233
 
-  See the documentation for [`<<>>`](`<<>>/1`) or the Patterns and Guards
-  guide for more information on binary pattern matching
+  See the [*Patterns and Guards* guide](patterns-and-guards.md) and the documentation for
+  [`<<>>`](`<<>>/1`) for more information on binary pattern matching.
 
   You can also fully convert a string into a list of integer code points,
   known as "charlists" in Elixir, by calling `String.to_charlist/1`:


### PR DESCRIPTION
As a user of the docs, when looking for information on how to pattern match with strings and binaries the first place one looks is the String docs.

Currently there isn't anything here for pattern matching besides a small example matching a character. The user would either have to go from the reference section to the patterns and guards guide or go to the <<>>/1 special forms docs.

This change just adds a link to the special forms docs and the guide to signpost the user to those resources.