### PR TITLE
Soft-deprecate List.zip/1 in favor of Enum.zip/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ This release no longer supports WERL (a graphical user interface for the Erlang 
 
 ### 3. Soft deprecations (no warnings emitted)
 
+#### Elixir
+
+  * [List] `List.zip/1` is deprecated in favor of `Enum.zip/1`
+
 ### 4. Hard deprecations
 
 #### EEx

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -633,21 +633,7 @@ defmodule List do
     [other]
   end
 
-  @doc """
-  Zips corresponding elements from each list in `list_of_lists`.
-
-  The zipping finishes as soon as any list terminates.
-
-  ## Examples
-
-      iex> List.zip([[1, 2], [3, 4], [5, 6]])
-      [{1, 3, 5}, {2, 4, 6}]
-
-      iex> List.zip([[1, 2], [3], [5, 6]])
-      [{1, 3, 5}]
-
-  """
-  @spec zip([list]) :: [tuple]
+  @doc deprecated: "Use Enum.zip/1 instead"
   def zip([]), do: []
 
   def zip(list_of_lists) when is_list(list_of_lists) do

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -634,10 +634,8 @@ defmodule List do
   end
 
   @doc deprecated: "Use Enum.zip/1 instead"
-  def zip([]), do: []
-
   def zip(list_of_lists) when is_list(list_of_lists) do
-    do_zip(list_of_lists, [])
+    Enum.zip(list_of_lists)
   end
 
   @doc ~S"""
@@ -1358,33 +1356,4 @@ defmodule List do
   defp do_pop_at([head | tail], index, default, acc) do
     do_pop_at(tail, index - 1, default, [head | acc])
   end
-
-  # zip
-
-  defp do_zip(list, acc) do
-    converter = fn x, acc -> do_zip_each(to_list(x), acc) end
-
-    case :lists.mapfoldl(converter, [], list) do
-      {_, nil} ->
-        :lists.reverse(acc)
-
-      {mlist, heads} ->
-        do_zip(mlist, [to_tuple(:lists.reverse(heads)) | acc])
-    end
-  end
-
-  defp do_zip_each(_, nil) do
-    {nil, nil}
-  end
-
-  defp do_zip_each([head | tail], acc) do
-    {tail, [head | acc]}
-  end
-
-  defp do_zip_each([], _) do
-    {nil, nil}
-  end
-
-  defp to_list(tuple) when is_tuple(tuple), do: Tuple.to_list(tuple)
-  defp to_list(list) when is_list(list), do: list
 end

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -84,13 +84,6 @@ defmodule ListTest do
     assert List.last([1, 2, 3]) == 3
   end
 
-  test "zip/1" do
-    assert List.zip([[1, 4], [2, 5], [3, 6]]) == [{1, 2, 3}, {4, 5, 6}]
-    assert List.zip([[1, 4], [2, 5, 0], [3, 6]]) == [{1, 2, 3}, {4, 5, 6}]
-    assert List.zip([[1], [2, 5], [3, 6]]) == [{1, 2, 3}]
-    assert List.zip([[1, 4], [2, 5], []]) == []
-  end
-
   test "keyfind/4" do
     assert List.keyfind([a: 1, b: 2], :a, 0) == {:a, 1}
     assert List.keyfind([a: 1, b: 2], 2, 1) == {:b, 2}


### PR DESCRIPTION
As discussed, `List.zip/1` is actually [less efficient ](https://github.com/sabiwara/elixir_benches/commit/324187bee06dcc709bdea03a366acb4f8cae17ff)than its `Enum` counterpart and doesn't make much sense API-wise.

It seems it was just introduced [a long time ago](https://github.com/elixir-lang/elixir/commit/284012d46c30b526635f5077ea974bf5f7edf345) and was never removed after `Enum.zip/1` got introduced.