### PR TITLE
Fix spec for to_timeout/1

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -6212,7 +6212,7 @@ defmodule Kernel do
   """
   @doc since: "1.17.0"
   @spec to_timeout([component, ...] | timeout() | Duration.t()) :: timeout()
-        when component: [{unit, non_neg_integer()}, ...],
+        when component: {unit, non_neg_integer()},
              unit: :week | :day | :hour | :minute | :second | :millisecond
   def to_timeout(duration)
 


### PR DESCRIPTION
Otherwise, dialyzer always fails:
```elixir
defmodule MyTest do
  def test_function(expires_in_seconds) do
    to_timeout(second: expires_in_seconds)
  end
end
```
Error
```
lib/mytest.ex:2:no_return
Function test_function/1 has no local return.
________________________________________________________________________________
lib/mytest.ex:3:call
The function call will not succeed.

Kernel.to_timeout([{:second, _}, ...])

breaks the contract
([:component, ...] | timeout() | Duration.t()) :: timeout()
when component: [{:unit, non_neg_integer()}, ...],
     unit: :week | :day | :hour | :minute | :second | :millisecond
```