### PR TITLE
Explain keyword spec syntax in typespecs reference

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -748,7 +748,7 @@ defmodule Regex do
       "Abcadc"
 
   """
-  @spec replace(t, String.t(), String.t() | (... -> String.t()), [{:global, boolean()}]) ::
+  @spec replace(t, String.t(), String.t() | (... -> String.t()), global: boolean()) ::
           String.t()
   def replace(%Regex{} = regex, string, replacement, options \\ [])
       when is_binary(string) and is_list(options) do

--- a/lib/elixir/pages/references/typespecs.md
+++ b/lib/elixir/pages/references/typespecs.md
@@ -200,6 +200,14 @@ def start_link(opts) do
 end
 ```
 
+The following spec syntaxes are equivalent:
+
+```elixir
+@type options [{:name, String.t} | {:max, pos_integer} | {:min, pos_integer}]
+
+@type options [name: String.t, max: pos_integer, min: pos_integer]
+```
+
 ### User-defined types
 
 The `@type`, `@typep`, and `@opaque` module attributes can be used to define new types:


### PR DESCRIPTION
Even if I understand we might want to push defining type options over plural options type, it feels that the keyword syntax should still be documented explicitly in the [Typespecs reference](https://hexdocs.pm/elixir/main/typespecs.html#keyword-lists).

The first commit is a small fix to be consistent in the use of keyword spec syntax, I forgot to fix this one in #13552.