### PR TITLE
Support plus sign prefix in `Calendar.ISO.parse_duration/1`

### DIFF
--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -287,10 +287,16 @@ defmodule Duration do
   @doc """
   Parses an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) formatted duration string to a `Duration` struct.
 
-  - A duration string must be designated in order of magnitude: `P[n]Y[n]M[n]W[n]DT[n]H[n]M[n]S`.
-  - A duration string may be prefixed with a minus sign to negate it: `-P10DT4H`.
-  - Individual units may be prefixed with a minus sign: `P-10DT4H`.
-  - Only seconds may be specified with a decimal fraction, using either a comma or a full stop: `P1DT4,5S`.
+  Duration strings, as well as individual units, may be prefixed with plus/minus signs so that:
+
+  - `-PT6H3M` parses as `%Duration{hour: -6, minute: -3}`
+  - `-PT6H-3M` parses as `%Duration{hour: -6, minute: 3}`
+  - `+PT6H3M` parses as `%Duration{hour: 6, minute: 3}`
+  - `+PT6H-3M` parses as `%Duration{hour: 6, minute: -3}`
+
+  Duration designators must be provided in order of magnitude: `P[n]Y[n]M[n]W[n]DT[n]H[n]M[n]S`.
+
+  Only seconds may be specified with a decimal fraction, using either a comma or a full stop: `P1DT4,5S`.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -675,6 +675,10 @@ defmodule Calendar.ISO do
     parse_duration_date(string, [], year: ?Y, month: ?M, week: ?W, day: ?D)
   end
 
+  def parse_duration("+P" <> string) when byte_size(string) > 0 do
+    parse_duration_date(string, [], year: ?Y, month: ?M, week: ?W, day: ?D)
+  end
+
   def parse_duration("-P" <> string) when byte_size(string) > 0 do
     with {:ok, fields} <- parse_duration_date(string, [], year: ?Y, month: ?M, week: ?W, day: ?D) do
       {:ok,

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -265,6 +265,9 @@ defmodule DurationTest do
     assert Duration.from_iso8601!("-P10DT4H") == %Duration{day: -10, hour: -4}
     assert Duration.from_iso8601!("-P10DT-4H") == %Duration{day: -10, hour: 4}
     assert Duration.from_iso8601!("P-10D") == %Duration{day: -10}
+    assert Duration.from_iso8601!("+P10DT-4H") == %Duration{day: 10, hour: -4}
+    assert Duration.from_iso8601!("P+10D") == %Duration{day: 10}
+    assert Duration.from_iso8601!("-P+10D") == %Duration{day: -10}
 
     assert Duration.from_iso8601!("PT-1.234567S") == %Duration{
              second: -1,


### PR DESCRIPTION
Following up to supporting the minus sign prefix, this adds support for the plus sign prefix to comply with the ISO 8601-2 Duration specification.

Referencing PR: https://github.com/elixir-lang/elixir/pull/13608