### PR TITLE
Inline more functions

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -589,6 +589,8 @@ defmodule Float do
 
   For a configurable representation, use `:erlang.float_to_list/2`.
 
+  Inlined by the compiler.
+
   ## Examples
 
       iex> Float.to_charlist(7.0)
@@ -596,7 +598,7 @@ defmodule Float do
 
   """
   @spec to_charlist(float) :: charlist
-  def to_charlist(float) when is_float(float) do
+  def to_charlist(float) do
     :erlang.float_to_list(float, [:short])
   end
 
@@ -616,6 +618,8 @@ defmodule Float do
 
   For a configurable representation, use `:erlang.float_to_binary/2`.
 
+  Inlined by the compiler.
+
   ## Examples
 
       iex> Float.to_string(7.0)
@@ -623,7 +627,7 @@ defmodule Float do
 
   """
   @spec to_string(float) :: String.t()
-  def to_string(float) when is_float(float) do
+  def to_string(float) do
     :erlang.float_to_binary(float, [:short])
   end
 

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -128,6 +128,8 @@ defmodule Map do
   @doc """
   Builds a map from the given `keys` and the fixed `value`.
 
+  Inlined by the compiler.
+
   ## Examples
 
       iex> Map.from_keys([1, 2, 3], :number)
@@ -136,9 +138,7 @@ defmodule Map do
   """
   @doc since: "1.14.0"
   @spec from_keys([key], value) :: map
-  def from_keys(keys, value) do
-    :maps.from_keys(keys, value)
-  end
+  defdelegate from_keys(keys, value), to: :maps
 
   @doc """
   Returns all keys from `map`.

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -146,6 +146,7 @@ inline(Mod, Fun, Arity) -> inner_inline(ex_to_erl, Mod, Fun, Arity).
 ?inline(?list, to_integer, 2, erlang, list_to_integer);
 ?inline(?list, to_tuple, 1, erlang, list_to_tuple);
 
+?inline(?map, from_keys, 2, maps, from_keys);
 ?inline(?map, intersect, 2, maps, intersect);
 ?inline(?map, keys, 1, maps, keys);
 ?inline(?map, merge, 2, maps, merge);

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -8,6 +8,7 @@
 -define(atom, 'Elixir.Atom').
 -define(bitwise, 'Elixir.Bitwise').
 -define(enum, 'Elixir.Enum').
+-define(float, 'Elixir.Float').
 -define(function, 'Elixir.Function').
 -define(integer, 'Elixir.Integer').
 -define(io, 'Elixir.IO').
@@ -239,6 +240,8 @@ rewrite(Receiver, DotMeta, Right, Meta, Args) ->
   {EReceiver, ERight, EArgs} = inner_rewrite(ex_to_erl, DotMeta, Receiver, Right, Args),
   {{'.', DotMeta, [EReceiver, ERight]}, Meta, EArgs}.
 
+?rewrite(?float, to_charlist, [Arg], erlang, float_to_list, [Arg, [short]]);
+?rewrite(?float, to_string, [Arg], erlang, float_to_binary, [Arg, [short]]);
 ?rewrite(?kernel, is_map_key, [Map, Key], erlang, is_map_key, [Key, Map]);
 ?rewrite(?map, delete, [Map, Key], maps, remove, [Key, Map]);
 ?rewrite(?map, fetch, [Map, Key], maps, find, [Key, Map]);


### PR DESCRIPTION
Inline more regularly used functions in the standard Elixir modules to their Erlang STDLIB counterparts:

- `Float.to_charlist/1`
- `Float.to_string/1`
- ~~`List.duplicate/2`~~
- ~~`List.flatten/1`~~
- ~~`List.flatten/2`~~
- `Map.from_keys/2`
- ~~`Map.merge/3`~~

Great care was taken to ensure function guards already applied to the Elixir functions were subsets of the function guards in Erlang's STDLIB. ~~For example, `Map.merge/3` [specified](https://github.com/elixir-lang/elixir/blob/v1.17.1/lib/elixir/lib/map.ex#L651) the combiner function must be `is_function(fun, 3)` and Erlang's `:maps.merge_with` also [already specifies](https://github.com/erlang/otp/blob/OTP-27.0/lib/stdlib/src/maps.erl#L381) that argument must be `is_function(Combiner, 3)`.~~

The one exception to the above is the inlining of `Float.to_charlist/1` and `Float.to_string/1`. The Elixir functions specified that the argument must be a float with `is_float(float)` and thus will raise a `FunctionClauseError` exception if e.g. an integer is passed, while `:erlang.float_to_list/2` and `:erlang.float_to_binary/2` will instead throw an `ArgumentError` exception. However, changing to the Erlang behavior brings those functions *more* in line with the behavior of the rest of the Elixir modules, e.g. `Atom.to_charlist/1`, `Atom.to_string/1`, `Integer.to_charlist/1` and `Integer.to_string/1` will all throw an `ArgumentError` exception on an unexpected argument type.