### PR TITLE
Update RELEASE_DISTRIBUTION docs

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -833,9 +833,9 @@ defmodule Mix.Tasks.Release do
 
     * `RELEASE_DISTRIBUTION` - how do we want to run the distribution.
       May be `name` (long names), `sname` (short names) or `none`
-      (distribution is not started automatically). Defaults to
-      `sname` which allows access only within the current system.
-      `name` allows external connections
+      (distribution is not started automatically). Defaults to `sname`.
+      When connecting nodes across hosts, you typically want to set
+      this to `name` (required to use IPs as host names)
 
     * `RELEASE_BOOT_SCRIPT` - the name of the boot script to use when starting
       the release. This script is used when running commands such as `start` and


### PR DESCRIPTION
Nodes using short names can still be connected across machines.

See question 1. in [this thread](https://erlangforums.com/t/difference-between-short-and-long-names-how-erlang-resolves-them/1531). I also verified this with two machines on a local network by adding an entry to `/etc/hosts`, such that the short name is resolved to the peer IP.

My understanding is that the resolution is exactly the same. Picking one or the other only determines if the validation requires FQDN or rejects FQDN, and nodes can only connect to other nodes using the same mode. I am interested to know what was the original motivation for two distinct modes in the first place (in Erlang), if someone is aware, please leave a comment.