### PR TITLE
Clarify what specifying the module name does with &

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1786,12 +1786,15 @@ defmodule Kernel.SpecialForms do
 
       &local_function/1
 
-  When the capture operator is given a module name, a remote/external capture
-  is created. Remote captures are faster than local captures. For more
-  information, refer to the ["Functions" section in the Erlang Reference Manual](https://www.erlang.org/doc/system/eff_guide_functions.html#function-calls).
+  Note that `&local_function/1` creates a local capture, but
+  `&__MODULE__.local_function/1` or `&imported_function/1` create a remote
+  capture. This has performance implications: remote captures are faster than
+  local captures. For more information, refer to the ["Functions" section in the Erlang Reference Manual](https://www.erlang.org/doc/system/eff_guide_functions.html#function-calls).
 
-  Note that local captures dispatch to the version of the module which created
-  them, while remote captures dispatch to the current version of the module.
+  Whether a capture is local or remote has implications when using hot code
+  reloading: local captures dispatch to the version of the module that existed
+  at the time they were created, while remote captures dispatch to the current
+  version of the module.
 
   See also `Function.capture/3`.
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1786,6 +1786,13 @@ defmodule Kernel.SpecialForms do
 
       &local_function/1
 
+  When the capture operator is given a module name, a remote/external capture
+  is created. Remote captures are faster than local captures. For more
+  information, refer to the ["Functions" section in the Erlang Reference Manual](https://www.erlang.org/doc/system/eff_guide_functions.html#function-calls).
+
+  Note that local captures dispatch to the version of the module which created
+  them, while remote captures dispatch to the current version of the module.
+
   See also `Function.capture/3`.
 
   ## Anonymous functions

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1788,7 +1788,7 @@ defmodule Kernel.SpecialForms do
 
   Note that `&local_function/1` creates a local capture, but
   `&__MODULE__.local_function/1` or `&imported_function/1` create a remote
-  capture. This has performance implications: remote captures are faster than
+  capture. This has performance implications: remote captures are slightly faster than
   local captures. For more information, refer to the ["Functions" section in the Erlang Reference Manual](https://www.erlang.org/doc/system/eff_guide_functions.html#function-calls).
 
   Whether a capture is local or remote has implications when using hot code

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1788,8 +1788,7 @@ defmodule Kernel.SpecialForms do
 
   Note that `&local_function/1` creates a local capture, but
   `&__MODULE__.local_function/1` or `&imported_function/1` create a remote
-  capture. This has performance implications: remote captures are slightly faster than
-  local captures. For more information, refer to the ["Functions" section in the Erlang Reference Manual](https://www.erlang.org/doc/system/eff_guide_functions.html#function-calls).
+  capture. For more information, refer to the ["Functions" section in the Erlang Reference Manual](https://www.erlang.org/doc/system/eff_guide_functions.html#function-calls).
 
   Whether a capture is local or remote has implications when using hot code
   reloading: local captures dispatch to the version of the module that existed


### PR DESCRIPTION
Hello! Thanks for making Elixir.

I ran into this error message from `:telemetry` and couldn't understand why it was happening, even after doing some web searches & reading the Elixir docs:

> [info] The function passed as a handler with ID “…” is a local function.
This means that it is either an anonymous function or a capture of a function without a module specified. That may cause a performance penalty when calling that handler. For more details see the note in telemetry:attach/4 documentation.
[telemetry — telemetry v1.2.1](https://hexdocs.pm/telemetry/telemetry.html#attach/4)

After I asked on the Elixir Forums, I was pointed to a mailing list thread ([https://groups.google.com/g/elixir-lang-core/c/rW_BRCULsGk/m/9rrYEwwtAwAJ 1](https://groups.google.com/g/elixir-lang-core/c/rW_BRCULsGk/m/9rrYEwwtAwAJ)) where someone said:

> The difference comes into play with code loading. The local captures will reference the version of the module they were captured with, while remote/external captures will always reference the latest version of the module.

This is a PR to add a note about that to the docs for &. I am still new to the language so I am of course happy to move the documentation elsewhere and/or change the wording!