### PR TITLE
Add parameterized tests

### DIFF
--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -1,1009 +1,968 @@
 Code.require_file("test_helper.exs", __DIR__)
 
-defmodule RegistryTest do
+defmodule Registry.CommonTest do
   use ExUnit.Case, async: true
   doctest Registry, except: [:moduledoc]
+end
+
+defmodule Registry.Test do
+  use ExUnit.Case, async: true
+
+  setup_all do
+    [
+      parameterize: [
+        %{partitions: 1},
+        %{partitions: 8}
+      ]
+    ]
+  end
 
   setup config do
-    keys = config[:keys] || :unique
-    partitions = config[:partitions] || 1
+    keys = config.keys || :unique
+    partitions = config.partitions
     listeners = List.wrap(config[:listener])
     opts = [keys: keys, name: config.test, partitions: partitions, listeners: listeners]
     {:ok, _} = start_supervised({Registry, opts})
-    {:ok, %{registry: config.test, partitions: partitions}}
+    %{registry: config.test}
   end
 
-  for {describe, partitions} <- ["with 1 partition": 1, "with 8 partitions": 8] do
-    describe "unique #{describe}" do
-      @describetag keys: :unique, partitions: partitions
+  describe "unique" do
+    @describetag keys: :unique
 
-      test "starts configured number of partitions", %{registry: registry, partitions: partitions} do
-        assert length(Supervisor.which_children(registry)) == partitions
+    test "starts configured number of partitions", %{registry: registry, partitions: partitions} do
+      assert length(Supervisor.which_children(registry)) == partitions
+    end
+
+    test "counts 0 keys in an empty registry", %{registry: registry} do
+      assert 0 == Registry.count(registry)
+    end
+
+    test "counts the number of keys in a registry", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, "hello", :value)
+      {:ok, _} = Registry.register(registry, "world", :value)
+
+      assert 2 == Registry.count(registry)
+    end
+
+    test "has unique registrations", %{registry: registry} do
+      {:ok, pid} = Registry.register(registry, "hello", :value)
+      assert is_pid(pid)
+      assert Registry.keys(registry, self()) == ["hello"]
+      assert Registry.values(registry, "hello", self()) == [:value]
+
+      assert {:error, {:already_registered, pid}} = Registry.register(registry, "hello", :value)
+      assert pid == self()
+      assert Registry.keys(registry, self()) == ["hello"]
+      assert Registry.values(registry, "hello", self()) == [:value]
+
+      {:ok, pid} = Registry.register(registry, "world", :value)
+      assert is_pid(pid)
+      assert Registry.keys(registry, self()) |> Enum.sort() == ["hello", "world"]
+    end
+
+    test "has unique registrations across processes", %{registry: registry} do
+      {_, task} = register_task(registry, "hello", :value)
+      Process.link(Process.whereis(registry))
+      assert Registry.keys(registry, task) == ["hello"]
+      assert Registry.values(registry, "hello", task) == [:value]
+
+      assert {:error, {:already_registered, ^task}} =
+               Registry.register(registry, "hello", :recent)
+
+      assert Registry.keys(registry, self()) == []
+      assert Registry.values(registry, "hello", self()) == []
+
+      {:links, links} = Process.info(self(), :links)
+      assert Process.whereis(registry) in links
+    end
+
+    test "has unique registrations even if partition is delayed", %{registry: registry} do
+      {owner, task} = register_task(registry, "hello", :value)
+
+      assert Registry.register(registry, "hello", :other) ==
+               {:error, {:already_registered, task}}
+
+      :sys.suspend(owner)
+      kill_and_assert_down(task)
+      Registry.register(registry, "hello", :other)
+      assert Registry.lookup(registry, "hello") == [{self(), :other}]
+    end
+
+    test "supports match patterns", %{registry: registry} do
+      value = {1, :atom, 1}
+      {:ok, _} = Registry.register(registry, "hello", value)
+      assert Registry.match(registry, "hello", {1, :_, :_}) == [{self(), value}]
+      assert Registry.match(registry, "hello", {1.0, :_, :_}) == []
+      assert Registry.match(registry, "hello", {:_, :atom, :_}) == [{self(), value}]
+      assert Registry.match(registry, "hello", {:"$1", :_, :"$1"}) == [{self(), value}]
+      assert Registry.match(registry, "hello", :_) == [{self(), value}]
+      assert Registry.match(registry, :_, :_) == []
+
+      value2 = %{a: "a", b: "b"}
+      {:ok, _} = Registry.register(registry, "world", value2)
+      assert Registry.match(registry, "world", %{b: "b"}) == [{self(), value2}]
+    end
+
+    test "supports guard conditions", %{registry: registry} do
+      value = {1, :atom, 2}
+      {:ok, _} = Registry.register(registry, "hello", value)
+
+      assert Registry.match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 1}]) ==
+               [{self(), value}]
+
+      assert Registry.match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 2}]) == []
+
+      assert Registry.match(registry, "hello", {:_, :"$1", :_}, [{:is_atom, :"$1"}]) ==
+               [{self(), value}]
+    end
+
+    test "count_match supports match patterns", %{registry: registry} do
+      value = {1, :atom, 1}
+      {:ok, _} = Registry.register(registry, "hello", value)
+      assert 1 == Registry.count_match(registry, "hello", {1, :_, :_})
+      assert 0 == Registry.count_match(registry, "hello", {1.0, :_, :_})
+      assert 1 == Registry.count_match(registry, "hello", {:_, :atom, :_})
+      assert 1 == Registry.count_match(registry, "hello", {:"$1", :_, :"$1"})
+      assert 1 == Registry.count_match(registry, "hello", :_)
+      assert 0 == Registry.count_match(registry, :_, :_)
+
+      value2 = %{a: "a", b: "b"}
+      {:ok, _} = Registry.register(registry, "world", value2)
+      assert 1 == Registry.count_match(registry, "world", %{b: "b"})
+    end
+
+    test "count_match supports guard conditions", %{registry: registry} do
+      value = {1, :atom, 2}
+      {:ok, _} = Registry.register(registry, "hello", value)
+
+      assert 1 == Registry.count_match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 1}])
+      assert 0 == Registry.count_match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 2}])
+      assert 1 == Registry.count_match(registry, "hello", {:_, :"$1", :_}, [{:is_atom, :"$1"}])
+    end
+
+    test "unregister_match supports patterns", %{registry: registry} do
+      value = {1, :atom, 1}
+      {:ok, _} = Registry.register(registry, "hello", value)
+
+      Registry.unregister_match(registry, "hello", {2, :_, :_})
+      assert Registry.lookup(registry, "hello") == [{self(), value}]
+      Registry.unregister_match(registry, "hello", {1.0, :_, :_})
+      assert Registry.lookup(registry, "hello") == [{self(), value}]
+      Registry.unregister_match(registry, "hello", {:_, :atom, :_})
+      assert Registry.lookup(registry, "hello") == []
+    end
+
+    test "unregister_match supports guards", %{registry: registry} do
+      value = {1, :atom, 1}
+      {:ok, _} = Registry.register(registry, "hello", value)
+
+      Registry.unregister_match(registry, "hello", {:"$1", :_, :_}, [{:<, :"$1", 2}])
+      assert Registry.lookup(registry, "hello") == []
+    end
+
+    test "unregister_match supports tricky keys", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, :_, :foo)
+      {:ok, _} = Registry.register(registry, "hello", "b")
+
+      Registry.unregister_match(registry, :_, :foo)
+      assert Registry.lookup(registry, :_) == []
+      assert Registry.keys(registry, self()) |> Enum.sort() == ["hello"]
+    end
+
+    test "compares using ===", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, 1.0, :value)
+      {:ok, _} = Registry.register(registry, 1, :value)
+      assert Registry.keys(registry, self()) |> Enum.sort() == [1, 1.0]
+    end
+
+    test "updates current process value", %{registry: registry} do
+      assert Registry.update_value(registry, "hello", &raise/1) == :error
+      register_task(registry, "hello", :value)
+      assert Registry.update_value(registry, "hello", &raise/1) == :error
+
+      Registry.register(registry, "world", 1)
+      assert Registry.lookup(registry, "world") == [{self(), 1}]
+      assert Registry.update_value(registry, "world", &(&1 + 1)) == {2, 1}
+      assert Registry.lookup(registry, "world") == [{self(), 2}]
+    end
+
+    test "dispatches to a single key", %{registry: registry} do
+      fun = fn _ -> raise "will never be invoked" end
+      assert Registry.dispatch(registry, "hello", fun) == :ok
+
+      {:ok, _} = Registry.register(registry, "hello", :value)
+
+      fun = fn [{pid, value}] -> send(pid, {:dispatch, value}) end
+      assert Registry.dispatch(registry, "hello", fun)
+
+      assert_received {:dispatch, :value}
+    end
+
+    test "unregisters process by key", %{registry: registry} do
+      :ok = Registry.unregister(registry, "hello")
+
+      {:ok, _} = Registry.register(registry, "hello", :value)
+      {:ok, _} = Registry.register(registry, "world", :value)
+      assert Registry.keys(registry, self()) |> Enum.sort() == ["hello", "world"]
+
+      :ok = Registry.unregister(registry, "hello")
+      assert Registry.keys(registry, self()) == ["world"]
+
+      :ok = Registry.unregister(registry, "world")
+      assert Registry.keys(registry, self()) == []
+    end
+
+    test "unregisters with no entries", %{registry: registry} do
+      assert Registry.unregister(registry, "hello") == :ok
+    end
+
+    test "unregisters with tricky keys", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, :_, :foo)
+      {:ok, _} = Registry.register(registry, "hello", "b")
+
+      Registry.unregister(registry, :_)
+      assert Registry.lookup(registry, :_) == []
+      assert Registry.keys(registry, self()) |> Enum.sort() == ["hello"]
+    end
+
+    @tag listener: :duplicate_listener
+    test "allows listeners", %{registry: registry, listener: listener} do
+      Process.register(self(), listener)
+      {_, task} = register_task(registry, "hello", :world)
+      assert_received {:register, ^registry, "hello", ^task, :world}
+
+      self = self()
+      {:ok, _} = Registry.register(registry, "world", :value)
+      assert_received {:register, ^registry, "world", ^self, :value}
+
+      :ok = Registry.unregister(registry, "world")
+      assert_received {:unregister, ^registry, "world", ^self}
+    after
+      Process.unregister(listener)
+    end
+
+    test "links and unlinks on register/unregister", %{registry: registry} do
+      {:ok, pid} = Registry.register(registry, "hello", :value)
+      {:links, links} = Process.info(self(), :links)
+      assert pid in links
+
+      {:ok, pid} = Registry.register(registry, "world", :value)
+      {:links, links} = Process.info(self(), :links)
+      assert pid in links
+
+      :ok = Registry.unregister(registry, "hello")
+      {:links, links} = Process.info(self(), :links)
+      assert pid in links
+
+      :ok = Registry.unregister(registry, "world")
+      {:links, links} = Process.info(self(), :links)
+      refute pid in links
+    end
+
+    test "raises on unknown registry name" do
+      assert_raise ArgumentError, ~r/unknown registry/, fn ->
+        Registry.register(:unknown, "hello", :value)
       end
+    end
 
-      test "counts 0 keys in an empty registry", %{registry: registry} do
-        assert 0 == Registry.count(registry)
+    test "via callbacks", %{registry: registry} do
+      name = {:via, Registry, {registry, "hello"}}
+
+      # register_name
+      {:ok, pid} = Agent.start_link(fn -> 0 end, name: name)
+
+      # send
+      assert Agent.update(name, &(&1 + 1)) == :ok
+
+      # whereis_name
+      assert Agent.get(name, & &1) == 1
+
+      # unregister_name
+      assert {:error, _} = Agent.start(fn -> raise "oops" end)
+
+      # errors
+      assert {:error, {:already_started, ^pid}} = Agent.start(fn -> 0 end, name: name)
+    end
+
+    test "uses value provided in via", %{registry: registry} do
+      name = {:via, Registry, {registry, "hello", :value}}
+      {:ok, pid} = Agent.start_link(fn -> 0 end, name: name)
+      assert Registry.lookup(registry, "hello") == [{pid, :value}]
+    end
+
+    test "empty list for empty registry", %{registry: registry} do
+      assert Registry.select(registry, [{{:_, :_, :_}, [], [:"$_"]}]) == []
+    end
+
+    test "select all", %{registry: registry} do
+      name = {:via, Registry, {registry, "hello"}}
+      {:ok, pid} = Agent.start_link(fn -> 0 end, name: name)
+      {:ok, _} = Registry.register(registry, "world", :value)
+
+      assert Registry.select(registry, [{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2", :"$3"}}]}])
+             |> Enum.sort() ==
+               [{"hello", pid, nil}, {"world", self(), :value}]
+    end
+
+    test "select supports full match specs", %{registry: registry} do
+      value = {1, :atom, 1}
+      {:ok, _} = Registry.register(registry, "hello", value)
+
+      assert [{"hello", self(), value}] ==
+               Registry.select(registry, [
+                 {{"hello", :"$2", :"$3"}, [], [{{"hello", :"$2", :"$3"}}]}
+               ])
+
+      assert [{"hello", self(), value}] ==
+               Registry.select(registry, [
+                 {{:"$1", self(), :"$3"}, [], [{{:"$1", self(), :"$3"}}]}
+               ])
+
+      assert [{"hello", self(), value}] ==
+               Registry.select(registry, [
+                 {{:"$1", :"$2", value}, [], [{{:"$1", :"$2", {value}}}]}
+               ])
+
+      assert [] ==
+               Registry.select(registry, [
+                 {{"world", :"$2", :"$3"}, [], [{{"world", :"$2", :"$3"}}]}
+               ])
+
+      assert [] == Registry.select(registry, [{{:"$1", :"$2", {1.0, :_, :_}}, [], [:"$_"]}])
+
+      assert [{"hello", self(), value}] ==
+               Registry.select(registry, [
+                 {{:"$1", :"$2", {:"$3", :atom, :"$4"}}, [],
+                  [{{:"$1", :"$2", {{:"$3", :atom, :"$4"}}}}]}
+               ])
+
+      assert [{"hello", self(), {1, :atom, 1}}] ==
+               Registry.select(registry, [
+                 {{:"$1", :"$2", {:"$3", :"$4", :"$3"}}, [],
+                  [{{:"$1", :"$2", {{:"$3", :"$4", :"$3"}}}}]}
+               ])
+
+      value2 = %{a: "a", b: "b"}
+      {:ok, _} = Registry.register(registry, "world", value2)
+
+      assert [:match] ==
+               Registry.select(registry, [{{"world", self(), %{b: "b"}}, [], [:match]}])
+
+      assert ["hello", "world"] ==
+               Registry.select(registry, [{{:"$1", :_, :_}, [], [:"$1"]}]) |> Enum.sort()
+    end
+
+    test "select supports guard conditions", %{registry: registry} do
+      value = {1, :atom, 2}
+      {:ok, _} = Registry.register(registry, "hello", value)
+
+      assert [{"hello", self(), {1, :atom, 2}}] ==
+               Registry.select(registry, [
+                 {{:"$1", :"$2", {:"$3", :"$4", :"$5"}}, [{:>, :"$5", 1}],
+                  [{{:"$1", :"$2", {{:"$3", :"$4", :"$5"}}}}]}
+               ])
+
+      assert [] ==
+               Registry.select(registry, [
+                 {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}], [:"$_"]}
+               ])
+
+      assert ["hello"] ==
+               Registry.select(registry, [
+                 {{:"$1", :_, {:_, :"$2", :_}}, [{:is_atom, :"$2"}], [:"$1"]}
+               ])
+    end
+
+    test "select allows multiple specs", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, "hello", :value)
+      {:ok, _} = Registry.register(registry, "world", :value)
+
+      assert ["hello", "world"] ==
+               Registry.select(registry, [
+                 {{"hello", :_, :_}, [], [{:element, 1, :"$_"}]},
+                 {{"world", :_, :_}, [], [{:element, 1, :"$_"}]}
+               ])
+               |> Enum.sort()
+    end
+
+    test "select raises on incorrect shape of match spec", %{registry: registry} do
+      assert_raise ArgumentError, fn ->
+        Registry.select(registry, [{:_, [], []}])
       end
+    end
 
-      test "counts the number of keys in a registry", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, "hello", :value)
-        {:ok, _} = Registry.register(registry, "world", :value)
+    test "count_select supports match specs", %{registry: registry} do
+      value = {1, :atom, 1}
+      {:ok, _} = Registry.register(registry, "hello", value)
+      assert 1 == Registry.count_select(registry, [{{:_, :_, value}, [], [true]}])
+      assert 1 == Registry.count_select(registry, [{{"hello", :_, :_}, [], [true]}])
+      assert 1 == Registry.count_select(registry, [{{:_, :_, {1, :atom, :_}}, [], [true]}])
+      assert 1 == Registry.count_select(registry, [{{:_, :_, {:"$1", :_, :"$1"}}, [], [true]}])
+      assert 0 == Registry.count_select(registry, [{{"hello", :_, nil}, [], [true]}])
 
-        assert 2 == Registry.count(registry)
+      value2 = %{a: "a", b: "b"}
+      {:ok, _} = Registry.register(registry, "world", value2)
+      assert 1 == Registry.count_select(registry, [{{"world", :_, :_}, [], [true]}])
+    end
+
+    test "count_select supports guard conditions", %{registry: registry} do
+      value = {1, :atom, 2}
+      {:ok, _} = Registry.register(registry, "hello", value)
+
+      assert 1 ==
+               Registry.count_select(registry, [
+                 {{:_, :_, {:_, :"$1", :_}}, [{:is_atom, :"$1"}], [true]}
+               ])
+
+      assert 1 ==
+               Registry.count_select(registry, [
+                 {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 1}], [true]}
+               ])
+
+      assert 0 ==
+               Registry.count_select(registry, [
+                 {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}], [true]}
+               ])
+    end
+
+    test "count_select allows multiple specs", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, "hello", :value)
+      {:ok, _} = Registry.register(registry, "world", :value)
+
+      assert 2 ==
+               Registry.count_select(registry, [
+                 {{"hello", :_, :_}, [], [true]},
+                 {{"world", :_, :_}, [], [true]}
+               ])
+    end
+
+    test "count_select raises on incorrect shape of match spec", %{registry: registry} do
+      assert_raise ArgumentError, fn ->
+        Registry.count_select(registry, [{:_, [], []}])
       end
+    end
 
-      test "has unique registrations", %{registry: registry} do
-        {:ok, pid} = Registry.register(registry, "hello", :value)
-        assert is_pid(pid)
-        assert Registry.keys(registry, self()) == ["hello"]
-        assert Registry.values(registry, "hello", self()) == [:value]
+    test "doesn't grow ets on already_registered",
+         %{registry: registry, partitions: partitions} do
+      assert sum_pid_entries(registry, partitions) == 0
 
-        assert {:error, {:already_registered, pid}} = Registry.register(registry, "hello", :value)
-        assert pid == self()
-        assert Registry.keys(registry, self()) == ["hello"]
-        assert Registry.values(registry, "hello", self()) == [:value]
+      {:ok, pid} = Registry.register(registry, "hello", :value)
+      assert is_pid(pid)
+      assert sum_pid_entries(registry, partitions) == 1
 
-        {:ok, pid} = Registry.register(registry, "world", :value)
-        assert is_pid(pid)
-        assert Registry.keys(registry, self()) |> Enum.sort() == ["hello", "world"]
-      end
+      {:ok, pid} = Registry.register(registry, "world", :value)
+      assert is_pid(pid)
+      assert sum_pid_entries(registry, partitions) == 2
 
-      test "has unique registrations across processes", %{registry: registry} do
-        {_, task} = register_task(registry, "hello", :value)
-        Process.link(Process.whereis(registry))
-        assert Registry.keys(registry, task) == ["hello"]
-        assert Registry.values(registry, "hello", task) == [:value]
+      assert {:error, {:already_registered, _pid}} =
+               Registry.register(registry, "hello", :value)
 
-        assert {:error, {:already_registered, ^task}} =
-                 Registry.register(registry, "hello", :recent)
+      assert sum_pid_entries(registry, partitions) == 2
+    end
 
-        assert Registry.keys(registry, self()) == []
-        assert Registry.values(registry, "hello", self()) == []
+    test "doesn't grow ets on already_registered across processes",
+         %{registry: registry, partitions: partitions} do
+      assert sum_pid_entries(registry, partitions) == 0
 
-        {:links, links} = Process.info(self(), :links)
-        assert Process.whereis(registry) in links
-      end
+      {_, task} = register_task(registry, "hello", :value)
+      Process.link(Process.whereis(registry))
 
-      test "has unique registrations even if partition is delayed", %{registry: registry} do
-        {owner, task} = register_task(registry, "hello", :value)
+      assert sum_pid_entries(registry, partitions) == 1
 
-        assert Registry.register(registry, "hello", :other) ==
-                 {:error, {:already_registered, task}}
+      {:ok, pid} = Registry.register(registry, "world", :value)
+      assert is_pid(pid)
+      assert sum_pid_entries(registry, partitions) == 2
 
-        :sys.suspend(owner)
-        kill_and_assert_down(task)
-        Registry.register(registry, "hello", :other)
-        assert Registry.lookup(registry, "hello") == [{self(), :other}]
-      end
+      assert {:error, {:already_registered, ^task}} =
+               Registry.register(registry, "hello", :recent)
 
-      test "supports match patterns", %{registry: registry} do
-        value = {1, :atom, 1}
-        {:ok, _} = Registry.register(registry, "hello", value)
-        assert Registry.match(registry, "hello", {1, :_, :_}) == [{self(), value}]
-        assert Registry.match(registry, "hello", {1.0, :_, :_}) == []
-        assert Registry.match(registry, "hello", {:_, :atom, :_}) == [{self(), value}]
-        assert Registry.match(registry, "hello", {:"$1", :_, :"$1"}) == [{self(), value}]
-        assert Registry.match(registry, "hello", :_) == [{self(), value}]
-        assert Registry.match(registry, :_, :_) == []
-
-        value2 = %{a: "a", b: "b"}
-        {:ok, _} = Registry.register(registry, "world", value2)
-        assert Registry.match(registry, "world", %{b: "b"}) == [{self(), value2}]
-      end
-
-      test "supports guard conditions", %{registry: registry} do
-        value = {1, :atom, 2}
-        {:ok, _} = Registry.register(registry, "hello", value)
-
-        assert Registry.match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 1}]) ==
-                 [{self(), value}]
-
-        assert Registry.match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 2}]) == []
-
-        assert Registry.match(registry, "hello", {:_, :"$1", :_}, [{:is_atom, :"$1"}]) ==
-                 [{self(), value}]
-      end
-
-      test "count_match supports match patterns", %{registry: registry} do
-        value = {1, :atom, 1}
-        {:ok, _} = Registry.register(registry, "hello", value)
-        assert 1 == Registry.count_match(registry, "hello", {1, :_, :_})
-        assert 0 == Registry.count_match(registry, "hello", {1.0, :_, :_})
-        assert 1 == Registry.count_match(registry, "hello", {:_, :atom, :_})
-        assert 1 == Registry.count_match(registry, "hello", {:"$1", :_, :"$1"})
-        assert 1 == Registry.count_match(registry, "hello", :_)
-        assert 0 == Registry.count_match(registry, :_, :_)
-
-        value2 = %{a: "a", b: "b"}
-        {:ok, _} = Registry.register(registry, "world", value2)
-        assert 1 == Registry.count_match(registry, "world", %{b: "b"})
-      end
-
-      test "count_match supports guard conditions", %{registry: registry} do
-        value = {1, :atom, 2}
-        {:ok, _} = Registry.register(registry, "hello", value)
-
-        assert 1 == Registry.count_match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 1}])
-        assert 0 == Registry.count_match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 2}])
-        assert 1 == Registry.count_match(registry, "hello", {:_, :"$1", :_}, [{:is_atom, :"$1"}])
-      end
-
-      test "unregister_match supports patterns", %{registry: registry} do
-        value = {1, :atom, 1}
-        {:ok, _} = Registry.register(registry, "hello", value)
-
-        Registry.unregister_match(registry, "hello", {2, :_, :_})
-        assert Registry.lookup(registry, "hello") == [{self(), value}]
-        Registry.unregister_match(registry, "hello", {1.0, :_, :_})
-        assert Registry.lookup(registry, "hello") == [{self(), value}]
-        Registry.unregister_match(registry, "hello", {:_, :atom, :_})
-        assert Registry.lookup(registry, "hello") == []
-      end
-
-      test "unregister_match supports guards", %{registry: registry} do
-        value = {1, :atom, 1}
-        {:ok, _} = Registry.register(registry, "hello", value)
-
-        Registry.unregister_match(registry, "hello", {:"$1", :_, :_}, [{:<, :"$1", 2}])
-        assert Registry.lookup(registry, "hello") == []
-      end
-
-      test "unregister_match supports tricky keys", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, :_, :foo)
-        {:ok, _} = Registry.register(registry, "hello", "b")
-
-        Registry.unregister_match(registry, :_, :foo)
-        assert Registry.lookup(registry, :_) == []
-        assert Registry.keys(registry, self()) |> Enum.sort() == ["hello"]
-      end
-
-      test "compares using ===", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, 1.0, :value)
-        {:ok, _} = Registry.register(registry, 1, :value)
-        assert Registry.keys(registry, self()) |> Enum.sort() == [1, 1.0]
-      end
-
-      test "updates current process value", %{registry: registry} do
-        assert Registry.update_value(registry, "hello", &raise/1) == :error
-        register_task(registry, "hello", :value)
-        assert Registry.update_value(registry, "hello", &raise/1) == :error
-
-        Registry.register(registry, "world", 1)
-        assert Registry.lookup(registry, "world") == [{self(), 1}]
-        assert Registry.update_value(registry, "world", &(&1 + 1)) == {2, 1}
-        assert Registry.lookup(registry, "world") == [{self(), 2}]
-      end
-
-      test "dispatches to a single key", %{registry: registry} do
-        fun = fn _ -> raise "will never be invoked" end
-        assert Registry.dispatch(registry, "hello", fun) == :ok
-
-        {:ok, _} = Registry.register(registry, "hello", :value)
-
-        fun = fn [{pid, value}] -> send(pid, {:dispatch, value}) end
-        assert Registry.dispatch(registry, "hello", fun)
-
-        assert_received {:dispatch, :value}
-      end
-
-      test "unregisters process by key", %{registry: registry} do
-        :ok = Registry.unregister(registry, "hello")
-
-        {:ok, _} = Registry.register(registry, "hello", :value)
-        {:ok, _} = Registry.register(registry, "world", :value)
-        assert Registry.keys(registry, self()) |> Enum.sort() == ["hello", "world"]
-
-        :ok = Registry.unregister(registry, "hello")
-        assert Registry.keys(registry, self()) == ["world"]
-
-        :ok = Registry.unregister(registry, "world")
-        assert Registry.keys(registry, self()) == []
-      end
-
-      test "unregisters with no entries", %{registry: registry} do
-        assert Registry.unregister(registry, "hello") == :ok
-      end
-
-      test "unregisters with tricky keys", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, :_, :foo)
-        {:ok, _} = Registry.register(registry, "hello", "b")
-
-        Registry.unregister(registry, :_)
-        assert Registry.lookup(registry, :_) == []
-        assert Registry.keys(registry, self()) |> Enum.sort() == ["hello"]
-      end
-
-      @tag listener: :"unique_listener_#{partitions}"
-      test "allows listeners", %{registry: registry, listener: listener} do
-        Process.register(self(), listener)
-        {_, task} = register_task(registry, "hello", :world)
-        assert_received {:register, ^registry, "hello", ^task, :world}
-
-        self = self()
-        {:ok, _} = Registry.register(registry, "world", :value)
-        assert_received {:register, ^registry, "world", ^self, :value}
-
-        :ok = Registry.unregister(registry, "world")
-        assert_received {:unregister, ^registry, "world", ^self}
-      end
-
-      test "links and unlinks on register/unregister", %{registry: registry} do
-        {:ok, pid} = Registry.register(registry, "hello", :value)
-        {:links, links} = Process.info(self(), :links)
-        assert pid in links
-
-        {:ok, pid} = Registry.register(registry, "world", :value)
-        {:links, links} = Process.info(self(), :links)
-        assert pid in links
-
-        :ok = Registry.unregister(registry, "hello")
-        {:links, links} = Process.info(self(), :links)
-        assert pid in links
-
-        :ok = Registry.unregister(registry, "world")
-        {:links, links} = Process.info(self(), :links)
-        refute pid in links
-      end
-
-      test "raises on unknown registry name" do
-        assert_raise ArgumentError, ~r/unknown registry/, fn ->
-          Registry.register(:unknown, "hello", :value)
-        end
-      end
-
-      test "via callbacks", %{registry: registry} do
-        name = {:via, Registry, {registry, "hello"}}
-
-        # register_name
-        {:ok, pid} = Agent.start_link(fn -> 0 end, name: name)
-
-        # send
-        assert Agent.update(name, &(&1 + 1)) == :ok
-
-        # whereis_name
-        assert Agent.get(name, & &1) == 1
-
-        # unregister_name
-        assert {:error, _} = Agent.start(fn -> raise "oops" end)
-
-        # errors
-        assert {:error, {:already_started, ^pid}} = Agent.start(fn -> 0 end, name: name)
-      end
-
-      test "uses value provided in via", %{registry: registry} do
-        name = {:via, Registry, {registry, "hello", :value}}
-        {:ok, pid} = Agent.start_link(fn -> 0 end, name: name)
-        assert Registry.lookup(registry, "hello") == [{pid, :value}]
-      end
-
-      test "empty list for empty registry", %{registry: registry} do
-        assert Registry.select(registry, [{{:_, :_, :_}, [], [:"$_"]}]) == []
-      end
-
-      test "select all", %{registry: registry} do
-        name = {:via, Registry, {registry, "hello"}}
-        {:ok, pid} = Agent.start_link(fn -> 0 end, name: name)
-        {:ok, _} = Registry.register(registry, "world", :value)
-
-        assert Registry.select(registry, [{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2", :"$3"}}]}])
-               |> Enum.sort() ==
-                 [{"hello", pid, nil}, {"world", self(), :value}]
-      end
-
-      test "select supports full match specs", %{registry: registry} do
-        value = {1, :atom, 1}
-        {:ok, _} = Registry.register(registry, "hello", value)
-
-        assert [{"hello", self(), value}] ==
-                 Registry.select(registry, [
-                   {{"hello", :"$2", :"$3"}, [], [{{"hello", :"$2", :"$3"}}]}
-                 ])
-
-        assert [{"hello", self(), value}] ==
-                 Registry.select(registry, [
-                   {{:"$1", self(), :"$3"}, [], [{{:"$1", self(), :"$3"}}]}
-                 ])
-
-        assert [{"hello", self(), value}] ==
-                 Registry.select(registry, [
-                   {{:"$1", :"$2", value}, [], [{{:"$1", :"$2", {value}}}]}
-                 ])
-
-        assert [] ==
-                 Registry.select(registry, [
-                   {{"world", :"$2", :"$3"}, [], [{{"world", :"$2", :"$3"}}]}
-                 ])
-
-        assert [] == Registry.select(registry, [{{:"$1", :"$2", {1.0, :_, :_}}, [], [:"$_"]}])
-
-        assert [{"hello", self(), value}] ==
-                 Registry.select(registry, [
-                   {{:"$1", :"$2", {:"$3", :atom, :"$4"}}, [],
-                    [{{:"$1", :"$2", {{:"$3", :atom, :"$4"}}}}]}
-                 ])
-
-        assert [{"hello", self(), {1, :atom, 1}}] ==
-                 Registry.select(registry, [
-                   {{:"$1", :"$2", {:"$3", :"$4", :"$3"}}, [],
-                    [{{:"$1", :"$2", {{:"$3", :"$4", :"$3"}}}}]}
-                 ])
-
-        value2 = %{a: "a", b: "b"}
-        {:ok, _} = Registry.register(registry, "world", value2)
-
-        assert [:match] ==
-                 Registry.select(registry, [{{"world", self(), %{b: "b"}}, [], [:match]}])
-
-        assert ["hello", "world"] ==
-                 Registry.select(registry, [{{:"$1", :_, :_}, [], [:"$1"]}]) |> Enum.sort()
-      end
-
-      test "select supports guard conditions", %{registry: registry} do
-        value = {1, :atom, 2}
-        {:ok, _} = Registry.register(registry, "hello", value)
-
-        assert [{"hello", self(), {1, :atom, 2}}] ==
-                 Registry.select(registry, [
-                   {{:"$1", :"$2", {:"$3", :"$4", :"$5"}}, [{:>, :"$5", 1}],
-                    [{{:"$1", :"$2", {{:"$3", :"$4", :"$5"}}}}]}
-                 ])
-
-        assert [] ==
-                 Registry.select(registry, [
-                   {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}], [:"$_"]}
-                 ])
-
-        assert ["hello"] ==
-                 Registry.select(registry, [
-                   {{:"$1", :_, {:_, :"$2", :_}}, [{:is_atom, :"$2"}], [:"$1"]}
-                 ])
-      end
-
-      test "select allows multiple specs", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, "hello", :value)
-        {:ok, _} = Registry.register(registry, "world", :value)
-
-        assert ["hello", "world"] ==
-                 Registry.select(registry, [
-                   {{"hello", :_, :_}, [], [{:element, 1, :"$_"}]},
-                   {{"world", :_, :_}, [], [{:element, 1, :"$_"}]}
-                 ])
-                 |> Enum.sort()
-      end
-
-      test "select raises on incorrect shape of match spec", %{registry: registry} do
-        assert_raise ArgumentError, fn ->
-          Registry.select(registry, [{:_, [], []}])
-        end
-      end
-
-      test "count_select supports match specs", %{registry: registry} do
-        value = {1, :atom, 1}
-        {:ok, _} = Registry.register(registry, "hello", value)
-        assert 1 == Registry.count_select(registry, [{{:_, :_, value}, [], [true]}])
-        assert 1 == Registry.count_select(registry, [{{"hello", :_, :_}, [], [true]}])
-        assert 1 == Registry.count_select(registry, [{{:_, :_, {1, :atom, :_}}, [], [true]}])
-        assert 1 == Registry.count_select(registry, [{{:_, :_, {:"$1", :_, :"$1"}}, [], [true]}])
-        assert 0 == Registry.count_select(registry, [{{"hello", :_, nil}, [], [true]}])
-
-        value2 = %{a: "a", b: "b"}
-        {:ok, _} = Registry.register(registry, "world", value2)
-        assert 1 == Registry.count_select(registry, [{{"world", :_, :_}, [], [true]}])
-      end
-
-      test "count_select supports guard conditions", %{registry: registry} do
-        value = {1, :atom, 2}
-        {:ok, _} = Registry.register(registry, "hello", value)
-
-        assert 1 ==
-                 Registry.count_select(registry, [
-                   {{:_, :_, {:_, :"$1", :_}}, [{:is_atom, :"$1"}], [true]}
-                 ])
-
-        assert 1 ==
-                 Registry.count_select(registry, [
-                   {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 1}], [true]}
-                 ])
-
-        assert 0 ==
-                 Registry.count_select(registry, [
-                   {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}], [true]}
-                 ])
-      end
-
-      test "count_select allows multiple specs", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, "hello", :value)
-        {:ok, _} = Registry.register(registry, "world", :value)
-
-        assert 2 ==
-                 Registry.count_select(registry, [
-                   {{"hello", :_, :_}, [], [true]},
-                   {{"world", :_, :_}, [], [true]}
-                 ])
-      end
-
-      test "count_select raises on incorrect shape of match spec", %{registry: registry} do
-        assert_raise ArgumentError, fn ->
-          Registry.count_select(registry, [{:_, [], []}])
-        end
-      end
-
-      test "doesn't grow ets on already_registered",
-           %{registry: registry, partitions: partitions} do
-        assert sum_pid_entries(registry, partitions) == 0
-
-        {:ok, pid} = Registry.register(registry, "hello", :value)
-        assert is_pid(pid)
-        assert sum_pid_entries(registry, partitions) == 1
-
-        {:ok, pid} = Registry.register(registry, "world", :value)
-        assert is_pid(pid)
-        assert sum_pid_entries(registry, partitions) == 2
-
-        assert {:error, {:already_registered, _pid}} =
-                 Registry.register(registry, "hello", :value)
-
-        assert sum_pid_entries(registry, partitions) == 2
-      end
-
-      test "doesn't grow ets on already_registered across processes",
-           %{registry: registry, partitions: partitions} do
-        assert sum_pid_entries(registry, partitions) == 0
-
-        {_, task} = register_task(registry, "hello", :value)
-        Process.link(Process.whereis(registry))
-
-        assert sum_pid_entries(registry, partitions) == 1
-
-        {:ok, pid} = Registry.register(registry, "world", :value)
-        assert is_pid(pid)
-        assert sum_pid_entries(registry, partitions) == 2
-
-        assert {:error, {:already_registered, ^task}} =
-                 Registry.register(registry, "hello", :recent)
-
-        assert sum_pid_entries(registry, partitions) == 2
-      end
+      assert sum_pid_entries(registry, partitions) == 2
     end
   end
 
-  for {describe, partitions} <- ["with 1 partition": 1, "with 8 partitions": 8] do
-    describe "duplicate #{describe}" do
-      @describetag keys: :duplicate, partitions: partitions
+  describe "duplicate" do
+    @describetag keys: :duplicate
 
-      test "starts configured number of partitions", %{registry: registry, partitions: partitions} do
-        assert length(Supervisor.which_children(registry)) == partitions
+    test "starts configured number of partitions", %{registry: registry, partitions: partitions} do
+      assert length(Supervisor.which_children(registry)) == partitions
+    end
+
+    test "counts 0 keys in an empty registry", %{registry: registry} do
+      assert 0 == Registry.count(registry)
+    end
+
+    test "counts the number of keys in a registry", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, "hello", :value)
+      {:ok, _} = Registry.register(registry, "hello", :value)
+
+      assert 2 == Registry.count(registry)
+    end
+
+    test "has duplicate registrations", %{registry: registry} do
+      {:ok, pid} = Registry.register(registry, "hello", :value)
+      assert is_pid(pid)
+      assert Registry.keys(registry, self()) == ["hello"]
+      assert Registry.values(registry, "hello", self()) == [:value]
+
+      assert {:ok, pid} = Registry.register(registry, "hello", :value)
+      assert is_pid(pid)
+      assert Registry.keys(registry, self()) == ["hello", "hello"]
+      assert Registry.values(registry, "hello", self()) == [:value, :value]
+
+      {:ok, pid} = Registry.register(registry, "world", :value)
+      assert is_pid(pid)
+      assert Registry.keys(registry, self()) |> Enum.sort() == ["hello", "hello", "world"]
+    end
+
+    test "has duplicate registrations across processes", %{registry: registry} do
+      {_, task} = register_task(registry, "hello", :world)
+      assert Registry.keys(registry, self()) == []
+      assert Registry.keys(registry, task) == ["hello"]
+      assert Registry.values(registry, "hello", self()) == []
+      assert Registry.values(registry, "hello", task) == [:world]
+
+      assert {:ok, _pid} = Registry.register(registry, "hello", :value)
+      assert Registry.keys(registry, self()) == ["hello"]
+      assert Registry.values(registry, "hello", self()) == [:value]
+    end
+
+    test "compares using matches", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, 1.0, :value)
+      {:ok, _} = Registry.register(registry, 1, :value)
+      assert Registry.keys(registry, self()) |> Enum.sort() == [1, 1.0]
+    end
+
+    test "dispatches to multiple keys in serial", %{registry: registry} do
+      Process.flag(:trap_exit, true)
+      parent = self()
+
+      fun = fn _ -> raise "will never be invoked" end
+      assert Registry.dispatch(registry, "hello", fun, parallel: false) == :ok
+
+      {:ok, _} = Registry.register(registry, "hello", :value1)
+      {:ok, _} = Registry.register(registry, "hello", :value2)
+      {:ok, _} = Registry.register(registry, "world", :value3)
+
+      fun = fn entries ->
+        assert parent == self()
+        for {pid, value} <- entries, do: send(pid, {:dispatch, value})
       end
 
-      test "counts 0 keys in an empty registry", %{registry: registry} do
-        assert 0 == Registry.count(registry)
+      assert Registry.dispatch(registry, "hello", fun, parallel: false)
+
+      assert_received {:dispatch, :value1}
+      assert_received {:dispatch, :value2}
+      refute_received {:dispatch, :value3}
+
+      fun = fn entries ->
+        assert parent == self()
+        for {pid, value} <- entries, do: send(pid, {:dispatch, value})
       end
 
-      test "counts the number of keys in a registry", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, "hello", :value)
-        {:ok, _} = Registry.register(registry, "hello", :value)
+      assert Registry.dispatch(registry, "world", fun, parallel: false)
 
-        assert 2 == Registry.count(registry)
-      end
+      refute_received {:dispatch, :value1}
+      refute_received {:dispatch, :value2}
+      assert_received {:dispatch, :value3}
 
-      test "has duplicate registrations", %{registry: registry} do
-        {:ok, pid} = Registry.register(registry, "hello", :value)
-        assert is_pid(pid)
-        assert Registry.keys(registry, self()) == ["hello"]
-        assert Registry.values(registry, "hello", self()) == [:value]
+      refute_received {:EXIT, _, _}
+    end
 
-        assert {:ok, pid} = Registry.register(registry, "hello", :value)
-        assert is_pid(pid)
-        assert Registry.keys(registry, self()) == ["hello", "hello"]
-        assert Registry.values(registry, "hello", self()) == [:value, :value]
+    test "dispatches to multiple keys in parallel", context do
+      %{registry: registry, partitions: partitions} = context
+      Process.flag(:trap_exit, true)
+      parent = self()
 
-        {:ok, pid} = Registry.register(registry, "world", :value)
-        assert is_pid(pid)
-        assert Registry.keys(registry, self()) |> Enum.sort() == ["hello", "hello", "world"]
-      end
+      fun = fn _ -> raise "will never be invoked" end
+      assert Registry.dispatch(registry, "hello", fun, parallel: true) == :ok
 
-      test "has duplicate registrations across processes", %{registry: registry} do
-        {_, task} = register_task(registry, "hello", :world)
-        assert Registry.keys(registry, self()) == []
-        assert Registry.keys(registry, task) == ["hello"]
-        assert Registry.values(registry, "hello", self()) == []
-        assert Registry.values(registry, "hello", task) == [:world]
+      {:ok, _} = Registry.register(registry, "hello", :value1)
+      {:ok, _} = Registry.register(registry, "hello", :value2)
+      {:ok, _} = Registry.register(registry, "world", :value3)
 
-        assert {:ok, _pid} = Registry.register(registry, "hello", :value)
-        assert Registry.keys(registry, self()) == ["hello"]
-        assert Registry.values(registry, "hello", self()) == [:value]
-      end
-
-      test "compares using matches", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, 1.0, :value)
-        {:ok, _} = Registry.register(registry, 1, :value)
-        assert Registry.keys(registry, self()) |> Enum.sort() == [1, 1.0]
-      end
-
-      test "dispatches to multiple keys in serial", %{registry: registry} do
-        Process.flag(:trap_exit, true)
-        parent = self()
-
-        fun = fn _ -> raise "will never be invoked" end
-        assert Registry.dispatch(registry, "hello", fun, parallel: false) == :ok
-
-        {:ok, _} = Registry.register(registry, "hello", :value1)
-        {:ok, _} = Registry.register(registry, "hello", :value2)
-        {:ok, _} = Registry.register(registry, "world", :value3)
-
-        fun = fn entries ->
+      fun = fn entries ->
+        if partitions == 8 do
+          assert parent != self()
+        else
           assert parent == self()
-          for {pid, value} <- entries, do: send(pid, {:dispatch, value})
         end
 
-        assert Registry.dispatch(registry, "hello", fun, parallel: false)
+        for {pid, value} <- entries, do: send(pid, {:dispatch, value})
+      end
 
-        assert_received {:dispatch, :value1}
-        assert_received {:dispatch, :value2}
-        refute_received {:dispatch, :value3}
+      assert Registry.dispatch(registry, "hello", fun, parallel: true)
 
-        fun = fn entries ->
+      assert_received {:dispatch, :value1}
+      assert_received {:dispatch, :value2}
+      refute_received {:dispatch, :value3}
+
+      fun = fn entries ->
+        if partitions == 8 do
+          assert parent != self()
+        else
           assert parent == self()
-          for {pid, value} <- entries, do: send(pid, {:dispatch, value})
         end
 
-        assert Registry.dispatch(registry, "world", fun, parallel: false)
-
-        refute_received {:dispatch, :value1}
-        refute_received {:dispatch, :value2}
-        assert_received {:dispatch, :value3}
-
-        refute_received {:EXIT, _, _}
+        for {pid, value} <- entries, do: send(pid, {:dispatch, value})
       end
 
-      test "dispatches to multiple keys in parallel", context do
-        %{registry: registry, partitions: partitions} = context
-        Process.flag(:trap_exit, true)
-        parent = self()
+      assert Registry.dispatch(registry, "world", fun, parallel: true)
 
-        fun = fn _ -> raise "will never be invoked" end
-        assert Registry.dispatch(registry, "hello", fun, parallel: true) == :ok
+      refute_received {:dispatch, :value1}
+      refute_received {:dispatch, :value2}
+      assert_received {:dispatch, :value3}
 
-        {:ok, _} = Registry.register(registry, "hello", :value1)
-        {:ok, _} = Registry.register(registry, "hello", :value2)
-        {:ok, _} = Registry.register(registry, "world", :value3)
+      refute_received {:EXIT, _, _}
+    end
 
-        fun = fn entries ->
-          if partitions == 8 do
-            assert parent != self()
-          else
-            assert parent == self()
-          end
+    test "unregisters by key", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, "hello", :value)
+      {:ok, _} = Registry.register(registry, "hello", :value)
+      {:ok, _} = Registry.register(registry, "world", :value)
+      assert Registry.keys(registry, self()) |> Enum.sort() == ["hello", "hello", "world"]
 
-          for {pid, value} <- entries, do: send(pid, {:dispatch, value})
-        end
+      :ok = Registry.unregister(registry, "hello")
+      assert Registry.keys(registry, self()) == ["world"]
 
-        assert Registry.dispatch(registry, "hello", fun, parallel: true)
+      :ok = Registry.unregister(registry, "world")
+      assert Registry.keys(registry, self()) == []
+    end
 
-        assert_received {:dispatch, :value1}
-        assert_received {:dispatch, :value2}
-        refute_received {:dispatch, :value3}
+    test "unregisters with no entries", %{registry: registry} do
+      assert Registry.unregister(registry, "hello") == :ok
+    end
 
-        fun = fn entries ->
-          if partitions == 8 do
-            assert parent != self()
-          else
-            assert parent == self()
-          end
+    test "unregisters with tricky keys", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, :_, :foo)
+      {:ok, _} = Registry.register(registry, :_, :bar)
+      {:ok, _} = Registry.register(registry, "hello", "a")
+      {:ok, _} = Registry.register(registry, "hello", "b")
 
-          for {pid, value} <- entries, do: send(pid, {:dispatch, value})
-        end
+      Registry.unregister(registry, :_)
+      assert Registry.keys(registry, self()) |> Enum.sort() == ["hello", "hello"]
+    end
 
-        assert Registry.dispatch(registry, "world", fun, parallel: true)
+    test "supports match patterns", %{registry: registry} do
+      value1 = {1, :atom, 1}
+      value2 = {2, :atom, 2}
 
-        refute_received {:dispatch, :value1}
-        refute_received {:dispatch, :value2}
-        assert_received {:dispatch, :value3}
+      {:ok, _} = Registry.register(registry, "hello", value1)
+      {:ok, _} = Registry.register(registry, "hello", value2)
 
-        refute_received {:EXIT, _, _}
+      assert Registry.match(registry, "hello", {1, :_, :_}) == [{self(), value1}]
+      assert Registry.match(registry, "hello", {1.0, :_, :_}) == []
+
+      assert Registry.match(registry, "hello", {:_, :atom, :_}) |> Enum.sort() ==
+               [{self(), value1}, {self(), value2}]
+
+      assert Registry.match(registry, "hello", {:"$1", :_, :"$1"}) |> Enum.sort() ==
+               [{self(), value1}, {self(), value2}]
+
+      assert Registry.match(registry, "hello", {2, :_, :_}) == [{self(), value2}]
+      assert Registry.match(registry, "hello", {2.0, :_, :_}) == []
+    end
+
+    test "supports guards", %{registry: registry} do
+      value1 = {1, :atom, 1}
+      value2 = {2, :atom, 2}
+
+      {:ok, _} = Registry.register(registry, "hello", value1)
+      {:ok, _} = Registry.register(registry, "hello", value2)
+
+      assert Registry.match(registry, "hello", {:"$1", :_, :_}, [{:<, :"$1", 2}]) ==
+               [{self(), value1}]
+
+      assert Registry.match(registry, "hello", {:"$1", :_, :_}, [{:>, :"$1", 3}]) == []
+
+      assert Registry.match(registry, "hello", {:"$1", :_, :_}, [{:<, :"$1", 3}]) |> Enum.sort() ==
+               [{self(), value1}, {self(), value2}]
+
+      assert Registry.match(registry, "hello", {:_, :"$1", :_}, [{:is_atom, :"$1"}])
+             |> Enum.sort() == [{self(), value1}, {self(), value2}]
+    end
+
+    test "count_match supports match patterns", %{registry: registry} do
+      value = {1, :atom, 1}
+      {:ok, _} = Registry.register(registry, "hello", value)
+      assert 1 == Registry.count_match(registry, "hello", {1, :_, :_})
+      assert 0 == Registry.count_match(registry, "hello", {1.0, :_, :_})
+      assert 1 == Registry.count_match(registry, "hello", {:_, :atom, :_})
+      assert 1 == Registry.count_match(registry, "hello", {:"$1", :_, :"$1"})
+      assert 1 == Registry.count_match(registry, "hello", :_)
+      assert 0 == Registry.count_match(registry, :_, :_)
+
+      value2 = %{a: "a", b: "b"}
+      {:ok, _} = Registry.register(registry, "world", value2)
+      assert 1 == Registry.count_match(registry, "world", %{b: "b"})
+    end
+
+    test "count_match supports guard conditions", %{registry: registry} do
+      value = {1, :atom, 2}
+      {:ok, _} = Registry.register(registry, "hello", value)
+
+      assert 1 == Registry.count_match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 1}])
+      assert 0 == Registry.count_match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 2}])
+      assert 1 == Registry.count_match(registry, "hello", {:_, :"$1", :_}, [{:is_atom, :"$1"}])
+    end
+
+    test "unregister_match supports patterns", %{registry: registry} do
+      value1 = {1, :atom, 1}
+      value2 = {2, :atom, 2}
+
+      {:ok, _} = Registry.register(registry, "hello", value1)
+      {:ok, _} = Registry.register(registry, "hello", value2)
+
+      Registry.unregister_match(registry, "hello", {2, :_, :_})
+      assert Registry.lookup(registry, "hello") == [{self(), value1}]
+
+      {:ok, _} = Registry.register(registry, "hello", value2)
+      Registry.unregister_match(registry, "hello", {2.0, :_, :_})
+      assert Registry.lookup(registry, "hello") == [{self(), value1}, {self(), value2}]
+      Registry.unregister_match(registry, "hello", {:_, :atom, :_})
+      assert Registry.lookup(registry, "hello") == []
+    end
+
+    test "unregister_match supports guards", %{registry: registry} do
+      value1 = {1, :atom, 1}
+      value2 = {2, :atom, 2}
+
+      {:ok, _} = Registry.register(registry, "hello", value1)
+      {:ok, _} = Registry.register(registry, "hello", value2)
+
+      Registry.unregister_match(registry, "hello", {:"$1", :_, :_}, [{:<, :"$1", 2}])
+      assert Registry.lookup(registry, "hello") == [{self(), value2}]
+    end
+
+    test "unregister_match supports tricky keys", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, :_, :foo)
+      {:ok, _} = Registry.register(registry, :_, :bar)
+      {:ok, _} = Registry.register(registry, "hello", "a")
+      {:ok, _} = Registry.register(registry, "hello", "b")
+
+      Registry.unregister_match(registry, :_, :foo)
+      assert Registry.lookup(registry, :_) == [{self(), :bar}]
+
+      assert Registry.keys(registry, self()) |> Enum.sort() == [:_, "hello", "hello"]
+    end
+
+    @tag listener: :duplicate_listener
+    test "allows listeners", %{registry: registry, listener: listener} do
+      Process.register(self(), listener)
+      {_, task} = register_task(registry, "hello", :world)
+      assert_received {:register, ^registry, "hello", ^task, :world}
+
+      self = self()
+      {:ok, _} = Registry.register(registry, "hello", :value)
+      assert_received {:register, ^registry, "hello", ^self, :value}
+
+      :ok = Registry.unregister(registry, "hello")
+      assert_received {:unregister, ^registry, "hello", ^self}
+    after
+      Process.unregister(listener)
+    end
+
+    test "links and unlinks on register/unregister", %{registry: registry} do
+      {:ok, pid} = Registry.register(registry, "hello", :value)
+      {:links, links} = Process.info(self(), :links)
+      assert pid in links
+
+      {:ok, pid} = Registry.register(registry, "world", :value)
+      {:links, links} = Process.info(self(), :links)
+      assert pid in links
+
+      :ok = Registry.unregister(registry, "hello")
+      {:links, links} = Process.info(self(), :links)
+      assert pid in links
+
+      :ok = Registry.unregister(registry, "world")
+      {:links, links} = Process.info(self(), :links)
+      refute pid in links
+    end
+
+    test "raises on unknown registry name" do
+      assert_raise ArgumentError, ~r/unknown registry/, fn ->
+        Registry.register(:unknown, "hello", :value)
       end
+    end
 
-      test "unregisters by key", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, "hello", :value)
-        {:ok, _} = Registry.register(registry, "hello", :value)
-        {:ok, _} = Registry.register(registry, "world", :value)
-        assert Registry.keys(registry, self()) |> Enum.sort() == ["hello", "hello", "world"]
-
-        :ok = Registry.unregister(registry, "hello")
-        assert Registry.keys(registry, self()) == ["world"]
-
-        :ok = Registry.unregister(registry, "world")
-        assert Registry.keys(registry, self()) == []
+    test "raises if attempt to be used on via", %{registry: registry} do
+      assert_raise ArgumentError, ":via is not supported for duplicate registries", fn ->
+        name = {:via, Registry, {registry, "hello"}}
+        Agent.start_link(fn -> 0 end, name: name)
       end
-
-      test "unregisters with no entries", %{registry: registry} do
-        assert Registry.unregister(registry, "hello") == :ok
-      end
-
-      test "unregisters with tricky keys", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, :_, :foo)
-        {:ok, _} = Registry.register(registry, :_, :bar)
-        {:ok, _} = Registry.register(registry, "hello", "a")
-        {:ok, _} = Registry.register(registry, "hello", "b")
-
-        Registry.unregister(registry, :_)
-        assert Registry.keys(registry, self()) |> Enum.sort() == ["hello", "hello"]
-      end
-
-      test "supports match patterns", %{registry: registry} do
-        value1 = {1, :atom, 1}
-        value2 = {2, :atom, 2}
-
-        {:ok, _} = Registry.register(registry, "hello", value1)
-        {:ok, _} = Registry.register(registry, "hello", value2)
-
-        assert Registry.match(registry, "hello", {1, :_, :_}) == [{self(), value1}]
-        assert Registry.match(registry, "hello", {1.0, :_, :_}) == []
-
-        assert Registry.match(registry, "hello", {:_, :atom, :_}) |> Enum.sort() ==
-                 [{self(), value1}, {self(), value2}]
-
-        assert Registry.match(registry, "hello", {:"$1", :_, :"$1"}) |> Enum.sort() ==
-                 [{self(), value1}, {self(), value2}]
-
-        assert Registry.match(registry, "hello", {2, :_, :_}) == [{self(), value2}]
-        assert Registry.match(registry, "hello", {2.0, :_, :_}) == []
-      end
-
-      test "supports guards", %{registry: registry} do
-        value1 = {1, :atom, 1}
-        value2 = {2, :atom, 2}
-
-        {:ok, _} = Registry.register(registry, "hello", value1)
-        {:ok, _} = Registry.register(registry, "hello", value2)
-
-        assert Registry.match(registry, "hello", {:"$1", :_, :_}, [{:<, :"$1", 2}]) ==
-                 [{self(), value1}]
-
-        assert Registry.match(registry, "hello", {:"$1", :_, :_}, [{:>, :"$1", 3}]) == []
-
-        assert Registry.match(registry, "hello", {:"$1", :_, :_}, [{:<, :"$1", 3}]) |> Enum.sort() ==
-                 [{self(), value1}, {self(), value2}]
-
-        assert Registry.match(registry, "hello", {:_, :"$1", :_}, [{:is_atom, :"$1"}])
-               |> Enum.sort() == [{self(), value1}, {self(), value2}]
-      end
-
-      test "count_match supports match patterns", %{registry: registry} do
-        value = {1, :atom, 1}
-        {:ok, _} = Registry.register(registry, "hello", value)
-        assert 1 == Registry.count_match(registry, "hello", {1, :_, :_})
-        assert 0 == Registry.count_match(registry, "hello", {1.0, :_, :_})
-        assert 1 == Registry.count_match(registry, "hello", {:_, :atom, :_})
-        assert 1 == Registry.count_match(registry, "hello", {:"$1", :_, :"$1"})
-        assert 1 == Registry.count_match(registry, "hello", :_)
-        assert 0 == Registry.count_match(registry, :_, :_)
-
-        value2 = %{a: "a", b: "b"}
-        {:ok, _} = Registry.register(registry, "world", value2)
-        assert 1 == Registry.count_match(registry, "world", %{b: "b"})
-      end
-
-      test "count_match supports guard conditions", %{registry: registry} do
-        value = {1, :atom, 2}
-        {:ok, _} = Registry.register(registry, "hello", value)
-
-        assert 1 == Registry.count_match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 1}])
-        assert 0 == Registry.count_match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 2}])
-        assert 1 == Registry.count_match(registry, "hello", {:_, :"$1", :_}, [{:is_atom, :"$1"}])
-      end
-
-      test "unregister_match supports patterns", %{registry: registry} do
-        value1 = {1, :atom, 1}
-        value2 = {2, :atom, 2}
-
-        {:ok, _} = Registry.register(registry, "hello", value1)
-        {:ok, _} = Registry.register(registry, "hello", value2)
-
-        Registry.unregister_match(registry, "hello", {2, :_, :_})
-        assert Registry.lookup(registry, "hello") == [{self(), value1}]
-
-        {:ok, _} = Registry.register(registry, "hello", value2)
-        Registry.unregister_match(registry, "hello", {2.0, :_, :_})
-        assert Registry.lookup(registry, "hello") == [{self(), value1}, {self(), value2}]
-        Registry.unregister_match(registry, "hello", {:_, :atom, :_})
-        assert Registry.lookup(registry, "hello") == []
-      end
-
-      test "unregister_match supports guards", %{registry: registry} do
-        value1 = {1, :atom, 1}
-        value2 = {2, :atom, 2}
-
-        {:ok, _} = Registry.register(registry, "hello", value1)
-        {:ok, _} = Registry.register(registry, "hello", value2)
-
-        Registry.unregister_match(registry, "hello", {:"$1", :_, :_}, [{:<, :"$1", 2}])
-        assert Registry.lookup(registry, "hello") == [{self(), value2}]
-      end
-
-      test "unregister_match supports tricky keys", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, :_, :foo)
-        {:ok, _} = Registry.register(registry, :_, :bar)
-        {:ok, _} = Registry.register(registry, "hello", "a")
-        {:ok, _} = Registry.register(registry, "hello", "b")
-
-        Registry.unregister_match(registry, :_, :foo)
-        assert Registry.lookup(registry, :_) == [{self(), :bar}]
-
-        assert Registry.keys(registry, self()) |> Enum.sort() == [:_, "hello", "hello"]
-      end
-
-      @tag listener: :"duplicate_listener_#{partitions}"
-      test "allows listeners", %{registry: registry, listener: listener} do
-        Process.register(self(), listener)
-        {_, task} = register_task(registry, "hello", :world)
-        assert_received {:register, ^registry, "hello", ^task, :world}
-
-        self = self()
-        {:ok, _} = Registry.register(registry, "hello", :value)
-        assert_received {:register, ^registry, "hello", ^self, :value}
-
-        :ok = Registry.unregister(registry, "hello")
-        assert_received {:unregister, ^registry, "hello", ^self}
-      end
-
-      test "links and unlinks on register/unregister", %{registry: registry} do
-        {:ok, pid} = Registry.register(registry, "hello", :value)
-        {:links, links} = Process.info(self(), :links)
-        assert pid in links
-
-        {:ok, pid} = Registry.register(registry, "world", :value)
-        {:links, links} = Process.info(self(), :links)
-        assert pid in links
-
-        :ok = Registry.unregister(registry, "hello")
-        {:links, links} = Process.info(self(), :links)
-        assert pid in links
-
-        :ok = Registry.unregister(registry, "world")
-        {:links, links} = Process.info(self(), :links)
-        refute pid in links
-      end
-
-      test "raises on unknown registry name" do
-        assert_raise ArgumentError, ~r/unknown registry/, fn ->
-          Registry.register(:unknown, "hello", :value)
-        end
-      end
-
-      test "raises if attempt to be used on via", %{registry: registry} do
-        assert_raise ArgumentError, ":via is not supported for duplicate registries", fn ->
-          name = {:via, Registry, {registry, "hello"}}
-          Agent.start_link(fn -> 0 end, name: name)
-        end
-      end
-
-      test "empty list for empty registry", %{registry: registry} do
-        assert Registry.select(registry, [{{:_, :_, :_}, [], [:"$_"]}]) == []
-      end
-
-      test "select all", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, "hello", :value)
-        {:ok, _} = Registry.register(registry, "hello", :value)
-
-        assert Registry.select(registry, [{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2", :"$3"}}]}])
-               |> Enum.sort() ==
-                 [{"hello", self(), :value}, {"hello", self(), :value}]
-      end
-
-      test "select supports full match specs", %{registry: registry} do
-        value = {1, :atom, 1}
-        {:ok, _} = Registry.register(registry, "hello", value)
-
-        assert [{"hello", self(), value}] ==
-                 Registry.select(registry, [
-                   {{"hello", :"$2", :"$3"}, [], [{{"hello", :"$2", :"$3"}}]}
-                 ])
-
-        assert [{"hello", self(), value}] ==
-                 Registry.select(registry, [
-                   {{:"$1", self(), :"$3"}, [], [{{:"$1", self(), :"$3"}}]}
-                 ])
-
-        assert [{"hello", self(), value}] ==
-                 Registry.select(registry, [
-                   {{:"$1", :"$2", value}, [], [{{:"$1", :"$2", {value}}}]}
-                 ])
-
-        assert [] ==
-                 Registry.select(registry, [
-                   {{"world", :"$2", :"$3"}, [], [{{"world", :"$2", :"$3"}}]}
-                 ])
-
-        assert [] == Registry.select(registry, [{{:"$1", :"$2", {1.0, :_, :_}}, [], [:"$_"]}])
-
-        assert [{"hello", self(), value}] ==
-                 Registry.select(registry, [
-                   {{:"$1", :"$2", {:"$3", :atom, :"$4"}}, [],
-                    [{{:"$1", :"$2", {{:"$3", :atom, :"$4"}}}}]}
-                 ])
-
-        assert [{"hello", self(), {1, :atom, 1}}] ==
-                 Registry.select(registry, [
-                   {{:"$1", :"$2", {:"$3", :"$4", :"$3"}}, [],
-                    [{{:"$1", :"$2", {{:"$3", :"$4", :"$3"}}}}]}
-                 ])
-
-        value2 = %{a: "a", b: "b"}
-        {:ok, _} = Registry.register(registry, "world", value2)
-
-        assert [:match] ==
-                 Registry.select(registry, [{{"world", self(), %{b: "b"}}, [], [:match]}])
-
-        assert ["hello", "world"] ==
-                 Registry.select(registry, [{{:"$1", :_, :_}, [], [:"$1"]}]) |> Enum.sort()
-      end
-
-      test "select supports guard conditions", %{registry: registry} do
-        value = {1, :atom, 2}
-        {:ok, _} = Registry.register(registry, "hello", value)
-
-        assert [{"hello", self(), {1, :atom, 2}}] ==
-                 Registry.select(registry, [
-                   {{:"$1", :"$2", {:"$3", :"$4", :"$5"}}, [{:>, :"$5", 1}],
-                    [{{:"$1", :"$2", {{:"$3", :"$4", :"$5"}}}}]}
-                 ])
-
-        assert [] ==
-                 Registry.select(registry, [
-                   {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}], [:"$_"]}
-                 ])
-
-        assert ["hello"] ==
-                 Registry.select(registry, [
-                   {{:"$1", :_, {:_, :"$2", :_}}, [{:is_atom, :"$2"}], [:"$1"]}
-                 ])
-      end
-
-      test "select allows multiple specs", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, "hello", :value)
-        {:ok, _} = Registry.register(registry, "world", :value)
-
-        assert ["hello", "world"] ==
-                 Registry.select(registry, [
-                   {{"hello", :_, :_}, [], [{:element, 1, :"$_"}]},
-                   {{"world", :_, :_}, [], [{:element, 1, :"$_"}]}
-                 ])
-                 |> Enum.sort()
-      end
-
-      test "count_select supports match specs", %{registry: registry} do
-        value = {1, :atom, 1}
-        {:ok, _} = Registry.register(registry, "hello", value)
-        assert 1 == Registry.count_select(registry, [{{:_, :_, value}, [], [true]}])
-        assert 1 == Registry.count_select(registry, [{{"hello", :_, :_}, [], [true]}])
-        assert 1 == Registry.count_select(registry, [{{:_, :_, {1, :atom, :_}}, [], [true]}])
-        assert 1 == Registry.count_select(registry, [{{:_, :_, {:"$1", :_, :"$1"}}, [], [true]}])
-        assert 0 == Registry.count_select(registry, [{{"hello", :_, nil}, [], [true]}])
-
-        value2 = %{a: "a", b: "b"}
-        {:ok, _} = Registry.register(registry, "world", value2)
-        assert 1 == Registry.count_select(registry, [{{"world", :_, :_}, [], [true]}])
-      end
-
-      test "count_select supports guard conditions", %{registry: registry} do
-        value = {1, :atom, 2}
-        {:ok, _} = Registry.register(registry, "hello", value)
-
-        assert 1 ==
-                 Registry.count_select(registry, [
-                   {{:_, :_, {:_, :"$1", :_}}, [{:is_atom, :"$1"}], [true]}
-                 ])
-
-        assert 1 ==
-                 Registry.count_select(registry, [
-                   {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 1}], [true]}
-                 ])
-
-        assert 0 ==
-                 Registry.count_select(registry, [
-                   {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}], [true]}
-                 ])
-      end
-
-      test "count_select allows multiple specs", %{registry: registry} do
-        {:ok, _} = Registry.register(registry, "hello", :value)
-        {:ok, _} = Registry.register(registry, "world", :value)
-
-        assert 2 ==
-                 Registry.count_select(registry, [
-                   {{"hello", :_, :_}, [], [true]},
-                   {{"world", :_, :_}, [], [true]}
-                 ])
-      end
+    end
+
+    test "empty list for empty registry", %{registry: registry} do
+      assert Registry.select(registry, [{{:_, :_, :_}, [], [:"$_"]}]) == []
+    end
+
+    test "select all", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, "hello", :value)
+      {:ok, _} = Registry.register(registry, "hello", :value)
+
+      assert Registry.select(registry, [{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2", :"$3"}}]}])
+             |> Enum.sort() ==
+               [{"hello", self(), :value}, {"hello", self(), :value}]
+    end
+
+    test "select supports full match specs", %{registry: registry} do
+      value = {1, :atom, 1}
+      {:ok, _} = Registry.register(registry, "hello", value)
+
+      assert [{"hello", self(), value}] ==
+               Registry.select(registry, [
+                 {{"hello", :"$2", :"$3"}, [], [{{"hello", :"$2", :"$3"}}]}
+               ])
+
+      assert [{"hello", self(), value}] ==
+               Registry.select(registry, [
+                 {{:"$1", self(), :"$3"}, [], [{{:"$1", self(), :"$3"}}]}
+               ])
+
+      assert [{"hello", self(), value}] ==
+               Registry.select(registry, [
+                 {{:"$1", :"$2", value}, [], [{{:"$1", :"$2", {value}}}]}
+               ])
+
+      assert [] ==
+               Registry.select(registry, [
+                 {{"world", :"$2", :"$3"}, [], [{{"world", :"$2", :"$3"}}]}
+               ])
+
+      assert [] == Registry.select(registry, [{{:"$1", :"$2", {1.0, :_, :_}}, [], [:"$_"]}])
+
+      assert [{"hello", self(), value}] ==
+               Registry.select(registry, [
+                 {{:"$1", :"$2", {:"$3", :atom, :"$4"}}, [],
+                  [{{:"$1", :"$2", {{:"$3", :atom, :"$4"}}}}]}
+               ])
+
+      assert [{"hello", self(), {1, :atom, 1}}] ==
+               Registry.select(registry, [
+                 {{:"$1", :"$2", {:"$3", :"$4", :"$3"}}, [],
+                  [{{:"$1", :"$2", {{:"$3", :"$4", :"$3"}}}}]}
+               ])
+
+      value2 = %{a: "a", b: "b"}
+      {:ok, _} = Registry.register(registry, "world", value2)
+
+      assert [:match] ==
+               Registry.select(registry, [{{"world", self(), %{b: "b"}}, [], [:match]}])
+
+      assert ["hello", "world"] ==
+               Registry.select(registry, [{{:"$1", :_, :_}, [], [:"$1"]}]) |> Enum.sort()
+    end
+
+    test "select supports guard conditions", %{registry: registry} do
+      value = {1, :atom, 2}
+      {:ok, _} = Registry.register(registry, "hello", value)
+
+      assert [{"hello", self(), {1, :atom, 2}}] ==
+               Registry.select(registry, [
+                 {{:"$1", :"$2", {:"$3", :"$4", :"$5"}}, [{:>, :"$5", 1}],
+                  [{{:"$1", :"$2", {{:"$3", :"$4", :"$5"}}}}]}
+               ])
+
+      assert [] ==
+               Registry.select(registry, [
+                 {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}], [:"$_"]}
+               ])
+
+      assert ["hello"] ==
+               Registry.select(registry, [
+                 {{:"$1", :_, {:_, :"$2", :_}}, [{:is_atom, :"$2"}], [:"$1"]}
+               ])
+    end
+
+    test "select allows multiple specs", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, "hello", :value)
+      {:ok, _} = Registry.register(registry, "world", :value)
+
+      assert ["hello", "world"] ==
+               Registry.select(registry, [
+                 {{"hello", :_, :_}, [], [{:element, 1, :"$_"}]},
+                 {{"world", :_, :_}, [], [{:element, 1, :"$_"}]}
+               ])
+               |> Enum.sort()
+    end
+
+    test "count_select supports match specs", %{registry: registry} do
+      value = {1, :atom, 1}
+      {:ok, _} = Registry.register(registry, "hello", value)
+      assert 1 == Registry.count_select(registry, [{{:_, :_, value}, [], [true]}])
+      assert 1 == Registry.count_select(registry, [{{"hello", :_, :_}, [], [true]}])
+      assert 1 == Registry.count_select(registry, [{{:_, :_, {1, :atom, :_}}, [], [true]}])
+      assert 1 == Registry.count_select(registry, [{{:_, :_, {:"$1", :_, :"$1"}}, [], [true]}])
+      assert 0 == Registry.count_select(registry, [{{"hello", :_, nil}, [], [true]}])
+
+      value2 = %{a: "a", b: "b"}
+      {:ok, _} = Registry.register(registry, "world", value2)
+      assert 1 == Registry.count_select(registry, [{{"world", :_, :_}, [], [true]}])
+    end
+
+    test "count_select supports guard conditions", %{registry: registry} do
+      value = {1, :atom, 2}
+      {:ok, _} = Registry.register(registry, "hello", value)
+
+      assert 1 ==
+               Registry.count_select(registry, [
+                 {{:_, :_, {:_, :"$1", :_}}, [{:is_atom, :"$1"}], [true]}
+               ])
+
+      assert 1 ==
+               Registry.count_select(registry, [
+                 {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 1}], [true]}
+               ])
+
+      assert 0 ==
+               Registry.count_select(registry, [
+                 {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}], [true]}
+               ])
+    end
+
+    test "count_select allows multiple specs", %{registry: registry} do
+      {:ok, _} = Registry.register(registry, "hello", :value)
+      {:ok, _} = Registry.register(registry, "world", :value)
+
+      assert 2 ==
+               Registry.count_select(registry, [
+                 {{"hello", :_, :_}, [], [true]},
+                 {{"world", :_, :_}, [], [true]}
+               ])
     end
   end
 
   # Note: those tests relies on internals
   for keys <- [:unique, :duplicate] do
-    describe "clean up #{keys} registry on process crash" do
-      @describetag keys: keys
+    @tag keys: keys
+    test "clean up #{keys} registry on process crash",
+         %{registry: registry, partitions: partitions} do
+      {_, task1} = register_task(registry, "hello", :value)
+      {_, task2} = register_task(registry, "world", :value)
 
-      @tag partitions: 8
-      test "with 8 partitions", %{registry: registry} do
-        {_, task1} = register_task(registry, "hello", :value)
-        {_, task2} = register_task(registry, "world", :value)
+      kill_and_assert_down(task1)
+      kill_and_assert_down(task2)
 
-        kill_and_assert_down(task1)
-        kill_and_assert_down(task2)
-
-        # pid might be in different partition to key so need to sync with all
-        # partitions before checking ETS tables are empty.
-        for i <- 0..7 do
+      # pid might be in different partition to key so need to sync with all
+      # partitions before checking ETS tables are empty.
+      if partitions > 1 do
+        for i <- 0..(partitions - 1) do
           [{_, _, {partition, _}}] = :ets.lookup(registry, i)
           GenServer.call(partition, :sync)
         end
 
-        for i <- 0..7 do
+        for i <- 0..(partitions - 1) do
           [{_, key, {_, pid}}] = :ets.lookup(registry, i)
           assert :ets.tab2list(key) == []
           assert :ets.tab2list(pid) == []
         end
-      end
-
-      @tag partitions: 1
-      test "with 1 partition", %{registry: registry} do
-        {_, task1} = register_task(registry, "hello", :value)
-        {_, task2} = register_task(registry, "world", :value)
-
-        kill_and_assert_down(task1)
-        kill_and_assert_down(task2)
-
+      else
         [{-1, {_, _, key, {partition, pid}, _}}] = :ets.lookup(registry, -1)
         GenServer.call(partition, :sync)
         assert :ets.tab2list(key) == []
         assert :ets.tab2list(pid) == []
       end
     end
-  end
-
-  test "child_spec/1 uses :name as :id" do
-    assert %{id: :custom_name} = Registry.child_spec(name: :custom_name)
-    assert %{id: Registry} = Registry.child_spec([])
-  end
-
-  test "raises if :name is missing" do
-    assert_raise ArgumentError, ~r/expected :name option to be present/, fn ->
-      Registry.start_link(keys: :unique)
-    end
-  end
-
-  test "raises if :name is not an atom" do
-    assert_raise ArgumentError, ~r/expected :name to be an atom, got/, fn ->
-      Registry.start_link(keys: :unique, name: [])
-    end
-  end
-
-  test "raises if :compressed is not a boolean" do
-    assert_raise ArgumentError, ~r/expected :compressed to be a boolean, got/, fn ->
-      Registry.start_link(keys: :unique, name: :name, compressed: :fail)
-    end
-  end
-
-  test "unregistration on crash with {registry, key, value} via tuple", %{registry: registry} do
-    name = {:via, Registry, {registry, :name, :value}}
-    spec = %{id: :foo, start: {Agent, :start_link, [fn -> raise "some error" end, [name: name]]}}
-    assert {:error, {error, _childspec}} = start_supervised(spec)
-    assert {%RuntimeError{message: "some error"}, _stacktrace} = error
-  end
-
-  test "send works", %{registry: registry} do
-    name = {registry, "self"}
-    Registry.register_name(name, self())
-    GenServer.cast({:via, Registry, name}, :message)
-    assert_received {:"$gen_cast", :message}
-  end
-
-  test "send works with value", %{registry: registry} do
-    name = {registry, "self", "value"}
-    Registry.register_name(name, self())
-    GenServer.cast({:via, Registry, name}, :message)
-    assert_received {:"$gen_cast", :message}
   end
 
   defp register_task(registry, key, value) do

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -101,9 +101,10 @@ defmodule ExUnit do
       * `:time` - the duration in microseconds of the test's runtime
       * `:tags` - the test tags
       * `:logs` - the captured logs
+      * `:parameters` - the test parameters
 
     """
-    defstruct [:name, :case, :module, :state, time: 0, tags: %{}, logs: ""]
+    defstruct [:name, :case, :module, :state, time: 0, tags: %{}, logs: "", parameters: %{}]
 
     # TODO: Remove the `:case` field on v2.0
     @type t :: %__MODULE__{

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -189,6 +189,8 @@ defmodule ExUnit.Case do
 
     * `:capture_log` - see the "Log Capture" section below
 
+    * `:parameterize` - see the "Parameterize tests" section below
+
     * `:skip` - skips the test with the given reason
 
     * `:timeout` - customizes the test timeout in milliseconds (defaults to 60000).
@@ -226,6 +228,36 @@ defmodule ExUnit.Case do
 
   Keep in mind that all tests are included by default, so unless they are
   excluded first, the `include` option has no effect.
+
+  ## Parameterized tests
+
+  Sometimes you want to run the same tests but with different parameters.
+  In ExUnit, it is possible to do by returning a `:parameterize` key in
+  your `setup_all` context. The value must be a list of maps which will be
+  the parameters merged into the test context.
+
+  For example, Elixir has a module called `Registry`, which can have type
+  `:unique` or `:duplicate`, and can control its concurrency factor using
+  the `:partitions` option. If you have a number of tests that *behave the
+  same* across all of those values, I can parameterize those tests with:
+
+      setup_all do
+        parameters =
+          for kind <- [:unique, :duplicate],
+              partitions <- [1, 8],
+              do: %{kind: kind, partitions: partitions}
+
+        [parameterize: parameters]
+      end
+
+  Use parameterized tests with care:
+
+  * Abuse of parameterized tests may make your test suite considerably slower
+
+  * If you use parameterized tests and then find yourself adding conditionals
+    in your tests to deal with different parameters, then parameterized tests
+    may be the wrong solution to your problem. Consider creating separated
+    tests and sharing logic between them using regular functions
 
   ## Log Capture
 

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -213,7 +213,7 @@ defmodule ExUnit.CLIFormatter do
   end
 
   defp trace_test_started(test) do
-    String.replace("  * #{test.name}", "\n", " ")
+    String.replace("  * #{trace_test_name(test)}", "\n", " ")
   end
 
   defp trace_test_result(test) do
@@ -229,11 +229,19 @@ defmodule ExUnit.CLIFormatter do
   end
 
   defp trace_aborted(%ExUnit.Test{} = test) do
-    "* #{test.name} [#{trace_test_file_line(test)}]"
+    "* #{trace_test_name(test)} [#{trace_test_file_line(test)}]"
   end
 
   defp trace_aborted(%ExUnit.TestModule{name: name, file: file}) do
     "* #{inspect(name)} [#{Path.relative_to_cwd(file)}]"
+  end
+
+  defp trace_test_name(%{name: name, parameters: parameters}) do
+    if parameters == %{} do
+      Atom.to_string(name)
+    else
+      "#{name} (parameters: #{inspect(parameters)})"
+    end
   end
 
   defp normalize_us(us) do

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -94,6 +94,7 @@ defmodule ExUnit.Formatter do
           | :error_info
           | :test_module_info
           | :test_info
+          | :parameters_info
           | :location_info
           | :stacktrace_info
           | :blame_diff
@@ -119,7 +120,7 @@ defmodule ExUnit.Formatter do
     * `:diff_insert` and `:diff_insert_whitespace` - Should format a diff insertion,
       with or without whitespace respectively.
 
-    * `:extra_info` - Should format extra information, such as the `"code: "` label
+    * `:extra_info` - Should format optional extra labels, such as the `"code: "` label
       that precedes code to show.
 
     * `:error_info` - Should format error information.
@@ -128,6 +129,8 @@ defmodule ExUnit.Formatter do
     when this key is passed precedes messages such as `"failure on setup_all callback [...]"`.
 
     * `:test_info` - Should format test information.
+
+    * `:parameters_info` - Should format test parameters.
 
     * `:location_info` - Should format test location information.
 
@@ -266,9 +269,10 @@ defmodule ExUnit.Formatter do
         ) :: String.t()
         when failure: {atom, term, Exception.stacktrace()}
   def format_test_failure(test, failures, counter, width, formatter) do
-    %ExUnit.Test{name: name, module: module, tags: tags} = test
+    %ExUnit.Test{name: name, module: module, tags: tags, parameters: parameters} = test
 
     test_info(with_counter(counter, "#{name} (#{inspect(module)})"), formatter) <>
+      test_parameters(parameters, formatter) <>
       test_location(with_location(tags), formatter) <>
       Enum.map_join(Enum.with_index(failures), "", fn {{kind, reason, stack}, index} ->
         {text, stack} = format_kind_reason(test, kind, reason, stack, width, formatter)
@@ -710,6 +714,15 @@ defmodule ExUnit.Formatter do
 
   defp test_info(msg, nil), do: msg <> "\n"
   defp test_info(msg, formatter), do: test_info(formatter.(:test_info, msg), nil)
+
+  defp test_parameters(params, _formatter) when params == %{}, do: ""
+  defp test_parameters(params, nil) when is_binary(params), do: "     " <> params <> "\n"
+
+  defp test_parameters(params, nil) when is_map(params),
+    do: test_parameters("Parameters: #{inspect(params)}", nil)
+
+  defp test_parameters(params, formatter),
+    do: test_parameters(formatter.(:parameters_info, params), nil)
 
   defp test_location(msg, nil), do: "     " <> msg <> "\n"
   defp test_location(msg, formatter), do: test_location(formatter.(:location_info, msg), nil)

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -230,6 +230,31 @@ defmodule ExUnit.FormatterTest do
            """
   end
 
+  test "formats test errors with parameters" do
+    failure = [{:error, catch_error(raise "oops"), []}]
+
+    assert format_test_failure(%{test() | parameters: %{foo: :bar}}, failure, 1, 80, &formatter/2) =~
+             """
+               1) world (Hello)
+                  Parameters: %{foo: :bar}
+                  test/ex_unit/formatter_test.exs:1
+                  ** (RuntimeError) oops
+             """
+
+    formatter = fn
+      :parameters_info, map -> Map.put(map, :more, :keys)
+      key, val -> formatter(key, val)
+    end
+
+    assert format_test_failure(%{test() | parameters: %{foo: :bar}}, failure, 1, 80, formatter) =~
+             """
+               1) world (Hello)
+                  Parameters: #{inspect(%{foo: :bar, more: :keys})}
+                  test/ex_unit/formatter_test.exs:1
+                  ** (RuntimeError) oops
+             """
+  end
+
   test "formats stacktraces" do
     stacktrace = [{Oops, :wrong, 1, [file: "formatter_test.exs", line: 1]}]
     failure = [{:error, catch_error(raise "oops"), stacktrace}]


### PR DESCRIPTION
Sometimes you want to run the same tests but with different parameters. In ExUnit, it is possible to do by returning a `:parameterize` key in your `setup_all` context. The value must be a list of maps which will be the parameters merged into the test context.

For example, Elixir has a module called `Registry`, which can have type `:unique` or `:duplicate`, and can control its concurrency factor using the `:partitions` option. If you have a number of tests that *behave the same* across all of those values, I can parameterize those tests with:

    setup_all do
      parameters =
        for kind <- [:unique, :duplicate],
            partitions <- [1, 8],
            do: %{kind: kind, partitions: partitions}

      [parameterize: parameters]
    end

Look at the changes to registry_test.exs in this pull request as an example. As a benefit, tests now run faster too, as there is less code to compile.

Use parameterized tests with care:

* Abuse of parameterized tests may make your test suite considerably slower

* If you use parameterized tests and then find yourself adding conditionals in your tests to deal with different parameters, then parameterized tests may be the wrong solution to your problem. Consider creating separated tests and sharing logic between them using regular functions