### PR TITLE
Add more information to anonymous rescue hint

### DIFF
--- a/lib/elixir/lib/module/types/helpers.ex
+++ b/lib/elixir/lib/module/types/helpers.ex
@@ -41,7 +41,9 @@ defmodule Module.Types.Helpers do
         """
 
         #{hint()} when you rescue without specifying exception names, \
-        the variable is assigned a type of a struct but all of its fields are unknown
+        the variable is assigned a type of a struct but all of its fields are unknown. \
+        If you are trying to access an exception's :message key, either specify the \
+        exception names or use `Exception.message/1`.
         """
     end)
   end


### PR DESCRIPTION
This hint should help users fixing these warning, like [this one](https://github.com/phoenixframework/phoenix/commit/34d0ffef6aebcb5d4f210978aabca53b0e57f1ae#diff-d939a953683e8fcff02626d9d2e4f3a473107a977eddf6bf043117a2eded463fR149).

<img width="716" alt="Screenshot 2024-06-06 at 10 36 05" src="https://github.com/elixir-lang/elixir/assets/11598866/364cc31b-5e25-490f-a385-61881e3d1883">

Sample code which can trigger the issue:

```elixir
  def inverse(x) do
    1 / x
  rescue
    err -> err.message
  end
```