### PR TITLE
Document default unit of DateTime.utc_now/1

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -170,7 +170,8 @@ defmodule DateTime do
   truncate the resulting datetime. This is available
   since v1.15.0.
 
-  The default unit if none gets passed is `:native`.
+  The default unit if none gets passed is `:native`,
+  which results on a default resolution of microseconds.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -170,6 +170,8 @@ defmodule DateTime do
   truncate the resulting datetime. This is available
   since v1.15.0.
 
+  The default unit if none gets passed is `:native`.
+
   ## Examples
 
       iex> datetime = DateTime.utc_now()


### PR DESCRIPTION
I had to lookup the code to find the answer, I thought it would be nice to document it?