### PR TITLE
Document bare decimal case on String.to_float/1 and Float.parse/1

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -139,6 +139,8 @@ defmodule Float do
       iex> Float.parse("56.5xyz")
       {56.5, "xyz"}
 
+      iex> Float.parse(".12")
+      :error
       iex> Float.parse("pi")
       :error
       iex> Float.parse("1.7976931348623159e+308")

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2961,9 +2961,9 @@ defmodule String do
   @doc """
   Returns a float whose text representation is `string`.
 
-  `string` must be the string representation of a float including a decimal point.
-  In order to parse a string without decimal point as a float then `Float.parse/1`
-  should be used. Otherwise, an `ArgumentError` will be raised.
+  `string` must be the string representation of a float including leading digits and a decimal
+  point. To parse a string without decimal point as a float, refer to `Float.parse/1`. Otherwise,
+  an `ArgumentError` will be raised.
 
   Inlined by the compiler.
 
@@ -2976,6 +2976,9 @@ defmodule String do
       3.0
 
       String.to_float("3")
+      ** (ArgumentError) argument error
+
+      String.to_float(".3")
       ** (ArgumentError) argument error
 
   """

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -971,6 +971,9 @@ defmodule StringTest do
 
     three = fn -> "3" end
     assert_raise ArgumentError, fn -> String.to_float(three.()) end
+
+    dot_three = fn -> ".3" end
+    assert_raise ArgumentError, fn -> String.to_float(dot_three.()) end
   end
 
   test "jaro_distance/2" do


### PR DESCRIPTION
Strings like `.3` cannot be parsed using `String.to_float/1` or `Float.parse/1`, which is a surprising and noteworthy difference from other languages like JS and Ruby which can parse this.