### PR TITLE
Add Warning Prompt for File Write Operations in Elixir Learning Documentation

### DIFF
--- a/lib/elixir/pages/getting-started/io-and-the-file-system.md
+++ b/lib/elixir/pages/getting-started/io-and-the-file-system.md
@@ -28,7 +28,7 @@ hello world
 The `File` module contains functions that allow us to open files as IO devices. By default, files are opened in binary mode, which requires developers to use the specific `IO.binread/2` and `IO.binwrite/2` functions from the `IO` module:
 
 > #### Potential data loss warning {: .warning}
-> 
+>
 > The following code opens a file for writing. If an existing file is available at the given path, its contents will be deleted.
 
 ```elixir

--- a/lib/elixir/pages/getting-started/io-and-the-file-system.md
+++ b/lib/elixir/pages/getting-started/io-and-the-file-system.md
@@ -27,6 +27,10 @@ hello world
 
 The `File` module contains functions that allow us to open files as IO devices. By default, files are opened in binary mode, which requires developers to use the specific `IO.binread/2` and `IO.binwrite/2` functions from the `IO` module:
 
+> #### Potential Data Loss Warning {: .warning}
+> 
+> The following code opens a file for writing. Be mindful that providing an incorrect file path will lead to the unintended deletion of the file's contents. Always verify the accuracy of the file path to avoid data loss.
+
 ```elixir
 iex> {:ok, file} = File.open("path/to/file/hello", [:write])
 {:ok, #PID<0.47.0>}
@@ -94,6 +98,10 @@ With this, we have covered the main modules that Elixir provides for dealing wit
 ## Processes
 
 You may have noticed that `File.open/2` returns a tuple like `{:ok, pid}`:
+
+> #### Potential Data Loss Warning {: .warning}
+> 
+> The following code opens a file for writing. Be mindful that providing an incorrect file path will lead to the unintended deletion of the file's contents. Always verify the accuracy of the file path to avoid data loss.
 
 ```elixir
 iex> {:ok, file} = File.open("hello", [:write])

--- a/lib/elixir/pages/getting-started/io-and-the-file-system.md
+++ b/lib/elixir/pages/getting-started/io-and-the-file-system.md
@@ -27,9 +27,9 @@ hello world
 
 The `File` module contains functions that allow us to open files as IO devices. By default, files are opened in binary mode, which requires developers to use the specific `IO.binread/2` and `IO.binwrite/2` functions from the `IO` module:
 
-> #### Potential Data Loss Warning {: .warning}
+> #### Potential data loss warning {: .warning}
 > 
-> The following code opens a file for writing. Be mindful that providing an incorrect file path will lead to the unintended deletion of the file's contents. Always verify the accuracy of the file path to avoid data loss.
+> The following code opens a file for writing. If an existing file is available at the given path, its contents will be deleted.
 
 ```elixir
 iex> {:ok, file} = File.open("path/to/file/hello", [:write])
@@ -42,7 +42,7 @@ iex> File.read("path/to/file/hello")
 {:ok, "world"}
 ```
 
-A file can also be opened with `:utf8` encoding, which tells the `File` module to interpret the bytes read from the file as UTF-8-encoded bytes.
+The file could be opened with the `:append` option, instead of `:write`, to preserve its contents. You may also pass the `:utf8` option, which tells the `File` module to interpret the bytes read from the file as UTF-8-encoded bytes.
 
 Besides functions for opening, reading and writing files, the `File` module has many functions to work with the file system. Those functions are named after their UNIX equivalents. For example, `File.rm/1` can be used to remove files, `File.mkdir/1` to create directories, `File.mkdir_p/1` to create directories and all their parent chain. There are even `File.cp_r/2` and `File.rm_rf/1` to respectively copy and remove files and directories recursively (i.e., copying and removing the contents of the directories too).
 
@@ -99,12 +99,8 @@ With this, we have covered the main modules that Elixir provides for dealing wit
 
 You may have noticed that `File.open/2` returns a tuple like `{:ok, pid}`:
 
-> #### Potential Data Loss Warning {: .warning}
-> 
-> The following code opens a file for writing. Be mindful that providing an incorrect file path will lead to the unintended deletion of the file's contents. Always verify the accuracy of the file path to avoid data loss.
-
 ```elixir
-iex> {:ok, file} = File.open("hello", [:write])
+iex> {:ok, file} = File.open("hello")
 {:ok, #PID<0.47.0>}
 ```
 


### PR DESCRIPTION
When I was following the documentation to learn Elixir just now, I entered the following code in iex: `{:ok, file} = File.open("/home/username/.zshrc", [:write])`. This ended up clearing my `.zshrc` configuration file. Fortunately, I had a backup. However, if others don't have a backup or input the path to a more important file, I understand this could result in their files being cleared. Therefore, I added a warning prompt when dealing with `File.open("path/to/file/hello", [:write])`. English is not my native language, and I used AI to translate these prompts. Feel free to modify if it's not good enough, but I feel it's necessary to give readers a heads-up, as there's still some risk involved.