### PR TITLE
Enforce parens when formatting on more operators

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -71,7 +71,7 @@ Left     120 or_op_eol.       %% ||, |||, or
 Left     130 and_op_eol.      %% &&, &&&, and
 Left     140 comp_op_eol.     %% ==, !=, =~, ===, !==
 Left     150 rel_op_eol.      %% <, >, <=, >=
-Left     160 arrow_op_eol.    %% |>, <<<, >>>, <<~, ~>>, <~, ~>, <~>, <|>
+Left     160 arrow_op_eol.    %% <<<, >>>, |>, <<~, ~>>, <~, ~>, <~>, <|>
 Left     170 in_op_eol.       %% in, not in
 Left     180 xor_op_eol.      %% ^^^
 Right    190 ternary_op_eol.  %% //

--- a/lib/elixir/test/elixir/code_formatter/operators_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/operators_test.exs
@@ -170,7 +170,7 @@ defmodule Code.Formatter.OperatorsTest do
     end
 
     test "bitwise precedence" do
-      assert_format "(crc >>> 8) ||| byte", "crc >>> 8 ||| byte"
+      assert_same "(crc >>> 8) ||| byte"
       assert_same "crc >>> (8 ||| byte)"
     end
   end
@@ -423,6 +423,9 @@ defmodule Code.Formatter.OperatorsTest do
 
     test "with multiple of the same entry and right associative" do
       assert_same "foo ++ bar ++ baz"
+      assert_format "foo -- bar -- baz", "foo -- (bar -- baz)"
+      assert_same "foo +++ bar +++ baz"
+      assert_format "foo --- bar --- baz", "foo --- (bar --- baz)"
 
       bad = "a ++ b ++ c"
 


### PR DESCRIPTION
* On bitwise operators

* On right precedence operators which are semantically non-associative (such as -- and potentially ---)

Closes #13710.