### PR TITLE
Add transitive dependencies section to Meta-programming anti-pattern

### DIFF
--- a/lib/elixir/pages/mix-and-otp/introduction-to-mix.md
+++ b/lib/elixir/pages/mix-and-otp/introduction-to-mix.md
@@ -176,8 +176,6 @@ iex> recompile()
 
 If anything had to be compiled, you see some informative text, and get the `:ok` atom back, otherwise the function is silent, and returns `:noop`.
 
-To go further, check out [`mix compile.elixir`](https://hexdocs.pm/mix/Mix.Tasks.Compile.Elixir.html) documentation.
-
 ## Running tests
 
 Mix also generated the appropriate structure for running our project tests. Mix projects usually follow the convention of having a `<filename>_test.exs` file in the `test` directory for each file in the `lib` directory. For this reason, we can already find a `test/kv_test.exs` corresponding to our `lib/kv.ex` file. It doesn't do much at this point:

--- a/lib/elixir/pages/mix-and-otp/introduction-to-mix.md
+++ b/lib/elixir/pages/mix-and-otp/introduction-to-mix.md
@@ -176,6 +176,8 @@ iex> recompile()
 
 If anything had to be compiled, you see some informative text, and get the `:ok` atom back, otherwise the function is silent, and returns `:noop`.
 
+To go further, check out [`mix compile.elixir`](https://hexdocs.pm/mix/Mix.Tasks.Compile.Elixir.html) documentation.
+
 ## Running tests
 
 Mix also generated the appropriate structure for running our project tests. Mix projects usually follow the convention of having a `<filename>_test.exs` file in the `test` directory for each file in the `lib` directory. For this reason, we can already find a `test/kv_test.exs` corresponding to our `lib/kv.ex` file. It doesn't do much at this point:

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -10,7 +10,9 @@ defmodule Mix.Tasks.Compile.Elixir do
   Elixir is smart enough to recompile only files that have changed
   and their dependencies. This means if `lib/a.ex` is invoking
   a function defined over `lib/b.ex` at compile time, whenever
-  `lib/b.ex` changes, `lib/a.ex` is also recompiled.
+  `lib/b.ex` changes, `lib/a.ex` is also recompiled. More details
+  about dependencies between files can be found in the documentation
+  of [`mix xref`](`Mix.Tasks.Xref`).
 
   Note Elixir considers a file as changed if its source file has
   changed on disk since the last compilation AND its contents are

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Xref do
   touching one file in a project causes a large subset of the project
   to recompile. The most common cause of these problems are the so-called
   "compile-connected" files. Those are files you depend on at compile-time
-  (for example, by invoking its macro or using it in the body of amodule)
+  (for example, by invoking its macro or using it in the body of a module)
   which also have their own dependencies.
 
   Therefore, if your goal is to reduce recompilations, the first step is to run:

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -61,8 +61,8 @@ defmodule Mix.Tasks.Xref do
   because compile time dependencies are transitive.
 
   Having compile time dependencies is a common feature in Elixir projects.
-  However, the modules you depend on at compile-time must avoid runtime
-  dependencies within the same project. You can understand all of the
+  However, the modules you depend on at compile-time must avoid dependencies
+  to modules within the same project. You can understand all of the
   dependencies of a given file by running:
 
       $ mix xref trace lib/livebook_web.ex
@@ -75,7 +75,7 @@ defmodule Mix.Tasks.Xref do
   Elixir tracks three types of dependencies between modules: compile,
   exports, and runtime. If a module has a compile time dependency on
   another module, the caller module has to be recompiled whenever the
-  callee changes (or any runtime dependency of the callee changes).
+  callee changes (or any dependency of the callee changes).
   Let's see an example:
 
       # lib/a.ex


### PR DESCRIPTION
As discussed in #13762 ([comment](https://github.com/elixir-lang/elixir/issues/13762#issuecomment-2275246711)), I added a "transitive dependencies" section to "Meta-programming anti-patterns".
I obviously open to feedback, whether typos or more general remarks about the content of the section. I've tried to keep it simple whilst exposing the problem, linking to `mix xref` when complexity arises.

This also fixes the documentation of `mix xref` a bit, since it only stated "runtime dependencies" can cause compile-connected ones, whilst all dependencies are affected.
