### PR TITLE
Generate cover HTML files in parallel

### DIFF
--- a/lib/mix/lib/mix/tasks/test.coverage.ex
+++ b/lib/mix/lib/mix/tasks/test.coverage.ex
@@ -290,9 +290,9 @@ defmodule Mix.Tasks.Test.Coverage do
 
     modules
     |> Enum.map(fn mod ->
-      :cover.async_analyse_to_file(mod, ~c"#{output}/#{mod}.html", [:html])
+      pid = :cover.async_analyse_to_file(mod, ~c"#{output}/#{mod}.html", [:html])
+      Process.monitor(pid)
     end)
-    |> Enum.map(&Process.monitor/1)
     |> Enum.each(fn ref ->
       receive do
         {:DOWN, ^ref, :process, _pid, _reason} ->


### PR DESCRIPTION
Today the coverage HTML files are generated one at a time using `:cover.analyse_to_file`.

This PR changes this code to use `:cover.async_analyse_to_file` to generate the files in parallel, speeding up the coverage report. 

On a M1 in a project with 1k modules, the time to generate the HTML files went from 4 seconds to 1.2 seconds.