### PR TITLE
Set-theoretic tuple types (using lists)

### DIFF
--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -559,12 +559,6 @@ defmodule Module.Types.DescrTest do
 
       assert union(dynamic(open_map(a: atom())), open_map(a: integer()))
              |> map_fetch(:a) == {false, union(dynamic(atom()), integer())}
-
-      # this is bad
-      assert dynamic() |> map_fetch(:a) == {true, dynamic()}
-      assert union(dynamic(), integer()) |> map_fetch(:a) == {true, dynamic()}
-      assert union(dynamic(open_map(a: integer())), integer()) |> map_fetch(:a) == :badmap
-      assert union(dynamic(integer()), integer()) |> map_fetch(:a) == :badmap
     end
   end
 


### PR DESCRIPTION
This is a rewrite of #13576 that uses lists instead of relying on the map type implementation.

It adds to the Descr fixed-size tuple types such as `{:ok, binary(), integer()}` and open tuple types (such as `{atom(), boolean(), ...}`, which represent every tuple of at least two elements that are an atom and a boolean).

Tuples are _now_ encoded as pairs {tag, elements} where element is a list of types.