### PR TITLE
Remove dot hint when the issue is a missing key in a map

### DIFF
--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -518,7 +518,7 @@ defmodule Module.Types.Of do
           #{to_quoted_string(type)}
       """,
       traces,
-      format_hints([:dot | trace_hints]),
+      format_hints(trace_hints),
       "\ntyping violation found at:"
     ]
   end

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -260,8 +260,6 @@ defmodule Module.Types.ExprTest do
 
                     %Point{x: nil, y: nil, z: integer()}
 
-                #{hints(:dot)}
-
                 typing violation found at:\
                 """}
     end


### PR DESCRIPTION
The hint makes sense for the `:bad_map` case but seems unwarranted for `:bad_key`: 

<img width="883" alt="Screenshot 2024-04-30 at 21 10 06" src="https://github.com/elixir-lang/elixir/assets/11598866/0ed092a5-de80-42d6-bfce-7a6ed7627332">
