### PR TITLE
Mention the Erlang uri_string module in the URI moduledoc

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -5,6 +5,9 @@ defmodule URI do
   This module provides functions for working with URIs (for example, parsing
   URIs or encoding query strings). The functions in this module are implemented
   according to [RFC 3986](https://tools.ietf.org/html/rfc3986).
+
+  Additionally, the Erlang `uri_string` module provides certain functionalities,
+  such as RFC 3986 compliant URI normalization.
   """
 
   @doc """


### PR DESCRIPTION
This pull request enables users to quickly discover the additional functionality provided by the Erlang `uri_string` module.

Closes PR #13523