### PR TITLE
Add PowerShell scripts

### DIFF
--- a/bin/elixir.ps1
+++ b/bin/elixir.ps1
@@ -281,4 +281,9 @@ if ($ErlExec -eq "werl") {
   $Command = "start `"`" $Command"
 }
 
-Write-Host $Command
+if ($Env:ELIXIR_CLI_DRY_RUN) {
+  Write-Host $Command
+}
+else {
+  Invoke-Expression $Command
+}

--- a/bin/elixir.ps1
+++ b/bin/elixir.ps1
@@ -5,6 +5,11 @@ $ELIXIR_VERSION = "1.18.0-dev"
 $scriptPath = Split-Path -Parent $PSCommandPath
 $erlExec = "erl"
 
+# The iex.ps1, elixirc.ps1 and mix.ps1 scripts may populate this var.
+if ($null -eq $allArgs) {
+  $allArgs = $args
+}
+
 function PrintElixirHelp {
   $scriptName = Split-Path -Leaf $PSCommandPath
   $help = @"
@@ -66,12 +71,12 @@ See run_erl to learn more. To reattach, run: to_erl PIPEDIR.
   Write-Host $help
 }
 
-if (($args.Count -eq 1) -and ($args[0] -eq "--short-version")) {
+if (($allArgs.Count -eq 1) -and ($allArgs[0] -eq "--short-version")) {
   Write-Host "$ELIXIR_VERSION"
   exit
 }
 
-if (($args.Count -eq 0) -or (($args.Count -eq 1) -and ($args[0] -in @("-h", "--help")))) {
+if (($allArgs.Count -eq 0) -or (($allArgs.Count -eq 1) -and ($allArgs[0] -in @("-h", "--help")))) {
   PrintElixirHelp
   exit 1
 }
@@ -111,12 +116,12 @@ $allOtherParams = @()
 $runErlPipe = $null
 $runErlLog = $null
 
-for ($i = 0; $i -lt $args.Count; $i++) {
-  $private:arg = $args[$i]
+for ($i = 0; $i -lt $allArgs.Count; $i++) {
+  $private:arg = $allArgs[$i]
 
   switch ($arg) {
     { $_ -in @("-e", "-r", "-pr", "-pa", "-pz", "--eval", "--remsh", "--dot-iex", "--dbg") } {
-      $private:nextArg = NormalizeArg($args[++$i])
+      $private:nextArg = NormalizeArg($allArgs[++$i])
 
       $elixirParams += $arg
       $elixirParams += $nextArg
@@ -142,7 +147,7 @@ for ($i = 0; $i -lt $args.Count; $i++) {
 
     "--cookie" {
       $erlangParams += "-setcookie"
-      $erlangParams += $args[++$i]
+      $erlangParams += $allArgs[++$i]
       break
     }
 
@@ -153,52 +158,52 @@ for ($i = 0; $i -lt $args.Count; $i++) {
 
     "--name" {
       $erlangParams += "-name"
-      $erlangParams += $args[++$i]
+      $erlangParams += $allArgs[++$i]
       break
     }
 
     "--sname" {
       $erlangParams += "-sname"
-      $erlangParams += $args[++$i]
+      $erlangParams += $allArgs[++$i]
       break
     }
 
     "--boot" {
       $erlangParams += "-boot"
-      $erlangParams += $args[++$i]
+      $erlangParams += $allArgs[++$i]
       break
     }
 
     "--erl-config" {
       $erlangParams += "-config"
-      $erlangParams += $args[++$i]
+      $erlangParams += $allArgs[++$i]
       break
     }
 
     "--vm-args" {
       $erlangParams += "-args_file"
-      $erlangParams += $args[++$i]
+      $erlangParams += $allArgs[++$i]
       break
     }
 
     "--logger-otp-reports" {
-      $private:tempVal = $args[$i + 1]
+      $private:tempVal = $allArgs[$i + 1]
       if ($tempVal -in @("true", "false")) {
-        $erlangParams.AddRange([string[]]@("-logger", "handle_otp_reports", $args[++$i]))
+        $erlangParams += @("-logger", "handle_otp_reports", $allArgs[++$i])
       }
       break
     }
 
     "--logger-sasl-reports" {
-      $private:tempVal = $args[$i + 1]
+      $private:tempVal = $allArgs[$i + 1]
       if ($tempVal -in @("true", "false")) {
-        $erlangParams.AddRange([string[]]@("-logger", "handle_sasl_reports", $args[++$i]))
+        $erlangParams += @("-logger", "handle_sasl_reports", $allArgs[++$i])
       }
       break
     }
 
     "--erl" {
-      $private:erlFlags = $args[++$i] -split " "
+      $private:erlFlags = $allArgs[++$i] -split " "
       $beforeExtras += $erlFlags
       break
     }
@@ -216,8 +221,8 @@ for ($i = 0; $i -lt $args.Count; $i++) {
     }
 
     "--rpc-eval" {
-      $private:key = $args[++$i]
-      $private:value = $args[++$i]
+      $private:key = $allArgs[++$i]
+      $private:value = $allArgs[++$i]
 
       if ($null -eq $key) {
         Write-Error "--rpc-eval: NODE must be present"
@@ -236,8 +241,8 @@ for ($i = 0; $i -lt $args.Count; $i++) {
     }
 
     "--boot-var" {
-      $private:key = $args[++$i]
-      $private:value = $args[++$i]
+      $private:key = $allArgs[++$i]
+      $private:value = $allArgs[++$i]
 
       if ($null -eq $key) {
         Write-Error "--boot-var: VAR must be present"
@@ -256,8 +261,8 @@ for ($i = 0; $i -lt $args.Count; $i++) {
     }
 
     "--pipe-to" {
-      $runErlPipe = $args[++$i]
-      $runErlLog = $args[++$i]
+      $runErlPipe = $allArgs[++$i]
+      $runErlLog = $allArgs[++$i]
 
       if ($null -eq $runErlPipe) {
         Write-Error "--pipe-to: PIPEDIR must be present"

--- a/bin/elixir.ps1
+++ b/bin/elixir.ps1
@@ -119,7 +119,7 @@ $runErlLog = $null
 for ($i = 0; $i -lt $allArgs.Count; $i++) {
   $private:arg = $allArgs[$i]
 
-  switch ($arg) {
+  switch -exact ($arg) {
     { $_ -in @("-e", "-r", "-pr", "-pa", "-pz", "--eval", "--remsh", "--dot-iex", "--dbg") } {
       $private:nextArg = NormalizeArg($allArgs[++$i])
 

--- a/bin/elixir.ps1
+++ b/bin/elixir.ps1
@@ -1,0 +1,258 @@
+$MinPowerShellVersion = [semver]::new(7, 2, 0)
+
+if ($MinPowerShellVersion.CompareTo($PSVersionTable.PSVersion) -eq 1) {
+  Write-Error "This script requires PowerShell version 7.2 or above. Running on $($PSVersionTable.PSVersion)"
+}
+
+$ELIXIR_VERSION = "1.17.0-dev"
+$ScriptPath = Split-Path -Parent $PSCommandPath
+$ErlExec = "erl"
+
+function PrintElixirHelp {
+  $ScriptName = Split-Path -Leaf $PSCommandPath
+  $Help = @"
+Usage: $ScriptName [options] [.exs file] [data]
+
+## General options
+
+  -e "COMMAND"                 Evaluates the given command (*)
+  -h, --help                   Prints this message (standalone)
+  -r "FILE"                    Requires the given files/patterns (*)
+  -S SCRIPT                    Finds and executes the given script in \$PATH
+  -pr "FILE"                   Requires the given files/patterns in parallel (*)
+  -pa "PATH"                   Prepends the given path to Erlang code path (*)
+  -pz "PATH"                   Appends the given path to Erlang code path (*)
+  -v, --version                Prints Erlang/OTP and Elixir versions (standalone)
+
+  --erl "SWITCHES"             Switches to be passed down to Erlang (*)
+  --eval "COMMAND"             Evaluates the given command, same as -e (*)
+  --logger-otp-reports BOOL    Enables or disables OTP reporting
+  --logger-sasl-reports BOOL   Enables or disables SASL reporting
+  --no-halt                    Does not halt the Erlang VM after execution
+  --short-version              Prints Elixir version (standalone)
+  --werl                       Uses Erlang's Windows shell GUI (Windows only)
+
+Options given after the .exs file or -- are passed down to the executed code.
+Options can be passed to the Erlang runtime using \$ELIXIR_ERL_OPTIONS or --erl.
+
+## Distribution options
+
+The following options are related to node distribution.
+
+  --cookie COOKIE              Sets a cookie for this distributed node
+  --hidden                     Makes a hidden node
+  --name NAME                  Makes and assigns a name to the distributed node
+  --rpc-eval NODE "COMMAND"    Evaluates the given command on the given remote node (*)
+  --sname NAME                 Makes and assigns a short name to the distributed node
+
+--name and --sname may be set to undefined so one is automatically generated.
+
+## Release options
+
+The following options are generally used under releases.
+
+  --boot "FILE"                Uses the given FILE.boot to start the system
+  --boot-var VAR "VALUE"       Makes \$VAR available as VALUE to FILE.boot (*)
+  --erl-config "FILE"          Loads configuration in FILE.config written in Erlang (*)
+  --pipe-to "PIPEDIR" "LOGDIR" Starts the Erlang VM as a named PIPEDIR and LOGDIR
+  --vm-args "FILE"             Passes the contents in file as arguments to the VM
+
+--pipe-to starts Elixir detached from console (Unix-like only).
+It will attempt to create PIPEDIR and LOGDIR if they don't exist.
+See run_erl to learn more. To reattach, run: to_erl PIPEDIR.
+
+--pipe-to is not supported on Windows. If set, Elixir won't boot.
+
+** Options marked with (*) can be given more than once.
+** Standalone options can't be combined with other options.
+"@
+
+  Write-Host $Help
+}
+
+if (($Args.Count -eq 1) -and ($Args[0] -eq "--short-version")) {
+  Write-Host "$ELIXIR_VERSION"
+  exit
+}
+
+if (($Args.Count -eq 0) -or (($Args.Count -eq 1) -and ($Args[0] -in @("-h", "--help")))) {
+  PrintElixirHelp
+  exit
+}
+
+$ElixirParams = New-Object Collections.Generic.List[String]
+$ErlangParams = New-Object Collections.Generic.List[String]
+$BeforeExtras = New-Object Collections.Generic.List[String]
+$AllOtherParams = New-Object Collections.Generic.List[String]
+
+for ($i = 0; $i -lt $Args.Count; $i++) {
+  $private:Arg = $Args[$i]
+
+  switch ($Arg) {
+    { $_ -in @("-e", "-r", "-pr", "-pa", "-pz", "--eval", "--remsh", "--dot-iex", "--dbg") } {
+      $ElixirParams.Add("$Arg $($Args[++$i])")
+    }
+
+    { $_ -in @("-v", "--version", "--no-halt") } {
+      $ElixirParams.Add($Arg)
+    }
+
+    "--cookie" {
+      $ErlangParams.Add("-setcookie $($Args[++$i])")
+    }
+
+    "--hidden" {
+      $ErlangParams.Add("-hidden")
+    }
+
+    "--name" {
+      $ErlangParams.Add("-name $($Args[++$i])")
+    }
+
+    "--sname" {
+      $ErlangParams.Add("-sname $($Args[++$i])")
+    }
+
+    "--boot" {
+      $ErlangParams.Add("-boot $($Args[++$i])")
+    }
+
+    "--erl-config" {
+      $ErlangParams.Add("-config $($Args[++$i])")
+    }
+
+    "--vm-args" {
+      $ErlangParams.Add("-args_file $($Args[++$i])")
+    }
+
+    "--logger-otp-reports" {
+      $private:TempVal = $Args[$i + 1]
+      if ($TempVal -in @("true", "false")) {
+
+        $ErlangParams.Add("-logger handle_otp_reports $($Args[++$i])")
+      }
+    }
+
+    "--logger-sasl-reports" {
+      $private:TempVal = $Args[$i + 1]
+      if ($TempVal -in @("true", "false")) {
+
+        $ErlangParams.Add("-logger handle_sasl $($Args[++$i])")
+      }
+    }
+
+    "--erl" {
+      $BeforeExtras.Add($Args[++$i])
+    }
+
+    "--werl" {
+      if ($IsWindows) {
+        $ErlExec = "werl"
+      }
+    }
+
+    "+iex" {
+      $ElixirParams.Add("+iex")
+      $UseIex = $true
+    }
+
+    "+elixirc" { $ElixirParams.Add("+elixirc") }
+
+    "--rpc-eval" {
+      $private:Key = $Args[++$i]
+      $private:Value = $Args[++$i]
+
+      if ($null -eq $Key) {
+        Write-Error "--rpc-eval: NODE must be present"
+        exit
+      }
+
+      if ($null -eq $Value) {
+        Write-Error "--rpc-eval: COMMAND for the '$Key' node must be present"
+        exit
+      }
+
+      $ElixirParams.Add("--rpc-eval $Key $Value")
+    }
+
+    "--boot-var" {
+      $private:Key = $Args[++$i]
+      $private:Value = $Args[++$i]
+
+      if ($null -eq $Key) {
+        Write-Error "--boot-var: VAR must be present"
+        exit
+      }
+
+      if ($null -eq $Value) {
+        Write-Error "--boot-var: Value for the '$Key' var must be present"
+        exit
+      }
+
+      $ErlangParams.Add("-boot_var $Key $Value")
+    }
+
+    "--pipe-to" {
+      $private:Key = $Args[++$i]
+      $private:Value = $Args[++$i]
+
+      Write-Warning "--pipe-to: Option is not yet supported. Ignoring $Key $Value"
+    }
+
+    Default {
+      $AllOtherParams.Add($Args[$i])
+    }
+  }
+}
+
+# Support for ANSI is only disable if TERM or NO_COLOR env vars are set.
+# This will change the $PSStyle.OutputRendering property.
+if ($PSStyle.OutputRendering -ne "PlainText") {
+  $BeforeExtras.Insert(0, "-elixir ansi_enabled true")
+}
+
+if ($null -eq $UseIEx) {
+  $BeforeExtras.Insert(0, "-s elixir start_cli")
+}
+
+$BeforeExtras.Insert(0, "-noshell -elixir_root $(Join-Path $ScriptPath -ChildPath "../lib")")
+$BeforeExtras.Insert(0, "-pa $(Join-Path $ScriptPath -ChildPath "../lib/elixir/ebin")")
+
+# One MAY change ERTS_BIN= but you MUST NOT change
+# ERTS_BIN=$ERTS_BIN as it is handled by Elixir releases.
+# TODO: change when we port the releases scripts.
+# $ERTS_BIN=
+$ERTS_BIN = "$Env:ERTS_BIN"
+
+$ELIXIR_ERL_OPTIONS = "$Env:ELIXIR_ERL_OPTIONS"
+
+$AllParams = New-Object Collections.Generic.List[String]
+
+$AllParams.Add($ELIXIR_ERL_OPTIONS)
+$AllParams.AddRange($ErlangParams)
+$AllParams.AddRange($BeforeExtras)
+$AllParams.Add("-extra")
+$AllParams.AddRange($ElixirParams)
+$AllParams.AddRange($AllOtherParams)
+
+$ParamsPart = [string]::Join(" ", ($AllParams | Where-Object { $_ -ne "" }))
+
+$BinSuffix = ""
+
+if ($IsWindows) {
+  $BinSuffix = ".exe"
+}
+
+$BinPath = "$ErlExec$BinSuffix"
+
+if ($ERTS_BIN) {
+  $BinPath = Join-Path -Path $ERTS_BIN -ChildPath $BinPath
+}
+
+$Command = "$BinPath $ParamsPart"
+
+if ($ErlExec -eq "werl") {
+  $Command = "start `"`" $Command"
+}
+
+Write-Host $Command

--- a/bin/elixir.ps1
+++ b/bin/elixir.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-$ELIXIR_VERSION = "1.17.0-dev"
+$ELIXIR_VERSION = "1.18.0-dev"
 
 $minPowerShellVersion = [version]"7.2.0"
 

--- a/bin/elixir.ps1
+++ b/bin/elixir.ps1
@@ -313,7 +313,8 @@ $allParams.AddRange($allOtherParams)
 
 $binSuffix = ""
 
-if ($isWindows) {
+# The variable is available after PowerShell 7.2. Previous to that, PS only worked on Windows.
+if ($isWindows -or ($null -eq $isWindows)) {
   $binSuffix = ".exe"
 }
 

--- a/bin/elixir.ps1
+++ b/bin/elixir.ps1
@@ -91,38 +91,47 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
   switch ($Arg) {
     { $_ -in @("-e", "-r", "-pr", "-pa", "-pz", "--eval", "--remsh", "--dot-iex", "--dbg") } {
       $ElixirParams.Add("$Arg $($Args[++$i])")
+      break
     }
 
     { $_ -in @("-v", "--version", "--no-halt") } {
       $ElixirParams.Add($Arg)
+      break
     }
 
     "--cookie" {
       $ErlangParams.Add("-setcookie $($Args[++$i])")
+      break
     }
 
     "--hidden" {
       $ErlangParams.Add("-hidden")
+      break
     }
 
     "--name" {
       $ErlangParams.Add("-name $($Args[++$i])")
+      break
     }
 
     "--sname" {
       $ErlangParams.Add("-sname $($Args[++$i])")
+      break
     }
 
     "--boot" {
       $ErlangParams.Add("-boot $($Args[++$i])")
+      break
     }
 
     "--erl-config" {
       $ErlangParams.Add("-config $($Args[++$i])")
+      break
     }
 
     "--vm-args" {
       $ErlangParams.Add("-args_file $($Args[++$i])")
+      break
     }
 
     "--logger-otp-reports" {
@@ -131,6 +140,7 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
 
         $ErlangParams.Add("-logger handle_otp_reports $($Args[++$i])")
       }
+      break
     }
 
     "--logger-sasl-reports" {
@@ -139,24 +149,29 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
 
         $ErlangParams.Add("-logger handle_sasl $($Args[++$i])")
       }
+      break
     }
 
     "--erl" {
       $BeforeExtras.Add($Args[++$i])
+      break
     }
 
     "--werl" {
       if ($IsWindows) {
         $ErlExec = "werl"
       }
+      break
     }
 
     "+iex" {
       $ElixirParams.Add("+iex")
       $UseIex = $true
+
+      break
     }
 
-    "+elixirc" { $ElixirParams.Add("+elixirc") }
+    "+elixirc" { $ElixirParams.Add("+elixirc"); break }
 
     "--rpc-eval" {
       $private:Key = $Args[++$i]
@@ -173,6 +188,7 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
       }
 
       $ElixirParams.Add("--rpc-eval $Key $Value")
+      break
     }
 
     "--boot-var" {
@@ -190,6 +206,7 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
       }
 
       $ErlangParams.Add("-boot_var $Key $Value")
+      break
     }
 
     "--pipe-to" {
@@ -197,10 +214,16 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
       $private:Value = $Args[++$i]
 
       Write-Warning "--pipe-to: Option is not yet supported. Ignoring $Key $Value"
+      break
     }
 
     Default {
-      $AllOtherParams.Add($Args[$i])
+      if ($Arg -is [string]) {
+        $AllOtherParams.Add($Arg)
+      } else {
+        $AllOtherParams.Add([string]::Join(",", $Arg))
+      }
+      break
     }
   }
 }
@@ -215,8 +238,8 @@ if ($null -eq $UseIEx) {
   $BeforeExtras.Insert(0, "-s elixir start_cli")
 }
 
-$BeforeExtras.Insert(0, "-noshell -elixir_root $(Join-Path $ScriptPath -ChildPath "../lib")")
 $BeforeExtras.Insert(0, "-pa $(Join-Path $ScriptPath -ChildPath "../lib/elixir/ebin")")
+$BeforeExtras.Insert(0, "-noshell -elixir_root $(Join-Path $ScriptPath -ChildPath "../lib")")
 
 # One MAY change ERTS_BIN= but you MUST NOT change
 # ERTS_BIN=$ERTS_BIN as it is handled by Elixir releases.

--- a/bin/elixir.ps1
+++ b/bin/elixir.ps1
@@ -348,7 +348,7 @@ else {
   $private:escaped = $allParams | ForEach-Object -Process { ($_ -replace "`"", "\`"") -replace "[^a-zA-Z0-9_/-]", "\$&" }
 
   # The args are surrounded here because we want to have only one argument for the entire command.
-  $paramsPart = @("-daemon","`"$runErlPipe/`"", "`"$runErlLog/`"", "`"$($escaped -join " ")`"")
+  $paramsPart = @("-daemon", "`"$runErlPipe/`"", "`"$runErlLog/`"", "`"$($escaped -join " ")`"")
 }
 
 if ($env:ELIXIR_CLI_DRY_RUN) {

--- a/bin/elixir.ps1
+++ b/bin/elixir.ps1
@@ -129,9 +129,9 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
       break
     }
 
-    { $_ -in @("-v", "--version", "--help", "-h") } {
+    { $_ -in @("-v", "--version") } {
       # Standalone options goes only once in the Elixir params, when they are empty.
-      if ($ElixirParams.Count -eq 0) {
+      if (($ElixirParams.Count -eq 0) -and ($AllOtherParams.Count -eq 0)) {
         $ElixirParams.Add($Arg)
       }
       else {

--- a/bin/elixir.ps1
+++ b/bin/elixir.ps1
@@ -220,7 +220,8 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
     Default {
       if ($Arg -is [string]) {
         $AllOtherParams.Add($Arg)
-      } else {
+      }
+      else {
         $AllOtherParams.Add([string]::Join(",", $Arg))
       }
       break

--- a/bin/elixir.ps1
+++ b/bin/elixir.ps1
@@ -2,12 +2,6 @@
 
 $ELIXIR_VERSION = "1.18.0-dev"
 
-$minPowerShellVersion = [version]"7.2.0"
-
-if ($minPowerShellVersion.CompareTo([version]$PSVersionTable.PSVersion) -eq 1) {
-  Write-Error "This script requires PowerShell version 7.2 or above. Running on $($PSVersionTable.PSVersion)"
-}
-
 $scriptPath = Split-Path -Parent $PSCommandPath
 $erlExec = "erl"
 

--- a/bin/elixir.ps1
+++ b/bin/elixir.ps1
@@ -1,3 +1,5 @@
+#!/usr/bin/env pwsh
+
 $MinPowerShellVersion = [semver]::new(7, 2, 0)
 
 if ($MinPowerShellVersion.CompareTo($PSVersionTable.PSVersion) -eq 1) {

--- a/bin/elixirc.ps1
+++ b/bin/elixirc.ps1
@@ -1,0 +1,41 @@
+$ScriptName = Split-Path -Leaf $PSCommandPath
+
+if (($Args.Count -eq 0) -or ($Args[0] -in @("-h", "--help"))) {
+  Write-Host @"
+Usage: $ScriptName [elixir switches] [compiler switches] [.ex files]
+
+  -h, --help                Prints this message and exits
+  -o                        The directory to output compiled files
+  -v, --version             Prints Elixir version and exits (standalone)
+
+  --ignore-module-conflict  Does not emit warnings if a module was previously defined
+  --no-debug-info           Does not attach debug info to compiled modules
+  --no-docs                 Does not attach documentation to compiled modules
+  --profile time            Profile the time to compile modules
+  --verbose                 Prints compilation status
+  --warnings-as-errors      Treats warnings as errors and returns non-zero exit status
+
+** Options given after -- are passed down to the executed code
+** Options can be passed to the Erlang runtime using ELIXIR_ERL_OPTIONS
+** Options can be passed to the Erlang compiler using ERL_COMPILER_OPTIONS
+"@
+exit
+}
+
+$ScriptPath = Split-Path -Parent $PSCommandPath
+$Command = Join-Path -Path $ScriptPath -ChildPath "elixir.ps1"
+
+$NewArgs = @()
+$NewArgs += "+elixirc"
+
+for ($i = 0; $i -lt $Args.Count; $i++) {
+  $Arg = $Args[$i]
+
+  if ($Arg -is [string]) {
+    $NewArgs += $Arg
+  } else {
+    $NewArgs += [string]::Join(",", $Arg)
+  }
+}
+
+Invoke-Expression "$Command $([string]::Join(" ", $NewArgs))"

--- a/bin/elixirc.ps1
+++ b/bin/elixirc.ps1
@@ -1,10 +1,10 @@
 #!/usr/bin/env pwsh
 
-$ScriptName = Split-Path -Leaf $PSCommandPath
+$scriptName = Split-Path -Leaf $PSCommandPath
 
-if (($Args.Count -eq 0) -or ($Args[0] -in @("-h", "--help"))) {
+if (($args.Count -eq 0) -or ($args[0] -in @("-h", "--help"))) {
   Write-Host @"
-Usage: $ScriptName [elixir switches] [compiler switches] [.ex files]
+Usage: $scriptName [elixir switches] [compiler switches] [.ex files]
 
   -h, --help                Prints this message and exits
   -o                        The directory to output compiled files
@@ -24,7 +24,7 @@ Usage: $ScriptName [elixir switches] [compiler switches] [.ex files]
   exit
 }
 
-$ScriptPath = Split-Path -Parent $PSCommandPath
-$Command = Join-Path -Path $ScriptPath -ChildPath "elixir.ps1"
+$scriptPath = Split-Path -Parent $PSCommandPath
+$command = Join-Path -Path $scriptPath -ChildPath "elixir.ps1"
 
-Invoke-Expression "$Command +elixirc $($Args -join " ")"
+Invoke-Expression "$command +elixirc $($args -join " ")"

--- a/bin/elixirc.ps1
+++ b/bin/elixirc.ps1
@@ -27,4 +27,25 @@ Usage: $scriptName [elixir switches] [compiler switches] [.ex files]
 $scriptPath = Split-Path -Parent $PSCommandPath
 $command = Join-Path -Path $scriptPath -ChildPath "elixir.ps1"
 
-Invoke-Expression "$command +elixirc $($args -join " ")"
+function QuoteString {
+  param(
+    [Parameter(ValueFromPipeline = $true)]
+    [string] $Item
+  )
+
+  # We surround the string with double quotes, in order to preserve its contents as
+  # only one command arg.
+  # This is needed because PowerShell consider spaces as separator of arguments.
+  # The double quotes around will be removed when PowerShell process the argument.
+  # See: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.4#passing-quoted-strings-to-external-commands
+  if ($Item.Contains(" ")) {
+    '"' + $Item + '"'
+  }
+  else {
+    $Item
+  }
+}
+
+$quotedArgs = $args | forEach-Object -Process { QuoteString($_) }
+
+Invoke-Expression "$command +elixirc $($quotedArgs -join " ")"

--- a/bin/elixirc.ps1
+++ b/bin/elixirc.ps1
@@ -25,27 +25,11 @@ Usage: $scriptName [elixir switches] [compiler switches] [.ex files]
 }
 
 $scriptPath = Split-Path -Parent $PSCommandPath
-$command = Join-Path -Path $scriptPath -ChildPath "elixir.ps1"
+$elixirMainScript = Join-Path -Path $scriptPath -ChildPath "elixir.ps1"
 
-function QuoteString {
-  param(
-    [Parameter(ValueFromPipeline = $true)]
-    [string] $Item
-  )
+$prependedArgs = @("+elixirc")
 
-  # We surround the string with double quotes, in order to preserve its contents as
-  # only one command arg.
-  # This is needed because PowerShell consider spaces as separator of arguments.
-  # The double quotes around will be removed when PowerShell process the argument.
-  # See: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.4#passing-quoted-strings-to-external-commands
-  if ($Item.Contains(" ")) {
-    '"' + $Item + '"'
-  }
-  else {
-    $Item
-  }
-}
+$allArgs = $prependedArgs + $args
 
-$quotedArgs = $args | forEach-Object -Process { QuoteString($_) }
-
-Invoke-Expression "$command +elixirc $($quotedArgs -join " ")"
+# The dot is going to evaluate the script with the vars defined here.
+. $elixirMainScript

--- a/bin/elixirc.ps1
+++ b/bin/elixirc.ps1
@@ -19,7 +19,7 @@ Usage: $ScriptName [elixir switches] [compiler switches] [.ex files]
 ** Options can be passed to the Erlang runtime using ELIXIR_ERL_OPTIONS
 ** Options can be passed to the Erlang compiler using ERL_COMPILER_OPTIONS
 "@
-exit
+  exit
 }
 
 $ScriptPath = Split-Path -Parent $PSCommandPath
@@ -33,7 +33,8 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
 
   if ($Arg -is [string]) {
     $NewArgs += $Arg
-  } else {
+  }
+  else {
     $NewArgs += [string]::Join(",", $Arg)
   }
 }

--- a/bin/elixirc.ps1
+++ b/bin/elixirc.ps1
@@ -41,4 +41,4 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
   }
 }
 
-Invoke-Expression "$Command $([string]::Join(" ", $NewArgs))"
+& $Command $NewArgs

--- a/bin/elixirc.ps1
+++ b/bin/elixirc.ps1
@@ -27,18 +27,4 @@ Usage: $ScriptName [elixir switches] [compiler switches] [.ex files]
 $ScriptPath = Split-Path -Parent $PSCommandPath
 $Command = Join-Path -Path $ScriptPath -ChildPath "elixir.ps1"
 
-$NewArgs = @()
-$NewArgs += "+elixirc"
-
-for ($i = 0; $i -lt $Args.Count; $i++) {
-  $Arg = $Args[$i]
-
-  if ($Arg -is [string]) {
-    $NewArgs += $Arg
-  }
-  else {
-    $NewArgs += [string]::Join(",", $Arg)
-  }
-}
-
-& $Command $NewArgs
+Invoke-Expression "$Command +elixirc $($Args -join " ")"

--- a/bin/elixirc.ps1
+++ b/bin/elixirc.ps1
@@ -1,3 +1,5 @@
+#!/usr/bin/env pwsh
+
 $ScriptName = Split-Path -Leaf $PSCommandPath
 
 if (($Args.Count -eq 0) -or ($Args[0] -in @("-h", "--help"))) {

--- a/bin/iex.ps1
+++ b/bin/iex.ps1
@@ -1,0 +1,35 @@
+$ScriptName = Split-Path -Leaf $PSCommandPath
+
+if ($Args[0] -in @("-h", "--help")) {
+  Write-Host @"
+Usage: $ScriptName [options] [.exs file] [data]
+
+The following options are exclusive to IEx:
+
+  --dbg pry           Sets the backend for Kernel.dbg/2 to IEx.pry/0
+  --dot-iex "FILE"    Evaluates FILE, line by line, to set up IEx' environment.
+                      Defaults to evaluating .iex.exs or ~/.iex.exs, if any exists.
+                      If FILE is empty, then no file will be loaded.
+  --remsh NAME        Connects to a node using a remote shell.
+
+It accepts all other options listed by "elixir --help".
+"@
+exit
+}
+
+$ScriptPath = Split-Path -Parent $PSCommandPath
+$Command = Join-Path -Path $ScriptPath -ChildPath "elixir.ps1"
+
+$NewArgs = @("--no-halt", "--erl `"-user elixir`"", "+iex")
+
+for ($i = 0; $i -lt $Args.Count; $i++) {
+  $Arg = $Args[$i]
+
+  if ($Arg -is [string]) {
+    $NewArgs += $Arg
+  } else {
+    $NewArgs += [string]::Join(",", $Arg)
+  }
+}
+
+Invoke-Expression "$Command $([string]::Join(" ", $NewArgs))"

--- a/bin/iex.ps1
+++ b/bin/iex.ps1
@@ -19,27 +19,12 @@ It accepts all other options listed by "elixir --help".
   exit
 }
 
-function QuoteString {
-  param(
-    [Parameter(ValueFromPipeline = $true)]
-    [string] $Item
-  )
-
-  # We surround the string with double quotes, in order to preserve its contents as
-  # only one command arg.
-  # This is needed because PowerShell consider spaces as separator of arguments.
-  # The double quotes around will be removed when PowerShell process the argument.
-  # See: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.4#passing-quoted-strings-to-external-commands
-  if ($Item.Contains(" ")) {
-    '"' + $Item + '"'
-  }
-  else {
-    $Item
-  }
-}
-
 $scriptPath = Split-Path -Parent $PSCommandPath
-$command = Join-Path -Path $scriptPath -ChildPath "elixir.ps1"
-$quotedArgs = $args | forEach-Object -Process { QuoteString($_) }
+$elixirMainScript = Join-Path -Path $scriptPath -ChildPath "elixir.ps1"
 
-Invoke-Expression "$command --no-halt --erl `"-user elixir`" +iex $($quotedArgs -join " ")"
+$prependedArgs = @("--no-halt", "--erl", "-user elixir", "+iex") 
+
+$allArgs = $prependedArgs + $args
+
+# The dot is going to evaluate the script with the vars defined here.
+. $elixirMainScript

--- a/bin/iex.ps1
+++ b/bin/iex.ps1
@@ -1,10 +1,10 @@
 #!/usr/bin/env pwsh
 
-$ScriptName = Split-Path -Leaf $PSCommandPath
+$scriptName = Split-Path -Leaf $PSCommandPath
 
-if ($Args[0] -in @("-h", "--help")) {
+if ($args[0] -in @("-h", "--help")) {
   Write-Host @"
-Usage: $ScriptName [options] [.exs file] [data]
+Usage: $scriptName [options] [.exs file] [data]
 
 The following options are exclusive to IEx:
 
@@ -19,7 +19,7 @@ It accepts all other options listed by "elixir --help".
   exit
 }
 
-$ScriptPath = Split-Path -Parent $PSCommandPath
-$Command = Join-Path -Path $ScriptPath -ChildPath "elixir.ps1"
+$scriptPath = Split-Path -Parent $PSCommandPath
+$command = Join-Path -Path $scriptPath -ChildPath "elixir.ps1"
 
-Invoke-Expression "$Command --no-halt --erl `"-user elixir`" +iex $($Args -join " ")"
+Invoke-Expression "$command --no-halt --erl `"-user elixir`" +iex $($args -join " ")"

--- a/bin/iex.ps1
+++ b/bin/iex.ps1
@@ -35,4 +35,4 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
   }
 }
 
-Invoke-Expression "$Command $([string]::Join(" ", $NewArgs))"
+& $Command $NewArgs

--- a/bin/iex.ps1
+++ b/bin/iex.ps1
@@ -19,7 +19,27 @@ It accepts all other options listed by "elixir --help".
   exit
 }
 
+function QuoteString {
+  param(
+    [Parameter(ValueFromPipeline = $true)]
+    [string] $Item
+  )
+
+  # We surround the string with double quotes, in order to preserve its contents as
+  # only one command arg.
+  # This is needed because PowerShell consider spaces as separator of arguments.
+  # The double quotes around will be removed when PowerShell process the argument.
+  # See: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.4#passing-quoted-strings-to-external-commands
+  if ($Item.Contains(" ")) {
+    '"' + $Item + '"'
+  }
+  else {
+    $Item
+  }
+}
+
 $scriptPath = Split-Path -Parent $PSCommandPath
 $command = Join-Path -Path $scriptPath -ChildPath "elixir.ps1"
+$quotedArgs = $args | forEach-Object -Process { QuoteString($_) }
 
-Invoke-Expression "$command --no-halt --erl `"-user elixir`" +iex $($args -join " ")"
+Invoke-Expression "$command --no-halt --erl `"-user elixir`" +iex $($quotedArgs -join " ")"

--- a/bin/iex.ps1
+++ b/bin/iex.ps1
@@ -14,7 +14,7 @@ The following options are exclusive to IEx:
 
 It accepts all other options listed by "elixir --help".
 "@
-exit
+  exit
 }
 
 $ScriptPath = Split-Path -Parent $PSCommandPath
@@ -27,7 +27,8 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
 
   if ($Arg -is [string]) {
     $NewArgs += $Arg
-  } else {
+  }
+  else {
     $NewArgs += [string]::Join(",", $Arg)
   }
 }

--- a/bin/iex.ps1
+++ b/bin/iex.ps1
@@ -22,17 +22,4 @@ It accepts all other options listed by "elixir --help".
 $ScriptPath = Split-Path -Parent $PSCommandPath
 $Command = Join-Path -Path $ScriptPath -ChildPath "elixir.ps1"
 
-$NewArgs = @("--no-halt", "--erl `"-user elixir`"", "+iex")
-
-for ($i = 0; $i -lt $Args.Count; $i++) {
-  $Arg = $Args[$i]
-
-  if ($Arg -is [string]) {
-    $NewArgs += $Arg
-  }
-  else {
-    $NewArgs += [string]::Join(",", $Arg)
-  }
-}
-
-& $Command $NewArgs
+Invoke-Expression "$Command --no-halt --erl `"-user elixir`" +iex $($Args -join " ")"

--- a/bin/iex.ps1
+++ b/bin/iex.ps1
@@ -1,3 +1,5 @@
+#!/usr/bin/env pwsh
+
 $ScriptName = Split-Path -Leaf $PSCommandPath
 
 if ($Args[0] -in @("-h", "--help")) {

--- a/bin/mix.ps1
+++ b/bin/mix.ps1
@@ -17,4 +17,4 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
   }
 }
 
-Invoke-Expression "$Command $([string]::Join(" ", $NewArgs))"
+& $Command $NewArgs

--- a/bin/mix.ps1
+++ b/bin/mix.ps1
@@ -4,4 +4,25 @@ $scriptPath = Split-Path -Parent $PSCommandPath
 $command = Join-Path -Path $scriptPath -ChildPath "elixir.ps1"
 $mixFile = Join-Path -Path $scriptPath -ChildPath "mix"
 
-Invoke-Expression "$command $mixFile $($args -join " ")"
+function QuoteString {
+  param(
+    [Parameter(ValueFromPipeline = $true)]
+    [string] $Item
+  )
+
+  # We surround the string with double quotes, in order to preserve its contents as
+  # only one command arg.
+  # This is needed because PowerShell consider spaces as separator of arguments.
+  # The double quotes around will be removed when PowerShell process the argument.
+  # See: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.4#passing-quoted-strings-to-external-commands
+  if ($Item.Contains(" ")) {
+    '"' + $Item + '"'
+  }
+  else {
+    $Item
+  }
+}
+
+$quotedArgs = $args | forEach-Object -Process { QuoteString($_) }
+
+Invoke-Expression "$command $mixFile $($quotedArgs -join " ")"

--- a/bin/mix.ps1
+++ b/bin/mix.ps1
@@ -1,28 +1,13 @@
 #!/usr/bin/env pwsh
 
 $scriptPath = Split-Path -Parent $PSCommandPath
-$command = Join-Path -Path $scriptPath -ChildPath "elixir.ps1"
+$elixirMainScript = Join-Path -Path $scriptPath -ChildPath "elixir.ps1"
+
 $mixFile = Join-Path -Path $scriptPath -ChildPath "mix"
 
-function QuoteString {
-  param(
-    [Parameter(ValueFromPipeline = $true)]
-    [string] $Item
-  )
+$prependedArgs = @($mixFile)
 
-  # We surround the string with double quotes, in order to preserve its contents as
-  # only one command arg.
-  # This is needed because PowerShell consider spaces as separator of arguments.
-  # The double quotes around will be removed when PowerShell process the argument.
-  # See: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.4#passing-quoted-strings-to-external-commands
-  if ($Item.Contains(" ")) {
-    '"' + $Item + '"'
-  }
-  else {
-    $Item
-  }
-}
+$allArgs = $prependedArgs + $args
 
-$quotedArgs = $args | forEach-Object -Process { QuoteString($_) }
-
-Invoke-Expression "$command $mixFile $($quotedArgs -join " ")"
+# The dot is going to evaluate the script with the vars defined here.
+. $elixirMainScript

--- a/bin/mix.ps1
+++ b/bin/mix.ps1
@@ -2,19 +2,6 @@
 
 $ScriptPath = Split-Path -Parent $PSCommandPath
 $Command = Join-Path -Path $ScriptPath -ChildPath "elixir.ps1"
-$MixCommand = Join-Path -Path $ScriptPath -ChildPath "mix"
+$MixFile = Join-Path -Path $ScriptPath -ChildPath "mix"
 
-$NewArgs = @($MixCommand)
-
-for ($i = 0; $i -lt $Args.Count; $i++) {
-  $Arg = $Args[$i]
-
-  if ($Arg -is [string]) {
-    $NewArgs += $Arg
-  }
-  else {
-    $NewArgs += [string]::Join(",", $Arg)
-  }
-}
-
-& $Command $NewArgs
+Invoke-Expression "$Command $MixFile $($Args -join " ")"

--- a/bin/mix.ps1
+++ b/bin/mix.ps1
@@ -1,3 +1,5 @@
+#!/usr/bin/env pwsh
+
 $ScriptPath = Split-Path -Parent $PSCommandPath
 $Command = Join-Path -Path $ScriptPath -ChildPath "elixir.ps1"
 $MixCommand = Join-Path -Path $ScriptPath -ChildPath "mix"

--- a/bin/mix.ps1
+++ b/bin/mix.ps1
@@ -1,23 +1,17 @@
-# Store path to mix.bat as a FileInfo object
-$mixBatPath = (Get-ChildItem (((Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName) + '\mix.bat'))
-$newArgs = @()
+$ScriptPath = Split-Path -Parent $PSCommandPath
+$Command = Join-Path -Path $ScriptPath -ChildPath "elixir.ps1"
+$MixCommand = Join-Path -Path $ScriptPath -ChildPath "mix"
 
-for ($i = 0; $i -lt $args.length; $i++)
-{
-  if ($args[$i] -is [array])
-  {
-    # Commas created the array so we need to reintroduce those commas
-    for ($j = 0; $j -lt $args[$i].length - 1; $j++)
-    {
-      $newArgs += ($args[$i][$j] + ',')
-    }
-    $newArgs += $args[$i][-1]
-  }
-  else
-  {
-    $newArgs += $args[$i]
+$NewArgs = @($MixCommand)
+
+for ($i = 0; $i -lt $Args.Count; $i++) {
+  $Arg = $Args[$i]
+
+  if ($Arg -is [string]) {
+    $NewArgs += $Arg
+  } else {
+    $NewArgs += [string]::Join(",", $Arg)
   }
 }
 
-# Corrected arguments are ready to pass to batch file
-& $mixBatPath $newArgs
+Invoke-Expression "$Command $([string]::Join(" ", $NewArgs))"

--- a/bin/mix.ps1
+++ b/bin/mix.ps1
@@ -9,7 +9,8 @@ for ($i = 0; $i -lt $Args.Count; $i++) {
 
   if ($Arg -is [string]) {
     $NewArgs += $Arg
-  } else {
+  }
+  else {
     $NewArgs += [string]::Join(",", $Arg)
   }
 }

--- a/bin/mix.ps1
+++ b/bin/mix.ps1
@@ -1,7 +1,7 @@
 #!/usr/bin/env pwsh
 
-$ScriptPath = Split-Path -Parent $PSCommandPath
-$Command = Join-Path -Path $ScriptPath -ChildPath "elixir.ps1"
-$MixFile = Join-Path -Path $ScriptPath -ChildPath "mix"
+$scriptPath = Split-Path -Parent $PSCommandPath
+$command = Join-Path -Path $scriptPath -ChildPath "elixir.ps1"
+$mixFile = Join-Path -Path $scriptPath -ChildPath "mix"
 
-Invoke-Expression "$Command $MixFile $($Args -join " ")"
+Invoke-Expression "$command $mixFile $($args -join " ")"

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -33,7 +33,13 @@ defmodule Retry do
 end
 
 defmodule Kernel.CLITest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case,
+    async: true,
+    parameterize:
+      if(PathHelpers.windows?(),
+        do: [%{cli_extension: ".bat"}, %{cli_extension: ".ps1"}],
+        else: [%{cli_extension: ""}, %{cli_extension: ".ps1"}]
+      )
 
   import ExUnit.CaptureIO
 
@@ -62,7 +68,15 @@ defmodule Kernel.CLITest do
 end
 
 defmodule Kernel.CLI.ExecutableTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case,
+    async: true,
+    parameterize:
+      if(PathHelpers.windows?(),
+        do: [%{cli_extension: ".bat"}, %{cli_extension: ".ps1"}],
+        else:
+          [%{cli_extension: ""}] ++
+            if(System.find_executable("pwsh"), do: [%{cli_extension: ".ps1"}], else: [])
+      )
 
   import Retry
 
@@ -70,78 +84,89 @@ defmodule Kernel.CLI.ExecutableTest do
   test "file smoke test", context do
     file = Path.join(context.tmp_dir, "hello_world!.exs")
     File.write!(file, "IO.puts :hello_world123")
-    {output, 0} = System.cmd(elixir_executable(), [file])
+    {output, 0} = System.cmd(elixir_executable(context.cli_extension), [file])
     assert output =~ "hello_world123"
   end
 
-  test "--eval smoke test" do
-    {output, 0} = System.cmd(elixir_executable(), ["--eval", "IO.puts :hello_world123"])
+  test "--eval smoke test", context do
+    {output, 0} =
+      System.cmd(elixir_executable(context.cli_extension), ["--eval", "IO.puts :hello_world123"])
+
     assert output =~ "hello_world123"
 
     # Check for -e and exclamation mark handling on Windows
-    assert {_output, 0} = System.cmd(elixir_executable(), ["-e", "Time.new!(0, 0, 0)"])
+    assert {_output, 0} =
+             System.cmd(elixir_executable(context.cli_extension), ["-e", "Time.new!(0, 0, 0)"])
 
     # TODO: remove this once we bump CI to 26.3
     unless windows?() and System.otp_release() == "26" do
       {output, 0} =
-        System.cmd(iex_executable(), ["--eval", "IO.puts :hello_world123; System.halt()"])
+        System.cmd(iex_executable(context.cli_extension), [
+          "--eval",
+          "IO.puts :hello_world123; System.halt()"
+        ])
 
       assert output =~ "hello_world123"
 
-      {output, 0} = System.cmd(iex_executable(), ["-e", "IO.puts :hello_world123; System.halt()"])
+      {output, 0} =
+        System.cmd(iex_executable(context.cli_extension), [
+          "-e",
+          "IO.puts :hello_world123; System.halt()"
+        ])
+
       assert output =~ "hello_world123"
     end
   end
 
-  test "--version smoke test" do
-    output = elixir(~c"--version")
+  test "--version smoke test", %{cli_extension: cli_extension} do
+    output = elixir(~c"--version", cli_extension)
     assert output =~ "Erlang/OTP #{System.otp_release()}"
     assert output =~ "Elixir #{System.version()}"
 
-    output = iex(~c"--version")
+    output = iex(~c"--version", cli_extension)
     assert output =~ "Erlang/OTP #{System.otp_release()}"
     assert output =~ "IEx #{System.version()}"
 
-    output = elixir(~c"--version -e \"IO.puts(:test_output)\"")
+    output = elixir(~c"--version -e \"IO.puts(:test_output)\"", cli_extension)
     assert output =~ "Erlang/OTP #{System.otp_release()}"
     assert output =~ "Elixir #{System.version()}"
     assert output =~ "Standalone options can't be combined with other options"
   end
 
-  test "--short-version smoke test" do
-    output = elixir(~c"--short-version")
+  test "--short-version smoke test", %{cli_extension: cli_extension} do
+    output = elixir(~c"--short-version", cli_extension)
     assert output =~ System.version()
     refute output =~ "Erlang"
   end
 
-  stderr_test "--help smoke test" do
-    output = elixir(~c"--help")
+  stderr_test "--help smoke test", %{cli_extension: cli_extension} do
+    output = elixir(~c"--help", cli_extension)
     assert output =~ "Usage: elixir"
   end
 
-  stderr_test "combining --help results in error" do
-    output = elixir(~c"-e 1 --help")
+  stderr_test "combining --help results in error", %{cli_extension: cli_extension} do
+    output = elixir(~c"-e 1 --help", cli_extension)
     assert output =~ "--help : Standalone options can't be combined with other options"
 
-    output = elixir(~c"--help -e 1")
+    output = elixir(~c"--help -e 1", cli_extension)
     assert output =~ "--help : Standalone options can't be combined with other options"
   end
 
-  stderr_test "combining --short-version results in error" do
-    output = elixir(~c"--short-version -e 1")
+  stderr_test "combining --short-version results in error", %{cli_extension: cli_extension} do
+    output = elixir(~c"--short-version -e 1", cli_extension)
     assert output =~ "--short-version : Standalone options can't be combined with other options"
 
-    output = elixir(~c"-e 1 --short-version")
+    output = elixir(~c"-e 1 --short-version", cli_extension)
     assert output =~ "--short-version : Standalone options can't be combined with other options"
   end
 
-  test "parses paths" do
+  test "parses paths", %{cli_extension: cli_extension} do
     root = fixture_path("../../..") |> to_charlist
 
     args =
       ~c"-pa \"#{root}/*\" -pz \"#{root}/lib/*\" -e \"IO.inspect(:code.get_path(), limit: :infinity)\""
 
-    list = elixir(args)
+    list = elixir(args, cli_extension)
     {path, _} = Code.eval_string(list, [])
 
     # pa
@@ -153,25 +178,31 @@ defmodule Kernel.CLI.ExecutableTest do
     assert to_charlist(Path.expand(~c"lib/list", root)) in path
   end
 
-  stderr_test "formats errors" do
-    assert String.starts_with?(elixir(~c"-e \":erlang.throw 1\""), "** (throw) 1")
+  stderr_test "formats errors", %{cli_extension: cli_extension} do
+    assert String.starts_with?(elixir(~c"-e \":erlang.throw 1\"", cli_extension), "** (throw) 1")
 
     assert String.starts_with?(
-             elixir(~c"-e \":erlang.error 1\""),
+             elixir(~c"-e \":erlang.error 1\"", cli_extension),
              "** (ErlangError) Erlang error: 1"
            )
 
-    assert String.starts_with?(elixir(~c"-e \"1 +\""), "** (TokenMissingError)")
+    assert String.starts_with?(elixir(~c"-e \"1 +\"", cli_extension), "** (TokenMissingError)")
 
-    assert elixir(~c"-e \"Task.async(fn -> raise ArgumentError end) |> Task.await\"") =~
+    assert elixir(
+             ~c"-e \"Task.async(fn -> raise ArgumentError end) |> Task.await\"",
+             cli_extension
+           ) =~
              "an exception was raised:\n    ** (ArgumentError) argument error"
 
-    assert elixir(~c"-e \"IO.puts(Process.flag(:trap_exit, false)); exit({:shutdown, 1})\"") ==
+    assert elixir(
+             ~c"-e \"IO.puts(Process.flag(:trap_exit, false)); exit({:shutdown, 1})\"",
+             cli_extension
+           ) ==
              "false\n"
   end
 
-  stderr_test "blames exceptions" do
-    error = elixir(~c"-e \"Access.fetch :foo, :bar\"")
+  stderr_test "blames exceptions", %{cli_extension: cli_extension} do
+    error = elixir(~c"-e \"Access.fetch :foo, :bar\"", cli_extension)
     assert error =~ "** (FunctionClauseError) no function clause matching in Access.fetch/2"
     assert error =~ "The following arguments were given to Access.fetch/2"
     assert error =~ ":foo"
@@ -238,7 +269,15 @@ defmodule Kernel.CLI.RPCTest do
 end
 
 defmodule Kernel.CLI.CompileTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case,
+    async: true,
+    parameterize:
+      if(PathHelpers.windows?(),
+        do: [%{cli_extension: ".bat"}, %{cli_extension: ".ps1"}],
+        else:
+          [%{cli_extension: ""}] ++
+            if(System.find_executable("pwsh"), do: [%{cli_extension: ".ps1"}], else: [])
+      )
 
   import Retry
   @moduletag :tmp_dir
@@ -250,7 +289,7 @@ defmodule Kernel.CLI.CompileTest do
   end
 
   test "compiles code", context do
-    assert elixirc(~c"#{context.fixture} -o #{context.tmp_dir}") == ""
+    assert elixirc(~c"#{context.fixture} -o #{context.tmp_dir}", context.cli_extension) == ""
     assert File.regular?(context.beam_file_path)
 
     # Assert that the module is loaded into memory with the proper destination for the BEAM file.
@@ -267,7 +306,7 @@ defmodule Kernel.CLI.CompileTest do
     try do
       fixture = String.replace(context.fixture, "/", "\\")
       tmp_dir_path = String.replace(context.tmp_dir, "/", "\\")
-      assert elixirc(~c"#{fixture} -o #{tmp_dir_path}") == ""
+      assert elixirc(~c"#{fixture} -o #{tmp_dir_path}", context.cli_extension) == ""
       assert File.regular?(context[:beam_file_path])
 
       # Assert that the module is loaded into memory with the proper destination for the BEAM file.
@@ -283,7 +322,9 @@ defmodule Kernel.CLI.CompileTest do
   end
 
   stderr_test "fails on missing patterns", context do
-    output = elixirc(~c"#{context.fixture} non_existing.ex -o #{context.tmp_dir}")
+    output =
+      elixirc(~c"#{context.fixture} non_existing.ex -o #{context.tmp_dir}", context.cli_extension)
+
     assert output =~ "non_existing.ex"
     refute output =~ "compile_sample.ex"
     refute File.exists?(context.beam_file_path)
@@ -292,7 +333,7 @@ defmodule Kernel.CLI.CompileTest do
   stderr_test "fails on missing write access to .beam file", context do
     compilation_args = ~c"#{context.fixture} -o #{context.tmp_dir}"
 
-    assert elixirc(compilation_args) == ""
+    assert elixirc(compilation_args, context.cli_extension) == ""
     assert File.regular?(context.beam_file_path)
 
     # Set the .beam file to read-only
@@ -301,7 +342,7 @@ defmodule Kernel.CLI.CompileTest do
 
     # Can only assert when read-only applies to the user
     if access != :read_write do
-      output = elixirc(compilation_args)
+      output = elixirc(compilation_args, context.cli_extension)
 
       expected =
         "(File.Error) could not write to file #{inspect(context.beam_file_path)}: permission denied"

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -63,7 +63,7 @@ end
 
 test_parameters =
   if(PathHelpers.windows?(),
-    do: [%{cli_extension: ".bat"}, %{cli_extension: ".ps1"}],
+    do: [%{cli_extension: ".bat"}],
     else:
       [%{cli_extension: ""}] ++
         if(System.find_executable("pwsh"), do: [%{cli_extension: ".ps1"}], else: [])

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -33,13 +33,7 @@ defmodule Retry do
 end
 
 defmodule Kernel.CLITest do
-  use ExUnit.Case,
-    async: true,
-    parameterize:
-      if(PathHelpers.windows?(),
-        do: [%{cli_extension: ".bat"}, %{cli_extension: ".ps1"}],
-        else: [%{cli_extension: ""}, %{cli_extension: ".ps1"}]
-      )
+  use ExUnit.Case, async: true
 
   import ExUnit.CaptureIO
 
@@ -67,16 +61,18 @@ defmodule Kernel.CLITest do
   end
 end
 
+test_parameters =
+  if(PathHelpers.windows?(),
+    do: [%{cli_extension: ".bat"}, %{cli_extension: ".ps1"}],
+    else:
+      [%{cli_extension: ""}] ++
+        if(System.find_executable("pwsh"), do: [%{cli_extension: ".ps1"}], else: [])
+  )
+
 defmodule Kernel.CLI.ExecutableTest do
   use ExUnit.Case,
     async: true,
-    parameterize:
-      if(PathHelpers.windows?(),
-        do: [%{cli_extension: ".bat"}, %{cli_extension: ".ps1"}],
-        else:
-          [%{cli_extension: ""}] ++
-            if(System.find_executable("pwsh"), do: [%{cli_extension: ".ps1"}], else: [])
-      )
+    parameterize: test_parameters
 
   import Retry
 
@@ -271,13 +267,7 @@ end
 defmodule Kernel.CLI.CompileTest do
   use ExUnit.Case,
     async: true,
-    parameterize:
-      if(PathHelpers.windows?(),
-        do: [%{cli_extension: ".bat"}, %{cli_extension: ".ps1"}],
-        else:
-          [%{cli_extension: ""}] ++
-            if(System.find_executable("pwsh"), do: [%{cli_extension: ".ps1"}], else: [])
-      )
+    parameterize: test_parameters
 
   import Retry
   @moduletag :tmp_dir

--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -23,28 +23,28 @@ defmodule PathHelpers do
     Path.join(tmp_path(), extra)
   end
 
-  def elixir(args) do
-    run_cmd(elixir_executable(), args)
+  def elixir(args, executable_extension \\ "") do
+    run_cmd(elixir_executable(executable_extension), args)
   end
 
-  def elixir_executable do
-    executable_path("elixir")
+  def elixir_executable(extension \\ "") do
+    executable_path("elixir", extension)
   end
 
-  def elixirc(args) do
-    run_cmd(elixirc_executable(), args)
+  def elixirc(args, executable_extension \\ "") do
+    run_cmd(elixirc_executable(executable_extension), args)
   end
 
-  def elixirc_executable do
-    executable_path("elixirc")
+  def elixirc_executable(extension \\ "") do
+    executable_path("elixirc", extension)
   end
 
-  def iex(args) do
-    run_cmd(iex_executable(), args)
+  def iex(args, executable_extension \\ "") do
+    run_cmd(iex_executable(executable_extension), args)
   end
 
-  def iex_executable do
-    executable_path("iex")
+  def iex_executable(extension \\ "") do
+    executable_path("iex", extension)
   end
 
   def write_beam({:module, name, bin, _} = res) do
@@ -60,8 +60,8 @@ defmodule PathHelpers do
     |> :unicode.characters_to_binary()
   end
 
-  defp executable_path(name) do
-    Path.expand("../../../../bin/#{name}#{executable_extension()}", __DIR__)
+  defp executable_path(name, extension) do
+    Path.expand("../../../../bin/#{name}#{extension}", __DIR__)
   end
 
   if match?({:win32, _}, :os.type()) do


### PR DESCRIPTION
This is the first step to replace _BAT_ scripts for Windows.

PowerShell works on Linux and MacOS too, so the scripts are supporting those systems as well.
~~The only requirement is that users have at least the version 7.2 LTS.~~

This feature was previously discussed with @josevalim :)

PS: I ran the test suite using "bin/elixir.ps1" in the `lib/mix/test/test_helper.exs` file (`elixir_executable` fun), and it's working good. I was not able to build and run on Windows yet, but the commands using the `ELIXIR_CLI_DRY_RUN` env var seems to be correct there :)