### PR TITLE
Use deterministic key order when quoting maps

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -860,7 +860,7 @@ defmodule Module.Types.Descr do
   end
 
   defp fields_to_quoted(tag, map) do
-    for {key, type} <- map,
+    for {key, type} <- Enum.sort(map),
         not (tag == :open and optional?(type) and term?(type)) do
       cond do
         optional?(type) and empty?(type) -> {literal(key), {:not_set, [], []}}


### PR DESCRIPTION
Makes the quoted representation deterministic and fixes this flaky test:

<img width="763" alt="Screenshot 2024-04-29 at 15 19 38" src="https://github.com/elixir-lang/elixir/assets/11598866/99635f27-1107-4b30-9344-747f598f40d6">
