### PR TITLE
Use Enum.sum_by/2 when appropriate

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1182,8 +1182,8 @@ defmodule Registry do
   def count(registry) when is_atom(registry) do
     case key_info!(registry) do
       {_kind, partitions, nil} ->
-        Enum.reduce(0..(partitions - 1), 0, fn partition_index, acc ->
-          acc + safe_size(key_ets!(registry, partition_index))
+        Enum.sum_by(0..(partitions - 1), fn partition_index ->
+          safe_size(key_ets!(registry, partition_index))
         end)
 
       {_kind, 1, key_ets} ->
@@ -1258,9 +1258,8 @@ defmodule Registry do
         :ets.select_count(key_ets, spec)
 
       {:duplicate, partitions, _key_ets} ->
-        Enum.reduce(0..(partitions - 1), 0, fn partition_index, acc ->
-          count = :ets.select_count(key_ets!(registry, partition_index), spec)
-          acc + count
+        Enum.sum_by(0..(partitions - 1), fn partition_index ->
+          :ets.select_count(key_ets!(registry, partition_index), spec)
         end)
     end
   end
@@ -1352,9 +1351,8 @@ defmodule Registry do
 
     case key_info!(registry) do
       {_kind, partitions, nil} ->
-        Enum.reduce(0..(partitions - 1), 0, fn partition_index, acc ->
-          count = :ets.select_count(key_ets!(registry, partition_index), spec)
-          acc + count
+        Enum.sum_by(0..(partitions - 1), fn partition_index ->
+          :ets.select_count(key_ets!(registry, partition_index), spec)
         end)
 
       {_kind, 1, key_ets} ->

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -3046,10 +3046,10 @@ defmodule String do
   end
 
   defp bag_difference(bag1, bag2) do
-    Enum.reduce(bag1, 0, fn {char, count1}, sum ->
+    Enum.sum_by(bag1, fn {char, count1} ->
       case bag2 do
-        %{^char => count2} -> sum + max(count1 - count2, 0)
-        %{} -> sum + count1
+        %{^char => count2} -> max(count1 - count2, 0)
+        %{} -> count1
       end
     end)
   end

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -716,7 +716,7 @@ defmodule Task do
 
       iex> strings = ["long string", "longer string", "there are many of these"]
       iex> stream = Task.async_stream(strings, fn text -> text |> String.codepoints() |> Enum.count() end)
-      iex> Enum.reduce(stream, 0, fn {:ok, num}, acc -> num + acc end)
+      iex> Enum.sum_by(stream, fn {:ok, num} -> num end)
       47
 
   See `async_stream/5` for discussion, options, and more examples.

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -982,14 +982,11 @@ defmodule Registry.Test do
   end
 
   defp sum_pid_entries(registry, partitions) do
-    Enum.map(0..(partitions - 1), &Module.concat(registry, "PIDPartition#{&1}"))
-    |> sum_ets_entries()
-  end
-
-  defp sum_ets_entries(table_names) do
-    table_names
-    |> Enum.map(&ets_entries/1)
-    |> Enum.sum()
+    Enum.sum_by(0..(partitions - 1), fn partition ->
+      registry
+      |> Module.concat("PIDPartition#{partition}")
+      |> ets_entries()
+    end)
   end
 
   defp ets_entries(table_name) do


### PR DESCRIPTION
Just a small refactoring to use the newly added `Enum.sum_by/2` when relevant.

I did this mostly out of curiosity, feel free to close.