### PR TITLE
Make clear the " alias, require, and import " also talks about use

### DIFF
--- a/lib/elixir/pages/getting-started/alias-require-and-import.md
+++ b/lib/elixir/pages/getting-started/alias-require-and-import.md
@@ -1,6 +1,6 @@
-# alias, require, import and use
+# alias, require, import, and use
 
-In order to facilitate software reuse, Elixir provides three directives (`alias`, `require` and `import`) plus a macro called `use` summarized below:
+In order to facilitate software reuse, Elixir provides three directives (`alias`, `require`, and `import`) plus a macro called `use` summarized below:
 
 ```elixir
 # Alias the module so it can be called as Bar instead of Foo.Bar

--- a/lib/elixir/pages/getting-started/alias-require-and-import.md
+++ b/lib/elixir/pages/getting-started/alias-require-and-import.md
@@ -1,4 +1,4 @@
-# alias, require, and import
+# alias, require, import and use
 
 In order to facilitate software reuse, Elixir provides three directives (`alias`, `require` and `import`) plus a macro called `use` summarized below:
 


### PR DESCRIPTION
Browsing the docs I found the page and found it weird that it didn't mention use (as the 4 of them go together), reading the page I realized that it _does_ mention `use` but it's just not mentioned in the headline so this seemed like an easy fix.

I did _not_ modify the file name, although I think it'd be better to also rename the file (and references to it). However, I was worried about breaking outside links to https://hexdocs.pm/elixir/alias-require-and-import.html I'm looking for guidance on:
* is the breakage ok
* should we just not break
* should we break and maybe leave a note in the existing file that documenation moved (and hide from the getting started)

Thanks for all your work as usual! :green_heart: 


![IMG20230429163945](https://github.com/elixir-lang/elixir/assets/606517/da68efd1-8c69-49e1-941c-ec6a014265f6)

