### PR TITLE
Fix false positive with nested shadowed alias

### DIFF
--- a/lib/elixir/lib/kernel/lexical_tracker.ex
+++ b/lib/elixir/lib/kernel/lexical_tracker.ex
@@ -40,8 +40,8 @@ defmodule Kernel.LexicalTracker do
   end
 
   @doc false
-  def add_alias(pid, module, meta, warn, function) when is_atom(module) do
-    :gen_server.cast(pid, {:add_alias, module, meta, warn, function})
+  def add_alias(pid, module, meta, warn_mode) when is_atom(module) do
+    :gen_server.cast(pid, {:add_alias, module, meta, warn_mode})
   end
 
   @doc false
@@ -225,12 +225,12 @@ defmodule Kernel.LexicalTracker do
     end
   end
 
-  def handle_cast({:add_alias, module, meta, warn, function}, state) do
-    if warn do
+  def handle_cast({:add_alias, module, meta, warn_mode}, state) do
+    if warn_mode != :never do
       state =
         case state do
           # we only track shadowed unused aliases at the top-level
-          %{aliases: %{^module => meta}} when function == nil ->
+          %{aliases: %{^module => meta}} when warn_mode == :always ->
             put_in(state.aliases[{:shadowed, module}], meta)
 
           _ ->

--- a/lib/elixir/lib/kernel/lexical_tracker.ex
+++ b/lib/elixir/lib/kernel/lexical_tracker.ex
@@ -40,8 +40,8 @@ defmodule Kernel.LexicalTracker do
   end
 
   @doc false
-  def add_alias(pid, module, meta, warn, function) when is_atom(module) do
-    :gen_server.cast(pid, {:add_alias, module, meta, warn, function})
+  def add_alias(pid, module, meta, warn, function?) when is_atom(module) do
+    :gen_server.cast(pid, {:add_alias, module, meta, warn, function?})
   end
 
   @doc false
@@ -225,12 +225,12 @@ defmodule Kernel.LexicalTracker do
     end
   end
 
-  def handle_cast({:add_alias, module, meta, warn, function}, state) do
+  def handle_cast({:add_alias, module, meta, warn, function?}, state) do
     if warn do
       state =
         case state do
           # we only track shadowed unused aliases at the top-level
-          %{aliases: %{^module => meta}} when function == nil ->
+          %{aliases: %{^module => meta}} when not function? ->
             put_in(state.aliases[{:shadowed, module}], meta)
 
           _ ->

--- a/lib/elixir/lib/kernel/lexical_tracker.ex
+++ b/lib/elixir/lib/kernel/lexical_tracker.ex
@@ -40,8 +40,8 @@ defmodule Kernel.LexicalTracker do
   end
 
   @doc false
-  def add_alias(pid, module, meta, warn) when is_atom(module) do
-    :gen_server.cast(pid, {:add_alias, module, meta, warn})
+  def add_alias(pid, module, meta, warn, function) when is_atom(module) do
+    :gen_server.cast(pid, {:add_alias, module, meta, warn, function})
   end
 
   @doc false
@@ -225,12 +225,16 @@ defmodule Kernel.LexicalTracker do
     end
   end
 
-  def handle_cast({:add_alias, module, meta, warn}, state) do
+  def handle_cast({:add_alias, module, meta, warn, function}, state) do
     if warn do
       state =
         case state do
-          %{aliases: %{^module => meta}} -> put_in(state.aliases[{:shadowed, module}], meta)
-          _ -> state
+          # we only track shadowed unused aliases at the top-level
+          %{aliases: %{^module => meta}} when function == nil ->
+            put_in(state.aliases[{:shadowed, module}], meta)
+
+          _ ->
+            state
         end
 
       {:noreply, put_in(state.aliases[module], meta)}

--- a/lib/elixir/lib/kernel/lexical_tracker.ex
+++ b/lib/elixir/lib/kernel/lexical_tracker.ex
@@ -40,8 +40,8 @@ defmodule Kernel.LexicalTracker do
   end
 
   @doc false
-  def add_alias(pid, module, meta, warn_mode) when is_atom(module) do
-    :gen_server.cast(pid, {:add_alias, module, meta, warn_mode})
+  def add_alias(pid, module, meta, warn, function) when is_atom(module) do
+    :gen_server.cast(pid, {:add_alias, module, meta, warn, function})
   end
 
   @doc false
@@ -225,12 +225,12 @@ defmodule Kernel.LexicalTracker do
     end
   end
 
-  def handle_cast({:add_alias, module, meta, warn_mode}, state) do
-    if warn_mode != :never do
+  def handle_cast({:add_alias, module, meta, warn, function}, state) do
+    if warn do
       state =
         case state do
           # we only track shadowed unused aliases at the top-level
-          %{aliases: %{^module => meta}} when warn_mode == :always ->
+          %{aliases: %{^module => meta}} when function == nil ->
             put_in(state.aliases[{:shadowed, module}], meta)
 
           _ ->

--- a/lib/elixir/src/elixir_lexical.erl
+++ b/lib/elixir/src/elixir_lexical.erl
@@ -41,12 +41,7 @@ trace({import, Meta, Module, Opts}, #{lexical_tracker := Pid}) ->
   ?tracker:add_import(Pid, Module, Only, Meta, Imported and should_warn(Meta, Opts)),
   ok;
 trace({alias, Meta, _Old, New, Opts}, #{lexical_tracker := Pid, function := Function}) ->
-  WarnMode = case should_warn(Meta, Opts) of
-    true when Function == nil -> always;
-    true -> except_unused_shadowed;
-    false -> never
-  end,
-  ?tracker:add_alias(Pid, New, Meta, WarnMode),
+  ?tracker:add_alias(Pid, New, Meta, should_warn(Meta, Opts), Function),
   ok;
 trace({alias_expansion, _Meta, Lookup, _Result}, #{lexical_tracker := Pid}) ->
   ?tracker:alias_dispatch(Pid, Lookup),

--- a/lib/elixir/src/elixir_lexical.erl
+++ b/lib/elixir/src/elixir_lexical.erl
@@ -40,8 +40,8 @@ trace({import, Meta, Module, Opts}, #{lexical_tracker := Pid}) ->
 
   ?tracker:add_import(Pid, Module, Only, Meta, Imported and should_warn(Meta, Opts)),
   ok;
-trace({alias, Meta, _Old, New, Opts}, #{lexical_tracker := Pid}) ->
-  ?tracker:add_alias(Pid, New, Meta, should_warn(Meta, Opts)),
+trace({alias, Meta, _Old, New, Opts}, #{lexical_tracker := Pid, function := Function}) ->
+  ?tracker:add_alias(Pid, New, Meta, should_warn(Meta, Opts), Function),
   ok;
 trace({alias_expansion, _Meta, Lookup, _Result}, #{lexical_tracker := Pid}) ->
   ?tracker:alias_dispatch(Pid, Lookup),

--- a/lib/elixir/src/elixir_lexical.erl
+++ b/lib/elixir/src/elixir_lexical.erl
@@ -41,7 +41,12 @@ trace({import, Meta, Module, Opts}, #{lexical_tracker := Pid}) ->
   ?tracker:add_import(Pid, Module, Only, Meta, Imported and should_warn(Meta, Opts)),
   ok;
 trace({alias, Meta, _Old, New, Opts}, #{lexical_tracker := Pid, function := Function}) ->
-  ?tracker:add_alias(Pid, New, Meta, should_warn(Meta, Opts), Function),
+  WarnMode = case should_warn(Meta, Opts) of
+    true when Function == nil -> always;
+    true -> except_unused_shadowed;
+    false -> never
+  end,
+  ?tracker:add_alias(Pid, New, Meta, WarnMode),
   ok;
 trace({alias_expansion, _Meta, Lookup, _Result}, #{lexical_tracker := Pid}) ->
   ?tracker:alias_dispatch(Pid, Lookup),

--- a/lib/elixir/src/elixir_lexical.erl
+++ b/lib/elixir/src/elixir_lexical.erl
@@ -41,7 +41,7 @@ trace({import, Meta, Module, Opts}, #{lexical_tracker := Pid}) ->
   ?tracker:add_import(Pid, Module, Only, Meta, Imported and should_warn(Meta, Opts)),
   ok;
 trace({alias, Meta, _Old, New, Opts}, #{lexical_tracker := Pid, function := Function}) ->
-  ?tracker:add_alias(Pid, New, Meta, should_warn(Meta, Opts), Function),
+  ?tracker:add_alias(Pid, New, Meta, should_warn(Meta, Opts), Function /= nil),
   ok;
 trace({alias_expansion, _Meta, Lookup, _Result}, #{lexical_tracker := Pid}) ->
   ?tracker:alias_dispatch(Pid, Lookup),

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -52,7 +52,7 @@ defmodule Kernel.LexicalTrackerTest do
   end
 
   test "can add aliases", config do
-    D.add_alias(config[:pid], String, 1, true, nil)
+    D.add_alias(config[:pid], String, 1, true, false)
     D.alias_dispatch(config[:pid], String)
     assert D.references(config[:pid]) == {[], [], [], []}
   end
@@ -93,18 +93,18 @@ defmodule Kernel.LexicalTrackerTest do
   end
 
   test "unused aliases", config do
-    D.add_alias(config[:pid], String, 1, true, nil)
+    D.add_alias(config[:pid], String, 1, true, false)
     assert D.collect_unused_aliases(config[:pid]) == [{String, 1}]
   end
 
   test "used aliases are not unused", config do
-    D.add_alias(config[:pid], String, 1, true, nil)
+    D.add_alias(config[:pid], String, 1, true, false)
     D.alias_dispatch(config[:pid], String)
     assert D.collect_unused_aliases(config[:pid]) == []
   end
 
   test "aliases with no warn are not unused", config do
-    D.add_alias(config[:pid], String, 1, false, nil)
+    D.add_alias(config[:pid], String, 1, false, false)
     assert D.collect_unused_aliases(config[:pid]) == []
   end
 

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -52,7 +52,7 @@ defmodule Kernel.LexicalTrackerTest do
   end
 
   test "can add aliases", config do
-    D.add_alias(config[:pid], String, 1, true)
+    D.add_alias(config[:pid], String, 1, true, nil)
     D.alias_dispatch(config[:pid], String)
     assert D.references(config[:pid]) == {[], [], [], []}
   end
@@ -93,18 +93,18 @@ defmodule Kernel.LexicalTrackerTest do
   end
 
   test "unused aliases", config do
-    D.add_alias(config[:pid], String, 1, true)
+    D.add_alias(config[:pid], String, 1, true, nil)
     assert D.collect_unused_aliases(config[:pid]) == [{String, 1}]
   end
 
   test "used aliases are not unused", config do
-    D.add_alias(config[:pid], String, 1, true)
+    D.add_alias(config[:pid], String, 1, true, nil)
     D.alias_dispatch(config[:pid], String)
     assert D.collect_unused_aliases(config[:pid]) == []
   end
 
   test "aliases with no warn are not unused", config do
-    D.add_alias(config[:pid], String, 1, false)
+    D.add_alias(config[:pid], String, 1, false, nil)
     assert D.collect_unused_aliases(config[:pid]) == []
   end
 

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -52,7 +52,7 @@ defmodule Kernel.LexicalTrackerTest do
   end
 
   test "can add aliases", config do
-    D.add_alias(config[:pid], String, 1, :always)
+    D.add_alias(config[:pid], String, 1, true, nil)
     D.alias_dispatch(config[:pid], String)
     assert D.references(config[:pid]) == {[], [], [], []}
   end
@@ -93,18 +93,18 @@ defmodule Kernel.LexicalTrackerTest do
   end
 
   test "unused aliases", config do
-    D.add_alias(config[:pid], String, 1, :always)
+    D.add_alias(config[:pid], String, 1, true, nil)
     assert D.collect_unused_aliases(config[:pid]) == [{String, 1}]
   end
 
   test "used aliases are not unused", config do
-    D.add_alias(config[:pid], String, 1, :always)
+    D.add_alias(config[:pid], String, 1, true, nil)
     D.alias_dispatch(config[:pid], String)
     assert D.collect_unused_aliases(config[:pid]) == []
   end
 
   test "aliases with no warn are not unused", config do
-    D.add_alias(config[:pid], String, 1, :never)
+    D.add_alias(config[:pid], String, 1, false, nil)
     assert D.collect_unused_aliases(config[:pid]) == []
   end
 

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -52,7 +52,7 @@ defmodule Kernel.LexicalTrackerTest do
   end
 
   test "can add aliases", config do
-    D.add_alias(config[:pid], String, 1, true, nil)
+    D.add_alias(config[:pid], String, 1, :always)
     D.alias_dispatch(config[:pid], String)
     assert D.references(config[:pid]) == {[], [], [], []}
   end
@@ -93,18 +93,18 @@ defmodule Kernel.LexicalTrackerTest do
   end
 
   test "unused aliases", config do
-    D.add_alias(config[:pid], String, 1, true, nil)
+    D.add_alias(config[:pid], String, 1, :always)
     assert D.collect_unused_aliases(config[:pid]) == [{String, 1}]
   end
 
   test "used aliases are not unused", config do
-    D.add_alias(config[:pid], String, 1, true, nil)
+    D.add_alias(config[:pid], String, 1, :always)
     D.alias_dispatch(config[:pid], String)
     assert D.collect_unused_aliases(config[:pid]) == []
   end
 
   test "aliases with no warn are not unused", config do
-    D.add_alias(config[:pid], String, 1, false, nil)
+    D.add_alias(config[:pid], String, 1, :never)
     assert D.collect_unused_aliases(config[:pid]) == []
   end
 

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -910,6 +910,23 @@ defmodule Kernel.WarningTest do
     purge(Sample)
   end
 
+  test "does not warn when shadowing alias in nested block" do
+    assert capture_compile("""
+           defmodule Sample do
+             alias Foo.Baz
+
+             def foo do
+               alias Bar.Baz
+               Baz
+             end
+
+             def baz, do: Baz
+           end
+           """) == ""
+  after
+    purge(Sample)
+  end
+
   test "unused inside dynamic module" do
     import List, only: [flatten: 1], warn: false
 


### PR DESCRIPTION
Closes https://github.com/elixir-lang/elixir/issues/13563.

For now, I went with the suggestion to fix the issue:
>  Perhaps we could track the scope of the alias in such cases (for example, only consider it overridden if outside of a function?).

We might be able to do something even smarter with `function` in order to track unused shadowing within a function, I'm not sure yet, will keep exploring. Otherwise seems like a good compromise if this keeps the `state` simpler.