### PR TITLE
Add Kernel.is_non_struct_map/1 guard

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -858,6 +858,22 @@ defmodule Kernel do
   Returns `true` if `term` is a map; otherwise returns `false`.
 
   Allowed in guard tests. Inlined by the compiler.
+
+  > #### Structs are maps {: .info}
+  >
+  > Structs are also maps, and many of elixir types are implemented
+  > using structs: `Range`s, `Regex`es, `Date`s...
+  >
+  >     iex> is_map(1..10)
+  >     true
+  >     iex> is_map(~D[2024-04-18])
+  >     true
+  >
+  > If you mean to specifically check for non-struct maps, use
+  > `is_non_struct_map/1` instead.
+  >
+  >     iex> is_non_struct_map(1..10)
+  >     false
   """
   @doc guard: true
   @spec is_map(term) :: boolean

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -861,7 +861,7 @@ defmodule Kernel do
 
   > #### Structs are maps {: .info}
   >
-  > Structs are also maps, and many of elixir types are implemented
+  > Structs are also maps, and many of Elixir data structures are implemented
   > using structs: `Range`s, `Regex`es, `Date`s...
   >
   >     iex> is_map(1..10)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2571,6 +2571,47 @@ defmodule Kernel do
   end
 
   @doc """
+  Returns `true` if `term` is a non-struct map; otherwise returns `false`.
+
+  Allowed in guard tests.
+
+  ## Examples
+
+      iex> is_non_struct_map(%{})
+      true
+
+      iex> is_non_struct_map(URI.parse("/"))
+      false
+
+      iex> is_non_struct_map(nil)
+      false
+
+  """
+  @doc since: "1.17.0", guard: true
+  defmacro is_non_struct_map(term) do
+    case __CALLER__.context do
+      nil ->
+        quote do
+          case unquote(term) do
+            %_{} -> false
+            %{} -> true
+            _ -> false
+          end
+        end
+
+      :match ->
+        invalid_match!(:is_non_struct_map)
+
+      :guard ->
+        quote do
+          is_map(unquote(term)) and
+            not (:erlang.is_map_key(:__struct__, unquote(term)) and
+                   is_atom(:erlang.map_get(:__struct__, unquote(term))))
+        end
+    end
+  end
+
+  @doc """
   Returns `true` if `term` is an exception; otherwise returns `false`.
 
   Allowed in guard tests.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -855,7 +855,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if `term` is a map; otherwise returns `false`.
+  Returns `true` if `term` is a map, otherwise returns `false`.
 
   Allowed in guard tests. Inlined by the compiler.
 
@@ -2587,7 +2587,8 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if `term` is a non-struct map; otherwise returns `false`.
+  Returns `true` if `term` is a map that is not a struct, otherwise
+  returns `false`.
 
   Allowed in guard tests.
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -367,6 +367,29 @@ defmodule KernelTest do
     assert struct_or_map?(%Macro.Env{}, Macro.Env) == true
   end
 
+  defp non_struct_map?(arg) when is_non_struct_map(arg), do: true
+  defp non_struct_map?(_arg), do: false
+
+  defp non_struct_map_or_struct?(arg) when is_non_struct_map(arg) or is_struct(arg), do: true
+  defp non_struct_map_or_struct?(_arg), do: false
+
+  test "is_non_struct_map/1" do
+    assert is_non_struct_map(%{}) == true
+    assert is_non_struct_map([]) == false
+    assert is_non_struct_map(%Macro.Env{}) == false
+    assert is_non_struct_map(%{__struct__: "foo"}) == true
+    assert non_struct_map?(%Macro.Env{}) == false
+    assert non_struct_map?(%{__struct__: "foo"}) == true
+    assert non_struct_map?([]) == false
+    assert non_struct_map?(%{}) == true
+  end
+
+  test "is_non_struct_map/1 and other match works" do
+    assert non_struct_map_or_struct?(%Macro.Env{}) == true
+    assert non_struct_map_or_struct?(%{}) == true
+    assert non_struct_map_or_struct?(10) == false
+  end
+
   defp exception?(arg) when is_exception(arg), do: true
   defp exception?(_arg), do: false
 


### PR DESCRIPTION
Implemented based on `is_struct/1`.

The second commit adds an admonition to `is_map/1` to increase awareness:
<img width="853" alt="Screenshot 2024-05-04 at 9 39 38" src="https://github.com/elixir-lang/elixir/assets/11598866/b4d38c13-6598-47b6-8f8e-1262688b7052">
