### PR TITLE
Add report for "normal" exits in IEx

### DIFF
--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -266,16 +266,14 @@ defmodule IEx.Server do
          input,
          _callback
        ) do
-    if abnormal_reason?(reason) do
-      try do
-        io_error(
-          "** (EXIT from #{inspect(evaluator)}) shell process exited with reason: " <>
-            Exception.format_exit(reason)
-        )
-      catch
-        type, detail ->
-          io_error("** (IEx.Error) #{type} when printing EXIT message: #{inspect(detail)}")
-      end
+    try do
+      io_error(
+        "** (EXIT from #{inspect(evaluator)}) shell process exited with reason: " <>
+          Exception.format_exit(reason)
+      )
+    catch
+      type, detail ->
+        io_error("** (IEx.Error) #{type} when printing EXIT message: #{inspect(detail)}")
     end
 
     rerun(state, [], evaluator, evaluator_ref, input)
@@ -284,11 +282,6 @@ defmodule IEx.Server do
   defp handle_common(_, state, _evaluator, _evaluator_ref, _input, callback) do
     callback.(state)
   end
-
-  defp abnormal_reason?(:normal), do: false
-  defp abnormal_reason?(:shutdown), do: false
-  defp abnormal_reason?({:shutdown, _}), do: false
-  defp abnormal_reason?(_), do: true
 
   defp take_over?(take_pid, take_ref, take_location, take_whereami, take_opts, counter) do
     evaluator = take_opts[:evaluator] || self()

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -198,6 +198,16 @@ defmodule IEx.InteractionTest do
              ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) shell process exited with reason: {:bye, \[:world\]}"
   end
 
+  test "receive normal exits" do
+    assert capture_iex("spawn_link(fn -> exit(:normal) end); Process.sleep(1000)") =~ ":ok"
+
+    assert capture_iex("spawn_link(fn -> exit(:shutdown) end); Process.sleep(1000)") =~
+             ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) shell process exited with reason: shutdown"
+
+    assert capture_iex("spawn_link(fn -> exit({:shutdown, :bye}) end); Process.sleep(1000)") =~
+             ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) shell process exited with reason: shutdown: :bye"
+  end
+
   test "receive exit from exception" do
     # use exit/1 to fake an error so that an error message
     # is not sent to the error logger.


### PR DESCRIPTION
Issue: #13745

I think rather than delete the `abnormal_reason?/1` directly, add the report with distinct color is better. 