### PR TITLE
implement dbg for if expressions

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2643,11 +2643,12 @@ defmodule Macro do
   end
 
   defp dbg_ast_to_debuggable({:if, _meta, [condition_ast, _clauses]} = ast, env) do
-    if get_in(env.macros, [
-         Access.find(&(elem(&1, 0) == Kernel)),
-         Access.elem(1),
-         :if
-       ]) == 2 do
+    if_from_kernel? =
+      for {Kernel, macros} <- env.macros, {:if, 2} <- macros do
+        true
+      end == [true]
+
+    if if_from_kernel? do
       quote do
         condition_result = unquote(condition_ast)
         result = unquote(ast)

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2642,14 +2642,17 @@ defmodule Macro do
     end
   end
 
-  defp dbg_ast_to_debuggable({:if, _meta, [condition_ast, _clauses]} = ast, env) do
+  defp dbg_ast_to_debuggable({:if, meta, [condition_ast, clauses]} = ast, env) do
     case Macro.Env.lookup_import(env, {:if, 2}) do
       [macro: Kernel] ->
-        quote do
-          condition_result = unquote(condition_ast)
-          result = if condition_result, unquote(clauses)
+        condition_result_var = unique_var(:condition_result, __MODULE__)
 
-          {:if, unquote(escape(ast)), unquote(escape(condition_ast)), condition_result, result}
+        quote do
+          unquote(condition_result_var) = unquote(condition_ast)
+          result = unquote({:if, meta, [condition_result_var, clauses]})
+
+          {:if, unquote(escape(ast)), unquote(escape(condition_ast)),
+           unquote(condition_result_var), result}
         end
 
       _ ->

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2647,7 +2647,7 @@ defmodule Macro do
       [macro: Kernel] ->
         quote do
           condition_result = unquote(condition_ast)
-          result = unquote(ast)
+          result = if condition_result, unquote(clauses)
 
           {:if, unquote(escape(ast)), unquote(escape(condition_ast)), condition_result, result}
         end

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2642,6 +2642,15 @@ defmodule Macro do
     end
   end
 
+  defp dbg_ast_to_debuggable({:if, _meta, [condition_ast, _clauses]} = ast) do
+    quote do
+      condition_result = unquote(condition_ast)
+      result = unquote(ast)
+
+      {:if, unquote(escape(ast)), unquote(escape(condition_ast)), condition_result, result}
+    end
+  end
+
   # Any other AST.
   defp dbg_ast_to_debuggable(ast) do
     quote do: {:value, unquote(escape(ast)), unquote(ast)}
@@ -2753,6 +2762,23 @@ defmodule Macro do
     ]
 
     {formatted, value}
+  end
+
+  defp dbg_format_ast_to_debug(
+         {:if, ast, condition_ast, condition_result, result},
+         options
+       ) do
+    formatted = [
+      dbg_maybe_underline("If condition", options),
+      ":\n",
+      dbg_format_ast_with_value(condition_ast, condition_result, options),
+      ?\n,
+      dbg_maybe_underline("If expression", options),
+      " (#{if result, do: "do", else: "else"} clause executed):\n",
+      dbg_format_ast_with_value(ast, result, options)
+    ]
+
+    {formatted, result}
   end
 
   defp dbg_format_ast_to_debug({:value, code_ast, value}, options) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -15,6 +15,12 @@ defmodule Macro.ExternalTest do
   end
 end
 
+defmodule CustomIf do
+  def if(_cond, _expr) do
+    "custom if result"
+  end
+end
+
 defmodule MacroTest do
   use ExUnit.Case, async: true
   doctest Macro
@@ -589,6 +595,26 @@ defmodule MacroTest do
              if false and x do
                map[:a] * 2
              end #=> nil
+             """
+    end
+
+    test "custom if definition" do
+      import Kernel, except: [if: 2]
+      import CustomIf, only: [if: 2]
+
+      {result, formatted} =
+        dbg_format(
+          if true do
+            "something"
+          end
+        )
+
+      assert result == "custom if result"
+
+      assert formatted =~ """
+             if true do
+               "something"
+             end #=> "custom if result"
              """
     end
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -563,7 +563,7 @@ defmodule MacroTest do
              If condition:
              true and x #=> true
 
-             If expression (do clause executed):
+             If expression:
              if true and x do
                map[:a] * 2
              else
@@ -591,7 +591,7 @@ defmodule MacroTest do
              If condition:
              false and x #=> false
 
-             If expression (else clause executed):
+             If expression:
              if false and x do
                map[:a] * 2
              end #=> nil

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -536,6 +536,62 @@ defmodule MacroTest do
              """
     end
 
+    test "if statement" do
+      x = true
+      map = %{a: 5, b: 1}
+
+      {result, formatted} =
+        dbg_format(
+          if true and x do
+            map[:a] * 2
+          else
+            map[:b]
+          end
+        )
+
+      assert result == 10
+
+      assert formatted =~ "macro_test.exs"
+
+      assert formatted =~ """
+             If condition:
+             true and x #=> true
+
+             If expression (do clause executed):
+             if true and x do
+               map[:a] * 2
+             else
+               map[:b]
+             end #=> 10
+             """
+    end
+
+    test "if statement without else" do
+      x = true
+      map = %{a: 5, b: 1}
+
+      {result, formatted} =
+        dbg_format(
+          if false and x do
+            map[:a] * 2
+          end
+        )
+
+      assert result == nil
+
+      assert formatted =~ "macro_test.exs"
+
+      assert formatted =~ """
+             If condition:
+             false and x #=> false
+
+             If expression (else clause executed):
+             if false and x do
+               map[:a] * 2
+             end #=> nil
+             """
+    end
+
     test "with \"syntax_colors: []\" it doesn't print any color sequences" do
       {_result, formatted} = dbg_format("hello")
       refute formatted =~ "\e["


### PR DESCRIPTION
Dbg currently is not showing any bindings when executed on if statement so it's very hard to guess what's going on:
```elixir
if a do
  b
else
  c
end #=> 2
```
This pr extends dbg to support if statements:
```elixir
 If condition:
 true and x #=> true
 
 If expression (do clause executed):
 if true and x do
     map[:a] * 2
 else
    map[:b]
 end #=> 10
 ```
 I proposed this on [elixir forum](https://elixirforum.com/t/dbg-block-and-better-dbg-for-case-if-with/63477) with other tweaks to dbg, but did not get any answers.