### PR TITLE
Implement `Duration.to_iso8601/1`

### DIFF
--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -286,6 +286,8 @@ defmodule Duration do
     }
   end
 
+  @doc since: "1.7.1"
+
   @doc """
   Parses an ISO 8601 formatted duration string to a `Duration` struct.
 
@@ -335,35 +337,40 @@ defmodule Duration do
   end
 
   @doc """
-  Converts the given duration to ISO 8601:TODO format.
+  Converts the given duration to [ISO 8601-2:2019](https://en.wikipedia.org/wiki/ISO_8601) format.
+
+  Note this function implements the *extension* of ISO 8601:2019. This extensions allows weeks to
+  appear in any case, which is not the case in the base standard. `"P3M3W"` is not allowed in
+  ISO 8601-1, but it is in ISO 8601-2. Thus, any duration can be output by this function.
 
   ## Examples
 
-  iex> Duration.new!([]) |> Duration.to_iso8601()
-  "PT0S"
-  iex> Duration.new!(year: 3) |> Duration.to_iso8601()
-  "P3Y"
-  iex> Duration.new!(year: 3, day: 6, minute: 9) |> Duration.to_iso8601()
-  "P3Y6DT9M"
-  iex> Duration.new!(second: 30) |> Duration.to_iso8601()
-  "PT30S"
+      iex> Duration.new!(year: 3) |> Duration.to_iso8601()
+      "P3Y"
+      iex> Duration.new!(day: 28, hour: 6, minute: 42, second: 12) |> Duration.to_iso8601()
+      "P28DT6H42M12S"
+      iex> Duration.new!(second: 30) |> Duration.to_iso8601()
+      "PT30S"
+      iex> Duration.new!(second: 30) |> Duration.multiply(-1) |> Duration.to_iso8601()
+      "PT-30S"
+      iex> Duration.new!([]) |> Duration.to_iso8601()
+      "PT0S"
 
-  iex> Duration.new!(day: 28, hour: 6, minute: 42, second: 12) |> Duration.multiply(-1) |> Duration.to_iso8601()
-  "P-28DT-6H-42M-12S"
-
-  iex> Duration.new!(hour: 2, microsecond: {2, 6}) |> Duration.to_iso8601()
-  "PT2H0.000002S"
-  iex> Duration.new!(hour: 2, microsecond: {2, 3}) |> Duration.to_iso8601()
-  "PT2H0.000S"
-  iex> Duration.new!(hour: 2, microsecond: {2, 0}) |> Duration.to_iso8601()
-  "PT2H"
-  iex> Duration.new!(microsecond: {2, 0}) |> Duration.to_iso8601()
-  "PT0S"
-  iex> Duration.new!(microsecond: {1_000_000, 6}) |> Duration.to_iso8601()
-  "PT1S"
+      iex> Duration.new!(hour: 2, microsecond: {2, 6}) |> Duration.to_iso8601()
+      "PT2H0.000002S"
+      iex> Duration.new!(hour: 2, microsecond: {2, 3}) |> Duration.to_iso8601()
+      "PT2H0.000S"
+      iex> Duration.new!(hour: 2, microsecond: {2, 0}) |> Duration.to_iso8601()
+      "PT2H"
+      iex> Duration.new!(microsecond: {2, 0}) |> Duration.to_iso8601()
+      "PT0S"
+      iex> Duration.new!(microsecond: {2_000_000, 6}) |> Duration.to_iso8601()
+      "PT2S"
   """
 
   @spec to_iso8601(t) :: String.t()
+  def to_iso8601(duration)
+
   def to_iso8601(%Duration{
         year: 0,
         month: 0,

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -338,8 +338,7 @@ defmodule Duration do
   Converts the given `duration` to an [ISO 8601-2:2019](https://en.wikipedia.org/wiki/ISO_8601) formatted string.
 
   Note this function implements the *extension* of ISO 8601:2019. This extensions allows weeks to
-  appear in any case, which is not the case in the base standard. `"P3M3W"` is not allowed in
-  ISO 8601-1, but it is in ISO 8601-2. Thus, any duration can be output by this function.
+  appear between months and days: `P3M3W3D`, making it fully compatible with any `Duration` struct.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -331,4 +331,77 @@ defmodule Duration do
         raise ArgumentError, ~s/failed to parse duration "#{string}". reason: #{inspect(reason)}/
     end
   end
+
+  @doc """
+  Converts the given duration to ISO 8601:TODO format.
+
+  ## Examples
+
+  iex> Duration.new!([]) |> Duration.to_iso8601()
+  "PT0S"
+  iex> Duration.new!(year: 3) |> Duration.to_iso8601()
+  "P3Y"
+  iex> Duration.new!(year: 3, day: 6, minute: 9) |> Duration.to_iso8601()
+  "P3Y6DT9M"
+  iex> Duration.new!(second: 30) |> Duration.to_iso8601()
+  "PT30S"
+  iex> Duration.new!(hour: 2, microsecond: {1000, 6}) |> Duration.to_iso8601()
+  "PT2H0.001S"
+  """
+
+  @spec to_iso8601(t) :: String.t()
+  def to_iso8601(%Duration{
+        year: 0,
+        month: 0,
+        week: 0,
+        day: 0,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        microsecond: {0, 0}
+      }) do
+    "PT0S"
+  end
+
+  def to_iso8601(%Duration{} = d) do
+    "P#{to_iso8601_left_part(d)}#{to_iso8601_right_part(d)}"
+  end
+
+  defp to_iso8601_left_part(d) do
+    year = unless d.year == 0, do: "#{d.year}Y"
+    month = unless d.month == 0, do: "#{d.month}M"
+    week = unless d.week == 0, do: "#{d.week}W"
+    day = unless d.day == 0, do: "#{d.day}D"
+
+    "#{year}#{month}#{week}#{day}"
+  end
+
+  defp to_iso8601_right_part(%Duration{hour: 0, minute: 0, second: 0, microsecond: {0, 0}}) do
+    ""
+  end
+
+  defp to_iso8601_right_part(d) do
+    hour = unless d.hour == 0, do: "#{d.hour}H"
+    minute = unless d.minute == 0, do: "#{d.minute}M"
+
+    second =
+      case d do
+        %Duration{second: 0, microsecond: {0, 0}} ->
+          ""
+
+        %Duration{microsecond: {0, _}} ->
+          "#{d.second}S"
+
+        %Duration{microsecond: {microsecond, _}} ->
+          microsecond =
+            microsecond
+            |> to_string()
+            |> String.pad_leading(6, "0")
+            |> String.trim_trailing("0")
+
+          "#{d.second}.#{microsecond}S"
+      end
+
+    "T#{hour}#{minute}#{second}"
+  end
 end

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -286,8 +286,6 @@ defmodule Duration do
     }
   end
 
-  @doc since: "1.7.1"
-
   @doc """
   Parses an ISO 8601 formatted duration string to a `Duration` struct.
 

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -389,20 +389,20 @@ defmodule Duration do
   end
 
   def to_iso8601(%Duration{} = d) do
-    "P#{to_iso8601_duration_date(d)}#{to_iso8601_duration_time(d)}"
+    IO.iodata_to_binary([?P, to_iso8601_duration_date(d), to_iso8601_duration_time(d)])
   end
 
   defp to_iso8601_duration_date(d) do
-    year = unless d.year == 0, do: "#{d.year}Y"
-    month = unless d.month == 0, do: "#{d.month}M"
-    week = unless d.week == 0, do: "#{d.week}W"
-    day = unless d.day == 0, do: "#{d.day}D"
-
-    "#{year}#{month}#{week}#{day}"
+    [
+      if(d.year == 0, do: [], else: [Integer.to_string(d.year), ?Y]),
+      if(d.month == 0, do: [], else: [Integer.to_string(d.month), ?M]),
+      if(d.week == 0, do: [], else: [Integer.to_string(d.week), ?W]),
+      if(d.day == 0, do: [], else: [Integer.to_string(d.day), ?D])
+    ]
   end
 
   defp to_iso8601_duration_time(%Duration{hour: 0, minute: 0, second: 0, microsecond: {0, _}}) do
-    ""
+    []
   end
 
   defp to_iso8601_duration_time(%Duration{microsecond: {ms, p}} = d)
@@ -414,16 +414,16 @@ defmodule Duration do
   end
 
   defp to_iso8601_duration_time(d) do
-    hour = unless d.hour == 0, do: "#{d.hour}H"
-    minute = unless d.minute == 0, do: "#{d.minute}M"
-
-    second =
+    [
+      ?T,
+      if(d.hour == 0, do: [], else: [Integer.to_string(d.hour), ?H]),
+      if(d.minute == 0, do: [], else: [Integer.to_string(d.minute), ?M]),
       case d do
         %Duration{second: 0, microsecond: {0, _}} ->
-          ""
+          []
 
         %Duration{microsecond: {0, _}} ->
-          "#{d.second}S"
+          [Integer.to_string(d.second), ?S]
 
         %Duration{microsecond: {ms, p}} ->
           microsecond =
@@ -432,9 +432,8 @@ defmodule Duration do
             |> String.pad_leading(6, "0")
             |> binary_part(0, p)
 
-          "#{d.second}.#{microsecond}S"
+          [Integer.to_string(d.second), ?., microsecond, ?S]
       end
-
-    "T#{hour}#{minute}#{second}"
+    ]
   end
 end

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -364,10 +364,10 @@ defmodule Duration do
   end
 
   def to_iso8601(%Duration{} = d) do
-    "P#{to_iso8601_left_part(d)}#{to_iso8601_right_part(d)}"
+    "P#{to_iso8601_duration_date(d)}#{to_iso8601_duration_time(d)}"
   end
 
-  defp to_iso8601_left_part(d) do
+  defp to_iso8601_duration_date(d) do
     year = unless d.year == 0, do: "#{d.year}Y"
     month = unless d.month == 0, do: "#{d.month}M"
     week = unless d.week == 0, do: "#{d.week}W"
@@ -376,11 +376,11 @@ defmodule Duration do
     "#{year}#{month}#{week}#{day}"
   end
 
-  defp to_iso8601_right_part(%Duration{hour: 0, minute: 0, second: 0, microsecond: {0, _}}) do
+  defp to_iso8601_duration_time(%Duration{hour: 0, minute: 0, second: 0, microsecond: {0, _}}) do
     ""
   end
 
-  defp to_iso8601_right_part(d) do
+  defp to_iso8601_duration_time(d) do
     hour = unless d.hour == 0, do: "#{d.hour}H"
     minute = unless d.minute == 0, do: "#{d.minute}M"
 

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -347,6 +347,8 @@ defmodule Duration do
   "PT30S"
   iex> Duration.new!(hour: 2, microsecond: {1000, 6}) |> Duration.to_iso8601()
   "PT2H0.001S"
+  iex> Duration.new!(day: 28, hour: 6, minute: 42, second: 12) |> Duration.multiply(-1) |> Duration.to_iso8601()
+  "P-28DT-6H-42M-12S"
   """
 
   @spec to_iso8601(t) :: String.t()

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -358,7 +358,7 @@ defmodule Duration do
         hour: 0,
         minute: 0,
         second: 0,
-        microsecond: {0, 0}
+        microsecond: {0, _}
       }) do
     "PT0S"
   end
@@ -376,7 +376,7 @@ defmodule Duration do
     "#{year}#{month}#{week}#{day}"
   end
 
-  defp to_iso8601_right_part(%Duration{hour: 0, minute: 0, second: 0, microsecond: {0, 0}}) do
+  defp to_iso8601_right_part(%Duration{hour: 0, minute: 0, second: 0, microsecond: {0, _}}) do
     ""
   end
 
@@ -386,7 +386,7 @@ defmodule Duration do
 
     second =
       case d do
-        %Duration{second: 0, microsecond: {0, 0}} ->
+        %Duration{second: 0, microsecond: {0, _}} ->
           ""
 
         %Duration{microsecond: {0, _}} ->

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -342,21 +342,19 @@ defmodule Duration do
 
   ## Examples
 
-      iex> Duration.new!(year: 3) |> Duration.to_iso8601()
+      iex> Duration.to_iso8601(%Duration{year: 3})
       "P3Y"
-      iex> Duration.new!(day: 40, hour: 12, minute: 42, second: 12) |> Duration.to_iso8601()
+      iex> Duration.to_iso8601(%Duration{day: 40, hour: 12, minute: 42, second: 12})
       "P40DT12H42M12S"
-      iex> Duration.new!(second: 30) |> Duration.to_iso8601()
+      iex> Duration.to_iso8601(%Duration{second: 30})
       "PT30S"
-      iex> Duration.new!(second: 30) |> Duration.multiply(-1) |> Duration.to_iso8601()
-      "PT-30S"
 
-      iex> Duration.new!([]) |> Duration.to_iso8601()
+      iex> Duration.to_iso8601(%Duration{})
       "PT0S"
 
-      iex> Duration.new!(second: 1, microsecond: {2_200, 3}) |> Duration.to_iso8601()
+      iex> Duration.to_iso8601(%Duration{second: 1, microsecond: {2_200, 3}})
       "PT1.002S"
-      iex> %Duration{second: 1, microsecond: {-1_200_000, 4}} |> Duration.to_iso8601()
+      iex> Duration.to_iso8601(%Duration{second: 1, microsecond: {-1_200_000, 4}})
       "PT-0.2000S"
   """
 

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -345,25 +345,18 @@ defmodule Duration do
 
       iex> Duration.new!(year: 3) |> Duration.to_iso8601()
       "P3Y"
-      iex> Duration.new!(day: 28, hour: 6, minute: 42, second: 12) |> Duration.to_iso8601()
-      "P28DT6H42M12S"
+      iex> Duration.new!(day: 40, hour: 12, minute: 42, second: 12) |> Duration.to_iso8601()
+      "P40DT12H42M12S"
       iex> Duration.new!(second: 30) |> Duration.to_iso8601()
       "PT30S"
       iex> Duration.new!(second: 30) |> Duration.multiply(-1) |> Duration.to_iso8601()
       "PT-30S"
+
       iex> Duration.new!([]) |> Duration.to_iso8601()
       "PT0S"
 
-      iex> Duration.new!(hour: 2, microsecond: {2, 6}) |> Duration.to_iso8601()
-      "PT2H0.000002S"
-      iex> Duration.new!(hour: 2, microsecond: {2, 3}) |> Duration.to_iso8601()
-      "PT2H0.000S"
-      iex> Duration.new!(hour: 2, microsecond: {2, 0}) |> Duration.to_iso8601()
-      "PT2H0S"
-      iex> Duration.new!(microsecond: {2, 0}) |> Duration.to_iso8601()
-      "PT0S"
-      iex> Duration.new!(microsecond: {2_000_000, 6}) |> Duration.to_iso8601()
-      "PT2.000000S"
+      iex> Duration.new!(second: 1, microsecond: {2_200, 3}) |> Duration.to_iso8601()
+      "PT1.002S"
       iex> %Duration{second: 1, microsecond: {-1_200_000, 4}} |> Duration.to_iso8601()
       "PT-0.2000S"
   """

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -384,7 +384,7 @@ defmodule Duration do
     "PT0S"
   end
 
-  def to_iso8601(%Duration{microsecond: {microsecond, 0}} = d) when microsecond != 0 do
+  def to_iso8601(%Duration{microsecond: {ms, 0}} = d) when ms != 0 do
     to_iso8601(%Duration{d | microsecond: {0, 0}})
   end
 
@@ -405,10 +405,10 @@ defmodule Duration do
     ""
   end
 
-  defp to_iso8601_duration_time(%Duration{microsecond: {microsecond, precision}} = d)
-       when microsecond >= @microseconds_per_second do
-    second = d.second + div(microsecond, @microseconds_per_second)
-    microsecond = {rem(microsecond, @microseconds_per_second), precision}
+  defp to_iso8601_duration_time(%Duration{microsecond: {ms, p}} = d)
+       when ms >= @microseconds_per_second do
+    second = d.second + div(ms, @microseconds_per_second)
+    microsecond = {rem(ms, @microseconds_per_second), p}
 
     to_iso8601_duration_time(%Duration{d | second: second, microsecond: microsecond})
   end
@@ -425,12 +425,12 @@ defmodule Duration do
         %Duration{microsecond: {0, _}} ->
           "#{d.second}S"
 
-        %Duration{microsecond: {microsecond, precision}} ->
+        %Duration{microsecond: {ms, p}} ->
           microsecond =
-            microsecond
+            ms
             |> Integer.to_string()
             |> String.pad_leading(6, "0")
-            |> binary_part(0, precision)
+            |> binary_part(0, p)
 
           "#{d.second}.#{microsecond}S"
       end

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -335,7 +335,7 @@ defmodule Duration do
   end
 
   @doc """
-  Converts the given duration to [ISO 8601-2:2019](https://en.wikipedia.org/wiki/ISO_8601) format.
+  Converts the given `duration` to an [ISO 8601-2:2019](https://en.wikipedia.org/wiki/ISO_8601) formatted string.
 
   Note this function implements the *extension* of ISO 8601:2019. This extensions allows weeks to
   appear in any case, which is not the case in the base standard. `"P3M3W"` is not allowed in

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -388,12 +388,10 @@ defmodule Duration do
 
   defp to_iso8601_duration_time(%Duration{microsecond: {microsecond, precision}} = d)
        when microsecond > @microseconds_per_second do
-    %Duration{
-      d
-      | second: d.second + div(microsecond, @microseconds_per_second),
-        microsecond: {rem(microsecond, @microseconds_per_second), precision}
-    }
-    |> to_iso8601_duration_time()
+    second = d.second + div(microsecond, @microseconds_per_second)
+    microsecond = {rem(microsecond, @microseconds_per_second), precision}
+
+    to_iso8601_duration_time(%Duration{d | second: second, microsecond: microsecond})
   end
 
   defp to_iso8601_duration_time(d) do

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -306,4 +306,45 @@ defmodule DurationTest do
                    Duration.from_iso8601!("P4.5YT6S")
                  end
   end
+
+  test "to_iso8601/1" do
+    assert %Duration{year: 1, month: 2, day: 3, hour: 4, minute: 5, second: 6}
+           |> Duration.to_iso8601() == "P1Y2M3DT4H5M6S"
+
+    assert %Duration{week: 3, hour: 5, minute: 3} |> Duration.to_iso8601() == "P3WT5H3M"
+    assert %Duration{hour: 5, minute: 3} |> Duration.to_iso8601() == "PT5H3M"
+    assert %Duration{year: 1, month: 2, day: 3} |> Duration.to_iso8601() == "P1Y2M3D"
+    assert %Duration{hour: 4, minute: 5, second: 6} |> Duration.to_iso8601() == "PT4H5M6S"
+    assert %Duration{year: 1, month: 2} |> Duration.to_iso8601() == "P1Y2M"
+    assert %Duration{day: 3} |> Duration.to_iso8601() == "P3D"
+    assert %Duration{hour: 4, minute: 5} |> Duration.to_iso8601() == "PT4H5M"
+    assert %Duration{second: 6} |> Duration.to_iso8601() == "PT6S"
+    assert %Duration{second: 1, microsecond: {600_000, 1}} |> Duration.to_iso8601() == "PT1.6S"
+    assert %Duration{second: -1, microsecond: {-600_000, 1}} |> Duration.to_iso8601() == "PT-1.6S"
+
+    assert %Duration{second: -1, microsecond: {-234_567, 6}} |> Duration.to_iso8601() ==
+             "PT-1.234567S"
+
+    assert %Duration{second: 1, microsecond: {123_456, 6}} |> Duration.to_iso8601() ==
+             "PT1.123456S"
+
+    assert %Duration{year: 3, week: 4, day: -3, second: -6} |> Duration.to_iso8601() ==
+             "P3Y4W-3DT-6S"
+
+    assert %Duration{second: -4, microsecond: {-230_000, 2}} |> Duration.to_iso8601() ==
+             "PT-4.23S"
+
+    assert %Duration{second: -4, microsecond: {230_000, 2}} |> Duration.to_iso8601() ==
+             "PT-3.77S"
+
+    assert %Duration{second: 2, microsecond: {-1_200_000, 4}} |> Duration.to_iso8601() ==
+             "PT0.8000S"
+
+    assert %Duration{second: 1, microsecond: {-1_200_000, 3}} |> Duration.to_iso8601() ==
+             "PT-0.200S"
+
+    assert %Duration{microsecond: {-800_000, 2}} |> Duration.to_iso8601() == "PT-0.80S"
+    assert %Duration{microsecond: {-800_000, 0}} |> Duration.to_iso8601() == "PT0S"
+    assert %Duration{microsecond: {-1_200_000, 2}} |> Duration.to_iso8601() == "PT-1.20S"
+  end
 end


### PR DESCRIPTION
This PR implements `Duration.to_iso8601/1` which transforms a `Duration.t()` to the ISO8601-2 duration string representation, for instance:

```elixir
iex> Duration.new!(year: 3, hour: 12) |> Duration.to_iso8601()
"P3YT12H"
```

A few open points:

### Zero duration

Zero duration is represented as `PT0S`. All other variants are possible (`P0D` for instance is shorter - this is the second example in the Wikipedia article).

### Inclusion of week number

The wikipedia states that the 3 following formats are permitted:

> PnYnMnDTnHnMnS
> PnW
> P\<date>T\<time> 

We don't need the 3rd.  The first two tell us that either you have a week-only duration, or a duration with all possible components except weeks.

According to the [iso8601-duration](https://www.npmjs.com/package/iso8601-duration) npm lib doc, an extension to iso8601:2019 allows weeks in the format: `PnYnMnWnDTnHnMnS`. Since `Duration.t()` may have a non-zero week. I've chosen to implement it so that we can always convert a `Duration.t()` to its ISO 8601 string representation. The downside is that some implementations (other libs) might not be able to parse it.

I have no access to these standards, so I can't say for sure this is what's written there :sweat: 

### Number of ms > 1s

Contrary to `Calendar`, the number of microseconds is not limited to `999_999`. The following duration is correct: `Duration{microsecond: {3_500_000, 6}}`.

In this case, we automatically convert extra 1_000_000 ms to seconds, and in this case we would output `PT3.500000S`.

### ~~Handling of precision~~

~~Not sure to have understood how we should handle precision here. I assumed this is the number of digits we have to show in the decimal part:~~

```elixir
iex> Duration.new!(hour: 2, microsecond: {1000, 3}) |> Duration.to_iso8601()
"PT2H0.001S"
```

~~Note a slight incoherence maybe (from the doctests):~~
```elixir
iex> Duration.new!(microsecond: {2_000_000, 6}) |> Duration.to_iso8601()
"PT2S"
```
~~→ here since the extra packets of `1_000_000` ms were converted to seconds, we don't show any fractional digits. That's still correct per ISO 8601-2 though.~~

### ~~@doc since: "1.7.1"~~

~~I'm not aware of Elixir dev process, but I'm assuming it'll be part of v1.7.1~~

-----------------------------------------------------------------

I think another pair of eyes, maybe from @tfiedlerdejanze who is working on the `Duration.from_iso8601/1`, could be useful :D