### PR TITLE
Keep position meta on & capture special variables in expanded AST

### DIFF
--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -128,12 +128,12 @@ validate(Meta, [{Pos, _} | _], Expected, E) ->
 validate(_Meta, [], _Pos, _E) ->
   [].
 
-escape({'&', _, [Pos]}, _E, Dict) when is_integer(Pos), Pos > 0 ->
+escape({'&', Meta, [Pos]}, _E, Dict) when is_integer(Pos), Pos > 0 ->
   % Using a nil context here to emit warnings when variable is unused.
   % This might pollute user space but is unlikely because variables
   % named :"&1" are not valid syntax.
-  Var = {list_to_atom([$& | integer_to_list(Pos)]), [], nil},
-  {Var, orddict:store(Pos, Var, Dict)};
+  Var = {list_to_atom([$& | integer_to_list(Pos)]), Meta, nil},
+  {Var, orddict:store(Pos, setelement(2, Var, []), Dict)};
 escape({'&', Meta, [Pos]}, E, _Dict) when is_integer(Pos) ->
   file_error(Meta, E, ?MODULE, {invalid_arity_for_capture, Pos});
 escape({'&', Meta, _} = Arg, E, _Dict) ->

--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -133,7 +133,7 @@ escape({'&', Meta, [Pos]}, _E, Dict) when is_integer(Pos), Pos > 0 ->
   % This might pollute user space but is unlikely because variables
   % named :"&1" are not valid syntax.
   Var = {list_to_atom([$& | integer_to_list(Pos)]), Meta, nil},
-  {Var, orddict:store(Pos, setelement(2, Var, []), Dict)};
+  {Var, orddict:store(Pos, Var, Dict)};
 escape({'&', Meta, [Pos]}, E, _Dict) when is_integer(Pos) ->
   file_error(Meta, E, ?MODULE, {invalid_arity_for_capture, Pos});
 escape({'&', Meta, _} = Arg, E, _Dict) ->

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1133,6 +1133,12 @@ defmodule Kernel.ExpansionTest do
       assert expand(quote(do: &unknown(&1, &2))) == {:&, [], [{:/, [], [{:unknown, [], nil}, 2]}]}
     end
 
+    test "keeps position meta on & variables" do
+      assert expand(Code.string_to_quoted!("& &1")) ==
+               {:fn, [{:line, 1}],
+                [{:->, [{:line, 1}], [[{:"&1", [], nil}], {:"&1", [line: 1], nil}]}]}
+    end
+
     test "expands remotes" do
       assert expand(quote(do: &List.flatten/2)) ==
                quote(do: &:"Elixir.List".flatten/2)

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1136,7 +1136,7 @@ defmodule Kernel.ExpansionTest do
     test "keeps position meta on & variables" do
       assert expand(Code.string_to_quoted!("& &1")) ==
                {:fn, [{:line, 1}],
-                [{:->, [{:line, 1}], [[{:"&1", [], nil}], {:"&1", [line: 1], nil}]}]}
+                [{:->, [{:line, 1}], [[{:"&1", [line: 1], nil}], {:"&1", [line: 1], nil}]}]}
     end
 
     test "expands remotes" do


### PR DESCRIPTION
`&` variables exist in the code so it makes sense to preserve the position in expansion