### PR TITLE
Fix escript archive layout and support priv

### DIFF
--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -183,7 +183,7 @@ defmodule Mix.Tasks.Escript.Build do
       end)
       |> parse_strip_beams_options()
 
-    escript_mod = String.to_atom(Atom.to_string(app) <> "_escript")
+    escript_mod = String.to_atom(Atom.to_string(app || project[:app]) <> "_escript")
 
     include_priv_for = MapSet.new(escript_opts[:include_priv_for] || [])
 

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -183,7 +183,7 @@ defmodule Mix.Tasks.Escript.Build do
       end)
       |> parse_strip_beams_options()
 
-    escript_mod = String.to_atom(Atom.to_string(app || project[:app]) <> "_escript")
+    escript_mod = String.to_atom(Atom.to_string(app) <> "_escript")
 
     include_priv_for = MapSet.new(escript_opts[:include_priv_for] || [])
 

--- a/lib/mix/test/fixtures/escript_test/lib/escript_test.ex
+++ b/lib/mix/test/fixtures/escript_test/lib/escript_test.ex
@@ -11,6 +11,17 @@ defmodule EscriptTest do
     IO.inspect(Application.get_env(:foobar, :nesting, "TEST"))
   end
 
+  def main(["--app-paths"]) do
+    elixir_path = Application.app_dir(:elixir) |> String.to_charlist()
+    escript_test_path = Application.app_dir(:escript_test) |> String.to_charlist()
+
+    IO.inspect({
+      elixir_path != escript_test_path,
+      match?({:ok, _}, :erl_prim_loader.list_dir(elixir_path)),
+      match?({:ok, _}, :erl_prim_loader.list_dir(escript_test_path))
+    })
+  end
+
   def main(_argv) do
     IO.puts(Application.get_env(:foobar, :value, "TEST"))
   end

--- a/lib/mix/test/fixtures/escript_test/lib/escript_test.ex
+++ b/lib/mix/test/fixtures/escript_test/lib/escript_test.ex
@@ -22,6 +22,14 @@ defmodule EscriptTest do
     })
   end
 
+  def main(["--list-priv", app_name]) do
+    # Note: :erl_prim_loader usage with Escript is currently deprecated,
+    # but we use it only in tests for convenience
+
+    app = String.to_atom(app_name)
+    :erl_prim_loader.list_dir(~c"#{:code.lib_dir(app)}/priv") |> IO.inspect()
+  end
+
   def main(_argv) do
     IO.puts(Application.get_env(:foobar, :value, "TEST"))
   end

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -116,6 +116,9 @@ defmodule Mix.Tasks.EscriptTest do
       assert System.cmd("escript", ["escript_test"]) == {"TEST\n", 0}
       assert count_abstract_code("escript_test") == 0
 
+      # Each app has a distinct, valid path
+      assert System.cmd("escript", ["escript_test", "--app-paths"]) == {"{true, true, true}\n", 0}
+
       # Does not include priv by default
       assert System.cmd("escript", ["escript_test", "--list-priv", "escript_test"]) ==
                {":error\n", 0}
@@ -295,16 +298,6 @@ defmodule Mix.Tasks.EscriptTest do
 
       assert System.cmd("escript", ["escript_test_consolidated", "--protocol", "Enumerable"]) ==
                {"true\n", 0}
-    end)
-  end
-
-  test "generate escript with distinct path for each application" do
-    in_fixture("escript_test", fn ->
-      Mix.Project.push(Escript)
-
-      Mix.Tasks.Escript.Build.run([])
-      assert_received {:mix_shell, :info, ["Generated escript escript_test with MIX_ENV=dev"]}
-      assert System.cmd("escript", ["escript_test", "--app-paths"]) == {"{true, true, true}\n", 0}
     end)
   end
 

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -249,7 +249,8 @@ defmodule Mix.Tasks.EscriptTest do
       assert System.cmd("escript", ["escript_test_with_deps"]) == {"TEST\n", 0}
 
       # Does not include priv for deps by default
-      assert System.cmd("escript", ["escript_test_with_deps", "--list-priv", "ok"]) == {":error\n", 0}
+      assert System.cmd("escript", ["escript_test_with_deps", "--list-priv", "ok"]) ==
+               {":error\n", 0}
     end)
   after
     purge([Ok.MixProject])

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -280,6 +280,16 @@ defmodule Mix.Tasks.EscriptTest do
     end)
   end
 
+  test "generate escript with distinct path for each application" do
+    in_fixture("escript_test", fn ->
+      Mix.Project.push(Escript)
+
+      Mix.Tasks.Escript.Build.run([])
+      assert_received {:mix_shell, :info, ["Generated escript escript_test with MIX_ENV=dev"]}
+      assert System.cmd("escript", ["escript_test", "--app-paths"]) == {"{true, true, true}\n", 0}
+    end)
+  end
+
   test "escript install and uninstall" do
     File.rm_rf!(tmp_path(".mix/escripts"))
 

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -96,6 +96,28 @@ defmodule Mix.Tasks.EscriptTest do
     end
   end
 
+  defmodule EscriptWithPrivs do
+    def project do
+      [
+        app: :escript_test_with_priv,
+        version: "0.0.1",
+        escript: [main_module: EscriptTest, include_priv_for: [:escript_test_with_priv, :ok]],
+        deps: [{:ok, path: fixture_path("deps_status/deps/ok")}]
+      ]
+    end
+  end
+
+  defmodule EscriptWithoutPrivs do
+    def project do
+      [
+        app: :escript_test_without_priv,
+        version: "0.0.1",
+        escript: [main_module: EscriptTest],
+        deps: [{:ok, path: fixture_path("deps_status/deps/ok")}]
+      ]
+    end
+  end
+
   test "generate escript" do
     in_fixture("escript_test", fn ->
       Mix.Project.push(Escript)
@@ -287,6 +309,47 @@ defmodule Mix.Tasks.EscriptTest do
       Mix.Tasks.Escript.Build.run([])
       assert_received {:mix_shell, :info, ["Generated escript escript_test with MIX_ENV=dev"]}
       assert System.cmd("escript", ["escript_test", "--app-paths"]) == {"{true, true, true}\n", 0}
+    end)
+  end
+
+  test "generate escript without priv" do
+    in_fixture("escript_test", fn ->
+      Mix.Project.push(EscriptWithoutPrivs)
+
+      Mix.Tasks.Escript.Build.run([])
+
+      message = "Generated escript escript_test_without_priv with MIX_ENV=dev"
+      assert_received {:mix_shell, :info, [^message]}
+
+      assert System.cmd("escript", [
+               "escript_test_without_priv",
+               "--list-priv",
+               "escript_test_without_priv"
+             ]) ==
+               {":error\n", 0}
+
+      assert System.cmd("escript", ["escript_test_without_priv", "--list-priv", "ok"]) ==
+               {":error\n", 0}
+    end)
+  end
+
+  test "generate escript with priv" do
+    in_fixture("escript_test", fn ->
+      Mix.Project.push(EscriptWithPrivs)
+
+      Mix.Tasks.Escript.Build.run([])
+
+      message = "Generated escript escript_test_with_priv with MIX_ENV=dev"
+      assert_received {:mix_shell, :info, [^message]}
+
+      assert System.cmd("escript", [
+               "escript_test_with_priv",
+               "--list-priv",
+               "escript_test_with_priv"
+             ]) == {~s/{:ok, [~c"hello"]}\n/, 0}
+
+      assert System.cmd("escript", ["escript_test_with_priv", "--list-priv", "ok"]) ==
+               {~s/{:ok, [~c"sample"]}\n/, 0}
     end)
   end
 


### PR DESCRIPTION
## Escript layout

I noticed that Elixir builds escript archive with all modules, app files and priv files flattened out. Contrarily rebar builds escript with directory layout batching `_build`.

The [:code](https://www.erlang.org/doc/apps/kernel/code) documentation states:

```
When an `escript` file contains an archive, there are no restrictions on the
name of the `escript` and no restrictions on how many applications that can be
stored in the embedded archive. Single Beam files can also reside on the top
level in the archive. At startup, the top directory in the embedded archive and
all (second level) `ebin` directories in the embedded archive are added to the
code path.
```

From the above it is clear that modules are loaded correctly with a flat structure, however when we deal with multiple applications, this may break other things, for example:

```elixir
:code.lib_dir(:my_escript) #=> {:ok, ~c"/path/to/my_escript"}
:code.lib_dir(:phoenix) #=> {:error, :bad_name}
```

Given this, I would consider the current layout to be a bug, and this PR switches to a `_build`-like layout.

With the new layout, the above works as expected:

```elixir
:code.lib_dir(:my_escript) #=> {:ok, ~c"/path/to/my_escript/my_escript"}
:code.lib_dir(:phoenix) #=> {:ok, ~c"/path/to/my_escript/phoenix"}
```

## priv dirs

Currently, all application priv dirs are included in the archive, however reading priv from the archive requires special care (regular file access doesn't work), so in most cases this just unnecessarily inflates the escript size. For example, Phoenix priv dir includes all generator templates, it doesn't make sense to include these in the escript.

I propose a new option `:include_priv_for` to opt-in which privs should be included.

Note that this is not a breaking change, because currently `escript.build` docs actually say:

> escripts do not support projects and dependencies that need to store or read artifacts from the priv directory.

Sidenote: due to flattening, `:code.priv_dir/1` does not point to a valid location in the archive. Also, the priv layout is lost, and files could even be lost if there are multiple with the same name. This is to say, even without the above restrictions, I does not really work as expected.

For the reference, rebar does not include priv dir (other than for the rebar escript itself, via a private `escript_incl_priv` option).