### PR TITLE
Enable use of unquote in defguard(p)

### DIFF
--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -60,6 +60,18 @@ defmodule Kernel.GuardTest do
       refute MacrosInGuards.is_foobar(:baz)
     end
 
+    defmodule UnquotedInGuardCall do
+      @value :foo
+
+      defguard unquote(String.to_atom("is_#{@value}"))(x) when x == unquote(@value)
+    end
+
+    test "guards names can be defined dynamically using unquote" do
+      require UnquotedInGuardCall
+      assert UnquotedInGuardCall.is_foo(:foo)
+      refute UnquotedInGuardCall.is_foo(:bar)
+    end
+
     defmodule GuardsInGuards do
       defguard is_foo(atom) when atom == :foo
       defguard is_foobar(atom) when is_foo(atom) or atom == :bar


### PR DESCRIPTION
Currently, it is not possible to define a guard in Elixir using a dynamic name at compile time like it it possible with `def` and `defmacro`.

As an example the following code fails to compile

```elixir
defmodule MyModule do
  @states [:a, :b, :c]

  for state <- @states do
    defguard unquote(String.to_atom("is_#{state}"))(state) when state == unquote(state)
  end
end
```

```
== Compilation error in file text.ex ==
** (ArgumentError) invalid syntax in defguard unquote(String.to_atom("is_#{state}"))(state)
    (elixir 1.17.0) lib/kernel.ex:5789: Kernel.define_guard/3
    (elixir 1.17.0) expanding macro: Kernel.defguard/1
    text.ex:5: MyModule (module)
```

This ensures that an unquote syntax is also accepted in `defguard` and `defguardp` + tests.