### PR TITLE
Type inference for structs and type checking for dot/remote

### DIFF
--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -208,10 +208,11 @@ defmodule Kernel.Utils do
 
     case enforce_keys -- :maps.keys(struct) do
       [] ->
-        # The __struct__ field is used for expansion and for loading remote structs
+        # The __struct__ attribute is public and it is used for expansion
+        # and for loading remote structs.
         :ets.insert(set, {:__struct__, struct, nil, []})
 
-        # Store all field metadata to go into __info__(:struct)
+        # The complete metadata goes into __info__(:struct)
         mapper = fn {key, val} ->
           %{field: key, default: val, required: :lists.member(key, enforce_keys)}
         end

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -52,8 +52,8 @@ defmodule Module.Types.Descr do
   def integer(), do: %{bitmap: @bit_integer}
   def float(), do: %{bitmap: @bit_float}
   def fun(), do: %{bitmap: @bit_fun}
-  def open_map(pairs), do: %{map: [{:open, Map.new(pairs), []}]}
-  def closed_map(pairs), do: %{map: [{:closed, Map.new(pairs), []}]}
+  def open_map(pairs), do: %{map: map_new(:open, Map.new(pairs))}
+  def closed_map(pairs), do: %{map: map_new(:closed, Map.new(pairs))}
   def open_map(), do: %{map: @map_top}
   def empty_map(), do: %{map: @map_empty}
   def non_empty_list(), do: %{bitmap: @bit_non_empty_list}
@@ -416,6 +416,54 @@ defmodule Module.Types.Descr do
   # an empty list of atoms. It is simplified to `0` in set operations, and the key
   # is removed from the map.
 
+  @doc """
+  Returns a set of all known atoms.
+
+  Returns `{:ok, known_set}` if it is an atom, `:error` otherwise.
+  Notice `known_set` may be empty and still return positive, due to
+  negations.
+  """
+  def atom_fetch(%{} = descr) do
+    case :maps.take(:dynamic, descr) do
+      :error ->
+        if atom_only?(descr) do
+          case descr do
+            %{atom: {:union, set}} -> {:ok, :sets.to_list(set)}
+            %{atom: {:negation, _}} -> {:ok, []}
+            %{} -> :error
+          end
+        else
+          :error
+        end
+
+      {dynamic, static} ->
+        if atom_only?(static) do
+          case {dynamic, static} do
+            {%{atom: {:union, d}}, %{atom: {:union, s}}} ->
+              {:ok, :sets.to_list(:sets.union(d, s))}
+
+            {_, %{atom: {:negation, _}}} ->
+              {:ok, []}
+
+            {%{atom: {:negation, _}}, _} ->
+              {:ok, []}
+
+            {%{atom: {:union, d}}, %{}} ->
+              {:ok, :sets.to_list(d)}
+
+            {%{}, %{atom: {:union, s}}} ->
+              {:ok, :sets.to_list(s)}
+
+            {%{}, %{}} ->
+              :error
+          end
+        else
+          :error
+        end
+    end
+  end
+
+  defp atom_only?(descr), do: empty?(Map.delete(descr, :atom))
   defp atom_new(as) when is_list(as), do: {:union, :sets.from_list(as, version: 2)}
 
   defp atom_intersection({tag1, s1}, {tag2, s2}) do
@@ -447,18 +495,35 @@ defmodule Module.Types.Descr do
     if tag == :union and :sets.size(s) == 0, do: 0, else: {tag, s}
   end
 
-  defp literal(lit), do: {:__block__, [], [lit]}
+  defp literal_to_quoted(lit) do
+    if is_atom(lit) and Macro.classify_atom(lit) == :alias do
+      segments =
+        case Atom.to_string(lit) do
+          "Elixir" ->
+            [:"Elixir"]
+
+          "Elixir." <> segments ->
+            segments
+            |> String.split(".")
+            |> Enum.map(&String.to_atom/1)
+        end
+
+      {:__aliases__, [], segments}
+    else
+      {:__block__, [], [lit]}
+    end
+  end
 
   defp atom_to_quoted({:union, a}) do
     if :sets.is_subset(@boolset, a) do
       :sets.subtract(a, @boolset)
       |> :sets.to_list()
       |> Enum.sort()
-      |> Enum.reduce({:boolean, [], []}, &{:or, [], [&2, literal(&1)]})
+      |> Enum.reduce({:boolean, [], []}, &{:or, [], [&2, literal_to_quoted(&1)]})
     else
       :sets.to_list(a)
       |> Enum.sort()
-      |> Enum.map(&literal/1)
+      |> Enum.map(&literal_to_quoted/1)
       |> Enum.reduce(&{:or, [], [&2, &1]})
     end
     |> List.wrap()
@@ -584,7 +649,8 @@ defmodule Module.Types.Descr do
   defp map_tag_to_type(:open), do: term_or_not_set()
   defp map_tag_to_type(:closed), do: not_set()
 
-  defp map_descr(tag, fields), do: %{map: [{tag, fields, []}]}
+  defp map_new(tag, fields), do: [{tag, fields, []}]
+  defp map_descr(tag, fields), do: %{map: map_new(tag, fields)}
 
   @doc """
   Gets the type of the value returned by accessing `key` on `map`
@@ -595,19 +661,19 @@ defmodule Module.Types.Descr do
   In static mode, we likely want to raise if `map.field`
   (or pattern matching?) is called on an optional key.
   """
-  def map_get(%{} = descr, key) do
+  def map_fetch(%{} = descr, key) do
     case :maps.take(:dynamic, descr) do
       :error ->
-        if map_only?(descr) do
-          map_get_static(descr, key)
+        if is_map_key(descr, :map) and map_only?(descr) do
+          map_fetch_static(descr, key)
         else
           :error
         end
 
       {dynamic, static} ->
-        if map_only?(static) do
-          {dynamic_optional?, dynamic_type} = map_get_static(dynamic, key)
-          {static_optional?, static_type} = map_get_static(static, key)
+        if (is_map_key(dynamic, :map) or is_map_key(static, :map)) and map_only?(static) do
+          {dynamic_optional?, dynamic_type} = map_fetch_static(dynamic, key)
+          {static_optional?, static_type} = map_fetch_static(static, key)
 
           {dynamic_optional? or static_optional?,
            union(intersection(dynamic(), dynamic_type), static_type)}
@@ -617,12 +683,9 @@ defmodule Module.Types.Descr do
     end
   end
 
-  # We do this quick check, instead of checking for compatibility,
-  # because if it resolves to an empty map, the type for key will be `none()` anyway.
-  defp map_only?(descr),
-    do: map_size(descr) == 0 or (map_size(descr) == 1 and is_map_key(descr, :map))
+  defp map_only?(descr), do: empty?(Map.delete(descr, :map))
 
-  defp map_get_static(descr, key) when is_atom(key) do
+  defp map_fetch_static(descr, key) when is_atom(key) do
     case descr do
       %{map: map} ->
         map_split_on_key(map, key)
@@ -846,18 +909,40 @@ defmodule Module.Types.Descr do
 
   def map_literal_to_quoted({tag, fields}) do
     case tag do
-      :closed -> {:%{}, [], map_fields_to_quoted(tag, fields)}
-      :open -> {:%{}, [], [{:..., [], nil} | map_fields_to_quoted(tag, fields)]}
+      :closed ->
+        with %{__struct__: struct_descr} <- fields,
+             {:ok, [struct]} <- atom_fetch(struct_descr) do
+          {:%, [],
+           [
+             literal_to_quoted(struct),
+             {:%{}, [], map_fields_to_quoted(tag, Map.delete(fields, :__struct__))}
+           ]}
+        else
+          _ -> {:%{}, [], map_fields_to_quoted(tag, fields)}
+        end
+
+      :open ->
+        {:%{}, [], [{:..., [], nil} | map_fields_to_quoted(tag, fields)]}
     end
   end
 
   defp map_fields_to_quoted(tag, map) do
-    for {key, type} <- Enum.sort(map),
+    sorted = Enum.sort(map)
+    keyword? = Inspect.List.keyword?(sorted)
+
+    for {key, type} <- sorted,
         not (tag == :open and optional?(type) and term?(type)) do
+      key =
+        if keyword? do
+          {:__block__, [format: :keyword], [key]}
+        else
+          literal_to_quoted(key)
+        end
+
       cond do
-        not optional?(type) -> {literal(key), to_quoted(type)}
-        empty?(type) -> {literal(key), {:not_set, [], []}}
-        true -> {literal(key), {:if_set, [], [to_quoted(type)]}}
+        not optional?(type) -> {key, to_quoted(type)}
+        empty?(type) -> {key, {:not_set, [], []}}
+        true -> {key, {:if_set, [], [to_quoted(type)]}}
       end
     end
   end

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -278,12 +278,12 @@ defmodule Module.Types.Expr do
     end
   end
 
-  # TODO: expr.key_or_fun
-  def of_expr({{:., _meta1, [expr1, _key_or_fun]}, meta2, []}, stack, context)
-      when not is_atom(expr1) do
+  # TODO: expr.fun()
+  def of_expr({{:., _meta1, [expr1, key_or_fun]}, meta2, []} = expr, stack, context)
+      when not is_atom(expr1) and is_atom(key_or_fun) do
     if Keyword.get(meta2, :no_parens, false) do
-      with {:ok, _, context} <- of_expr(expr1, stack, context) do
-        {:ok, dynamic(), context}
+      with {:ok, type1, context} <- of_expr(expr1, stack, context) do
+        Of.map_get(expr, type1, key_or_fun, stack, context)
       end
     else
       with {:ok, _, context} <- of_expr(expr1, stack, context) do

--- a/lib/elixir/lib/module/types/helpers.ex
+++ b/lib/elixir/lib/module/types/helpers.ex
@@ -29,6 +29,13 @@ defmodule Module.Types.Helpers do
         is an integer. Pass a modifier, such as <<expr::float>> or <<expr::binary>>, \
         to change the default behavior.
         """
+
+      :dot ->
+        """
+
+        #{hint()} "var.field" (without parentheses) means "var" is a map() while \
+        "var.fun()" (with parentheses) means "var" is an atom()
+        """
     end)
   end
 

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -24,7 +24,7 @@ defmodule Module.Types.Of do
         {:ok, dynamic(),
          warn({:badmap, expr, type, field, context}, elem(expr, 1), stack, context)}
 
-      # TODO: on static type checking, we want check if it is not optional.
+      # TODO: on static type checking, we want check it is not optional.
       {_optional?, value_type} ->
         if empty?(value_type) do
           {:ok, dynamic(),

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -105,19 +105,16 @@ defmodule Module.Types.Pattern do
   def of_pattern({:%, _meta1, [var, {:%{}, _meta2, args}]}, _expected_expr, stack, context)
       when not is_atom(var) do
     # TODO: validate var is an atom
-    with {:ok, _, context} = of_pattern(var, stack, context),
+    with {:ok, _, context} <- of_pattern(var, stack, context),
          {:ok, _, context} <- Of.open_map(args, stack, context, &of_pattern/3) do
       {:ok, open_map(), context}
     end
   end
 
   # %Struct{...}
-  def of_pattern({:%, meta1, [module, {:%{}, _meta2, args}]}, _expected_expr, stack, context)
+  def of_pattern({:%, _, [module, {:%{}, _, args}]} = expr, _expected_expr, stack, context)
       when is_atom(module) do
-    with {:ok, _, context} <- Of.struct(module, meta1, stack, context),
-         {:ok, _, context} <- Of.open_map(args, stack, context, &of_pattern/3) do
-      {:ok, open_map(), context}
-    end
+    Of.struct(expr, module, args, true, stack, context, &of_pattern/3)
   end
 
   # %{...}

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -102,10 +102,9 @@ defmodule Module.Types.Pattern do
   end
 
   # %var{...} and %^var{...}
-  def of_pattern({:%, _meta1, [var, {:%{}, _meta2, args}]}, _expected_expr, stack, context)
+  def of_pattern({:%, _meta1, [var, {:%{}, _meta2, args}]} = expr, _expected_expr, stack, context)
       when not is_atom(var) do
-    # TODO: validate var is an atom
-    with {:ok, _, context} <- of_pattern(var, stack, context),
+    with {:ok, _, context} <- of_pattern(var, {atom(), expr}, stack, context),
          {:ok, _, context} <- Of.open_map(args, stack, context, &of_pattern/3) do
       {:ok, open_map(), context}
     end

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -588,17 +588,25 @@ defmodule Kernel.ExpansionTest do
       assert expand(quote(do: %x{} = 1)) == quote(do: %x{} = 1)
     end
 
-    test "unknown ^keys in structs" do
-      message = ~r"unknown key \^my_key for struct Kernel\.ExpansionTest\.User"
+    test "invalid keys in structs" do
+      assert_compile_error(~r"invalid key :erlang\.\+\(1, 2\) for struct", fn ->
+        expand(
+          quote do
+            %User{(1 + 2) => :my_value}
+          end
+        )
+      end)
+    end
+
+    test "unknown key in structs" do
+      message = ~r"unknown key :foo for struct Kernel\.ExpansionTest\.User"
 
       assert_compile_error(message, fn ->
-        code =
+        expand(
           quote do
-            my_key = :my_key
-            %User{^my_key => :my_value} = %{}
+            %User{foo: :my_value} = %{}
           end
-
-        expand(code)
+        )
       end)
     end
   end

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -247,6 +247,9 @@ defmodule Module.Types.DescrTest do
   describe "map operations" do
     test "get field" do
       assert map_get(closed_map(a: integer()), :a) == {false, integer()}
+
+      assert map_get(term(), :a) == :error
+      assert map_get(union(open_map(), integer()), :a) == :error
       assert map_get(dynamic(), :a) == {true, dynamic()}
 
       assert intersection(dynamic(), open_map(a: integer()))
@@ -264,8 +267,6 @@ defmodule Module.Types.DescrTest do
 
       assert map_get(union(closed_map(a: integer()), closed_map(b: atom())), :a) ==
                {true, integer()}
-
-      assert map_get(term(), :a) == {true, term()}
 
       {false, value_type} =
         closed_map(a: union(integer(), atom()))

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -23,8 +23,12 @@ defmodule Module.Types.ExprTest do
     assert typecheck!(%{}) == open_map()
   end
 
-  describe "undefined functions" do
-    test "warnings" do
+  describe "remotes" do
+    test "dynamic calls" do
+      assert typecheck!([%x{}], x.foo_bar()) == dynamic()
+    end
+
+    test "undefined function warnings" do
       assert typewarn!(URI.unknown("foo")) ==
                {dynamic(), "URI.unknown/1 is undefined or private"}
 
@@ -33,6 +37,74 @@ defmodule Module.Types.ExprTest do
 
       assert typewarn!(try(do: :ok, after: URI.unknown("foo"))) ==
                {dynamic(), "URI.unknown/1 is undefined or private"}
+    end
+
+    test "calling a nullary function on non atoms" do
+      assert typewarn!([<<x::integer>>], x.foo_bar()) ==
+               {dynamic(),
+                ~l"""
+                expected a module (an atom) when invoking foo_bar/0 in expression:
+
+                    x.foo_bar()
+
+                but got type:
+
+                    integer()
+
+                where "x" was given the type:
+
+                    # type: integer()
+                    # from: types_test.ex:LINE-2
+                    <<x::integer>>
+
+                #{hints(:dot)}
+
+                typing violation found at:\
+                """}
+    end
+
+    test "calling a function on non atoms with arguments" do
+      assert typewarn!([<<x::integer>>], x.foo_bar(1, 2)) ==
+               {dynamic(),
+                ~l"""
+                expected a module (an atom) when invoking foo_bar/2 in expression:
+
+                    x.foo_bar(1, 2)
+
+                but got type:
+
+                    integer()
+
+                where "x" was given the type:
+
+                    # type: integer()
+                    # from: types_test.ex:LINE-2
+                    <<x::integer>>
+
+                typing violation found at:\
+                """}
+    end
+
+    test "capture a function with non atoms" do
+      assert typewarn!([<<x::integer>>], &x.foo_bar/2) ==
+               {dynamic(),
+                ~l"""
+                expected a module (an atom) when invoking foo_bar/2 in expression:
+
+                    &x.foo_bar/2
+
+                but got type:
+
+                    integer()
+
+                where "x" was given the type:
+
+                    # type: integer()
+                    # from: types_test.ex:LINE-2
+                    <<x::integer>>
+
+                typing violation found at:\
+                """}
     end
   end
 
@@ -116,33 +188,11 @@ defmodule Module.Types.ExprTest do
     end
   end
 
-  describe "modules" do
-    test "calling a function on not a map" do
-      assert typewarn!([<<x::integer>>], x.foo_bar()) ==
-               {dynamic(),
-                ~l"""
-                expected a module (an atom) when invoking .foo_bar() in expression:
-
-                    x.foo_bar()
-
-                but got type:
-
-                    integer()
-
-                where "x" was given the type:
-
-                    # type: integer()
-                    # from: types_test.ex:LINE-2
-                    <<x::integer>>
-
-                #{hints(:dot)}
-
-                typing violation found at:\
-                """}
-    end
-  end
-
   describe "maps/structs" do
+    test "matching struct name" do
+      assert typecheck!([%x{}], x) == atom()
+    end
+
     test "creating structs" do
       assert typecheck!(%Point{}) ==
                closed_map(__struct__: atom([Point]), x: atom([nil]), y: atom([nil]), z: integer())

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -111,4 +111,28 @@ defmodule Module.Types.ExprTest do
                 """}
     end
   end
+
+  describe "maps" do
+    test "accessing a field on not a map" do
+      assert typewarn!([<<x::integer>>], x.foo_bar) ==
+               {dynamic(),
+                ~l"""
+                expected map type when accessing .foo_bar in expression:
+
+                    x.foo_bar
+
+                but got type:
+
+                    integer()
+
+                where "x" was given the type:
+
+                    # type: integer()
+                    # from: types_test.ex:117
+                    <<x::integer>>
+
+                typing violation found at:\
+                """}
+    end
+  end
 end


### PR DESCRIPTION
With this pull request, we now warn:

* `expr.field` when `expr` may not be a map
* `expr.call()` when `expr` may not be an atom
* `expr.call(...)` when `expr` may not be an atom
* `&expr.foo/1` when `expr` may not be an atom

Furthermore, we lay down the ground work for checking undefined and deprecation warnings across unions. For example, if you write this code:

```elixir
mod = if something?, do: Foo, else: Bar
mod.some_function()
```

In the future, it will warn if any of Foo OR Bar do not define the relevant function.

Finally, we improve pretty printing of maps and aliases.