### PR TITLE
Add :report option to aggregate results over multiple processes in tprof

### DIFF
--- a/lib/mix/test/mix/tasks/profile.tprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.tprof_test.exs
@@ -97,6 +97,14 @@ defmodule Mix.Tasks.Profile.TprofTest do
     end)
   end
 
+  test "aggregates totals over all processes", context do
+    in_tmp(context.test, fn ->
+      assert capture_io(fn ->
+               Tprof.run(["--report", "total", "-e", @expr])
+             end) =~ "Profile results over all processes"
+    end)
+  end
+
   test "Module matching", context do
     in_tmp(context.test, fn ->
       refute capture_io(fn ->


### PR DESCRIPTION
Expose this "Type" param of tprof's [`inspect/3` function](https://www.erlang.org/doc/apps/tools/tprof.html#inspect/3).
I struggled a bit to find a good name for the argument, alternative proposals welcome.
I also considered making this a boolean flag but I finally decided to stick to Erlang's atoms.

`process` (default):

```elixir
$mix profile.tprof -e "Task.async_stream(1..2, & &1 ** 2) |> Enum.to_list()"
Warmup...


Profile results of #PID<0.109.0>
#                                               CALLS      % TIME µS/CALL
Total                                              99 100.00   16    0.16
:elixir_aliases.concat/1                            1   0.00    0    0.00
...
:erlang.send/2                                      6  31.25    5    0.83

Profile done over 53 matching functions

Profile results of #PID<0.110.0>
#                                            CALLS      % TIME µS/CALL
Total                                           51 100.00   12    0.24
:erts_internal.map_next/3                        2   0.00    0    0.00
...
```

`total`:

```elixir
$ mix profile.tprof -e "Task.async_stream(1..2, & &1 ** 2) |> Enum.to_list()" --report total
Warmup...


Profile results over all processes
#                                               CALLS      % TIME µS/CALL
Total                                             188 100.00   26    0.14
Module.concat/2                                     1   0.00    0    0.00
...
Task.Supervised.stream_reduce/7                     8  15.38    4    0.50
Task.Supervised.stream_monitor_loop/2               5  19.23    5    1.00
:erlang.send/2                                     12  19.23    5    0.42

Profile done over 89 matching functions
```