### PR TITLE
add --max-requires to mix test

### DIFF
--- a/lib/mix/lib/mix/compilers/test.ex
+++ b/lib/mix/lib/mix/compilers/test.ex
@@ -43,11 +43,11 @@ defmodule Mix.Compilers.Test do
         {matched_test_files, nil, []}
       end
 
-    parallel_require_options =
+    shared_require_options =
       if max_requires do
-        [{:max_concurrency, max_requires} | parallel_require_callbacks]
+        [max_concurrency: max_requires]
       else
-        parallel_require_callbacks
+        []
       end
 
     Application.ensure_all_started(:ex_unit)
@@ -66,7 +66,7 @@ defmodule Mix.Compilers.Test do
         end
 
       Keyword.get(opts, :profile_require) == "time" ->
-        Kernel.ParallelCompiler.require(test_files, profile: :time)
+        Kernel.ParallelCompiler.require(test_files, [profile: :time] ++ shared_require_options)
         :noop
 
       true ->
@@ -77,6 +77,8 @@ defmodule Mix.Compilers.Test do
         test_files = shuffle(seed, rand_algorithm, test_files)
 
         try do
+          parallel_require_options = shared_require_options ++ parallel_require_callbacks
+
           failed? =
             case Kernel.ParallelCompiler.require(test_files, parallel_require_options) do
               {:ok, _, [_ | _]} when warnings_as_errors? -> true

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -146,6 +146,9 @@ defmodule Mix.Tasks.Test do
     * `--max-failures` - the suite stops evaluating tests when this number of test
       failures is reached. It runs all tests if omitted
 
+    * `--max-requires` - sets the maximum number of test files to compile in parallel.
+      Setting this to 1 will compile test files sequentially.
+
     * `--no-archives-check` - does not check archives
 
     * `--no-color` - disables color in the output
@@ -439,6 +442,7 @@ defmodule Mix.Tasks.Test do
     trace: :boolean,
     max_cases: :integer,
     max_failures: :integer,
+    max_requires: :integer,
     include: :keep,
     exclude: :keep,
     seed: :integer,

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -609,6 +609,17 @@ defmodule Mix.Tasks.TestTest do
     end
   end
 
+  describe "--max-requires" do
+    test "runs tests with --max-requires 1" do
+      # this is only a smoke test to ensure that tests run with --max-requires 1
+      # it does not test the concurrency behavior
+      in_fixture("test_stale", fn ->
+        output = mix(["test", "--max-requires", "1"])
+        assert output =~ "0 failures"
+      end)
+    end
+  end
+
   defp receive_until_match(port, expected, acc) do
     receive do
       {^port, {:data, output}} ->


### PR DESCRIPTION
As discussed in https://github.com/elixir-lang/elixir/pull/13589. This adds a new option to mix test called `--max-requires` that controls the concurrency of the test file compilation. Setting this to 1 allows to enforce a deterministic compilation order to better reproduce flaky tests.

Relates to https://github.com/elixir-lang/elixir/pull/13634.

Again, sadly, I don't know a good way to add tests for this with the current setup.