### PR TITLE
Handle arbitrarily high integer values in Process.sleep/1

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -233,10 +233,10 @@ defmodule Process do
   the current process will sleep forever, and not
   consume or reply to messages.
 
-  > #### Note {: .info }
+  > #### Sleeping limit {: .info }
   >
-  > Before Elixir 18, `sleep/1` did not accept integer timeout values greater
-  > than `16#ffffffff`, that is, `2^32-1`. Since Elixir 18, arbitrarily high integer
+  > Before Elixir v1.18, `sleep/1` did not accept integer timeout values greater
+  > than `16#ffffffff`, that is, `2^32-1`. Since Elixir v1.18, arbitrarily high integer
   > values are accepted.
 
   **Use this function with extreme care**. For almost all situations

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -233,6 +233,12 @@ defmodule Process do
   the current process will sleep forever, and not
   consume or reply to messages.
 
+  > #### Note {: .info }
+  >
+  > Before Elixir 18, `sleep/1` did not accept integer timeout values greater
+  > than `16#ffffffff`, that is, `2^32-1`. Since Elixir 18, arbitrarily high integer
+  > values are accepted.
+
   **Use this function with extreme care**. For almost all situations
   where you would use `sleep/1` in Elixir, there is likely a
   more correct, faster and precise way of achieving the same with
@@ -299,7 +305,15 @@ defmodule Process do
       end
 
   """
+
+  # Max value for a receive's after clause
+  @max_receive_after 0xFFFFFFFF
+
   @spec sleep(timeout) :: :ok
+  def sleep(timeout) when is_integer(timeout) and timeout > @max_receive_after do
+    receive after: (@max_receive_after -> sleep(timeout - @max_receive_after))
+  end
+
   def sleep(timeout)
       when is_integer(timeout) and timeout >= 0
       when timeout == :infinity do

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -57,6 +57,12 @@ defmodule ProcessTest do
     assert Process.sleep(0) == :ok
   end
 
+  test "sleep/1 with 2^32" do
+    {pid, monitor_ref} = spawn_monitor(fn -> Process.sleep(2 ** 32) end)
+    refute_receive {:DOWN, ^monitor_ref, :process, ^pid, {:timeout_value, _trace}}
+    Process.exit(pid, :kill)
+  end
+
   test "info/2" do
     pid = spawn(fn -> Process.sleep(1000) end)
     assert Process.info(pid, :priority) == {:priority, :normal}


### PR DESCRIPTION
A while ago OTP timer module was [changed](https://github.com/erlang/otp/commit/06cacbca485bbd4dc64e24d7e9fe743fb0a3610b) to support sleeping with arbitrarily high integer timeout values. Given that `Process.sleep/1` is almost the same as `:timer.sleep/1` it seems that Elixir could support this too.

There are a number of ways to implement it, each with it's own tradeoffs regarding backward compatibility when supplying wrong types.

In this PR I just translated Erlang's implementation to Elixir. This allows it to keep `FunctionClauseError` on bad input, but error text now mentions  `timeout > 4_294_967_295` guard which can be confusing to the end user.
```
❯ bin/elixir -e "Process.sleep(:atom)"
** (FunctionClauseError) no function clause matching in Process.sleep/1    
    
    The following arguments were given to Process.sleep/1:
    
        # 1
        :atom
    
    Attempted function clauses (showing 2 out of 2):
    
        def sleep(timeout) when is_integer(timeout) and timeout > 4_294_967_295
        def sleep(timeout) when is_integer(timeout) and timeout >= 0 when timeout == :infinity
    
    (elixir 1.18.0-dev) lib/process.ex:313: Process.sleep/1
    nofile:1: (file)
    (stdlib 5.2.3) erl_eval.erl:750: :erl_eval.do_apply/7
    (elixir 1.18.0-dev) lib/code.ex:567: Code.validated_eval_string/3
```

There is also an option of just delegating sleep to `:timer`, though in this case we would be getting `ErlangError` instead of `FunctionClauseError`:
```
❯ bin/elixir -e "Process.sleep(:atom)"
** (ErlangError) Erlang error: :timeout_value
    (stdlib 5.2.3) timer.erl:235: :timer.sleep/1
    nofile:1: (file)
    (stdlib 5.2.3) erl_eval.erl:750: :erl_eval.do_apply/7
    (elixir 1.18.0-dev) lib/code.ex:567: Code.validated_eval_string/3
```

The third option is to keep the guards as is and "delegate" to `:timer.sleep` by hand in the function body.
This change allows to keep the error message exactly as it was, but introduces a function call with an additional (redundant) argument check.

I'm not sure what is Elixir's stability commitment in regards to exception values, so I'm ready to supply the code for any one of these cases :smiley: 