### PR TITLE
Fix default failures_manifest_file

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -773,8 +773,14 @@ defmodule Mix.Tasks.Test do
   @manifest_file_name ".mix_test_failures"
 
   defp manifest_opts(opts) do
-    manifest_file = Path.join(Mix.Project.manifest_path(), @manifest_file_name)
-    opts = Keyword.put(opts, :failures_manifest_file, manifest_file)
+    opts =
+      Keyword.put_new(
+        opts,
+        :failures_manifest_file,
+        Path.join(Mix.Project.manifest_path(), @manifest_file_name)
+      )
+
+    manifest_file = Keyword.get(opts, :failures_manifest_file)
 
     if opts[:failed] do
       if opts[:stale] do

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -45,6 +45,16 @@ defmodule Mix.Tasks.TestTest do
              ]
     end
 
+    test "respect failures_manifest_file option" do
+      custom_manifest_file = Path.join(Mix.Project.manifest_path(), ".mix_test_failures_custom")
+
+      assert ex_unit_opts(failures_manifest_file: custom_manifest_file) == [
+               autorun: false,
+               exit_status: 2,
+               failures_manifest_file: custom_manifest_file
+             ]
+    end
+
     defp ex_unit_opts(opts) do
       {ex_unit_opts, _allowed_files} = Mix.Tasks.Test.process_ex_unit_opts(opts)
       ex_unit_opts


### PR DESCRIPTION
Recently, we tried to override the `failures_manifest_file` configuration in our CI pipeline to achieve the partitioning of our test suite on top of the same file system. 

Thanks :) 