### PR TITLE
Set-theoretic tuple types

### DIFF
--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -347,6 +347,18 @@ defmodule Module.Types.DescrTest do
         tuple_fetch(union(tuple([integer(), atom()]), dynamic(open_tuple([atom()]))), 1)
 
       assert equal?(type, union(atom(), dynamic()))
+
+      assert tuple_fetch(union(tuple([integer()]), tuple([atom()])), 0) ==
+               {false, union(integer(), atom())}
+
+      assert tuple_fetch(tuple(), 0) == :badindex
+    end
+
+    test "tuple_fetch with dynamic" do
+      assert tuple_fetch(dynamic(), 0) == {true, dynamic()}
+
+      assert tuple_fetch(union(dynamic(), open_tuple([atom()])), 0) ==
+               {true, union(atom(), dynamic())}
     end
 
     test "map_fetch" do


### PR DESCRIPTION
Adds to the Descr tuple types `{:ok, binary(), integer()}` and open tuple types `{atom(), boolean(), ...}` which represent every tuple of at least two elements that are an atom and a boolean.
 
Tuples are encoded as map records, where the keys are the indices. E.g., type `{integer(), atom()}` is encoded as type `%{0 => integer(), 1 => atom()}` and `{atom(), boolean(), ...}` is encoded as the open map `%{..., 0 => atom(), 1 => boolean()}`.

Emptiness checking is slightly modified to account for the fact that tuple types do not admit explicit optional indices.