### PR TITLE
Fix regression in Logger `:metadata` config

### DIFF
--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -37,7 +37,14 @@ defmodule Logger.App do
     # If there is additional metadata in the :logger config, we merge it into
     # the primary :logger metadata.
     with [_ | _] = metadata <- Application.fetch_env!(:logger, :metadata) do
-      :ok = :logger.set_primary_config(:metadata, Enum.into(metadata, primary_config.metadata))
+      :ok =
+        :logger.set_primary_config(
+          :metadata,
+          Enum.into(metadata, primary_config.metadata, fn
+            {_key, _val} = el -> el
+            el -> {el, :yes}
+          end)
+        )
     end
 
     process_level_filter = {&Logger.Utils.process_level/2, []}


### PR DESCRIPTION
When upgrading Elixir from 1.14 to 1.16 in our Phoenix app the project fails to start when Logger exits due to an argument error in the `Enum.into/2` call in `logger/app.ex` when reading in the values from config.

<img width="928" alt="Screenshot 2024-05-08 at 9 27 18 AM" src="https://github.com/elixir-lang/elixir/assets/2472733/c653bef2-bd9e-44f2-9880-1bee66393f59">

The Logger documentation describes the `metadata` property of the config as a list of atoms.
```
config :logger, :default_formatter,
  format: "[$level] $message $metadata\n",
  metadata: [:error_code, :file]
```

`Enum.into/2` on `logger/app.ex:40` fails when reading this structure in as it expects a keyword list it can convert to map. 

Looking at `logger_test.exs` from [the PR](https://github.com/elixir-lang/elixir/pull/12413/files) where the `Enum.into/2` call was added shows that the test is setting the metadata config as a keyword list

```
Application.put_env(:logger, :metadata, global_meta: :yes)
```

This patch uses `Enum.into/3` to handle both cases with a transform, defaulting to `:yes` as the value when receiving a list of atoms as described throughout the Logger docs.