### PR TITLE
Fix warn case return value in pid expansion

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -464,7 +464,7 @@ expand(Pid, S, E) when is_pid(Pid) ->
     Function ->
       %% TODO: Make me an error on v2.0
       elixir_errors:file_warn([], E, ?MODULE, {invalid_pid_in_function, Pid, Function}),
-      {Pid, E}
+      {Pid, S, E}
   end;
 
 expand(Zero, S, #{context := match} = E) when is_float(Zero), Zero == 0.0 ->


### PR DESCRIPTION
There are no tests covering this case and probably it's very rare so it went undetected for long time