### PR TITLE
Support negative period prefix in `Calendar.ISO.parse_duration/1`

### DIFF
--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -285,20 +285,23 @@ defmodule Duration do
   end
 
   @doc """
-  Parses an ISO 8601 formatted duration string to a `Duration` struct.
+  Parses an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) formatted duration string to a `Duration` struct.
 
-  A decimal fraction may be specified for seconds only, using either a comma or a full stop.
+  - A duration string must be designated in order of magnitude: `P[n]Y[n]M[n]W[n]DT[n]H[n]M[n]S`.
+  - A duration string may be prefixed with a minus sign to negate it: `-P10DT4H`.
+  - Individual units may be prefixed with a minus sign: `P-10DT4H`.
+  - Only seconds may be specified with a decimal fraction, using either a comma or a full stop: `P1DT4,5S`.
 
   ## Examples
 
       iex> Duration.from_iso8601("P1Y2M3DT4H5M6S")
       {:ok, %Duration{year: 1, month: 2, day: 3, hour: 4, minute: 5, second: 6}}
-      iex> Duration.from_iso8601("PT10H30M")
-      {:ok, %Duration{hour: 10, minute: 30, second: 0}}
       iex> Duration.from_iso8601("P3Y-2MT3H")
       {:ok, %Duration{year: 3, month: -2, hour: 3}}
-      iex> Duration.from_iso8601("P1YT4.650S")
-      {:ok, %Duration{year: 1, second: 4, microsecond: {650000, 3}}}
+      iex> Duration.from_iso8601("-PT10H-30M")
+      {:ok, %Duration{hour: -10, minute: 30}}
+      iex> Duration.from_iso8601("PT4.650S")
+      {:ok, %Duration{second: 4, microsecond: {650000, 3}}}
 
   """
   @spec from_iso8601(String.t()) :: {:ok, t} | {:error, atom}
@@ -313,12 +316,14 @@ defmodule Duration do
   end
 
   @doc """
-  Same as `from_iso8601/1` but raises an ArgumentError.
+  Same as `from_iso8601/1` but raises an `ArgumentError`.
 
   ## Examples
 
       iex> Duration.from_iso8601!("P1Y2M3DT4H5M6S")
       %Duration{year: 1, month: 2, day: 3, hour: 4, minute: 5, second: 6}
+      iex> Duration.from_iso8601!("P10D")
+      %Duration{day: 10}
 
   """
   @spec from_iso8601!(String.t()) :: t

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -676,16 +676,12 @@ defmodule Calendar.ISO do
   end
 
   def parse_duration("-P" <> string) when byte_size(string) > 0 do
-    case parse_duration_date(string, [], year: ?Y, month: ?M, week: ?W, day: ?D) do
-      {:ok, fields} ->
-        {:ok,
-         Enum.map(fields, fn
-           {:microsecond, {value, precision}} -> {:microsecond, {-value, precision}}
-           {unit, value} -> {unit, -value}
-         end)}
-
-      error ->
-        error
+    with {:ok, fields} <- parse_duration_date(string, [], year: ?Y, month: ?M, week: ?W, day: ?D) do
+      {:ok,
+       Enum.map(fields, fn
+         {:microsecond, {value, precision}} -> {:microsecond, {-value, precision}}
+         {unit, value} -> {unit, -value}
+       end)}
     end
   end
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -670,9 +670,23 @@ defmodule Calendar.ISO do
   See `Duration.from_iso8601/1`.
   """
   @doc since: "1.17.0"
-  @spec parse_duration(String.t()) :: {:ok, [Duration.unit_pair()]} | {:error, atom()}
+  @spec parse_duration(String.t()) :: {:ok, [Duration.unit_pair()]} | {:error, atom}
   def parse_duration("P" <> string) when byte_size(string) > 0 do
     parse_duration_date(string, [], year: ?Y, month: ?M, week: ?W, day: ?D)
+  end
+
+  def parse_duration("-P" <> string) when byte_size(string) > 0 do
+    case parse_duration_date(string, [], year: ?Y, month: ?M, week: ?W, day: ?D) do
+      {:ok, fields} ->
+        {:ok,
+         Enum.map(fields, fn
+           {:microsecond, {value, precision}} -> {:microsecond, {-value, precision}}
+           {unit, value} -> {unit, -value}
+         end)}
+
+      error ->
+        error
+    end
   end
 
   def parse_duration(_) do

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -262,6 +262,9 @@ defmodule DurationTest do
     assert Duration.from_iso8601!("PT6S") == %Duration{second: 6}
     assert Duration.from_iso8601!("PT1,6S") == %Duration{second: 1, microsecond: {600_000, 1}}
     assert Duration.from_iso8601!("PT-1.6S") == %Duration{second: -1, microsecond: {-600_000, 1}}
+    assert Duration.from_iso8601!("-P10DT4H") == %Duration{day: -10, hour: -4}
+    assert Duration.from_iso8601!("-P10DT-4H") == %Duration{day: -10, hour: 4}
+    assert Duration.from_iso8601!("P-10D") == %Duration{day: -10}
 
     assert Duration.from_iso8601!("PT-1.234567S") == %Duration{
              second: -1,


### PR DESCRIPTION
Negative durations are actually [specified](https://tc39.es/proposal-temporal/docs/duration.html#from) in ISO 8601-2 while individual negative units are not. The [Java Duration class](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-) supports both features and i think the negative duration prefix may actually be more common than the one for individual units. IMHO it makes sense that we also support both in the standard library.