### PR TITLE
Correct link in GenEvent docs

### DIFF
--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -22,7 +22,7 @@ defmodule GenEvent do
   This approach has some shortcomings (it provides no back-pressure for example)
   but can still replace GenEvent for low-profile usages of it. [This blog post
   by José
-  Valim](http://blog.plataformatec.com.br/2016/11/replacing-genevent-by-a-supervisor-genserver/)
+  Valim](https://dashbit.co/blog/replacing-genevent-by-a-supervisor-plus-genserver)
   has more detailed information on this approach.
 
   ### GenStage


### PR DESCRIPTION
The link in the documentation is not up-to-date. The article is now hosted on the Dashbit Blog