### PR TITLE
Implement String.Chars protocol for `Duration`

### DIFF
--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -423,4 +423,10 @@ defmodule Duration do
   @compile {:inline, pair: 2}
   defp pair(0, _key), do: []
   defp pair(num, key), do: [Integer.to_string(num), key]
+
+  defimpl String.Chars do
+    def to_string(%Duration{} = duration) do
+      Duration.to_iso8601(duration)
+    end
+  end
 end

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -353,4 +353,13 @@ defmodule DurationTest do
     assert %Duration{microsecond: {-800_000, 0}} |> Duration.to_iso8601() == "PT0S"
     assert %Duration{microsecond: {-1_200_000, 2}} |> Duration.to_iso8601() == "PT-1.20S"
   end
+
+  test "to_string/1" do
+    assert to_string(%Duration{year: 1, second: 1}) == "P1YT1S"
+    assert to_string(%Duration{week: 3, hour: 5, minute: 3}) == "P3WT5H3M"
+    assert to_string(%Duration{hour: 5, minute: 3}) == "PT5H3M"
+    assert to_string(%Duration{year: 1, month: 2, day: 3}) == "P1Y2M3D"
+    assert to_string(%Duration{microsecond: {-800_000, 2}}) == "PT-0.80S"
+    assert to_string(%Duration{microsecond: {-1_200_000, 2}}) == "PT-1.20S"
+  end
 end


### PR DESCRIPTION
Allows Duration structs to be formatted to ISO 8601 when passed in `to_string/1` or when interpolating them.

This is useful when building payloads that expect ISO 8601 formatted durations and it's supported by all other calendar types to return ISO formatted 8601 string representations.