### PR TITLE
Fix link to official GIT docs

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -135,7 +135,7 @@ defmodule Mix.Tasks.Deps do
       $ git config --global url."https://YOUR_USER:YOUR_PASS@example.com/".insteadOf "https://example.com/"
 
   For more information, see the `git config` documentation:
-  https://git-scm.com/docs/git-config#git-config-urlltbasegtinsteadOf
+  https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
 
   ### Path options (`:path`)
 


### PR DESCRIPTION
The link to the `url.<base>.insteadOf ` section inside GIT's official docs was out of date. This PR fixes it.