### PR TITLE
`mix test --warnings-as-errors` fail on runtime warnings

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -392,6 +392,12 @@ defmodule IO do
     end
   end
 
+  @doc "TODO"
+  @doc since: "1.18.0"
+  def warning_emitted? do
+    :persistent_term.get({:elixir_errors, :warning_emitted}, false)
+  end
+
   @doc """
   Writes a `message` to stderr, along with the current stacktrace.
 

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -90,6 +90,18 @@ emit_diagnostic(Severity, Position, File, Message, Stacktrace, Options) ->
     _ -> nil
   end,
 
+  case Severity of
+    warning ->
+      case persistent_term:get({?MODULE, warning_emitted}, false) of
+        true ->
+          ok;
+        false ->
+          persistent_term:put({?MODULE, warning_emitted}, true)
+      end;
+    _ ->
+      ok
+  end,
+
   Diagnostic = #{
     severity => Severity,
     source => File,


### PR DESCRIPTION
Before this patch, `mix test --warnings-as-errors` failed only on compilation warnings. For example even though this emitted a warning:

```elixir
defmodule WarningTest do
  use ExUnit.Case

  test "warning" do
    inspect(~c"foo", char_lists: :as_char_lists)
  end
end
```

```
warning: the :char_lists inspect option and its :as_char_lists value are deprecated, use the :charlists option and its :as_charlists value instead
```

it did not fail the test suite. After this patch it would.

The function `IO.warning_emitted?/0` (exact name TBD) is useful outside of Elixir itself. For example, with it, implementing ExDoc `mix docs --warnings-as-errors` is trivial:

```diff
--- a/lib/mix/tasks/docs.ex
+++ b/lib/mix/tasks/docs.ex
@@ -322,7 +322,8 @@ defmodule Mix.Tasks.Docs do
     language: :string,
     open: :boolean,
     output: :string,
-    proglang: :string
+    proglang: :string,
+    warnings_as_errors: :boolean
   ]

   @aliases [
@@ -344,6 +345,18 @@ defmodule Mix.Tasks.Docs do

     {cli_opts, args, _} = OptionParser.parse(args, aliases: @aliases, switches: @switches)

+    if cli_opts[:warnings_as_errors] do
+      System.at_exit(fn _ ->
+        if IO.warning_emitted?() do
+          message =
+            "\nERROR! Docs generation aborted after successful execution due to warnings while using the --warnings-as-errors option"
+
+          IO.puts(:stderr, IO.ANSI.format([:red, message]))
+          exit({:shutdown, 1})
+        end
+      end)
+    end
+
     if args != [] do
       Mix.raise("Extraneous arguments on the command line")
     end
```
