### PR TITLE
edit keywords-and-maps.md

### DIFF
--- a/lib/elixir/pages/getting-started/keywords-and-maps.md
+++ b/lib/elixir/pages/getting-started/keywords-and-maps.md
@@ -265,7 +265,7 @@ There is more to learn about `get_in/1`, `pop_in/1` and others, including the `g
 
 There are two different data structures for working with key-value stores in Elixir. Alongside the `Access` module and pattern matching, they provide a rich set of tools for manipulating complex, potentially nested, data structures.
 
-As we conclude this chapter, the important to keep in mind is that you should:
+As we conclude this chapter, remember that you should:
 
   * Use keyword lists for passing optional values to functions
 


### PR DESCRIPTION
The text contains "the important to keep in mind is that you should". 

I claim: that phrase lacks a noun, and the intent of the text is for the sentence to resemble "the important {things|notes|takeaways|lessons} to keep in mind are that you should".

This commit replaces
"the important to keep in mind is that you should" with
"remember you should".

For edits to the sentence I am open to any of the alternatives above and others not-yet-proposed. I open this pull request just to note that sentence needs to be edited.