### PR TITLE
Correctly Macro.escape :quote triplet without meta

### DIFF
--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -263,7 +263,7 @@ quote(Expr, Q) ->
 
 %% quote/unquote
 
-do_quote({quote, Meta, [Arg]}, Q) ->
+do_quote({quote, Meta, [Arg]}, Q) when is_list(Meta) ->
   TArg = do_quote(Arg, Q#elixir_quote{unquote=false}),
 
   NewMeta = case Q of
@@ -273,7 +273,7 @@ do_quote({quote, Meta, [Arg]}, Q) ->
 
   {'{}', [], [quote, meta(NewMeta, Q), [TArg]]};
 
-do_quote({quote, Meta, [Opts, Arg]}, Q) ->
+do_quote({quote, Meta, [Opts, Arg]}, Q) when is_list(Meta) ->
   TOpts = do_quote(Opts, Q),
   TArg = do_quote(Arg, Q#elixir_quote{unquote=false}),
 
@@ -539,9 +539,7 @@ update_last([H | T], F) -> [H | update_last(T, F)].
 keyfind(Key, Meta) ->
   lists:keyfind(Key, 1, Meta).
 keydelete(Key, Meta) when is_list(Meta) ->
-  lists:keydelete(Key, 1, Meta);
-keydelete(_Key, Meta) ->
-  Meta.
+  lists:keydelete(Key, 1, Meta).
 keystore(_Key, Meta, nil) ->
   Meta;
 keystore(Key, Meta, Value) ->

--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -139,7 +139,7 @@ escape(Expr, Op, Unquote) ->
     unquote=Unquote
   }).
 
-do_escape({Left, Meta, Right}, #elixir_quote{op=prune_metadata} = Q) ->
+do_escape({Left, Meta, Right}, #elixir_quote{op=prune_metadata} = Q) when is_list(Meta) ->
   TM = [{K, V} || {K, V} <- Meta, (K == no_parens) orelse (K == line)],
   TL = do_quote(Left, Q),
   TR = do_quote(Right, Q),
@@ -284,13 +284,13 @@ do_quote({quote, Meta, [Opts, Arg]}, Q) when is_list(Meta) ->
 
   {'{}', [], [quote, meta(NewMeta, Q), [TOpts, TArg]]};
 
-do_quote({unquote, _Meta, [Expr]}, #elixir_quote{unquote=true}) ->
+do_quote({unquote, Meta, [Expr]}, #elixir_quote{unquote=true}) when is_list(Meta) ->
   Expr;
 
 %% Aliases
 
 do_quote({'__aliases__', Meta, [H | T]}, #elixir_quote{aliases_hygiene=(#{}=E)} = Q)
-    when is_atom(H), H /= 'Elixir' ->
+     when is_list(Meta), is_atom(H), H /= 'Elixir' ->
   Annotation =
     case elixir_aliases:expand(Meta, [H | T], E, true) of
       Atom when is_atom(Atom) -> Atom;
@@ -312,16 +312,16 @@ do_quote({Name, Meta, nil}, #elixir_quote{op=add_context} = Q)
 
 %% Unquote
 
-do_quote({{{'.', Meta, [Left, unquote]}, _, [Expr]}, _, Args}, #elixir_quote{unquote=true} = Q) ->
+do_quote({{{'.', Meta, [Left, unquote]}, _, [Expr]}, _, Args}, #elixir_quote{unquote=true} = Q) when is_list(Meta) ->
   do_quote_call(Left, Meta, Expr, Args, Q);
 
-do_quote({{'.', Meta, [Left, unquote]}, _, [Expr]}, #elixir_quote{unquote=true} = Q) ->
+do_quote({{'.', Meta, [Left, unquote]}, _, [Expr]}, #elixir_quote{unquote=true} = Q) when is_list(Meta) ->
   do_quote_call(Left, Meta, Expr, nil, Q);
 
 %% Imports
 
 do_quote({'&', Meta, [{'/', _, [{F, _, C}, A]}] = Args},
-  #elixir_quote{imports_hygiene=(#{}=E)} = Q) when is_atom(F), is_integer(A), is_atom(C) ->
+  #elixir_quote{imports_hygiene=(#{}=E)} = Q) when is_atom(F), is_integer(A), is_atom(C), is_list(Meta) ->
   NewMeta =
     case elixir_dispatch:find_import(Meta, F, A, E) of
       false ->
@@ -538,7 +538,7 @@ update_last([H | T], F) -> [H | update_last(T, F)].
 
 keyfind(Key, Meta) ->
   lists:keyfind(Key, 1, Meta).
-keydelete(Key, Meta) when is_list(Meta) ->
+keydelete(Key, Meta) ->
   lists:keydelete(Key, 1, Meta).
 keystore(_Key, Meta, nil) ->
   Meta;

--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -538,8 +538,10 @@ update_last([H | T], F) -> [H | update_last(T, F)].
 
 keyfind(Key, Meta) ->
   lists:keyfind(Key, 1, Meta).
-keydelete(Key, Meta) ->
-  lists:keydelete(Key, 1, Meta).
+keydelete(Key, Meta) when is_list(Meta) ->
+  lists:keydelete(Key, 1, Meta);
+keydelete(_Key, Meta) ->
+  Meta.
 keystore(_Key, Meta, nil) ->
   Meta;
 keystore(Key, Meta, Value) ->

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -37,7 +37,7 @@ defmodule MacroTest do
       assert Macro.escape({:a, :b, :c}) == {:{}, [], [:a, :b, :c]}
       assert Macro.escape({:a, {1, 2, 3}, :c}) == {:{}, [], [:a, {:{}, [], [1, 2, 3]}, :c]}
 
-    # False positives
+      # False positives
       assert Macro.escape({:quote, :foo, [:bar]}) == {:{}, [], [:quote, :foo, [:bar]]}
       assert Macro.escape({:quote, :foo, [:bar, :baz]}) == {:{}, [], [:quote, :foo, [:bar, :baz]]}
     end

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -38,6 +38,11 @@ defmodule MacroTest do
       assert Macro.escape({:a, {1, 2, 3}, :c}) == {:{}, [], [:a, {:{}, [], [1, 2, 3]}, :c]}
     end
 
+    test "correctly escapes tuples where the first element is :quote" do
+      assert Macro.escape({:quote, :foo, [:bar]}) == {:{}, [], [:quote, :foo, [:bar]]}
+      assert Macro.escape({:quote, :foo, [:bar, :baz]}) == {:{}, [], [:quote, :foo, [:bar, :baz]]}
+    end
+
     test "escapes maps" do
       assert Macro.escape(%{a: 1}) == {:%{}, [], [a: 1]}
     end

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -36,9 +36,8 @@ defmodule MacroTest do
       assert Macro.escape({:a}) == {:{}, [], [:a]}
       assert Macro.escape({:a, :b, :c}) == {:{}, [], [:a, :b, :c]}
       assert Macro.escape({:a, {1, 2, 3}, :c}) == {:{}, [], [:a, {:{}, [], [1, 2, 3]}, :c]}
-    end
 
-    test "correctly escapes tuples where the first element is :quote" do
+    # False positives
       assert Macro.escape({:quote, :foo, [:bar]}) == {:{}, [], [:quote, :foo, [:bar]]}
       assert Macro.escape({:quote, :foo, [:bar, :baz]}) == {:{}, [], [:quote, :foo, [:bar, :baz]]}
     end


### PR DESCRIPTION
Attempts to solve #13593 
Attempts to solve an issue that causes `Macro.escape/2` to crash when
given certain tuples.

Note that, as discussed in the reported issue, `Macro.escape({:quote, [column: 10], [:foo]})` still produces
: `{:{}, [], [:quote, [], [:foo]]}` which is arguably wrong.