### PR TITLE
Add short flags to `OptionParser.to_argv/2`

### DIFF
--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -413,6 +413,16 @@ defmodule OptionParserTest do
       {opts, [], []} = OptionParser.parse(original, switches: [counter: :count])
       assert original == OptionParser.to_argv(opts, switches: [counter: :count])
     end
+
+    test "uses short flags when available in aliases" do
+      assert OptionParser.to_argv([f: "bar"], aliases: [f: :foo]) == ["-f", "bar"]
+
+      assert OptionParser.to_argv([f: false], switches: [foo: :boolean], aliases: [f: :foo]) == [
+               "--no-f"
+             ]
+
+      assert OptionParser.to_argv([foo: "baz"], aliases: [f: :foo]) == ["--foo", "baz"]
+    end
   end
 end
 


### PR DESCRIPTION
If the alias is set, and the key is the alias the flag should use the short flag representation