### PR TITLE
Fix crash when capturing ambiguous import

### DIFF
--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -77,7 +77,7 @@ import_function(Meta, Name, Arity, E) ->
       false;
     {import, Receiver} ->
       require_function(Meta, Receiver, Name, Arity, E);
-    {ambiguous, Ambiguous} ->
+    {ambiguous, _} = Ambiguous ->
       elixir_errors:file_error(Meta, E, ?MODULE, {import, Ambiguous, Name, Arity});
     false ->
       case elixir_import:special_form(Name, Arity) of


### PR DESCRIPTION
Fixes
```
** (FunctionClauseError) no function clause matching in :elixir_dispatch.format_error/1    
    
    The following arguments were given to :elixir_dispatch.format_error/1:
    
        # 1
        {:import, [Foo, Bar], :baz, 1}
    
    (elixir 1.17.0-rc.1) src/elixir_dispatch.erl:359: :elixir_dispatch.format_error/1
    (elixir 1.17.0-rc.1) src/elixir_errors.erl:295: :elixir_errors.print_error/4
    (elixir 1.17.0-rc.1) src/elixir_errors.erl:270: :elixir_errors.file_error/4
    (elixir 1.17.0-rc.1) src/elixir_fn.erl:79: :elixir_fn.capture_import/4
    lib/some.ex:10: (module)
    (elixir 1.17.0-rc.1) lib/kernel/parallel_compiler.ex:429: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/8
```

Problem introduced in https://github.com/elixir-lang/elixir/commit/5f2f626a05ccc6ca8a07118d56a8f2523d04c8e3. In other branches the code looks correct