### PR TITLE
Fix typo in meta key name in elixir_quote

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5543,7 +5543,7 @@ defmodule Kernel do
 
       # Calls to Kernel functions must be fully-qualified to ensure
       # reproducible builds, otherwise, this macro will generate ASTs
-      # with different metadata (:import, :context) depending on if
+      # with different metadata (:imports, :context) depending on if
       # it is the bootstrapped version or not.
       Elixir.Kernel.@(impl(true))
 

--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -397,7 +397,7 @@ do_quote(Other, _, _) ->
   Other.
 
 import_meta(Meta, Name, Arity, Q, E) ->
-  case (keyfind(import, Meta) == false) andalso
+  case (keyfind(imports, Meta) == false) andalso
       elixir_dispatch:find_imports(Meta, Name, E) of
     [] ->
       case (Arity == 1) andalso keyfind(ambiguous_op, Meta) of

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1150,7 +1150,7 @@ defmodule Kernel.ExpansionTest do
           fn -> 17 end
         end
 
-      assert clean_meta(expand(before_expansion), [:import, :context, :no_parens]) ==
+      assert clean_meta(expand(before_expansion), [:imports, :context, :no_parens]) ==
                after_expansion
     end
 


### PR DESCRIPTION
It seems the bug has been introduced in df64d5c6a1be3c3d24e2db43bda0c19ff0d36366 (and 169595f5347bc6f1c6fd8234a9478b794cb853fe) where `import` meta has been renamed to `imports` but some places were missed This bug was present since 1.14.0