### PR TITLE
Add sort :per_call option to tprof

### DIFF
--- a/lib/mix/lib/mix/tasks/profile.tprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.tprof.ex
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Profile.Tprof do
     * `--calls` - filters out any results with a call count lower than this
     * `--time` - filters out any results that took lower than specified (in µs), the `type` needs to be `time`
     * `--memory` - filters out any results that used less memory than specified (in words), the `type` needs to be `memory`
-    * `--sort` - sorts the results by `calls` or by the value of `type` (default: the value of `type`)
+    * `--sort` - sorts the results by `calls`, `per_call` or by the value of `type` (default: the value of `type`)
     * `--eval`, `-e` - evaluates the given code
     * `--require`, `-r` - requires pattern before running the command
     * `--parallel`, `-p` - makes all requires parallel
@@ -214,6 +214,7 @@ defmodule Mix.Tasks.Profile.Tprof do
   defp parse_opt({:sort, "time"}), do: {:sort, :time}
   defp parse_opt({:sort, "calls"}), do: {:sort, :calls}
   defp parse_opt({:sort, "memory"}), do: {:sort, :memory}
+  defp parse_opt({:sort, "per_call"}), do: {:sort, :per_call}
   defp parse_opt({:sort, other}), do: Mix.raise("Invalid sort option: #{other}")
   defp parse_opt(other), do: other
 
@@ -235,7 +236,7 @@ defmodule Mix.Tasks.Profile.Tprof do
       `type` needs to be `:time`
     * `:memory` - filters out any results that used less memory than specified (in words),
       `type` needs to be `:memory`
-    * `:sort` - sort the results by `:calls` or by the value of `type`
+    * `:sort` - sort the results by `:calls`, `:per_call` or by the value of `type`
       (default: the value of `type`)
     * `:warmup` - if the code should be warmed up before profiling (default: `true`)
     * `:set_on_spawn` - if newly spawned processes should be measured (default: `true`)
@@ -266,6 +267,9 @@ defmodule Mix.Tasks.Profile.Tprof do
 
         :calls ->
           :calls
+
+        :per_call ->
+          :measurement_per_call
 
         ^type ->
           :measurement

--- a/lib/mix/test/mix/tasks/profile.tprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.tprof_test.exs
@@ -77,7 +77,7 @@ defmodule Mix.Tasks.Profile.TprofTest do
     in_tmp(context.test, fn ->
       assert capture_io(fn ->
                Tprof.run(["--sort", "calls", "-e", @expr])
-             end) =~ ~r/Enum\.each\/2.*String\.Chars\.Integer\.to_string\/1/s
+             end) =~ ~r/\nEnum\.each\/2.*\nString\.Chars\.Integer\.to_string\/1/s
     end)
   end
 
@@ -85,7 +85,15 @@ defmodule Mix.Tasks.Profile.TprofTest do
     in_tmp(context.test, fn ->
       assert capture_io(fn ->
                Tprof.run(["--type", "memory", "--sort", "calls", "-e", @expr])
-             end) =~ ~r/Enum\.each\/2.*:erlang\.integer_to_binary\/1/s
+             end) =~ ~r/\nEnum\.each\/2.*\n:erlang\.integer_to_binary\/1/s
+    end)
+  end
+
+  test "sorts based on memory per call", context do
+    in_tmp(context.test, fn ->
+      assert capture_io(fn ->
+               Tprof.run(["--type", "memory", "--sort", "per_call", "-e", @expr])
+             end) =~ ~r/\n:erlang\.integer_to_binary\/1.*\nEnum\.each\/2/s
     end)
   end
 


### PR DESCRIPTION
A small follow-up for https://github.com/elixir-lang/elixir/pull/13605, I didn't include it in the MVP to keep the PR smaller.

One of the niceties of `tprof` is the ability to sort per "per call measurement", perhaps we can expose the option?
We might consider some other [options](https://www.erlang.org/doc/apps/tools/tprof.html#t:column/0) as well, but sorting by percentage seems redundant since it should be proportional?

```elixir
$ mix profile.tprof -e "Enum.each(1..5, &String.Chars.Integer.to_string/1)" --sort per_call
Warmup...


Profile results of #PID<0.106.0>
#                                               CALLS      % TIME µS/CALL
Total                                              20 100.00    6    0.30
String.Chars.Integer.to_string/1                    5   0.00    0    0.00
Enum.reduce_range/5                                 3   0.00    0    0.00
:erlang.integer_to_binary/1                         5  16.67    1    0.20
anonymous fn/3 in Enum.each/2                       5  33.33    2    0.40
anonymous fn/0 in :elixir_compiler_1.__FILE__/1     1  16.67    1    1.00
Enum.each/2                                         1  33.33    2    2.00

Profile done over 6 matching functions
```

```elixir
mix profile.tprof -e "Enum.each(1..5, &String.Chars.Integer.to_string/1)" --type memory --sort per_call
Warmup...


Profile results of #PID<0.106.0>
#                           CALLS      % WORDS PER CALL
Total                           6 100.00    19     3.17
:erlang.integer_to_binary/1     5  78.95    15     3.00
Enum.each/2                     1  21.05     4     4.00

Profile done over 2 matching functions
```