### PR TITLE
Draft of directional confusability protection & allowing script mixing in identifiers when separated by underscores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,8 @@ unicode: $(UNICODE)
 $(UNICODE): lib/elixir/unicode/*
 	@ echo "==> unicode (compile)";
 	$(Q) $(ELIXIRC) lib/elixir/unicode/unicode.ex -o lib/elixir/ebin;
-	$(Q) $(ELIXIRC) lib/elixir/unicode/security.ex -o lib/elixir/ebin;
 	$(Q) $(ELIXIRC) lib/elixir/unicode/tokenizer.ex -o lib/elixir/ebin;
+	$(Q) $(ELIXIRC) lib/elixir/unicode/security.ex -o lib/elixir/ebin;
 
 $(eval $(call APP_TEMPLATE,ex_unit,ExUnit))
 $(eval $(call APP_TEMPLATE,logger,Logger))

--- a/lib/elixir/pages/references/unicode-syntax.md
+++ b/lib/elixir/pages/references/unicode-syntax.md
@@ -136,11 +136,15 @@ Elixir will not warn on confusability for identifiers made up exclusively of cha
 
 ### C3. Mixed Script Detection
 
-Elixir will not allow tokenization of mixed-script identifiers unless the mixing is one of the exceptions defined in UTS 39 5.2, 'Highly Restrictive'. We use the means described in Section 5.1, Mixed-Script Detection, to determine if script mixing is occurring, with the modification documented in the section 'Additional Normalizations', below.
+Elixir will not allow tokenization of mixed-script identifiers unless it is via chunks separated by an underscore, like `http_сервер`, or unless the mixing within each of those chunks is one of the exceptions defined in UTS 39 5.2, 'Highly Restrictive'. We use the means described in Section 5.1, Mixed-Script Detection, to determine if script mixing is occurring, with the modification documented in the section 'Additional Normalizations', below.
 
 Examples: Elixir allows an identifiers like `幻ㄒㄧㄤ`, even though it includes characters from multiple 'scripts', because those scripts all 'resolve' to Japanese when applying the resolution rules from UTS 39 5.1. It also allows an atom like `:Tシャツ`, the Japanese word for 't-shirt', which incorporates a Latin capital T, because {Latn, Jpan} is one of the allowed script mixing in the definition of 'Highly Restrictive' in UTS 39 5.2, and it 'covers' the string.
 
+Elixir does allow an identifier like `http_сервер`, where the identifier chunks on each side of the `_` are individually single-script.
+
 However, Elixir would prevent tokenization in code like `if аdmin, do: :ok, else: :err`, where the scriptset for the 'a' character is {Cyrillic} but all other characters have scriptsets of {Latin}. The scriptsets fail to resolve, and the scriptsets from the definition of 'Highly Restrictive' in UTS 39 5.2 do not cover the string either, so a descriptive error is shown.
+
+
 
 ### C4, C5 (inapplicable)
 

--- a/lib/elixir/pages/references/unicode-syntax.md
+++ b/lib/elixir/pages/references/unicode-syntax.md
@@ -144,8 +144,6 @@ Elixir does allow an identifier like `http_сервер`, where the identifier c
 
 However, Elixir would prevent tokenization in code like `if аdmin, do: :ok, else: :err`, where the scriptset for the 'a' character is {Cyrillic} but all other characters have scriptsets of {Latin}. The scriptsets fail to resolve, and the scriptsets from the definition of 'Highly Restrictive' in UTS 39 5.2 do not cover the string either, so a descriptive error is shown.
 
-
-
 ### C4, C5 (inapplicable)
 
 'C4 - Restriction Level detection' conformance is not claimed and does not apply to identifiers in code; rather, it applies to classifying the level of safety of a given arbitrary string into one of 5 restriction levels.

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -171,19 +171,19 @@ defmodule Kernel.WarningTest do
       # there's a spurious ;A; after the identifier, because the semicolon is dir-neutral, and
       # deleting it makes these examples hard to read in many/most editors!
       """
-      foo;0066 006F 006F;0 1 2
+      foo;A;0066 006F 006F;0 1 2
       _foo_ ;A;005F 0066 006F 006F 005F;0 1 2 3 4
       __foo__ ;A;005F 005F 0066 006F 006F 005F 005F;0 1 2 3 4 5 6
       لامدا_foo ;A;0644 0627 0645 062F 0627 005F 0066 006F 006F;4 3 2 1 0 5 6 7 8
       foo_لامدا_baz ;A;0066 006F 006F 005F 0644 0627 0645 062F 0627 005F 0062 0061 007A;0 1 2 3 8 7 6 5 4 9 10 11 12
-      foo_لامدا ;A;0066 006F 006F 005F 0644 0627 0645 062F 0627
+      foo_لامدا ;A;0066 006F 006F 005F 0644 0627 0645 062F 0627;0 1 2 3 8 7 6 5 4
       foo_لامدا1 ;A;0066 006F 006F 005F 0644 0627 0645 062F 0627 0031;0 1 2 3 9 8 7 6 5 4
       foo_لامدا_حدد ;A;0066 006F 006F 005F 0644 0627 0645 062F 0627 005F 062D 062F 062F;0 1 2 3 12 11 10 9 8 7 6 5 4
       foo_لامدا_حدد1 ;A;0066 006F 006F 005F 0644 0627 0645 062F 0627 005F 062D 062F 062F 0031;0 1 2 3 13 12 11 10 9 8 7 6 5 4
       foo_لامدا_حدد1_bar ;A; 0066 006F 006F 005F 0644 0627 0645 062F 0627 005F 062D 062F 062F 0031 005F 0062 0061 0072;0 1 2 3 13 12 11 10 9 8 7 6 5 4 14 15 16 17
       foo_لامدا_حدد1_bar1 ;A;0066 006F 006F 005F 0644 0627 0645 062F 0627 005F 062D 062F 062F 0031 005F 0062 0061 0072 0031;0 1 2 3 13 12 11 10 9 8 7 6 5 4 14 15 16 17 18
       """
-      |> String.split("\n")
+      |> String.split("\n", trim: true)
       |> Enum.map(&String.split(&1, ";", trim: true))
       |> Enum.each(fn
         [ident, _, bytes, indices | _rest] ->

--- a/lib/elixir/unicode/security.ex
+++ b/lib/elixir/unicode/security.ex
@@ -53,7 +53,7 @@ defmodule String.Tokenizer.Security do
       {line, _, previous_name} when name != previous_name ->
         {:warn,
          "confusable identifier: '#{name}' looks like '#{previous_name}' on line #{line}, " <>
-           "but they are written using different characters"}
+           "but they are written using different characters" <> dir_compare(name, previous_name)}
 
       _ ->
         {:ok, Map.put(skeletons, skeleton, info)}
@@ -106,7 +106,133 @@ defmodule String.Tokenizer.Security do
     #    the specified data, producing a string of exemplar characters.
     #  - Reapply NFD." (UTS 39 section 4, skeleton definition)
     :unicode.characters_to_nfd_list(s)
-    |> Enum.map(&confusable_prototype/1)
+    |> bidi_skeleton()
     |> :unicode.characters_to_nfd_list()
   end
+
+  # unicode 15 adds bidiSkeleton because, w/RTL codepoints, idents that
+  # aren't confusable LTR *are* confusable in most places human review
+  # occurs (editors/browsers, thanks to bidi algo, UAX9).
+  #
+  # The solution is to detect spans with reversed visual direction,
+  # and reverse those, so that the input we check for confusability
+  # matches the perceived sequence instead of the byte sequence.
+  #
+  # (we need this regardless of script mixing, because direction-neutral
+  # chars like _ or 0..9 can mix w/RTL chars).
+  def bidi_skeleton(s) do
+    # UTS39-28 4:
+    #  'Bidirectional confusability is costlier to check than
+    #   confusability, as [unicode bidi algo] must be applied.
+    #   [...] a fast path can be used: [...] if X has no characters
+    #   w/bidi classes R or AL, bidiSkeleton(X) = skeleton(X)
+    #
+    if length(s) > 1 and any_rtl?(s) do
+      unbidify(s) |> Enum.map(&confusable_prototype/1)
+    else
+      Enum.map(s, &confusable_prototype/1)
+    end
+  end
+
+  # load direction-changing and neutral codepoints valid in idents
+  {rtls, neutrals} =
+    Path.join(__DIR__, "UnicodeData.txt")
+    |> File.read!()
+    |> String.split(["\r\n", "\n"], trim: true)
+    |> Enum.reduce({[], []}, fn line, {rtls, neutrals} = acc ->
+      with [point, _, _, _, bidi | _] <- String.split(line, ";"),
+           codepoint = String.to_integer(point, 16),
+           true <- String.Tokenizer.id_codepoint?(codepoint) do
+        # https://www.unicode.org/reports/tr44/tr44-32.html#Bidi_Class_Values
+        cond do
+          bidi in ~w(R AL)s -> {[codepoint | rtls], neutrals}
+          bidi in ~w(WS ON CS EN ES ET NSM)s -> {rtls, [codepoint | neutrals]}
+          true -> acc
+        end
+      else
+        _ -> acc
+      end
+    end)
+
+  rangify = fn [head | tail] ->
+    {first, last, acc} =
+      Enum.reduce(tail, {head, head, []}, fn
+        number, {first, last, acc} when number == first - 1 ->
+          {number, last, acc}
+
+        number, {first, last, acc} ->
+          {number, number, [{first, last} | acc]}
+      end)
+
+    [{first, last} | acc]
+  end
+
+  # direction of a codepoint. (rtl, neutral, ltr fallback)
+  for {first, last} <- rangify.(rtls) do
+    if first == last do
+      defp dir(unquote(first)), do: :rtl
+    else
+      defp dir(i) when i in unquote(first)..unquote(last), do: :rtl
+    end
+  end
+
+  for {first, last} <- rangify.(neutrals) do
+    if first == last do
+      defp dir(unquote(first)), do: :neutral
+    else
+      defp dir(i) when i in unquote(first)..unquote(last), do: :neutral
+    end
+  end
+
+  defp dir(i) when is_integer(i), do: :ltr
+  defp dir(_), do: {:error, :codepoint_must_be_integer}
+
+  defp any_rtl?(s), do: Enum.any?(s, &(:rtl == dir(&1)))
+
+  defp dir_compare(a, b) do
+    """
+    #{if any_rtl?(a), do: "\n\n" <> dir_breakdown(a)}
+    #{if any_rtl?(b), do: dir_breakdown(b)}
+    """
+  end
+
+  defp dir_breakdown(s) do
+    init = "'#{s}' includes right-to-left characters:\n"
+
+    for codepoint <- s, into: init do
+      hex = :io_lib.format(~c"~4.16.0B", [codepoint])
+      "  \\u#{hex} #{[codepoint]} #{dir(codepoint)}\n"
+    end
+  end
+
+  # make charlist match visual order by reversing spans of {rtl, neutral}
+  #  UTS39-28 4: '[...] if the strings are known not to contain explicit
+  #   directional formatting characters[...], the algorithm can
+  #   be drastically simplified, [...], obviating the need for
+  #   the [...] stack of the [unicode bidi algo]'
+  def unbidify([head | tail]), do: unbidify({tail, dir(head), [head], []})
+
+  def unbidify({[head | tail], part_dir, part, acc}) do
+    {dir, part, acc} = unbidify_part({head, dir(head), part, part_dir, acc})
+    unbidify({tail, dir, part, acc})
+  end
+
+  def unbidify({[], dir, part, acc}) do
+    acc = [maybe_reverse_part(dir, part) | acc]
+    acc |> Enum.reverse() |> List.flatten()
+  end
+
+  defp unbidify_part({head, head_dir, part, part_dir, acc})
+       when head_dir == :neutral or head_dir == part_dir do
+    {part_dir, [head | part], acc}
+  end
+
+  defp unbidify_part({head, head_dir, part, part_dir, acc})
+       when head_dir != :neutral and head_dir != part_dir do
+    part = maybe_reverse_part(part_dir, part)
+    {head_dir, [head], [part | acc]}
+  end
+
+  defp maybe_reverse_part(dir, part) when dir in [:ltr, :neutral], do: Enum.reverse(part)
+  defp maybe_reverse_part(:rtl, part), do: part
 end

--- a/lib/elixir/unicode/tokenizer.ex
+++ b/lib/elixir/unicode/tokenizer.ex
@@ -28,15 +28,19 @@ defmodule String.Tokenizer do
     end
   end
 
-  {letter_uptitlecase, start, continue, _} =
+  {letter_uptitlecase, start, continue, dir_rtls, dir_neutrals, _} =
     Path.join(__DIR__, "UnicodeData.txt")
     |> File.read!()
     |> String.split(["\r\n", "\n"], trim: true)
-    |> Enum.reduce({[], [], [], nil}, fn line, acc ->
-      {letter_uptitlecase, start, continue, first} = acc
+    |> Enum.reduce({[], [], [], [], [], nil}, fn line, acc ->
+      {letter_uptitlecase, start, continue, rtls, neutrals, first} = acc
+
+      # https://www.unicode.org/reports/tr44/tr44-32.html#UnicodeData.txt
       [codepoint, line] = :binary.split(line, ";")
       [name, line] = :binary.split(line, ";")
-      [category, _] = :binary.split(line, ";")
+      [category, line] = :binary.split(line, ";")
+      [_canonical_combining, line] = :binary.split(line, ";")
+      [bidi, _] = :binary.split(line, ";")
 
       {codepoints, first} =
         case name do
@@ -52,18 +56,25 @@ defmodule String.Tokenizer do
             {[String.to_integer(codepoint, 16)], nil}
         end
 
+      {rtls, neutrals} =
+        cond do
+          bidi in ~w(R AL)s -> {codepoints ++ rtls, neutrals}
+          bidi in ~w(WS ON CS EN ES ET NSM)s -> {rtls, codepoints ++ neutrals}
+          true -> {rtls, neutrals}
+        end
+
       cond do
         category in ~w(Lu Lt) ->
-          {codepoints ++ letter_uptitlecase, start, continue, first}
+          {codepoints ++ letter_uptitlecase, start, continue, rtls, neutrals, first}
 
         category in ~w(Ll Lm Lo Nl) ->
-          {letter_uptitlecase, codepoints ++ start, continue, first}
+          {letter_uptitlecase, codepoints ++ start, continue, rtls, neutrals, first}
 
         category in ~w(Mn Mc Nd Pc) ->
-          {letter_uptitlecase, start, codepoints ++ continue, first}
+          {letter_uptitlecase, start, codepoints ++ continue, rtls, neutrals, first}
 
         true ->
-          {letter_uptitlecase, start, continue, first}
+          {letter_uptitlecase, start, continue, rtls, neutrals, first}
       end
     end)
 
@@ -327,6 +338,28 @@ defmodule String.Tokenizer do
 
   defp unicode_continue(_), do: @bottom
 
+  # subset of direction-changing/neutral characters valid in idents
+  id_all = id_upper ++ id_start ++ id_continue
+  dir_rtls = for c <- dir_rtls, c in id_all, do: {c, :rtl}
+  dir_neutrals = for c <- dir_neutrals, c not in 48..57, c in id_all, do: {c, :neutral}
+  dir_ranges = rangify.(dir_rtls) ++ rangify.(dir_neutrals)
+
+  # direction of a codepoint. (rtl, neutral, weak, ltr fallback)
+  # weaks are pulled towards previous directional spans,
+  # but the only weaks allowed in idents are numbers 0..9
+  def dir(i) when i in 48..57, do: :weak_number
+
+  for {first, last, direction} <- dir_ranges do
+    if first == last do
+      def dir(unquote(first)), do: unquote(direction)
+    else
+      def dir(i) when i in unquote(first)..unquote(last), do: unquote(direction)
+    end
+  end
+
+  def dir(i) when is_integer(i), do: :ltr
+  def dir(_), do: {:error, :codepoint_must_be_integer}
+
   # Hard-coded normalizations. Also split by upper, start, continue.
 
   for {from, to} <- start_normalizations do
@@ -486,10 +519,8 @@ defmodule String.Tokenizer do
   end
 
   defp chunks_single_or_highly_restrictive?(acc) do
-    # support script mixing via chunked identifiers (UTS 55-5, strong
-    # recco) to be kinder to users of other scripts,
-    # chunked around the _ character; each chunk
-    # in an ident like foo_bar_baz should pass checks
+    # support script mixing via chunked identifiers (UTS 55-5's strong recco)
+    # each chunk in an ident like foo_bar_baz should pass checks
     acc
     |> :string.tokens([?_])
     |> Enum.all?(&single_or_highly_restrictive?/1)
@@ -522,18 +553,6 @@ defmodule String.Tokenizer do
              @bottom <- unicode_upper(head),
              @bottom <- unicode_continue(head),
              do: @top
-    end
-  end
-
-  # security.ex uses, to filter non-ident codepoints
-  def id_codepoint?(p) when is_integer(p) do
-    if p < 127 and (p == ?_ or ascii_continue?(p) or ascii_lower?(p) or ascii_continue?(p)) do
-      true
-    else
-      @bottom !=
-        unicode_start(p)
-        |> ScriptSet.union(unicode_continue(p))
-        |> ScriptSet.union(unicode_upper(p))
     end
   end
 end


### PR DESCRIPTION
PR following up on [Directional confusability: _א1 and _1א not detected -- unicode 15.1's new TR55, and updated TR39](https://github.com/elixir-lang/elixir/issues/12929), proposing two changes:

1. per discussion of recent updates to Unicode's UTS39/55 in the issue linked above, we allow safe script mixing in identifiers, using a heuristic derived from the concept of identifier chunks from uts55. Basically we allow limited script mixing in identifiers like `foo_bar_baz`, only when separated by underscore, where `foo`, `bar`, `baz` chunks must be single-script or highly-restrictive.

2. provide directional confusability detection (which was needed even without script mixing, as the example from the issue above shows) by reversing spans of rtl-direction chars in bidi_skeleton, so that we default to checking confusability based on display order versus byte order in these relatively rare cases (eg, tools like github/vs code impl. the bidi algo from uax9).

These changes are also in harmony with the latest versions of the unicode technical reports, example from UTS39 as of version 15+ (similar reasoning in 55):

> ... it is inappropriate to enforce that strings be single-script, or at least single-directionality; this is the case in programming language identifiers ...

This PR maintains Elixir's script-mixing protections; for instance, we still don't allow an identifier like `аdmin_`, and the error shows us why:

    Mixed-script identifiers are not supported for security reasons. 'аdmin_' is made of the following scripts:

      \u0430 а {Cyrillic}
      \u0064 d {Latin}
      \u006D m {Latin}
      \u0069 i {Latin}
      \u006E n {Latin}
      \u005F _

    All characters in identifier chunks should resolve to a single script, or a highly restrictive set of scripts.

However, for identifiers separated by an underscore, we now make an exception:

```elixir
    http_सर्वर = 1
    http_cервер = 1
```

... as long as the chunks, themselves, are 'single-script' or 'highly restrictive'. (If they aren't, we will see the same kind of error message as above; see test cases w/this PR).

Similarly, the confusability additions build on existing messages, but now include a breakdown of directionality if tokens are confusable and they include any RTL characters:

```
warning: confusable identifier: '_1א' looks like '_א1' on line 1, but they are written using different characters

'_1א' includes right-to-left characters:
  \u005F _ neutral
  \u0031 1 neutral
  \u05D0 א rtl

'_א1' includes right-to-left characters:
  \u005F _ neutral
  \u05D0 א rtl
  \u0031 1 neutral
```

@josevalim this is a first pass -- here's what I think is good/bad/ugly

* I think/hope this should have basically no perf impact because of where the additions live
* the .beam file sizes are bumped a little bit because of the new `rtl?` functions in `Tokenizer.Security` used for bidi_skeleton, by approx. 10kb:

  ```
  ➜  elixir-clean git:(main) ls -l lib/elixir/ebin/Elixir.String.Tokenizer*
  -rw-r--r--  1 mrluc  staff    2660 Jun 25 06:55 lib/elixir/ebin/Elixir.String.Tokenizer.ScriptSet.beam
  -rw-r--r--  1 mrluc  staff  134312 Jun 25 06:55 lib/elixir/ebin/Elixir.String.Tokenizer.Security.beam
  -rw-r--r--  1 mrluc  staff   35456 Jun 25 06:55 lib/elixir/ebin/Elixir.String.Tokenizer.beam
  ➜  elixir git:(unicode-15-ltr-confusability-chunked-idents) ls -lh lib/elixir/ebin/Elixir.String.Tokenizer*
  -rw-r--r--  1 mrluc  staff   2.6K Jun 25 09:46 lib/elixir/ebin/Elixir.String.Tokenizer.ScriptSet.beam
  -rw-r--r--  1 mrluc  staff   141K Jun 25 09:46 lib/elixir/ebin/Elixir.String.Tokenizer.Security.beam
  -rw-r--r--  1 mrluc  staff    36K Jun 25 09:46 lib/elixir/ebin/Elixir.String.Tokenizer.beam
  ```
* I switched the order of `Tokenizer` and `Tokenizer.Security` in the makefile, and export an undocumented function from `Tokenizer`, so that `Security` can use it to filter the list of RTL and directionally 'neutral' characters to be just those that we know could legally appear in an identifier. Let me know if that's undesirable/I should do that a better way.
* maybe this should have tests of directional confusability w/more complex identifiers, lmk if you agree; I never circled back to more realistic examples.