### PR TITLE
implement dbg for code blocks

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2603,7 +2603,7 @@ defmodule Macro do
     end
   end
 
-  defp dbg_ast_to_debuggable({:__block__, _meta, _clauses} = ast, _env) do
+  defp dbg_ast_to_debuggable({:__block__, _meta, exprs} = ast, _env) when exprs != [] do
     acc_var = unique_var(:acc, __MODULE__)
     result_var = unique_var(:result, __MODULE__)
 
@@ -2703,16 +2703,16 @@ defmodule Macro do
     end
   end
 
-  defp dbg_block({:__block__, meta, clauses}, acc_var, result_var) do
-    modified_clauses =
-      Enum.map(clauses, fn clause ->
+  defp dbg_block({:__block__, meta, exprs}, acc_var, result_var) do
+    modified_exprs =
+      Enum.map(exprs, fn expr ->
         quote do
-          unquote(result_var) = unquote(clause)
-          unquote(acc_var) = [{unquote(escape(clause)), unquote(result_var)} | unquote(acc_var)]
+          unquote(result_var) = unquote(expr)
+          unquote(acc_var) = [{unquote(escape(expr)), unquote(result_var)} | unquote(acc_var)]
         end
       end)
 
-    {:__block__, meta, modified_clauses}
+    {:__block__, meta, modified_exprs}
   end
 
   # Made public to be called from Macro.dbg/3, so that we generate as little code
@@ -2769,8 +2769,7 @@ defmodule Macro do
         Enum.map(components, fn {ast, value} ->
           ["  ", dbg_format_ast_with_value(ast, value, options)]
         end),
-        ?),
-        ?\n
+        ")\n"
       ]
 
     {formatted, value}

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2599,7 +2599,7 @@ defmodule Macro do
     quote do
       unquote(acc_var) = []
       unquote(dbg_boolean_tree(ast, acc_var, result_var))
-      {:logic_op, Enum.reverse(unquote(acc_var))}
+      {:logic_op, Enum.reverse(unquote(acc_var)), unquote(result_var)}
     end
   end
 
@@ -2610,7 +2610,7 @@ defmodule Macro do
     quote do
       unquote(acc_var) = []
       unquote(dbg_block(ast, acc_var, result_var))
-      {:block, Enum.reverse(unquote(acc_var))}
+      {:block, Enum.reverse(unquote(acc_var)), unquote(result_var)}
     end
   end
 
@@ -2712,7 +2712,7 @@ defmodule Macro do
         end
       end)
 
-    {:__block__, meta, modified_clauses ++ [result_var]}
+    {:__block__, meta, modified_clauses}
   end
 
   # Made public to be called from Macro.dbg/3, so that we generate as little code
@@ -2752,28 +2752,28 @@ defmodule Macro do
     {[first_formatted | rest_formatted], result}
   end
 
-  defp dbg_format_ast_to_debug({:logic_op, components}, options) do
-    {_ast, final_value} = List.last(components)
-
+  defp dbg_format_ast_to_debug({:logic_op, components, value}, options) do
     formatted =
       Enum.map(components, fn {ast, value} ->
         [dbg_format_ast(to_string_with_colors(ast, options)), " ", inspect(value, options), ?\n]
       end)
 
-    {formatted, final_value}
+    {formatted, value}
   end
 
-  defp dbg_format_ast_to_debug({:block, components}, options) do
-    {_ast, final_value} = List.last(components)
-
+  defp dbg_format_ast_to_debug({:block, components, value}, options) do
     formatted =
-      [dbg_maybe_underline("Code block", options), ":\n(\n"] ++
+      [
+        dbg_maybe_underline("Code block", options),
+        ":\n(\n",
         Enum.map(components, fn {ast, value} ->
           ["  ", dbg_format_ast_with_value(ast, value, options)]
-        end) ++
-        [?), ?\n]
+        end),
+        ?),
+        ?\n
+      ]
 
-    {formatted, final_value}
+    {formatted, value}
   end
 
   defp dbg_format_ast_to_debug({:case, ast, expr_value, clause_index, value}, options) do

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2709,11 +2709,10 @@ defmodule Macro do
         quote do
           unquote(result_var) = unquote(clause)
           unquote(acc_var) = [{unquote(escape(clause)), unquote(result_var)} | unquote(acc_var)]
-          unquote(result_var)
         end
       end)
 
-    {:__block__, meta, modified_clauses}
+    {:__block__, meta, modified_clauses ++ [result_var]}
   end
 
   # Made public to be called from Macro.dbg/3, so that we generate as little code

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -465,6 +465,8 @@ defmodule MacroTest do
 
       assert result == 4
 
+      assert formatted =~ "macro_test.exs"
+
       assert formatted =~ """
              Code block:
              (

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -453,6 +453,28 @@ defmodule MacroTest do
              """
     end
 
+    test "with block of code" do
+      {result, formatted} =
+        dbg_format(
+          (
+            a = 1
+            b = a + 2
+            a + b
+          )
+        )
+
+      assert result == 4
+
+      assert formatted =~ """
+             Code block:
+             (
+               a = 1 #=> 1
+               b = a + 2 #=> 3
+               a + b #=> 4
+             )
+             """
+    end
+
     test "with case" do
       list = [1, 2, 3]
 


### PR DESCRIPTION
It's slightly modified code from boolean operator dbg code:
```elixir
(
  a = 1
  b = a + 2
  a + b
)
|> dbg()
```
generates:

```elixir
Code block:
(
  a = 1 #=> 1
  b = a + 2 #=> 3
  a + b #=> 4
)
```
I was thinking of adding also the value returned from the block, but it's the same as last expression - for integers it may be ok, but for bigger data structures it will be just noise.

## Livebook:
![image](https://github.com/elixir-lang/elixir/assets/904179/fd2e1433-b8c8-4f15-b4e4-256cc4343963)
