### PR TITLE
Remove redundant case clause from Macro.Env.expand_require

### DIFF
--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -572,9 +572,6 @@ defmodule Macro.Env do
       {:macro, receiver, expander} ->
         {:macro, receiver, wrap_expansion(receiver, expander, meta, name, arity, env, opts)}
 
-      {:function, receiver, name} ->
-        {:function, receiver, name}
-
       :error ->
         :error
     end


### PR DESCRIPTION
:elixir_dispatch.expand_require/6 does not return a {:function, receiver, name} tuple

https://github.com/elixir-lang/elixir/blob/37d36f8bd6d4d8e9f0f4e179bf607b9644447638/lib/elixir/src/elixir_dispatch.erl#L237-L244