### PR TITLE
Only use shell_docs for html docs (OTP26-)

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -259,6 +259,7 @@ defmodule IEx.Introspection do
     case Code.ensure_loaded(module) do
       {:module, _} ->
         case Code.fetch_docs(module) do
+          # TODO remove once we require Erlang/OTP 27+
           {:docs_v1, _, :erlang, "application/erlang+html", _, _, _} = erl_docs ->
             :shell_docs.render(module, erl_docs) |> IO.puts()
 
@@ -378,6 +379,7 @@ defmodule IEx.Introspection do
     spec = get_spec(mod, fun, arity)
 
     cond do
+      # TODO remove once we require Erlang/OTP 27+
       language == :erlang and format == "application/erlang+html" ->
         print_erlang_doc(mod, fun, arity, docs_v1)
         :ok
@@ -667,6 +669,7 @@ defmodule IEx.Introspection do
   """
   def t(module) when is_atom(module) do
     case :code.get_doc(module) do
+      # TODO remove once we require Erlang/OTP 27+
       {:ok, {:docs_v1, _, :erlang, "application/erlang+html", _, _, _} = erl_docs} ->
         :shell_docs.render_type(module, erl_docs) |> IO.puts()
 
@@ -690,6 +693,7 @@ defmodule IEx.Introspection do
 
   def t({module, type}) when is_atom(module) and is_atom(type) do
     case get_docs(module, [:type]) do
+      # TODO remove once we require Erlang/OTP 27+
       {:erlang, "application/erlang+html", _, erl_docs} ->
         case :shell_docs.render_type(module, type, erl_docs) do
           {:error, :type_missing} -> types_not_found_or_private("#{inspect(module)}.#{type}")
@@ -724,6 +728,7 @@ defmodule IEx.Introspection do
 
   def t({module, type, arity}) when is_atom(module) and is_atom(type) and is_integer(arity) do
     case get_docs(module, [:type]) do
+      # TODO remove once we require Erlang/OTP 27+
       {:erlang, "application/erlang+html", _, erl_docs} ->
         case :shell_docs.render_type(module, type, arity, erl_docs) do
           {:error, :type_missing} -> types_not_found_or_private("#{inspect(module)}.#{type}")

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -259,7 +259,7 @@ defmodule IEx.Introspection do
     case Code.ensure_loaded(module) do
       {:module, _} ->
         case Code.fetch_docs(module) do
-          {:docs_v1, _, :erlang, _, _, _, _} = erl_docs ->
+          {:docs_v1, _, :erlang, "application/erlang+html", _, _, _} = erl_docs ->
             :shell_docs.render(module, erl_docs) |> IO.puts()
 
           {:docs_v1, _, _, format, %{} = doc, metadata, _} ->
@@ -378,7 +378,7 @@ defmodule IEx.Introspection do
     spec = get_spec(mod, fun, arity)
 
     cond do
-      language == :erlang ->
+      language == :erlang and format == "application/erlang+html" ->
         print_erlang_doc(mod, fun, arity, docs_v1)
         :ok
 
@@ -667,7 +667,7 @@ defmodule IEx.Introspection do
   """
   def t(module) when is_atom(module) do
     case :code.get_doc(module) do
-      {:ok, {:docs_v1, _, :erlang, _, _, _, _} = erl_docs} ->
+      {:ok, {:docs_v1, _, :erlang, "application/erlang+html", _, _, _} = erl_docs} ->
         :shell_docs.render_type(module, erl_docs) |> IO.puts()
 
       _ ->
@@ -690,7 +690,7 @@ defmodule IEx.Introspection do
 
   def t({module, type}) when is_atom(module) and is_atom(type) do
     case get_docs(module, [:type]) do
-      {:erlang, _, _, erl_docs} ->
+      {:erlang, "application/erlang+html", _, erl_docs} ->
         case :shell_docs.render_type(module, type, erl_docs) do
           {:error, :type_missing} -> types_not_found_or_private("#{inspect(module)}.#{type}")
           iodata -> IO.puts(iodata)
@@ -724,7 +724,7 @@ defmodule IEx.Introspection do
 
   def t({module, type, arity}) when is_atom(module) and is_atom(type) and is_integer(arity) do
     case get_docs(module, [:type]) do
-      {:erlang, _, _, erl_docs} ->
+      {:erlang, "application/erlang+html", _, erl_docs} ->
         case :shell_docs.render_type(module, type, arity, erl_docs) do
           {:error, :type_missing} -> types_not_found_or_private("#{inspect(module)}.#{type}")
           chardata -> IO.puts(chardata)

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -341,20 +341,27 @@ defmodule IEx.HelpersTest do
     @tag :erlang_doc
     test "prints Erlang module function specs" do
       captured = capture_io(fn -> h(:timer.sleep() / 1) end)
-      assert captured =~ ":timer.sleep/1"
 
-      # TODO Fix for OTP 27 once specs are available
+      # TODO remove once we require Erlang/OTP 27+
       if System.otp_release() < "27" do
+        assert captured =~ ":timer.sleep/1"
         assert captured =~ "-spec sleep(Time) -> ok when Time :: timeout()."
       else
         assert captured =~ "sleep(Time)"
+        assert captured =~ "@spec sleep(time) :: :ok when time: timeout()"
       end
     end
 
     @tag :erlang_doc
     test "handles non-existing Erlang module function" do
       captured = capture_io(fn -> h(:timer.baz() / 1) end)
-      assert captured =~ "No documentation for :timer.baz was found"
+
+      # TODO remove once we require Erlang/OTP 27+
+      if System.otp_release() < "27" do
+        assert captured =~ "No documentation for :timer.baz was found"
+      else
+        assert captured =~ "No documentation for :timer.baz/1 was found"
+      end
     end
 
     test "prints module documentation" do
@@ -1021,13 +1028,13 @@ defmodule IEx.HelpersTest do
     test "prints all types in Erlang module" do
       captured = capture_io(fn -> t(:queue) end)
 
-      # TODO Fix for OTP 27 once specs are available
+      # TODO remove once we require Erlang/OTP 27+
       if System.otp_release() < "27" do
         assert captured =~ "-type queue() :: queue(_)"
         assert captured =~ "-opaque queue(Item)"
       else
-        assert captured =~ "queue()"
-        assert captured =~ "queue(Item)"
+        assert captured =~ "@type queue() :: queue(_)"
+        assert captured =~ "@opaque queue(item)"
       end
     end
 
@@ -1035,22 +1042,22 @@ defmodule IEx.HelpersTest do
     test "prints single type from Erlang module" do
       captured = capture_io(fn -> t(:erlang.iovec()) end)
 
-      # TODO Fix for OTP 27 once specs are available
+      # TODO remove once we require Erlang/OTP 27+
       if System.otp_release() < "27" do
         assert captured =~ "-type iovec() :: [binary()]"
       else
-        assert captured =~ "iovec()"
+        assert captured =~ "@type iovec() :: [binary()]"
       end
 
       assert captured =~ "A list of binaries."
 
       captured = capture_io(fn -> t(:erlang.iovec() / 0) end)
 
-      # TODO Fix for OTP 27 once specs are available
+      # TODO remove once we require Erlang/OTP 27+
       if System.otp_release() < "27" do
         assert captured =~ "-type iovec() :: [binary()]"
       else
-        assert captured =~ "iovec()"
+        assert captured =~ "@type iovec() :: [binary()]"
       end
 
       assert captured =~ "A list of binaries."


### PR DESCRIPTION
Approach 1 for discussion - only use shell docs for OTP26-, and use the new markdown + existing IO.ANSI.Docs markdown.
Will bring back specs, supports tables & skips mermaid charts.

Still need to fix tests.

<img width="210" alt="Screenshot 2024-05-21 at 20 54 59" src="https://github.com/elixir-lang/elixir/assets/11598866/e58e024d-a73c-45ea-8d85-de9abe8a270a">
<img width="589" alt="Screenshot 2024-05-21 at 20 55 06" src="https://github.com/elixir-lang/elixir/assets/11598866/6991acfb-9f82-4509-bbf0-2687cc6f4864">
