### PR TITLE
Remove duplicated is_integer in Calendar.ISO.valid_date?/3

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1364,7 +1364,7 @@ defmodule Calendar.ISO do
   @spec valid_date?(year, month, day) :: boolean
   def valid_date?(year, month, day)
       when is_integer(year) and is_integer(month) and is_integer(day) do
-    is_year(year) and is_month(month) and day in 1..days_in_month(year, month)
+    is_month(month) and day in 1..days_in_month(year, month)
   end
 
   @doc """


### PR DESCRIPTION
is_year used to do more before 3d7f4dddbf9759fbc003518a802ec6cccdbfdc6a