### PR TITLE
Move concurrency to only the step that updates builds.txt

### DIFF
--- a/.github/workflows/builds.hex.pm.yml
+++ b/.github/workflows/builds.hex.pm.yml
@@ -13,13 +13,10 @@ env:
   ERLC_OPTS: "warnings_as_errors"
   LANG: C.UTF-8
 
-concurrency: builds_txt
-
 jobs:
   release_pre_built:
     strategy:
       fail-fast: true
-      max-parallel: 1
       matrix:
         include:
           - otp: 25
@@ -107,6 +104,22 @@ jobs:
             aws s3 cp elixir-otp-${{ matrix.otp }}.zip "s3://${{ env.AWS_S3_BUCKET }}/builds/elixir/${{github.ref_name}}.zip" --cache-control "public,max-age=3600" --metadata "{\"surrogate-key\":\"builds builds/elixir builds/elixir/${{github.ref_name}}\",\"surrogate-control\":\"public,max-age=604800\"}"
             purge builds/elixir/${{github.ref_name}}
           fi
+  update_builds_txt:
+    needs: release_pre_built
+    concurrency: builds_txt
+    strategy:
+      matrix:
+        include:
+          - otp: 25
+            otp_version: "25.3"
+            upload_generic_version: upload_generic_version
+          - otp: 26
+            otp_version: "26.0"
+          - otp: 27
+            otp_version: "27.0"
+            build_docs: build_docs
+    runs-on: ubuntu-22.04
+    steps:
       - name: Update builds txt
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.HEX_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
This should help prevent GitHub from cancelling the job.