### PR TITLE
Make logger_translator not be a primary filter

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -881,10 +881,16 @@ defmodule Logger do
       translators = updater.(Application.fetch_env!(:logger, :translators))
       Application.put_env(:logger, :translators, translators)
 
-      with %{filters: filters} <- :logger.get_primary_config(),
+      with {:ok, %{filters: filters}} <- :logger.get_handler_config(:default),
            {{_, {fun, config}}, filters} <- List.keytake(filters, :logger_translator, 0) do
         config = %{config | translators: translators}
-        :ok = :logger.set_primary_config(:filters, filters ++ [logger_translator: {fun, config}])
+
+        :ok =
+          :logger.set_handler_config(
+            :default,
+            :filters,
+            [logger_translator: {fun, config}] ++ filters
+          )
       end
     end)
 

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -161,7 +161,10 @@ defmodule Logger.TranslatorTest do
       :ignore
     end
 
+    {:ok, %{filters: [{key, filter} | _]}} = :logger.get_handler_config(:default)
+    :logger.remove_handler_filter(:default, key)
     :logger.add_handler_filter(:default, :forwarder, {fun, self()})
+    :logger.add_handler_filter(:default, key, filter)
     on_exit(fn -> :logger.remove_handler_filter(:default, :forwarder) end)
   end
 


### PR DESCRIPTION
Followup to https://groups.google.com/g/elixir-lang-core/c/bQFdc2RfG28

Not done yet, but here to get some first feedback. 

Essentially the goal here is to remove the fact that elixir is adding primary filters, which mean you either e.g. get sasl logs or not at all instead of being able to make that decision on a per handler basis.