### PR TITLE
Inline Version parse* functions when constant

### DIFF
--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -680,6 +680,10 @@ inline_pure_function('Elixir.URI', encode_query) -> true;
 inline_pure_function('Elixir.URI', encode_www_form) -> true;
 inline_pure_function('Elixir.URI', decode) -> true;
 inline_pure_function('Elixir.URI', decode_www_for) -> true;
+inline_pure_function('Elixir.Version', parse) -> true;
+inline_pure_function('Elixir.Version', 'parse!') -> true;
+inline_pure_function('Elixir.Version', parse_requirement) -> true;
+inline_pure_function('Elixir.Version', 'parse_requirement!') -> true;
 inline_pure_function(_Left, _Right) -> false.
 
 % we do not want to try and inline calls which might depend on protocols that might be overridden later


### PR DESCRIPTION
Inline cases like `Version.parse!("2.0.1")` or `Version.parse_requirement!("== 2.0.1")`, which don't need to be parsed on the fly, very similar to the `URI.parse` or `Duration.new!` use cases.

This is a small proposal, I thought it could be nice for code performing comparisons with a fixed version/requirement on the fly.