### PR TITLE
[WIP] [Q] formatting long literals in test results

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -1007,8 +1007,12 @@ defmodule ExUnit.Diff do
     literal.(diff_wrapper)
   end
 
+  defp safe_to_algebra(map, diff_wrapper) when is_map(map) and not is_struct(map) do
+    safe_to_algebra(Macro.escape(map), diff_wrapper)
+  end
+
   defp safe_to_algebra(literal, _diff_wrapper) do
-    inspect(literal)
+    inspect(literal, pretty: true, width: 98)
   end
 
   defp keyword_to_algebra(quoted, diff_wrapper) do

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -1141,7 +1141,16 @@ defmodule ExUnit.DiffTest do
     refute_diff(identity == :a, "-#{inspect}-", "+:a+")
     refute_diff({identity, identity} == :a, "-{#{inspect}, #{inspect}}", "+:a+")
     refute_diff({identity, :a} == {:a, identity}, "{-#{inspect}-, -:a-}", "{+:a+, +#{inspect}+}")
-    refute_diff(%{identity => identity} == :a, "-%{#{inspect} => #{inspect}}", "+:a+")
+
+    refute_diff(
+      %{identity => identity} == :a,
+      """
+      -%{
+        #{inspect} => #{inspect}
+      }-\
+      """,
+      "+:a+"
+    )
 
     refute_diff(
       (&String.to_charlist/1) == (&String.unknown/1),

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -469,6 +469,31 @@ defmodule ExUnit.FormatterTest do
            """
   end
 
+  test "formats nested maps with column limit" do
+    long_string = String.duplicate("a", 10)
+    map = %{a: long_string}
+    failure = [{:error, catch_assertion(assert [map] == [map, map]), []}]
+
+    assert format_test_all_failure(test_module(), failure, 1, 20, &formatter/2) == """
+             1) Hello: failure on setup_all callback, all tests have been invalidated
+                Assertion with == failed
+                code:  assert [map] == [map, map]
+                left:  [
+                         %{
+                           a: "aaaaaaaaaa"
+                         }
+                       ]
+                right: [
+                         %{
+                           a: "aaaaaaaaaa"
+                         },
+                         %{
+                           a: "aaaaaaaaaa"
+                         }
+                       ]
+           """
+  end
+
   test "formats assertions with complex function call arguments" do
     failure = [{:error, catch_assertion(assert is_list(List.to_tuple([1, 2, 3]))), []}]
 


### PR DESCRIPTION
The nested data structures are not escaped and so failing to the last clause that does `inspect(literal)`

There are multiple options how to do this:
- `Macro.escape` - Current version - but it fails for map keys/values that are functions (2 tests) and I need suggestions how to fix this.
- Changing the `inspect(literal)` to `inspect(literal, pretty: true)`  - but this is missing padding, so it would require to work around this somehow because only the first line is padded. (the width 98 is the same as the default in `Macro.to_string` used in a function few lines above)
Maybe `Algebra.nest should` support multiline strings?
- Changing the diff code so it returns escaped data structures - This may not be backwards compatible.
- Probably other.
![image](https://github.com/elixir-lang/elixir/assets/904179/3d0c1b60-726d-449b-bcd8-a9de97636e1c)
