### PR TITLE
Clarify map key ordering functionality in docs

### DIFF
--- a/lib/elixir/pages/getting-started/keywords-and-maps.md
+++ b/lib/elixir/pages/getting-started/keywords-and-maps.md
@@ -149,7 +149,7 @@ nil
 Compared to keyword lists, we can already see two differences:
 
   * Maps allow any value as a key.
-  * Maps' keys do not follow any ordering.
+  * Maps' keys are "user ordered" within the same node, but are not guaranteed to maintain that ordering across nodes.
 
 In contrast to keyword lists, maps are very useful with pattern matching. When a map is used in a pattern, it will always match on a subset of the given value:
 

--- a/lib/elixir/pages/getting-started/keywords-and-maps.md
+++ b/lib/elixir/pages/getting-started/keywords-and-maps.md
@@ -149,7 +149,7 @@ nil
 Compared to keyword lists, we can already see two differences:
 
   * Maps allow any value as a key.
-  * Maps' keys are "user ordered" within the same node, but are not guaranteed to maintain that ordering across nodes.
+  * Maps have their own internal ordering, which is not guaranteed to be the same across different maps, even if they have the same keys
 
 In contrast to keyword lists, maps are very useful with pattern matching. When a map is used in a pattern, it will always match on a subset of the given value:
 


### PR DESCRIPTION
Per the discussion at the Elixir forum:

https://elixirforum.com/t/why-are-reverse-1-and-at-1-in-enum/65353/20

Update the documentation to better clarify the actual behavior of maps in Elixir.