### PR TITLE
Use GitHub Actions' "artifact attestation" feature 

### DIFF
--- a/.github/workflows/builds.hex.pm.yml
+++ b/.github/workflows/builds.hex.pm.yml
@@ -17,6 +17,9 @@ concurrency: builds_txt
 
 jobs:
   release_pre_built:
+    permissions:
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: true
       max-parallel: 1
@@ -42,6 +45,13 @@ jobs:
           otp_version: ${{ matrix.otp_version }}
           otp: ${{ matrix.otp }}
           build_docs: ${{ matrix.build_docs }}
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'elixir-otp-${{ matrix.otp }}.*'
+      - uses: actions/attest-build-provenance@v1
+        if: ${{ matrix.build_docs }}
+        with:
+          subject-path: 'Docs.*'
       - name: Utils.sh
         run: |
           cat << 'EOF' > utils.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ env:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   create_draft_release:
@@ -50,6 +52,17 @@ jobs:
           otp_version: ${{ matrix.otp_version }}
           otp: ${{ matrix.otp }}
           build_docs: ${{ matrix.build_docs }}
+      - uses: actions/attest-build-provenance@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          subject-path: 'elixir-otp-${{ matrix.otp }}.*'
+      - uses: actions/attest-build-provenance@v1
+        if: ${{ matrix.build_docs }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          subject-path: 'Docs.*'
       - name: Upload Pre-built
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_pre_built/action.yml
+++ b/.github/workflows/release_pre_built/action.yml
@@ -46,7 +46,7 @@ runs:
           ref=v$(curl -s https://hex.pm/api/packages/ex_doc | jq --raw-output '.latest_stable_version')
         fi
         echo "EX_DOC_REF=$ref" >> $GITHUB_ENV
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: ${{ inputs.build_docs }}
       with:
         repository: elixir-lang/ex_doc


### PR DESCRIPTION
The idea is to have a way to ensure that the artifacts were not tempered after the build.

You can find details in the projects page:
https://github.com/actions/attest-build-provenance

There is also the docs page:
https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds