### PR TITLE
add --sort-first and --sort-last to mix test

### DIFF
--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -290,21 +290,24 @@ defmodule ExUnit.Runner do
   end
 
   defp sort_first_last(%{sort_first: nil, sort_last: nil}, tests), do: tests
+
   defp sort_first_last(config, tests) do
     tests = maybe_sort(:first, config.sort_first, tests)
     maybe_sort(:last, config.sort_last, tests)
   end
 
   defp maybe_sort(_where, nil, tests), do: tests
-  defp maybe_sort(where, filter, tests) do
-    {to_sort, rest} = Enum.split_with(tests, fn test ->
-      tags = Map.merge(test.tags, %{test: test.name, module: test.module})
 
-      case ExUnit.Filters.eval(filter, [:test], tags, tests) do
-        :ok -> true
-        _excluded_or_skipped -> false
-      end
-    end)
+  defp maybe_sort(where, filter, tests) do
+    {to_sort, rest} =
+      Enum.split_with(tests, fn test ->
+        tags = Map.merge(test.tags, %{test: test.name, module: test.module})
+
+        case ExUnit.Filters.eval(filter, [:test], tags, tests) do
+          :ok -> true
+          _excluded_or_skipped -> false
+        end
+      end)
 
     # the test list is reversed afterwards, therefore this is reversed as well
     case where do

--- a/lib/mix/lib/mix/compilers/test.ex
+++ b/lib/mix/lib/mix/compilers/test.ex
@@ -82,12 +82,6 @@ defmodule Mix.Compilers.Test do
               {:error, _, _} -> exit({:shutdown, 1})
             end
 
-          if last != [] do
-            # this ensures that modules loaded afterwards are appended to the end of async modules
-            # instead of the front to ensure that --sort-last works as expected
-            ExUnit.Server.append_async()
-          end
-
           # TODO: what about parallel_require_callbacks?
           for file <- last, do: Code.require_file(file)
 

--- a/lib/mix/lib/mix/compilers/test.ex
+++ b/lib/mix/lib/mix/compilers/test.ex
@@ -337,7 +337,7 @@ defmodule Mix.Compilers.Test do
     Enum.shuffle(list)
   end
 
-  defp maybe_sort_first_last(test_files, nil, nil), do: test_files
+  defp maybe_sort_first_last(test_files, nil, nil), do: {[], test_files, []}
 
   defp maybe_sort_first_last(test_files, first, last) do
     {first, test_files} = maybe_sort(test_files, first)

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -461,7 +461,9 @@ defmodule Mix.Tasks.Test do
     warnings_as_errors: :boolean,
     profile_require: :string,
     exit_status: :integer,
-    repeat_until_failure: :integer
+    repeat_until_failure: :integer,
+    sort_first: :keep,
+    sort_last: :keep
   ]
 
   @cover [output: "cover", tool: Mix.Tasks.Test.Coverage]
@@ -610,7 +612,7 @@ defmodule Mix.Tasks.Test do
       warn_test_pattern
     )
 
-    case CT.require_and_run(matched_test_files, test_paths, test_elixirc_options, opts) do
+    case CT.require_and_run(matched_test_files, test_paths, test_elixirc_options, opts, ex_unit_opts) do
       {:ok, %{excluded: excluded, failures: failures, total: total}} ->
         Mix.shell(shell)
         cover && cover.()
@@ -695,7 +697,9 @@ defmodule Mix.Tasks.Test do
     :only_test_ids,
     :test_location_relative_path,
     :exit_status,
-    :repeat_until_failure
+    :repeat_until_failure,
+    :sort_first,
+    :sort_last
   ]
 
   @doc false
@@ -707,6 +711,8 @@ defmodule Mix.Tasks.Test do
       |> filter_opts(:include)
       |> filter_opts(:exclude)
       |> filter_opts(:only)
+      |> filter_opts(:sort_first)
+      |> filter_opts(:sort_last)
       |> formatter_opts()
       |> color_opts()
       |> exit_status_opts()

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -612,7 +612,13 @@ defmodule Mix.Tasks.Test do
       warn_test_pattern
     )
 
-    case CT.require_and_run(matched_test_files, test_paths, test_elixirc_options, opts, ex_unit_opts) do
+    case CT.require_and_run(
+           matched_test_files,
+           test_paths,
+           test_elixirc_options,
+           opts,
+           ex_unit_opts
+         ) do
       {:ok, %{excluded: excluded, failures: failures, total: total}} ->
         Mix.shell(shell)
         cover && cover.()

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -200,10 +200,20 @@ defmodule Mix.Tasks.Test do
     * `--trace` - runs tests with detailed reporting. Automatically sets `--max-cases` to `1`.
       Note that in trace mode test timeouts will be ignored as timeout is set to `:infinity`
 
+    * `--trace-require` - compiles files sequentially. Useful for debugging race conditions when
+      compiling test files
+
     * `--warnings-as-errors` *(since v1.12.0)* - treats compilation warnings (from loading the
       test suite) as errors and returns a non-zero exit status if the test suite would otherwise
       pass. Note that failures reported by `--warnings-as-errors` cannot be retried with the
       `--failed` flag.
+
+    * `--sort-first` and `--sort-last` - sorts the tests that match the given pattern to be compiled
+      and run first or last, respectively. This is useful for debugging tests that might accidentally
+      rely on global state and fail when run in a specific order.
+      The argument is a filter in the same format as `--include`, `--exclude` and `--only`.
+      Note that compilation order is only affected when using the `file:path/to/test.exs` filter,
+      but for ordering tests inside individual test runs, any other tag can be used as well.
 
       This option only applies to test files. To treat warnings as errors during compilation and
       during tests, run:
@@ -437,6 +447,7 @@ defmodule Mix.Tasks.Test do
     cover: :boolean,
     export_coverage: :string,
     trace: :boolean,
+    trace_require: :boolean,
     max_cases: :integer,
     max_failures: :integer,
     include: :keep,

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -214,6 +214,7 @@ defmodule Mix.Tasks.Test do
       The argument is a filter in the same format as `--include`, `--exclude` and `--only`.
       Note that compilation order is only affected when using the `file:path/to/test.exs` filter,
       but for ordering tests inside individual test runs, any other tag can be used as well.
+      Automatically sets `--trace-require` if a file filter is used.
 
       This option only applies to test files. To treat warnings as errors during compilation and
       during tests, run:


### PR DESCRIPTION
This is based on an idea @josevalim had when debugging Phoenix tests. It is not working quite as intended though (yet?).

The goal is to provide an option to sort specific modules to be compiled first / last (and I extended this to also specify the order of tests based on the ExUnit filter syntax).

The problem as far as I can tell is that the test files are still compiled in parallel, so changing the order of the files passed to `Kernel.ParallelCompiler.require` does not guarantee that the modules are indeed compiled first or last.

Examples on how to use:

```
mix test --sort-first file:test/phoenix/router/resource_test.exs --sort-last mytag:true
```

This would ideally compile the given file first and run all tests matching the mytag:true filter after all the other tests in the file.