### PR TITLE
Add note about statically known maps keys and types tracking across function calls to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ We focused on atoms and maps on this initial release as they are respectively th
 
   * Accessing a field that is not defined in a rescued exception
 
-These new warnings help Elixir developers find bugs earlier and give more confidence when refactoring code, especially around maps and structs. While some of these warnings were emitted in the past, they were discovered using syntax analysis. The new warnings are more reliable, precise, and with better error messages.
+These new warnings help Elixir developers find bugs earlier and give more confidence when refactoring code, especially around maps and structs. While some of these warnings were emitted in the past, they were discovered using syntax analysis. The new warnings are more reliable, precise, and with better error messages. Keep in mind that not all maps have statically known keys, and the Elixir typechecker does not track types across all variables and function calls yet.
 
 Future Elixir versions will continue inferring more types and type checking more constructs, bringing Elixir developers more warnings and quality of life improvements without changes to code. For more details, see our new [reference document on gradual set-theoretic types](https://hexdocs.pm/elixir/main/gradual-set-theoretic-types.html).
 


### PR DESCRIPTION
When reading the 1.17 changelog, in my opinion people less familiar with how typecheckers work can read too much into the promised improvements, and they might be disappointed afterwards when trying out the typechecker. For example, these two points especially:

> Elixir v1.17 will emit the following warnings at compile-time:
> - Pattern matching against a map or a struct that does not have the given key, such as %{adress: ...} = user (notice address vs adress)
> - Updating a struct or a map that does not define the given key, such as %{user | adress: ...}

mention maps in general, but if I understand correctly this will only work for maps in limited situations when the map type with its keys is statically known, e.g. when updating a map literal defined in the same function.

I think it's better not to over-promise, so I would propose adding some kind of caveat / info mention about the current general limitations of how the typechecker works. This wording and the caveat placement is probably not very good, but I wanted to open the PR to illustrate what I meant