### PR TITLE
Inspect special purpose chars using their unicode representation

### DIFF
--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -131,6 +131,8 @@ defmodule Inspect.BitStringTest do
     assert inspect(" ゆんゆん") == "\" ゆんゆん\""
     # BOM
     assert inspect("\uFEFFhello world") == "\"\\uFEFFhello world\""
+    # Invisible characters
+    assert inspect("\u2063") == "\"\\u2063\""
   end
 
   test "infer" do


### PR DESCRIPTION
This reduces confusion when working with zero-width characters or alternative spaces.

Relates to #13673

I used [this](https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Special-purpose_characters) as a base and compared with python which seems to have a similar strategy for almost all of these.

 