### PR TITLE
Add option to formatter to rewrite unless

### DIFF
--- a/lib/elixir/lib/agent.ex
+++ b/lib/elixir/lib/agent.ex
@@ -207,7 +207,7 @@ defmodule Agent do
   @doc false
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
-      if !Module.has_attribute?(__MODULE__, :doc) do
+      if not Module.has_attribute?(__MODULE__, :doc) do
         @doc """
         Returns a specification to start this module under a supervisor.
 

--- a/lib/elixir/lib/agent.ex
+++ b/lib/elixir/lib/agent.ex
@@ -207,7 +207,7 @@ defmodule Agent do
   @doc false
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
-      unless Module.has_attribute?(__MODULE__, :doc) do
+      if !Module.has_attribute?(__MODULE__, :doc) do
         @doc """
         Returns a specification to start this module under a supervisor.
 

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -521,7 +521,7 @@ defmodule Time do
         do: unit > 0,
         else: unit in ~w(second millisecond microsecond nanosecond)a
 
-    unless valid? do
+    if !valid? do
       raise ArgumentError,
             "unsupported time unit. Expected :hour, :minute, :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got #{inspect(unit)}"
     end

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -191,6 +191,7 @@ defmodule Code.Formatter do
     sigils = Keyword.get(opts, :sigils, [])
     normalize_bitstring_modifiers = Keyword.get(opts, :normalize_bitstring_modifiers, true)
     normalize_charlists_as_sigils = Keyword.get(opts, :normalize_charlists_as_sigils, true)
+    rewrite_unless = Keyword.get(opts, :rewrite_unless, false)
     syntax_colors = Keyword.get(opts, :syntax_colors, [])
 
     sigils =
@@ -217,6 +218,7 @@ defmodule Code.Formatter do
       file: file,
       normalize_bitstring_modifiers: normalize_bitstring_modifiers,
       normalize_charlists_as_sigils: normalize_charlists_as_sigils,
+      rewrite_unless: rewrite_unless,
       inspect_opts: %Inspect.Opts{syntax_colors: syntax_colors}
     }
   end
@@ -482,6 +484,27 @@ defmodule Code.Formatter do
   # left not in right
   defp quoted_to_algebra({:not, meta, [{:in, _, [left, right]}]}, context, state) do
     binary_op_to_algebra(:in, "not in", meta, left, right, context, state)
+  end
+
+  # rewrite unless as if!
+  defp quoted_to_algebra(
+         {:unless, meta, [condition, block]},
+         context,
+         %{rewrite_unless: true} = state
+       ) do
+    quoted_to_algebra({:if, meta, [negate_condition(condition), block]}, context, state)
+  end
+
+  defp quoted_to_algebra(
+         {:|>, meta1, [condition, {:unless, meta2, [block]}]},
+         context,
+         %{rewrite_unless: true} = state
+       ) do
+    quoted_to_algebra(
+      {:|>, meta1, [negate_condition(condition), {:if, meta2, [block]}]},
+      context,
+      state
+    )
   end
 
   # ..
@@ -2448,5 +2471,40 @@ defmodule Code.Formatter do
 
   defp has_double_quote?(chunk) do
     is_binary(chunk) and chunk =~ @double_quote
+  end
+
+  # Migration rewrites
+
+  @bool_operators [
+    :>,
+    :>=,
+    :<,
+    :<=,
+    :in
+  ]
+  @guards [
+    :is_atom,
+    :is_number,
+    :is_integer,
+    :is_float,
+    :is_binary,
+    :is_map,
+    :is_struct
+    # ...
+    # TODO add more guards
+  ]
+
+  defp negate_condition(condition) do
+    case condition do
+      {neg, _, [condition]} when neg in [:!, :not] -> condition
+      {:|>, _, _} -> {:|>, [], [condition, {{:., [], [Kernel, :!]}, [closing: []], []}]}
+      {op, _, [_, _]} when op in @bool_operators -> {:not, [], [condition]}
+      {guard, _, [_ | _]} when guard in @guards -> {:not, [], [condition]}
+      {:==, meta, [left, right]} -> {:!=, meta, [left, right]}
+      {:===, meta, [left, right]} -> {:!==, meta, [left, right]}
+      {:!=, meta, [left, right]} -> {:==, meta, [left, right]}
+      {:!==, meta, [left, right]} -> {:===, meta, [left, right]}
+      _ -> {:!, [], [condition]}
+    end
   end
 end

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -2484,14 +2484,18 @@ defmodule Code.Formatter do
   ]
   @guards [
     :is_atom,
+    :is_boolean,
+    :is_nil,
     :is_number,
     :is_integer,
     :is_float,
     :is_binary,
+    :is_list,
     :is_map,
-    :is_struct
-    # ...
-    # TODO add more guards
+    :is_struct,
+    :is_function,
+    :is_reference,
+    :is_pid
   ]
 
   defp negate_condition(condition) do

--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -143,7 +143,7 @@ defmodule Config do
   """
   @doc since: "1.9.0"
   def config(root_key, opts) when is_atom(root_key) and is_list(opts) do
-    unless Keyword.keyword?(opts) do
+    if !Keyword.keyword?(opts) do
       raise ArgumentError, "config/2 expected a keyword list, got: #{inspect(opts)}"
     end
 

--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -143,7 +143,7 @@ defmodule Config do
   """
   @doc since: "1.9.0"
   def config(root_key, opts) when is_atom(root_key) and is_list(opts) do
-    if !Keyword.keyword?(opts) do
+    if not Keyword.keyword?(opts) do
       raise ArgumentError, "config/2 expected a keyword list, got: #{inspect(opts)}"
     end
 

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -274,7 +274,7 @@ defmodule DynamicSupervisor do
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
       @behaviour DynamicSupervisor
-      unless Module.has_attribute?(__MODULE__, :doc) do
+      if !Module.has_attribute?(__MODULE__, :doc) do
         @doc """
         Returns a specification to start this module under a supervisor.
 

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -274,7 +274,7 @@ defmodule DynamicSupervisor do
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
       @behaviour DynamicSupervisor
-      if !Module.has_attribute?(__MODULE__, :doc) do
+      if not Module.has_attribute?(__MODULE__, :doc) do
         @doc """
         Returns a specification to start this module under a supervisor.
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -845,7 +845,7 @@ defmodule GenServer do
     quote location: :keep, bind_quoted: [opts: opts] do
       @behaviour GenServer
 
-      if !Module.has_attribute?(__MODULE__, :doc) do
+      if not Module.has_attribute?(__MODULE__, :doc) do
         @doc """
         Returns a specification to start this module under a supervisor.
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -845,7 +845,7 @@ defmodule GenServer do
     quote location: :keep, bind_quoted: [opts: opts] do
       @behaviour GenServer
 
-      unless Module.has_attribute?(__MODULE__, :doc) do
+      if !Module.has_attribute?(__MODULE__, :doc) do
         @doc """
         Returns a specification to start this module under a supervisor.
 
@@ -945,7 +945,7 @@ defmodule GenServer do
   end
 
   defmacro __before_compile__(env) do
-    unless Module.defines?(env.module, {:init, 1}) do
+    if !Module.defines?(env.module, {:init, 1}) do
       message = """
       function init/1 required by behaviour GenServer is not implemented \
       (in module #{inspect(env.module)}).

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -350,7 +350,7 @@ defmodule IO.ANSI.Docs do
     |> String.split(@spaces)
     |> write_with_wrap(options[:width] - byte_size(indent), indent, no_wrap, prefix)
 
-    unless no_wrap, do: newline_after_block(options)
+    if !no_wrap, do: newline_after_block(options)
   end
 
   defp format_text(text, options) do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3956,7 +3956,7 @@ defmodule Kernel do
       "Math still works"
 
   """
-  defmacro if(!condition, clauses) do
+  defmacro unless(condition, clauses) do
     build_unless(condition, clauses)
   end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3956,7 +3956,7 @@ defmodule Kernel do
       "Math still works"
 
   """
-  defmacro unless(condition, clauses) do
+  defmacro if(!condition, clauses) do
     build_unless(condition, clauses)
   end
 

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -118,7 +118,7 @@ defmodule Kernel.Typespec do
     case spec_to_signature(expr) do
       {name, arity} ->
         # store doc only once in case callback has multiple clauses
-        if !:ets.member(set, {kind, name, arity}) do
+        if not :ets.member(set, {kind, name, arity}) do
           {line, doc} = get_doc_info(set, :doc, line)
           store_doc(set, kind, name, arity, line, :doc, doc, %{})
         end
@@ -380,7 +380,7 @@ defmodule Kernel.Typespec do
     ensure_no_defaults!(args)
     state = clean_local_state(state)
 
-    if !Keyword.keyword?(guard) do
+    if not Keyword.keyword?(guard) do
       error = "expected keywords as guard in type specification, got: #{Macro.to_string(guard)}"
       compile_error(caller, error)
     end
@@ -573,7 +573,7 @@ defmodule Kernel.Typespec do
           |> Map.delete(:__struct__)
           |> Map.to_list()
 
-        if !Keyword.keyword?(fields) do
+        if not Keyword.keyword?(fields) do
           compile_error(caller, "expected key-value pairs in struct #{Macro.to_string(name)}")
         end
 
@@ -587,7 +587,7 @@ defmodule Kernel.Typespec do
           )
 
         fun = fn {field, _} ->
-          if !Keyword.has_key?(struct, field) do
+          if not Keyword.has_key?(struct, field) do
             compile_error(
               caller,
               "undefined field #{inspect(field)} on struct #{inspect(module)}"
@@ -630,7 +630,7 @@ defmodule Kernel.Typespec do
           )
 
         fun = fn {field, _} ->
-          if !Keyword.has_key?(fields, field) do
+          if not Keyword.has_key?(fields, field) do
             compile_error(caller, "undefined field #{field} on record #{inspect(tag)}")
           end
         end

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -754,7 +754,7 @@ defmodule Kernel.Typespec do
        ) do
     remote = Module.get_attribute(caller.module, attr)
 
-    if !(is_atom(remote) and remote != nil) do
+    if not (is_atom(remote) and remote != nil) do
       message =
         "invalid remote in typespec: #{Macro.to_string(orig)} (@#{attr} is #{inspect(remote)})"
 

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -118,7 +118,7 @@ defmodule Kernel.Typespec do
     case spec_to_signature(expr) do
       {name, arity} ->
         # store doc only once in case callback has multiple clauses
-        unless :ets.member(set, {kind, name, arity}) do
+        if !:ets.member(set, {kind, name, arity}) do
           {line, doc} = get_doc_info(set, :doc, line)
           store_doc(set, kind, name, arity, line, :doc, doc, %{})
         end
@@ -320,7 +320,7 @@ defmodule Kernel.Typespec do
 
     invalid_args = :lists.filter(&(not valid_variable_ast?(&1)), args)
 
-    unless invalid_args == [] do
+    if invalid_args != [] do
       invalid_args = :lists.join(", ", :lists.map(&Macro.to_string/1, invalid_args))
 
       message =
@@ -380,7 +380,7 @@ defmodule Kernel.Typespec do
     ensure_no_defaults!(args)
     state = clean_local_state(state)
 
-    unless Keyword.keyword?(guard) do
+    if !Keyword.keyword?(guard) do
       error = "expected keywords as guard in type specification, got: #{Macro.to_string(guard)}"
       compile_error(caller, error)
     end
@@ -573,7 +573,7 @@ defmodule Kernel.Typespec do
           |> Map.delete(:__struct__)
           |> Map.to_list()
 
-        unless Keyword.keyword?(fields) do
+        if !Keyword.keyword?(fields) do
           compile_error(caller, "expected key-value pairs in struct #{Macro.to_string(name)}")
         end
 
@@ -587,7 +587,7 @@ defmodule Kernel.Typespec do
           )
 
         fun = fn {field, _} ->
-          unless Keyword.has_key?(struct, field) do
+          if !Keyword.has_key?(struct, field) do
             compile_error(
               caller,
               "undefined field #{inspect(field)} on struct #{inspect(module)}"
@@ -630,7 +630,7 @@ defmodule Kernel.Typespec do
           )
 
         fun = fn {field, _} ->
-          unless Keyword.has_key?(fields, field) do
+          if !Keyword.has_key?(fields, field) do
             compile_error(caller, "undefined field #{field} on record #{inspect(tag)}")
           end
         end
@@ -754,7 +754,7 @@ defmodule Kernel.Typespec do
        ) do
     remote = Module.get_attribute(caller.module, attr)
 
-    unless is_atom(remote) and remote != nil do
+    if !(is_atom(remote) and remote != nil) do
       message =
         "invalid remote in typespec: #{Macro.to_string(orig)} (@#{attr} is #{inspect(remote)})"
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -895,8 +895,8 @@ defmodule Macro do
   defp find_invalid(bin) when is_binary(bin), do: nil
 
   defp find_invalid(fun) when is_function(fun) do
-    if !(Function.info(fun, :env) == {:env, []} and
-           Function.info(fun, :type) == {:type, :external}) do
+    if Function.info(fun, :env) != {:env, []} or
+         Function.info(fun, :type) != {:type, :external} do
       {:error, fun}
     end
   end

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -895,8 +895,8 @@ defmodule Macro do
   defp find_invalid(bin) when is_binary(bin), do: nil
 
   defp find_invalid(fun) when is_function(fun) do
-    unless Function.info(fun, :env) == {:env, []} and
-             Function.info(fun, :type) == {:type, :external} do
+    if !(Function.info(fun, :env) == {:env, []} and
+           Function.info(fun, :type) == {:type, :external}) do
       {:error, fun}
     end
   end

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -902,7 +902,7 @@ defmodule Module do
   end
 
   def create(module, quoted, opts) when is_atom(module) and is_list(opts) do
-    if !Keyword.has_key?(opts, :file) do
+    if not Keyword.has_key?(opts, :file) do
       raise ArgumentError, "expected :file to be given as option"
     end
 
@@ -2260,7 +2260,7 @@ defmodule Module do
   end
 
   defp preprocess_attribute(:nifs, value) do
-    if !function_arity_list?(value) do
+    if not function_arity_list?(value) do
       raise ArgumentError,
             "@nifs is a built-in module attribute for specifying a list " <>
               "of functions and their arities that are NIFs, got: #{inspect(value)}"

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -902,7 +902,7 @@ defmodule Module do
   end
 
   def create(module, quoted, opts) when is_atom(module) and is_list(opts) do
-    unless Keyword.has_key?(opts, :file) do
+    if !Keyword.has_key?(opts, :file) do
       raise ArgumentError, "expected :file to be given as option"
     end
 
@@ -2260,7 +2260,7 @@ defmodule Module do
   end
 
   defp preprocess_attribute(:nifs, value) do
-    unless function_arity_list?(value) do
+    if !function_arity_list?(value) do
       raise ArgumentError,
             "@nifs is a built-in module attribute for specifying a list " <>
               "of functions and their arities that are NIFs, got: #{inspect(value)}"

--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -228,26 +228,26 @@ defmodule PartitionSupervisor do
   def start_link(opts) when is_list(opts) do
     name = opts[:name]
 
-    unless name do
+    if !name do
       raise ArgumentError, "the :name option must be given to PartitionSupervisor"
     end
 
     {child_spec, opts} = Keyword.pop(opts, :child_spec)
 
-    unless child_spec do
+    if !child_spec do
       raise ArgumentError, "the :child_spec option must be given to PartitionSupervisor"
     end
 
     {partitions, opts} = Keyword.pop(opts, :partitions, System.schedulers_online())
 
-    unless is_integer(partitions) and partitions >= 1 do
+    if !(is_integer(partitions) and partitions >= 1) do
       raise ArgumentError,
             "the :partitions option must be a positive integer, got: #{inspect(partitions)}"
     end
 
     {with_arguments, opts} = Keyword.pop(opts, :with_arguments, fn args, _partition -> args end)
 
-    unless is_function(with_arguments, 2) do
+    if !is_function(with_arguments, 2) do
       raise ArgumentError,
             "the :with_arguments option must be a function that receives two arguments, " <>
               "the current call arguments and the partition, got: #{inspect(with_arguments)}"
@@ -260,7 +260,7 @@ defmodule PartitionSupervisor do
       for partition <- 0..(partitions - 1) do
         args = with_arguments.(args, partition)
 
-        unless is_list(args) do
+        if !is_list(args) do
           raise "the call to the function in :with_arguments must return a list, got: #{inspect(args)}"
         end
 
@@ -270,7 +270,7 @@ defmodule PartitionSupervisor do
 
     auto_shutdown = Keyword.get(opts, :auto_shutdown, :never)
 
-    unless auto_shutdown == :never do
+    if auto_shutdown != :never do
       raise ArgumentError,
             "the :auto_shutdown option must be :never, got: #{inspect(auto_shutdown)}"
     end
@@ -319,7 +319,7 @@ defmodule PartitionSupervisor do
   defp init_partitions({:via, _, _}, partitions) do
     child_spec = {Registry, keys: :unique, name: @registry}
 
-    unless Process.whereis(@registry) do
+    if !Process.whereis(@registry) do
       Supervisor.start_child(:elixir_sup, child_spec)
     end
 

--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -240,7 +240,7 @@ defmodule PartitionSupervisor do
 
     {partitions, opts} = Keyword.pop(opts, :partitions, System.schedulers_online())
 
-    if !(is_integer(partitions) and partitions >= 1) do
+    if not (is_integer(partitions) and partitions >= 1) do
       raise ArgumentError,
             "the :partitions option must be a positive integer, got: #{inspect(partitions)}"
     end

--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -247,7 +247,7 @@ defmodule PartitionSupervisor do
 
     {with_arguments, opts} = Keyword.pop(opts, :with_arguments, fn args, _partition -> args end)
 
-    if !is_function(with_arguments, 2) do
+    if not is_function(with_arguments, 2) do
       raise ArgumentError,
             "the :with_arguments option must be a function that receives two arguments, " <>
               "the current call arguments and the partition, got: #{inspect(with_arguments)}"
@@ -260,7 +260,7 @@ defmodule PartitionSupervisor do
       for partition <- 0..(partitions - 1) do
         args = with_arguments.(args, partition)
 
-        if !is_list(args) do
+        if not is_list(args) do
           raise "the call to the function in :with_arguments must return a list, got: #{inspect(args)}"
         end
 

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -896,7 +896,7 @@ defmodule Protocol do
       # Inline struct implementation for performance
       @compile {:inline, struct_impl_for: 1}
 
-      unless Module.defines_type?(__MODULE__, {:t, 0}) do
+      if !Module.defines_type?(__MODULE__, {:t, 0}) do
         @typedoc """
         All the types that implement this protocol.
         """

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -331,7 +331,7 @@ defmodule Registry do
   def start_link(options) do
     keys = Keyword.get(options, :keys)
 
-    unless keys in @keys do
+    if keys not in @keys do
       raise ArgumentError,
             "expected :keys to be given and be one of :unique or :duplicate, got: #{inspect(keys)}"
     end
@@ -350,27 +350,27 @@ defmodule Registry do
 
     meta = Keyword.get(options, :meta, [])
 
-    unless Keyword.keyword?(meta) do
+    if !Keyword.keyword?(meta) do
       raise ArgumentError, "expected :meta to be a keyword list, got: #{inspect(meta)}"
     end
 
     partitions = Keyword.get(options, :partitions, 1)
 
-    unless is_integer(partitions) and partitions >= 1 do
+    if !(is_integer(partitions) and partitions >= 1) do
       raise ArgumentError,
             "expected :partitions to be a positive integer, got: #{inspect(partitions)}"
     end
 
     listeners = Keyword.get(options, :listeners, [])
 
-    unless is_list(listeners) and Enum.all?(listeners, &is_atom/1) do
+    if !(is_list(listeners) and Enum.all?(listeners, &is_atom/1)) do
       raise ArgumentError,
             "expected :listeners to be a list of named processes, got: #{inspect(listeners)}"
     end
 
     compressed = Keyword.get(options, :compressed, false)
 
-    unless is_boolean(compressed) do
+    if !is_boolean(compressed) do
       raise ArgumentError,
             "expected :compressed to be a boolean, got: #{inspect(compressed)}"
     end
@@ -1433,7 +1433,7 @@ defmodule Registry do
   end
 
   defp unlink_if_unregistered(pid_server, pid_ets, self) do
-    unless :ets.member(pid_ets, self) do
+    if !:ets.member(pid_ets, self) do
       Process.unlink(pid_server)
     end
   end

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -356,14 +356,14 @@ defmodule Registry do
 
     partitions = Keyword.get(options, :partitions, 1)
 
-    if !(is_integer(partitions) and partitions >= 1) do
+    if not (is_integer(partitions) and partitions >= 1) do
       raise ArgumentError,
             "expected :partitions to be a positive integer, got: #{inspect(partitions)}"
     end
 
     listeners = Keyword.get(options, :listeners, [])
 
-    if !(is_list(listeners) and Enum.all?(listeners, &is_atom/1)) do
+    if not (is_list(listeners) and Enum.all?(listeners, &is_atom/1)) do
       raise ArgumentError,
             "expected :listeners to be a list of named processes, got: #{inspect(listeners)}"
     end

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -350,7 +350,7 @@ defmodule Registry do
 
     meta = Keyword.get(options, :meta, [])
 
-    if !Keyword.keyword?(meta) do
+    if not Keyword.keyword?(meta) do
       raise ArgumentError, "expected :meta to be a keyword list, got: #{inspect(meta)}"
     end
 
@@ -370,7 +370,7 @@ defmodule Registry do
 
     compressed = Keyword.get(options, :compressed, false)
 
-    if !is_boolean(compressed) do
+    if not is_boolean(compressed) do
       raise ArgumentError,
             "expected :compressed to be a boolean, got: #{inspect(compressed)}"
     end
@@ -1433,7 +1433,7 @@ defmodule Registry do
   end
 
   defp unlink_if_unregistered(pid_server, pid_ets, self) do
-    if !:ets.member(pid_ets, self) do
+    if not :ets.member(pid_ets, self) do
       Process.unlink(pid_server)
     end
   end

--- a/lib/elixir/lib/stream/reducers.ex
+++ b/lib/elixir/lib/stream/reducers.ex
@@ -151,10 +151,10 @@ defmodule Stream.Reducers do
   defmacro reject(callback, fun \\ nil) do
     quote do
       fn entry, acc ->
-        if !unquote(callback).(entry) do
-          next(unquote(fun), entry, acc)
-        else
+        if unquote(callback).(entry) do
           skip(acc)
+        else
+          next(unquote(fun), entry, acc)
         end
       end
     end

--- a/lib/elixir/lib/stream/reducers.ex
+++ b/lib/elixir/lib/stream/reducers.ex
@@ -151,7 +151,7 @@ defmodule Stream.Reducers do
   defmacro reject(callback, fun \\ nil) do
     quote do
       fn entry, acc ->
-        unless unquote(callback).(entry) do
+        if !unquote(callback).(entry) do
           next(unquote(fun), entry, acc)
         else
           skip(acc)

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -525,7 +525,7 @@ defmodule Supervisor do
       import Supervisor.Spec
       @behaviour Supervisor
 
-      unless Module.has_attribute?(__MODULE__, :doc) do
+      if !Module.has_attribute?(__MODULE__, :doc) do
         @doc """
         Returns a specification to start this module under a supervisor.
 

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -525,7 +525,7 @@ defmodule Supervisor do
       import Supervisor.Spec
       @behaviour Supervisor
 
-      if !Module.has_attribute?(__MODULE__, :doc) do
+      if not Module.has_attribute?(__MODULE__, :doc) do
         @doc """
         Returns a specification to start this module under a supervisor.
 

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -168,7 +168,7 @@ defmodule Supervisor.Spec do
         ) :: {:ok, tuple}
   @deprecated "Use the new child specifications outlined in the Supervisor module instead"
   def supervise(children, options) do
-    unless strategy = options[:strategy] do
+    if !(strategy = options[:strategy]) do
       raise ArgumentError, "expected :strategy option to be given"
     end
 

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -1101,7 +1101,7 @@ defmodule System do
   def cmd(command, args, opts \\ []) when is_binary(command) and is_list(args) do
     assert_no_null_byte!(command, "System.cmd/3")
 
-    unless Enum.all?(args, &is_binary/1) do
+    if !Enum.all?(args, &is_binary/1) do
       raise ArgumentError, "all arguments for System.cmd/3 must be binaries"
     end
 

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -329,7 +329,7 @@ defmodule Task do
   @doc false
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
-      unless Module.has_attribute?(__MODULE__, :doc) do
+      if !Module.has_attribute?(__MODULE__, :doc) do
         @doc """
         Returns a specification to start this module under a supervisor.
 

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -329,7 +329,7 @@ defmodule Task do
   @doc false
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
-      if !Module.has_attribute?(__MODULE__, :doc) do
+      if not Module.has_attribute?(__MODULE__, :doc) do
         @doc """
         Returns a specification to start this module under a supervisor.
 

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -209,7 +209,7 @@ defmodule Task.Supervised do
     ordered = Keyword.get(options, :ordered, true)
     zip_input_on_exit = Keyword.get(options, :zip_input_on_exit, false)
 
-    if !(is_integer(max_concurrency) and max_concurrency > 0) do
+    if not (is_integer(max_concurrency) and max_concurrency > 0) do
       raise ArgumentError, ":max_concurrency must be an integer greater than zero"
     end
 
@@ -217,7 +217,7 @@ defmodule Task.Supervised do
       raise ArgumentError, ":on_timeout must be either :exit or :kill_task"
     end
 
-    if !((is_integer(timeout) and timeout >= 0) or timeout == :infinity) do
+    if not ((is_integer(timeout) and timeout >= 0) or timeout == :infinity) do
       raise ArgumentError, ":timeout must be either a positive integer or :infinity"
     end
 

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -209,15 +209,15 @@ defmodule Task.Supervised do
     ordered = Keyword.get(options, :ordered, true)
     zip_input_on_exit = Keyword.get(options, :zip_input_on_exit, false)
 
-    unless is_integer(max_concurrency) and max_concurrency > 0 do
+    if !(is_integer(max_concurrency) and max_concurrency > 0) do
       raise ArgumentError, ":max_concurrency must be an integer greater than zero"
     end
 
-    unless on_timeout in [:exit, :kill_task] do
+    if on_timeout not in [:exit, :kill_task] do
       raise ArgumentError, ":on_timeout must be either :exit or :kill_task"
     end
 
-    unless (is_integer(timeout) and timeout >= 0) or timeout == :infinity do
+    if !((is_integer(timeout) and timeout >= 0) or timeout == :infinity) do
       raise ArgumentError, ":timeout must be either a positive integer or :infinity"
     end
 

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -614,7 +614,7 @@ defmodule Task.Supervisor do
   defp build_stream(supervisor, link_type, enumerable, fun, options) do
     shutdown = Keyword.get(options, :shutdown, 5000)
 
-    unless (is_integer(shutdown) and shutdown >= 0) or shutdown == :brutal_kill do
+    if !((is_integer(shutdown) and shutdown >= 0) or shutdown == :brutal_kill) do
       raise ArgumentError, ":shutdown must be either a positive integer or :brutal_kill"
     end
 

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -614,7 +614,7 @@ defmodule Task.Supervisor do
   defp build_stream(supervisor, link_type, enumerable, fun, options) do
     shutdown = Keyword.get(options, :shutdown, 5000)
 
-    if !((is_integer(shutdown) and shutdown >= 0) or shutdown == :brutal_kill) do
+    if not ((is_integer(shutdown) and shutdown >= 0) or shutdown == :brutal_kill) do
       raise ArgumentError, ":shutdown must be either a positive integer or :brutal_kill"
     end
 

--- a/lib/elixir/scripts/diff.exs
+++ b/lib/elixir/scripts/diff.exs
@@ -131,7 +131,7 @@ defmodule Diff do
   end
 
   defp assert_dir!(dir) do
-    unless File.dir?(dir) do
+    if !File.dir?(dir) do
       raise ArgumentError, "#{inspect(dir)} is not a directory"
     end
   end

--- a/lib/elixir/test/elixir/code_formatter/migration_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/migration_test.exs
@@ -1,0 +1,77 @@
+Code.require_file("../test_helper.exs", __DIR__)
+
+defmodule Code.Formatter.MigrationTest do
+  use ExUnit.Case, async: true
+
+  import CodeFormatterHelpers
+
+  @rewrite_unless [rewrite_unless: true]
+
+  describe "rewrite_unless: true" do
+    test "rewrites unless as an if with negated condition" do
+      bad = "unless x, do: y"
+
+      good = "if !x, do: y"
+
+      assert_format bad, good, @rewrite_unless
+
+      bad = """
+      unless x do
+        y
+      else
+        z
+      end
+      """
+
+      good = """
+      if !x do
+        y
+      else
+        z
+      end
+      """
+
+      assert_format bad, good, @rewrite_unless
+    end
+
+    test "rewrites pipelines with negated condition" do
+      bad = "x |> unless(do: y)"
+
+      good = "!x |> if(do: y)"
+
+      assert_format bad, good, @rewrite_unless
+
+      bad = "x |> foo() |> unless(do: y)"
+
+      good = "x |> foo() |> Kernel.!() |> if(do: y)"
+
+      assert_format bad, good, @rewrite_unless
+    end
+
+    test "rewrites in as not in" do
+      assert_format "unless x in y, do: 1", "if x not in y, do: 1", @rewrite_unless
+    end
+
+    test "rewrites equality operators" do
+      assert_format "unless x == y, do: 1", "if x != y, do: 1", @rewrite_unless
+      assert_format "unless x === y, do: 1", "if x !== y, do: 1", @rewrite_unless
+      assert_format "unless x != y, do: 1", "if x == y, do: 1", @rewrite_unless
+      assert_format "unless x !== y, do: 1", "if x === y, do: 1", @rewrite_unless
+    end
+
+    test "rewrites boolean or is_* conditions with not" do
+      assert_format "unless x > 0, do: 1", "if not (x > 0), do: 1", @rewrite_unless
+      assert_format "unless is_atom(x), do: 1", "if not is_atom(x), do: 1", @rewrite_unless
+    end
+
+    test "removes ! or not in condition" do
+      assert_format "unless not x, do: 1", "if x, do: 1", @rewrite_unless
+      assert_format "unless !x, do: 1", "if x, do: 1", @rewrite_unless
+    end
+
+    test "does nothing without the rewrite_unless option" do
+      assert_same "unless x, do: y"
+      assert_same "unless x, do: y, else: z"
+    end
+  end
+end

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -1794,7 +1794,7 @@ defmodule FileTest do
         stat = File.stat!(fixture)
         assert stat.mode == 0o100666
 
-        if !windows?() do
+        if not windows?() do
           assert File.chmod(fixture, 0o100777) == :ok
           stat = File.stat!(fixture)
           assert stat.mode == 0o100777
@@ -1814,7 +1814,7 @@ defmodule FileTest do
         stat = File.stat!(fixture)
         assert stat.mode == 0o100666
 
-        if !windows?() do
+        if not windows?() do
           assert File.chmod!(fixture, 0o100777) == :ok
           stat = File.stat!(fixture)
           assert stat.mode == 0o100777

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -1794,7 +1794,7 @@ defmodule FileTest do
         stat = File.stat!(fixture)
         assert stat.mode == 0o100666
 
-        unless windows?() do
+        if !windows?() do
           assert File.chmod(fixture, 0o100777) == :ok
           stat = File.stat!(fixture)
           assert stat.mode == 0o100777
@@ -1814,7 +1814,7 @@ defmodule FileTest do
         stat = File.stat!(fixture)
         assert stat.mode == 0o100666
 
-        unless windows?() do
+        if !windows?() do
           assert File.chmod!(fixture, 0o100777) == :ok
           stat = File.stat!(fixture)
           assert stat.mode == 0o100777

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -95,7 +95,7 @@ defmodule Kernel.CLI.ExecutableTest do
              System.cmd(elixir_executable(context.cli_extension), ["-e", "Time.new!(0, 0, 0)"])
 
     # TODO: remove this once we bump CI to 26.3
-    if !(windows?() and System.otp_release() == "26") do
+    if not (windows?() and System.otp_release() == "26") do
       {output, 0} =
         System.cmd(iex_executable(context.cli_extension), [
           "--eval",

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -95,7 +95,7 @@ defmodule Kernel.CLI.ExecutableTest do
              System.cmd(elixir_executable(context.cli_extension), ["-e", "Time.new!(0, 0, 0)"])
 
     # TODO: remove this once we bump CI to 26.3
-    unless windows?() and System.otp_release() == "26" do
+    if !(windows?() and System.otp_release() == "26") do
       {output, 0} =
         System.cmd(iex_executable(context.cli_extension), [
           "--eval",

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -17,7 +17,7 @@ defmodule Kernel.DialyzerTest do
       |> String.to_charlist()
 
     # Some OSs (like Windows) do not provide the HOME environment variable.
-    unless System.get_env("HOME") do
+    if !System.get_env("HOME") do
       System.put_env("HOME", System.user_home())
     end
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -648,7 +648,7 @@ defmodule MacroTest do
 
       {result, formatted} =
         dbg_format(
-          unless true and x do
+          if !(true and x) do
             map[:a] * 2
           else
             map[:b]

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -648,7 +648,7 @@ defmodule MacroTest do
 
       {result, formatted} =
         dbg_format(
-          if !(true and x) do
+          unless true and x do
             map[:a] * 2
           else
             map[:b]

--- a/lib/elixir/test/elixir/supervisor_test.exs
+++ b/lib/elixir/test/elixir/supervisor_test.exs
@@ -277,7 +277,7 @@ defmodule SupervisorTest do
   end
 
   defp wait_until_registered(name) do
-    unless Process.whereis(name) do
+    if !Process.whereis(name) do
       wait_until_registered(name)
     end
   end

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -128,7 +128,7 @@ defmodule SystemTest do
         # There is a bug in OTP where find_executable is finding
         # entries on the current directory. If this is the case,
         # we should avoid the assertion below.
-        unless System.find_executable(@echo) do
+        if !System.find_executable(@echo) do
           assert :enoent = catch_error(System.cmd(@echo, ~w[/c echo hello]))
         end
 
@@ -212,7 +212,7 @@ defmodule SystemTest do
         # There is a bug in OTP where find_executable is finding
         # entries on the current directory. If this is the case,
         # we should avoid the assertion below.
-        unless System.find_executable(@echo) do
+        if !System.find_executable(@echo) do
           assert :enoent = catch_error(System.cmd(@echo, ["hello"]))
         end
 

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -410,7 +410,7 @@ defmodule ExUnit.Assertions do
   end
 
   def assert(value, opts) when is_list(opts) do
-    unless value, do: raise(ExUnit.AssertionError, opts)
+    if !value, do: raise(ExUnit.AssertionError, opts)
     true
   end
 
@@ -780,7 +780,7 @@ defmodule ExUnit.Assertions do
         "expected:\n  #{inspect(message)}\n" <>
         "actual:\n" <> "  #{inspect(Exception.message(error))}"
 
-    unless match?, do: flunk(message)
+    if !match?, do: flunk(message)
 
     error
   end

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -243,7 +243,7 @@ defmodule ExUnit.Callbacks do
 
   """
   defmacro setup(context, block) do
-    if !(Keyword.keyword?(block) and Keyword.has_key?(block, :do)) do
+    if not (Keyword.keyword?(block) and Keyword.has_key?(block, :do)) do
       raise ArgumentError,
             "setup/2 requires a block as the second argument after the context, got: #{Macro.to_string(block)}"
     end
@@ -378,7 +378,7 @@ defmodule ExUnit.Callbacks do
 
   """
   defmacro setup_all(context, block) do
-    if !(Keyword.keyword?(block) and Keyword.has_key?(block, :do)) do
+    if not (Keyword.keyword?(block) and Keyword.has_key?(block, :do)) do
       raise ArgumentError,
             "setup_all/2 requires a block as the second argument after the context, got: #{Macro.to_string(block)}"
     end

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -243,7 +243,7 @@ defmodule ExUnit.Callbacks do
 
   """
   defmacro setup(context, block) do
-    unless Keyword.keyword?(block) and Keyword.has_key?(block, :do) do
+    if !(Keyword.keyword?(block) and Keyword.has_key?(block, :do)) do
       raise ArgumentError,
             "setup/2 requires a block as the second argument after the context, got: #{Macro.to_string(block)}"
     end
@@ -378,7 +378,7 @@ defmodule ExUnit.Callbacks do
 
   """
   defmacro setup_all(context, block) do
-    unless Keyword.keyword?(block) and Keyword.has_key?(block, :do) do
+    if !(Keyword.keyword?(block) and Keyword.has_key?(block, :do)) do
       raise ArgumentError,
             "setup_all/2 requires a block as the second argument after the context, got: #{Macro.to_string(block)}"
     end

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -322,7 +322,7 @@ defmodule ExUnit.Case do
     {async?, opts} = Keyword.pop(opts, :async, false)
     {parameterize, opts} = Keyword.pop(opts, :parameterize, nil)
 
-    if !(parameterize == nil or (is_list(parameterize) and Enum.all?(parameterize, &is_map/1))) do
+    if not (parameterize == nil or (is_list(parameterize) and Enum.all?(parameterize, &is_map/1))) do
       raise ArgumentError, ":parameterize must be a list of maps, got: #{inspect(parameterize)}"
     end
 

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -312,7 +312,7 @@ defmodule ExUnit.Case do
 
   @doc false
   def __register__(module, opts) do
-    if !Keyword.keyword?(opts) do
+    if not Keyword.keyword?(opts) do
       raise ArgumentError,
             ~s(the argument passed to "use ExUnit.Case" must be a list of options, ) <>
               ~s(got: #{inspect(opts)})
@@ -381,7 +381,7 @@ defmodule ExUnit.Case do
 
   """
   defmacro test(message, var \\ quote(do: _), contents) do
-    if !is_tuple(var) do
+    if not is_tuple(var) do
       IO.warn(
         "test context is always a map. The pattern " <>
           "#{inspect(Macro.to_string(var))} will never match",
@@ -602,7 +602,7 @@ defmodule ExUnit.Case do
   """
   @doc since: "1.11.0"
   def register_test(mod, file, line, test_type, name, tags) do
-    if !Module.has_attribute?(mod, :ex_unit_tests) do
+    if not Module.has_attribute?(mod, :ex_unit_tests) do
       raise "cannot define #{test_type}. Please make sure you have invoked " <>
               "\"use ExUnit.Case\" in the current module"
     end

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -299,7 +299,7 @@ defmodule ExUnit.Case do
   @doc false
   defmacro __using__(opts) do
     quote do
-      unless ExUnit.Case.__register__(__MODULE__, unquote(opts)) do
+      if !ExUnit.Case.__register__(__MODULE__, unquote(opts)) do
         use ExUnit.Callbacks
       end
 
@@ -312,7 +312,7 @@ defmodule ExUnit.Case do
 
   @doc false
   def __register__(module, opts) do
-    unless Keyword.keyword?(opts) do
+    if !Keyword.keyword?(opts) do
       raise ArgumentError,
             ~s(the argument passed to "use ExUnit.Case" must be a list of options, ) <>
               ~s(got: #{inspect(opts)})
@@ -322,7 +322,7 @@ defmodule ExUnit.Case do
     {async?, opts} = Keyword.pop(opts, :async, false)
     {parameterize, opts} = Keyword.pop(opts, :parameterize, nil)
 
-    unless parameterize == nil or (is_list(parameterize) and Enum.all?(parameterize, &is_map/1)) do
+    if !(parameterize == nil or (is_list(parameterize) and Enum.all?(parameterize, &is_map/1))) do
       raise ArgumentError, ":parameterize must be a list of maps, got: #{inspect(parameterize)}"
     end
 
@@ -332,7 +332,7 @@ defmodule ExUnit.Case do
 
     registered? = Module.has_attribute?(module, :ex_unit_tests)
 
-    unless registered? do
+    if !registered? do
       tag_check = Enum.any?([:moduletag, :describetag, :tag], &Module.has_attribute?(module, &1))
 
       if tag_check do
@@ -381,7 +381,7 @@ defmodule ExUnit.Case do
 
   """
   defmacro test(message, var \\ quote(do: _), contents) do
-    unless is_tuple(var) do
+    if !is_tuple(var) do
       IO.warn(
         "test context is always a map. The pattern " <>
           "#{inspect(Macro.to_string(var))} will never match",
@@ -602,7 +602,7 @@ defmodule ExUnit.Case do
   """
   @doc since: "1.11.0"
   def register_test(mod, file, line, test_type, name, tags) do
-    unless Module.has_attribute?(mod, :ex_unit_tests) do
+    if !Module.has_attribute?(mod, :ex_unit_tests) do
       raise "cannot define #{test_type}. Please make sure you have invoked " <>
               "\"use ExUnit.Case\" in the current module"
     end
@@ -846,7 +846,7 @@ defmodule ExUnit.Case do
       raise "cannot set tag #{inspect(tag)} because it is reserved by ExUnit"
     end
 
-    unless is_atom(tags[:test_type]) do
+    if not is_atom(tags[:test_type]) do
       raise("value for tag \":test_type\" must be an atom")
     end
 

--- a/lib/ex_unit/test/ex_unit/supervised_test.exs
+++ b/lib/ex_unit/test/ex_unit/supervised_test.exs
@@ -149,7 +149,7 @@ defmodule ExUnit.SupervisedTest do
   end
 
   defp wait_until_registered(name) do
-    unless Process.whereis(name) do
+    if !Process.whereis(name) do
       wait_until_registered(name)
     end
   end

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -716,7 +716,7 @@ defmodule IEx do
   defp __break__!(ast, module, fun, args, guards, stops, env) do
     module = Macro.expand(module, env)
 
-    unless is_atom(module) do
+    if not is_atom(module) do
       raise_unknown_break_ast!(ast)
     end
 

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -335,7 +335,7 @@ defmodule IEx.Evaluator do
     forms = add_if_undefined_apply_to_vars(forms, env)
     {result, binding, env} = eval_expr_by_expr(forms, binding, env)
 
-    unless result == IEx.dont_display_result() do
+    if result != IEx.dont_display_result() do
       io_inspect(result)
     end
 

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -205,13 +205,13 @@ defmodule IEx.Helpers do
   def c(files, path \\ :in_memory) when is_binary(path) or path == :in_memory do
     files = List.wrap(files)
 
-    unless Enum.all?(files, &is_binary/1) do
+    if !Enum.all?(files, &is_binary/1) do
       raise ArgumentError, "expected a binary or a list of binaries as argument"
     end
 
     {found, not_found} = Enum.split_with(files, &File.exists?/1)
 
-    unless Enum.empty?(not_found) do
+    if !Enum.empty?(not_found) do
       raise ArgumentError, "could not find files #{Enum.join(not_found, ", ")}"
     end
 
@@ -462,7 +462,7 @@ defmodule IEx.Helpers do
 
     sources =
       Enum.map(modules, fn module ->
-        unless Code.ensure_loaded?(module) do
+        if !Code.ensure_loaded?(module) do
           raise ArgumentError, "could not load nor find module: #{inspect(module)}"
         end
 

--- a/lib/logger/lib/logger/backends/internal.ex
+++ b/lib/logger/lib/logger/backends/internal.ex
@@ -98,7 +98,7 @@ defmodule Logger.Backends.Internal do
   ## Supervisor callbacks
 
   defp ensure_started() do
-    unless Process.whereis(@name) do
+    if !Process.whereis(@name) do
       Supervisor.start_child(Logger.Supervisor, __MODULE__)
     end
 

--- a/lib/logger/test/test_helper.exs
+++ b/lib/logger/test/test_helper.exs
@@ -22,7 +22,7 @@ defmodule Logger.Case do
   end
 
   def wait_for_handler(manager, handler) do
-    unless handler in :gen_event.which_handlers(manager) do
+    if handler not in :gen_event.which_handlers(manager) do
       Process.sleep(10)
       wait_for_handler(manager, handler)
     end

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -640,7 +640,7 @@ defmodule Mix do
             )
 
           %{} ->
-            unless app in optional do
+            if app not in optional do
               Mix.raise(
                 "The application \"#{app}\" could not be found. This may happen if your " <>
                   "Operating System broke Erlang into multiple packages and may be fixed " <>
@@ -998,7 +998,7 @@ defmodule Mix do
         _ -> Mix.raise("unknown dependency #{inspect(app_name)} given to #{inspect(key)}")
       end
 
-    unless app_dir do
+    if !app_dir do
       Mix.raise("#{inspect(app_name)} given to #{inspect(key)} must be a path dependency")
     end
 

--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -206,7 +206,7 @@ defmodule Mix.Dep do
       end
 
     Enum.each(apps, fn app ->
-      unless Enum.any?(all_deps, &(&1.app == app)) do
+      if !Enum.any?(all_deps, &(&1.app == app)) do
         Mix.raise("Unknown dependency #{app} for environment #{Mix.env()}")
       end
     end)

--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -167,7 +167,7 @@ defmodule Mix.Dep.Loader do
   end
 
   defp with_scm_and_app(app, req, opts, original, locked?) do
-    unless Keyword.keyword?(opts) do
+    if !Keyword.keyword?(opts) do
       invalid_dep_format(original)
     end
 
@@ -192,7 +192,7 @@ defmodule Mix.Dep.Loader do
         {scm, opts}
       end
 
-    unless scm do
+    if !scm do
       Mix.raise(
         "Could not find an SCM for dependency #{inspect(app)} from #{inspect(Mix.Project.get())}"
       )

--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -167,7 +167,7 @@ defmodule Mix.Dep.Loader do
   end
 
   defp with_scm_and_app(app, req, opts, original, locked?) do
-    if !Keyword.keyword?(opts) do
+    if not Keyword.keyword?(opts) do
       invalid_dep_format(original)
     end
 

--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -30,7 +30,7 @@ defmodule Mix.Dep.Lock do
   def write(map, opts \\ []) do
     lockfile = opts[:file] || lockfile()
 
-    unless map == read() do
+    if map != read() do
       if Keyword.get(opts, :check_locked, false) do
         Mix.raise(
           "Your #{lockfile} is out of date and must be updated without the --check-locked flag"

--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -160,7 +160,7 @@ defmodule Mix.Generator do
   end
 
   defp log(color, command, message, opts) do
-    unless opts[:quiet] do
+    if !opts[:quiet] do
       Mix.shell().info([color, "* #{command} ", :reset, message])
     end
   end

--- a/lib/mix/lib/mix/local.ex
+++ b/lib/mix/lib/mix/local.ex
@@ -141,7 +141,7 @@ defmodule Mix.Local do
 
     case File.read(elixir) do
       {:ok, req} ->
-        unless Version.match?(System.version(), req) do
+        if !Version.match?(System.version(), req) do
           archive = ebin |> Path.dirname() |> Path.basename()
 
           Mix.shell().error(

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -188,13 +188,13 @@ defmodule Mix.Project do
 
       task = String.to_atom(task || config[:default_task] || "run")
 
-      unless System.get_env("MIX_ENV") do
+      if !System.get_env("MIX_ENV") do
         if env = config[:preferred_envs][task] || @preferred_envs[task] || config[:default_env] do
           Mix.env(env)
         end
       end
 
-      unless System.get_env("MIX_TARGET") do
+      if !System.get_env("MIX_TARGET") do
         if target = config[:preferred_targets][task] || config[:default_target] do
           Mix.target(target)
         end

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -75,7 +75,7 @@ defmodule Mix.Release do
   def from_config!(name, config, overrides) do
     {name, apps, opts} = find_release(name, config)
 
-    if !(Atom.to_string(name) =~ ~r/^[a-z][a-z0-9_]*$/) do
+    if not (Atom.to_string(name) =~ ~r/^[a-z][a-z0-9_]*$/) do
       Mix.raise(
         "Invalid release name. A release name must start with a lowercase ASCII letter, " <>
           "followed by lowercase ASCII letters, numbers, or underscores, got: #{inspect(name)}"

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -75,7 +75,7 @@ defmodule Mix.Release do
   def from_config!(name, config, overrides) do
     {name, apps, opts} = find_release(name, config)
 
-    unless Atom.to_string(name) =~ ~r/^[a-z][a-z0-9_]*$/ do
+    if !(Atom.to_string(name) =~ ~r/^[a-z][a-z0-9_]*$/) do
       Mix.raise(
         "Invalid release name. A release name must start with a lowercase ASCII letter, " <>
           "followed by lowercase ASCII letters, numbers, or underscores, got: #{inspect(name)}"

--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -197,7 +197,7 @@ defmodule Mix.SCM.Git do
   end
 
   defp ensure_feature_compatibility(version, required_version, feature) do
-    unless required_version <= version do
+    if not (required_version <= version) do
       Mix.raise(
         "Git >= #{format_version(required_version)} is required to use #{feature}. " <>
           "You are running version #{format_version(version)}"

--- a/lib/mix/lib/mix/shell/io.ex
+++ b/lib/mix/lib/mix/shell/io.ex
@@ -71,7 +71,7 @@ defmodule Mix.Shell.IO do
   def yes?(message, options \\ []) do
     default = Keyword.get(options, :default, :yes)
 
-    unless default in [:yes, :no] do
+    if default not in [:yes, :no] do
       raise ArgumentError,
             "expected :default to be either :yes or :no, got: #{inspect(default)}"
     end

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -397,7 +397,7 @@ defmodule Mix.Task do
   @doc since: "1.14.0"
   @spec run_in_apps(task_name, [atom], [any]) :: any
   def run_in_apps(task, apps, args \\ []) do
-    unless Mix.Project.umbrella?() do
+    if !Mix.Project.umbrella?() do
       Mix.raise(
         "Could not run #{inspect(task)} with the --app option because this is not an umbrella project"
       )

--- a/lib/mix/lib/mix/tasks/app.config.ex
+++ b/lib/mix/lib/mix/tasks/app.config.ex
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.App.Config do
     #
     # Therefore we let the application that owns the build path
     # to ultimately perform the check.
-    unless config[:build_path] do
+    if !config[:build_path] do
       check_configured()
     end
   end

--- a/lib/mix/lib/mix/tasks/archive.build.ex
+++ b/lib/mix/lib/mix/tasks/archive.build.ex
@@ -100,7 +100,7 @@ defmodule Mix.Tasks.Archive.Build do
           Mix.raise("Cannot create archive without output file, please pass -o as an option")
       end
 
-    unless File.dir?(source) do
+    if !File.dir?(source) do
       Mix.raise("Expected archive source #{inspect(source)} to be a directory")
     end
 

--- a/lib/mix/lib/mix/tasks/compile.all.ex
+++ b/lib/mix/lib/mix/tasks/compile.all.ex
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.Compile.All do
     # Compute the app cache if it is stale and we are
     # not compiling from a dependency.
     app_cache =
-      unless "--from-mix-deps-compile" in args do
+      if "--from-mix-deps-compile" not in args do
         Mix.AppLoader.stale_cache(config)
       end
 
@@ -66,7 +66,7 @@ defmodule Mix.Tasks.Compile.All do
       Mix.AppLoader.write_cache(app_cache, Map.new(loaded_modules))
     end
 
-    unless "--no-app-loading" in args do
+    if "--no-app-loading" not in args do
       app = config[:app]
 
       with {:ok, properties} <- Mix.AppLoader.load_app(app, "#{compile_path}/#{app}.app"),

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -211,7 +211,7 @@ defmodule Mix.Tasks.Compile.App do
   defp validate_version(version) do
     ensure_present(:version, version)
 
-    if !(is_binary(version) and match?({:ok, _}, Version.parse(version))) do
+    if not (is_binary(version) and match?({:ok, _}, Version.parse(version))) do
       Mix.raise(
         "Expected :version to be a valid Version, got: #{inspect(version)} (see the Version module for more information)"
       )
@@ -273,7 +273,7 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:maxT, value} ->
-        if !(value == :infinity or is_integer(value)) do
+        if not (value == :infinity or is_integer(value)) do
           Mix.raise(
             "Application maximum time (:maxT) is not an integer or :infinity, got: " <>
               inspect(value)
@@ -281,14 +281,14 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:modules, value} ->
-        if !(is_list(value) and Enum.all?(value, &is_atom(&1))) do
+        if not (is_list(value) and Enum.all?(value, &is_atom(&1))) do
           Mix.raise(
             "Application modules (:modules) should be a list of atoms, got: " <> inspect(value)
           )
         end
 
       {:registered, value} ->
-        if !(is_list(value) and Enum.all?(value, &is_atom(&1))) do
+        if not (is_list(value) and Enum.all?(value, &is_atom(&1))) do
           Mix.raise(
             "Application registered processes (:registered) should be a list of atoms, got: " <>
               inspect(value)
@@ -296,7 +296,7 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:included_applications, value} ->
-        if !(is_list(value) and Enum.all?(value, &is_atom(&1))) do
+        if not (is_list(value) and Enum.all?(value, &is_atom(&1))) do
           Mix.raise(
             "Application included applications (:included_applications) should be a list of atoms, got: " <>
               inspect(value)
@@ -304,7 +304,7 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:extra_applications, value} ->
-        if !(is_list(value) and Enum.all?(value, &typed_app?(&1))) do
+        if not (is_list(value) and Enum.all?(value, &typed_app?(&1))) do
           Mix.raise(
             "Application extra applications (:extra_applications) should be a list of atoms or " <>
               "{app, :required | :optional} pairs, got: " <> inspect(value)
@@ -312,7 +312,7 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:applications, value} ->
-        if !(is_list(value) and Enum.all?(value, &typed_app?(&1))) do
+        if not (is_list(value) and Enum.all?(value, &typed_app?(&1))) do
           Mix.raise(
             "Application applications (:applications) should be a list of atoms or " <>
               "{app, :required | :optional} pairs, got: " <> inspect(value)

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -211,7 +211,7 @@ defmodule Mix.Tasks.Compile.App do
   defp validate_version(version) do
     ensure_present(:version, version)
 
-    unless is_binary(version) and match?({:ok, _}, Version.parse(version)) do
+    if !(is_binary(version) and match?({:ok, _}, Version.parse(version))) do
       Mix.raise(
         "Expected :version to be a valid Version, got: #{inspect(version)} (see the Version module for more information)"
       )
@@ -240,7 +240,7 @@ defmodule Mix.Tasks.Compile.App do
     if function_exported?(project, :application, 0) do
       project_application = project.application()
 
-      unless Keyword.keyword?(project_application) do
+      if !Keyword.keyword?(project_application) do
         Mix.raise(
           "Application configuration returned from application/0 should be a keyword list"
         )
@@ -255,7 +255,7 @@ defmodule Mix.Tasks.Compile.App do
   defp validate_properties!(properties) do
     Enum.each(properties, fn
       {:description, value} ->
-        unless is_list(value) do
+        if !is_list(value) do
           Mix.raise(
             "Application description (:description) is not a character list, got: " <>
               inspect(value)
@@ -263,17 +263,17 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:id, value} ->
-        unless is_list(value) do
+        if !is_list(value) do
           Mix.raise("Application ID (:id) is not a character list, got: " <> inspect(value))
         end
 
       {:vsn, value} ->
-        unless is_list(value) do
+        if !is_list(value) do
           Mix.raise("Application vsn (:vsn) is not a character list, got: " <> inspect(value))
         end
 
       {:maxT, value} ->
-        unless value == :infinity or is_integer(value) do
+        if !(value == :infinity or is_integer(value)) do
           Mix.raise(
             "Application maximum time (:maxT) is not an integer or :infinity, got: " <>
               inspect(value)
@@ -281,14 +281,14 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:modules, value} ->
-        unless is_list(value) and Enum.all?(value, &is_atom(&1)) do
+        if !(is_list(value) and Enum.all?(value, &is_atom(&1))) do
           Mix.raise(
             "Application modules (:modules) should be a list of atoms, got: " <> inspect(value)
           )
         end
 
       {:registered, value} ->
-        unless is_list(value) and Enum.all?(value, &is_atom(&1)) do
+        if !(is_list(value) and Enum.all?(value, &is_atom(&1))) do
           Mix.raise(
             "Application registered processes (:registered) should be a list of atoms, got: " <>
               inspect(value)
@@ -296,7 +296,7 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:included_applications, value} ->
-        unless is_list(value) and Enum.all?(value, &is_atom(&1)) do
+        if !(is_list(value) and Enum.all?(value, &is_atom(&1))) do
           Mix.raise(
             "Application included applications (:included_applications) should be a list of atoms, got: " <>
               inspect(value)
@@ -304,7 +304,7 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:extra_applications, value} ->
-        unless is_list(value) and Enum.all?(value, &typed_app?(&1)) do
+        if !(is_list(value) and Enum.all?(value, &typed_app?(&1))) do
           Mix.raise(
             "Application extra applications (:extra_applications) should be a list of atoms or " <>
               "{app, :required | :optional} pairs, got: " <> inspect(value)
@@ -312,7 +312,7 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:applications, value} ->
-        unless is_list(value) and Enum.all?(value, &typed_app?(&1)) do
+        if !(is_list(value) and Enum.all?(value, &typed_app?(&1))) do
           Mix.raise(
             "Application applications (:applications) should be a list of atoms or " <>
               "{app, :required | :optional} pairs, got: " <> inspect(value)
@@ -320,14 +320,14 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:env, value} ->
-        unless Keyword.keyword?(value) do
+        if !Keyword.keyword?(value) do
           Mix.raise(
             "Application environment (:env) should be a keyword list, got: " <> inspect(value)
           )
         end
 
       {:start_phases, value} ->
-        unless Keyword.keyword?(value) do
+        if !Keyword.keyword?(value) do
           Mix.raise(
             "Application start phases (:start_phases) should be a keyword list, got: " <>
               inspect(value)

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -240,7 +240,7 @@ defmodule Mix.Tasks.Compile.App do
     if function_exported?(project, :application, 0) do
       project_application = project.application()
 
-      if !Keyword.keyword?(project_application) do
+      if not Keyword.keyword?(project_application) do
         Mix.raise(
           "Application configuration returned from application/0 should be a keyword list"
         )
@@ -255,7 +255,7 @@ defmodule Mix.Tasks.Compile.App do
   defp validate_properties!(properties) do
     Enum.each(properties, fn
       {:description, value} ->
-        if !is_list(value) do
+        if not is_list(value) do
           Mix.raise(
             "Application description (:description) is not a character list, got: " <>
               inspect(value)
@@ -263,12 +263,12 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:id, value} ->
-        if !is_list(value) do
+        if not is_list(value) do
           Mix.raise("Application ID (:id) is not a character list, got: " <> inspect(value))
         end
 
       {:vsn, value} ->
-        if !is_list(value) do
+        if not is_list(value) do
           Mix.raise("Application vsn (:vsn) is not a character list, got: " <> inspect(value))
         end
 
@@ -320,14 +320,14 @@ defmodule Mix.Tasks.Compile.App do
         end
 
       {:env, value} ->
-        if !Keyword.keyword?(value) do
+        if not Keyword.keyword?(value) do
           Mix.raise(
             "Application environment (:env) should be a keyword list, got: " <> inspect(value)
           )
         end
 
       {:start_phases, value} ->
-        if !Keyword.keyword?(value) do
+        if not Keyword.keyword?(value) do
           Mix.raise(
             "Application start phases (:start_phases) should be a keyword list, got: " <>
               inspect(value)

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -108,7 +108,7 @@ defmodule Mix.Tasks.Compile.Elixir do
     dest = Mix.Project.compile_path(project)
     srcs = project[:elixirc_paths]
 
-    if !is_list(srcs) do
+    if not is_list(srcs) do
       Mix.raise(":elixirc_paths should be a list of paths, got: #{inspect(srcs)}")
     end
 

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -108,7 +108,7 @@ defmodule Mix.Tasks.Compile.Elixir do
     dest = Mix.Project.compile_path(project)
     srcs = project[:elixirc_paths]
 
-    unless is_list(srcs) do
+    if !is_list(srcs) do
       Mix.raise(":elixirc_paths should be a list of paths, got: #{inspect(srcs)}")
     end
 

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Compile.Erlang do
     compile_path = Erlang.to_erl_file(Mix.Project.compile_path(project))
     erlc_options = project[:erlc_options] || []
 
-    if !is_list(erlc_options) do
+    if not is_list(erlc_options) do
       Mix.raise(":erlc_options should be a list of options, got: #{inspect(erlc_options)}")
     end
 

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Compile.Erlang do
     compile_path = Erlang.to_erl_file(Mix.Project.compile_path(project))
     erlc_options = project[:erlc_options] || []
 
-    unless is_list(erlc_options) do
+    if !is_list(erlc_options) do
       Mix.raise(":erlc_options should be a list of options, got: #{inspect(erlc_options)}")
     end
 

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Compile.Leex do
 
     leex_options = project[:leex_options] || []
 
-    unless is_list(leex_options) do
+    if !is_list(leex_options) do
       Mix.raise(":leex_options should be a list of options, got: #{inspect(leex_options)}")
     end
 
@@ -65,7 +65,7 @@ defmodule Mix.Tasks.Compile.Leex do
 
   defp preload(project) do
     # TODO: Remove me in Elixir v2.0
-    unless :leex in List.wrap(project[:compilers]) do
+    if :leex not in List.wrap(project[:compilers]) do
       Mix.shell().error(
         "warning: in order to compile .xrl files, you must add \"compilers: [:leex] ++ Mix.compilers()\" to the \"def project\" section of #{project[:app]}'s mix.exs"
       )

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Compile.Leex do
 
     leex_options = project[:leex_options] || []
 
-    if !is_list(leex_options) do
+    if not is_list(leex_options) do
       Mix.raise(":leex_options should be a list of options, got: #{inspect(leex_options)}")
     end
 

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Compile.Yecc do
 
     yecc_options = project[:yecc_options] || []
 
-    if !is_list(yecc_options) do
+    if not is_list(yecc_options) do
       Mix.raise(":yecc_options should be a list of options, got: #{inspect(yecc_options)}")
     end
 

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Compile.Yecc do
 
     yecc_options = project[:yecc_options] || []
 
-    unless is_list(yecc_options) do
+    if !is_list(yecc_options) do
       Mix.raise(":yecc_options should be a list of options, got: #{inspect(yecc_options)}")
     end
 
@@ -66,7 +66,7 @@ defmodule Mix.Tasks.Compile.Yecc do
 
   defp preload(project) do
     # TODO: Remove me in Elixir v2.0
-    unless :yecc in List.wrap(project[:compilers]) do
+    if :yecc not in List.wrap(project[:compilers]) do
       Mix.shell().error(
         "warning: in order to compile .yrl files, you must add \"compilers: [:yecc] ++ Mix.compilers()\" to the \"def project\" section of #{project[:app]}'s mix.exs"
       )

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -180,7 +180,7 @@ defmodule Mix.Tasks.Deps.Compile do
   end
 
   defp do_rebar3(%Mix.Dep{opts: opts} = dep, config) do
-    if !Mix.Rebar.available?(:rebar3) do
+    if not Mix.Rebar.available?(:rebar3) do
       handle_rebar_not_found(dep)
     end
 
@@ -247,7 +247,7 @@ defmodule Mix.Tasks.Deps.Compile do
       "Shall I install #{manager}? (if running non-interactively, " <>
         "use \"mix local.rebar --force\")"
 
-    if !shell.yes?(install_question) do
+    if not shell.yes?(install_question) do
       error_message =
         "Could not find \"#{manager}\" to compile " <>
           "dependency #{inspect(app)}, please ensure \"#{manager}\" is available"
@@ -257,7 +257,7 @@ defmodule Mix.Tasks.Deps.Compile do
 
     Mix.Tasks.Local.Rebar.run(["--force"])
 
-    if !Mix.Rebar.available?(manager) do
+    if not Mix.Rebar.available?(manager) do
       Mix.raise("\"#{manager}\" installation failed")
     end
   end

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Deps.Compile do
 
   @impl true
   def run(args) do
-    unless "--no-archives-check" in args do
+    if "--no-archives-check" not in args do
       Mix.Task.run("archive.check", args)
     end
 
@@ -180,7 +180,7 @@ defmodule Mix.Tasks.Deps.Compile do
   end
 
   defp do_rebar3(%Mix.Dep{opts: opts} = dep, config) do
-    unless Mix.Rebar.available?(:rebar3) do
+    if !Mix.Rebar.available?(:rebar3) do
       handle_rebar_not_found(dep)
     end
 
@@ -247,7 +247,7 @@ defmodule Mix.Tasks.Deps.Compile do
       "Shall I install #{manager}? (if running non-interactively, " <>
         "use \"mix local.rebar --force\")"
 
-    unless shell.yes?(install_question) do
+    if !shell.yes?(install_question) do
       error_message =
         "Could not find \"#{manager}\" to compile " <>
           "dependency #{inspect(app)}, please ensure \"#{manager}\" is available"
@@ -257,7 +257,7 @@ defmodule Mix.Tasks.Deps.Compile do
 
     Mix.Tasks.Local.Rebar.run(["--force"])
 
-    unless Mix.Rebar.available?(manager) do
+    if !Mix.Rebar.available?(manager) do
       Mix.raise("\"#{manager}\" installation failed")
     end
   end

--- a/lib/mix/lib/mix/tasks/deps.get.ex
+++ b/lib/mix/lib/mix/tasks/deps.get.ex
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.Deps.Get do
 
   @impl true
   def run(args) do
-    unless "--no-archives-check" in args do
+    if "--no-archives-check" not in args do
       Mix.Task.run("archive.check", args)
     end
 

--- a/lib/mix/lib/mix/tasks/deps.loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/deps.loadpaths.ex
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Deps.Loadpaths do
     if req = config[:elixir] do
       case Version.parse_requirement(req) do
         {:ok, req} ->
-          if !Version.match?(System.version(), req) do
+          if not Version.match?(System.version(), req) do
             raise Mix.ElixirVersionError,
               target: config[:app] || Mix.Project.get(),
               expected: req,

--- a/lib/mix/lib/mix/tasks/deps.loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/deps.loadpaths.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Deps.Loadpaths do
 
   @impl true
   def run(args) do
-    unless "--no-archives-check" in args do
+    if "--no-archives-check" not in args do
       Mix.Task.run("archive.check", args)
     end
 
@@ -40,15 +40,15 @@ defmodule Mix.Tasks.Deps.Loadpaths do
 
     config = Mix.Project.config()
 
-    unless "--no-elixir-version-check" in args do
+    if "--no-elixir-version-check" not in args do
       check_elixir_version(config)
     end
 
-    unless "--no-deps-check" in args do
+    if "--no-deps-check" not in args do
       deps_check(all, "--no-compile" in args)
     end
 
-    unless "--no-path-loading" in args do
+    if "--no-path-loading" not in args do
       Code.prepend_paths(Enum.flat_map(all, &Mix.Dep.load_paths/1), cache: true)
     end
 
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Deps.Loadpaths do
     if req = config[:elixir] do
       case Version.parse_requirement(req) do
         {:ok, req} ->
-          unless Version.match?(System.version(), req) do
+          if !Version.match?(System.version(), req) do
             raise Mix.ElixirVersionError,
               target: config[:app] || Mix.Project.get(),
               expected: req,

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Deps.Unlock do
         lock = Mix.Dep.Lock.read()
         unused_apps = unused_apps(lock)
 
-        unless unused_apps == [] do
+        if unused_apps != [] do
           Mix.raise("""
           Unused dependencies in mix.lock file:
 
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Deps.Unlock do
         lock = Mix.Dep.Lock.read()
         unused_apps = unused_apps(lock)
 
-        unless unused_apps == [] do
+        if unused_apps != [] do
           unlock(lock, unused_apps)
         end
 
@@ -92,7 +92,7 @@ defmodule Mix.Tasks.Deps.Unlock do
   end
 
   defp unlock(lock, apps) do
-    unless apps == [] do
+    if apps != [] do
       lock |> Map.drop(apps) |> Mix.Dep.Lock.write()
 
       Mix.shell().info("""

--- a/lib/mix/lib/mix/tasks/deps.update.ex
+++ b/lib/mix/lib/mix/tasks/deps.update.ex
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.Deps.Update do
 
   @impl true
   def run(args) do
-    unless "--no-archives-check" in args do
+    if "--no-archives-check" not in args do
       Mix.Task.run("archive.check", args)
     end
 

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -147,7 +147,7 @@ defmodule Mix.Tasks.Escript.Build do
     filename = escript_opts[:path] || script_name
     main = escript_opts[:main_module]
 
-    unless main do
+    if !main do
       error_message =
         "Could not generate escript, please set :main_module " <>
           "in your project configuration (under :escript option) to a module that implements main/1"
@@ -155,7 +155,7 @@ defmodule Mix.Tasks.Escript.Build do
       Mix.raise(error_message)
     end
 
-    unless Code.ensure_loaded?(main) do
+    if !Code.ensure_loaded?(main) do
       error_message =
         "Could not generate escript, module #{main} defined as " <>
           ":main_module could not be loaded"

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -155,7 +155,7 @@ defmodule Mix.Tasks.Escript.Build do
       Mix.raise(error_message)
     end
 
-    if !Code.ensure_loaded?(main) do
+    if not Code.ensure_loaded?(main) do
       error_message =
         "Could not generate escript, module #{main} defined as " <>
           ":main_module could not be loaded"

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -505,7 +505,7 @@ defmodule Mix.Tasks.Format do
   defp eval_file_with_keyword_list(path) do
     {opts, _} = Code.eval_file(path)
 
-    unless Keyword.keyword?(opts) do
+    if !Keyword.keyword?(opts) do
       Mix.raise("Expected #{inspect(path)} to return a keyword list, got: #{inspect(opts)}")
     end
 

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -505,7 +505,7 @@ defmodule Mix.Tasks.Format do
   defp eval_file_with_keyword_list(path) do
     {opts, _} = Code.eval_file(path)
 
-    if !Keyword.keyword?(opts) do
+    if not Keyword.keyword?(opts) do
       Mix.raise("Expected #{inspect(path)} to return a keyword list, got: #{inspect(opts)}")
     end
 

--- a/lib/mix/lib/mix/tasks/loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/loadpaths.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Loadpaths do
     # recursively checking and loading dependencies that have
     # already been loaded. It has no purpose from Mix.CLI
     # because running a task may load deps.
-    unless "--from-mix-deps-compile" in args do
+    if "--from-mix-deps-compile" not in args do
       Mix.Task.run("deps.loadpaths", args)
     end
 
@@ -61,7 +61,7 @@ defmodule Mix.Tasks.Loadpaths do
         :ok
     end
 
-    unless "--no-path-loading" in args do
+    if "--no-path-loading" not in args do
       # We don't cache the current application as we may still write to it
       Code.prepend_path(Mix.Project.compile_path(config))
     end

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -69,7 +69,7 @@ defmodule Mix.Tasks.New do
         check_mod_name_validity!(mod)
         check_mod_name_availability!(mod)
 
-        unless path == "." do
+        if path != "." do
           check_directory_existence!(path)
           File.mkdir_p!(path)
         end
@@ -195,7 +195,7 @@ defmodule Mix.Tasks.New do
   end
 
   defp invalid_app(name) do
-    unless name =~ ~r/^[a-z][a-z0-9_]*$/ do
+    if !(name =~ ~r/^[a-z][a-z0-9_]*$/) do
       "Application name must start with a lowercase ASCII letter, followed by " <>
         "lowercase ASCII letters, numbers, or underscores, got: #{inspect(name)}"
     end
@@ -210,7 +210,7 @@ defmodule Mix.Tasks.New do
   end
 
   defp check_mod_name_validity!(name) do
-    unless name =~ ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/ do
+    if !(name =~ ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/) do
       Mix.raise(
         "Module name must be a valid Elixir alias (for example: Foo.Bar), got: #{inspect(name)}"
       )

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -195,7 +195,7 @@ defmodule Mix.Tasks.New do
   end
 
   defp invalid_app(name) do
-    if !(name =~ ~r/^[a-z][a-z0-9_]*$/) do
+    if not (name =~ ~r/^[a-z][a-z0-9_]*$/) do
       "Application name must start with a lowercase ASCII letter, followed by " <>
         "lowercase ASCII letters, numbers, or underscores, got: #{inspect(name)}"
     end
@@ -210,7 +210,7 @@ defmodule Mix.Tasks.New do
   end
 
   defp check_mod_name_validity!(name) do
-    if !(name =~ ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/) do
+    if not (name =~ ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/) do
       Mix.raise(
         "Module name must be a valid Elixir alias (for example: Foo.Bar), got: #{inspect(name)}"
       )

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -1357,7 +1357,7 @@ defmodule Mix.Tasks.Release do
   end
 
   defp info(release, message) do
-    unless release.options[:quiet] do
+    if !release.options[:quiet] do
       Mix.shell().info(message)
     end
   end

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -83,7 +83,7 @@ defmodule Mix.Tasks.Run do
       )
 
     run(args, opts, head, &Code.eval_string/1, &Code.require_file/1)
-    unless Keyword.get(opts, :halt, true), do: System.no_halt(true)
+    if !Keyword.get(opts, :halt, true), do: System.no_halt(true)
     Mix.Task.reenable("run")
     :ok
   end

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -83,7 +83,7 @@ defmodule Mix.Tasks.Run do
       )
 
     run(args, opts, head, &Code.eval_string/1, &Code.require_file/1)
-    if !Keyword.get(opts, :halt, true), do: System.no_halt(true)
+    if not Keyword.get(opts, :halt, true), do: System.no_halt(true)
     Mix.Task.reenable("run")
     :ok
   end

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -512,7 +512,7 @@ defmodule Mix.Tasks.Test do
   defp do_run(opts, args, files) do
     _ = Mix.Project.get!()
 
-    unless System.get_env("MIX_ENV") || Mix.env() == :test do
+    if !(System.get_env("MIX_ENV") || Mix.env() == :test) do
       Mix.raise("""
       "mix test" is running in the \"#{Mix.env()}\" environment. If you are \
       running tests from within another command, you can either:

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -512,7 +512,7 @@ defmodule Mix.Tasks.Test do
   defp do_run(opts, args, files) do
     _ = Mix.Project.get!()
 
-    if !(System.get_env("MIX_ENV") || Mix.env() == :test) do
+    if System.get_env("MIX_ENV") == nil && Mix.env() != :test do
       Mix.raise("""
       "mix test" is running in the \"#{Mix.env()}\" environment. If you are \
       running tests from within another command, you can either:

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -512,7 +512,7 @@ defmodule Mix.Utils do
           do_symlink_or_copy(source, target, link)
 
         {:error, _} ->
-          unless File.dir?(target) do
+          if !File.dir?(target) do
             File.rm_rf!(target)
           end
 

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -512,7 +512,7 @@ defmodule Mix.Utils do
           do_symlink_or_copy(source, target, link)
 
         {:error, _} ->
-          if !File.dir?(target) do
+          if not File.dir?(target) do
             File.rm_rf!(target)
           end
 

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -659,7 +659,7 @@ defmodule Mix.ReleaseTest do
       assert File.read!(Path.join(destination, "bin/erl")) =~
                ~s|ROOTDIR="${ERL_ROOTDIR:-"$(dirname "$(dirname "$BINDIR")")"}|
 
-      unless match?({:win32, _}, :os.type()) do
+      if !match?({:win32, _}, :os.type()) do
         assert File.lstat!(Path.join(destination, "bin/erl")).mode |> rem(0o1000) == 0o755
       end
 

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -659,7 +659,7 @@ defmodule Mix.ReleaseTest do
       assert File.read!(Path.join(destination, "bin/erl")) =~
                ~s|ROOTDIR="${ERL_ROOTDIR:-"$(dirname "$(dirname "$BINDIR")")"}|
 
-      if !match?({:win32, _}, :os.type()) do
+      if not match?({:win32, _}, :os.type()) do
         assert File.lstat!(Path.join(destination, "bin/erl")).mode |> rem(0o1000) == 0o755
       end
 

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -263,7 +263,7 @@ System.cmd("git", ~w[config --global init.defaultBranch not-main])
 ### Git repo
 target = Path.expand("fixtures/git_repo", __DIR__)
 
-unless File.dir?(target) do
+if !File.dir?(target) do
   File.mkdir_p!(Path.join(target, "lib"))
 
   File.write!(Path.join(target, "mix.exs"), """
@@ -345,7 +345,7 @@ end
 ### Deps on Git repo
 target = Path.expand("fixtures/deps_on_git_repo", __DIR__)
 
-unless File.dir?(target) do
+if !File.dir?(target) do
   File.mkdir_p!(Path.join(target, "lib"))
 
   File.write!(Path.join(target, "mix.exs"), """
@@ -401,7 +401,7 @@ end
 # Git Rebar
 target = Path.expand("fixtures/git_rebar", __DIR__)
 
-unless File.dir?(target) do
+if !File.dir?(target) do
   File.mkdir_p!(Path.join(target, "ebin"))
   File.mkdir_p!(Path.join(target, "src"))
 
@@ -439,7 +439,7 @@ end)
 ### Archive ebin
 target = Path.expand("fixtures/archive", __DIR__)
 
-unless File.dir?(Path.join(target, "ebin")) do
+if !File.dir?(Path.join(target, "ebin")) do
   File.mkdir_p!(Path.join(target, "ebin"))
 
   File.write!(Path.join([target, "ebin", "local_sample.app"]), """

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -263,7 +263,7 @@ System.cmd("git", ~w[config --global init.defaultBranch not-main])
 ### Git repo
 target = Path.expand("fixtures/git_repo", __DIR__)
 
-if !File.dir?(target) do
+if not File.dir?(target) do
   File.mkdir_p!(Path.join(target, "lib"))
 
   File.write!(Path.join(target, "mix.exs"), """
@@ -345,7 +345,7 @@ end
 ### Deps on Git repo
 target = Path.expand("fixtures/deps_on_git_repo", __DIR__)
 
-if !File.dir?(target) do
+if not File.dir?(target) do
   File.mkdir_p!(Path.join(target, "lib"))
 
   File.write!(Path.join(target, "mix.exs"), """
@@ -401,7 +401,7 @@ end
 # Git Rebar
 target = Path.expand("fixtures/git_rebar", __DIR__)
 
-if !File.dir?(target) do
+if not File.dir?(target) do
   File.mkdir_p!(Path.join(target, "ebin"))
   File.mkdir_p!(Path.join(target, "src"))
 
@@ -439,7 +439,7 @@ end)
 ### Archive ebin
 target = Path.expand("fixtures/archive", __DIR__)
 
-if !File.dir?(Path.join(target, "ebin")) do
+if not File.dir?(Path.join(target, "ebin")) do
   File.mkdir_p!(Path.join(target, "ebin"))
 
   File.write!(Path.join([target, "ebin", "local_sample.app"]), """


### PR DESCRIPTION
This is still a draft in order to explore the possibility, not ready yet.

I haven't started to work on the `--migrate` flag in `mix format` yet, this is focusing on the `unless` rewrite itself.

Commits are organized to help the review:
- 4dd0d084d254df052cfb24872614ed6ebea7dc45 is the rewrite itself (esp. see the tests)
- e970466a3aa757e677d880fc7365e927a3412a29 shows what it did when run on the codebase
- 2c89d851ac6d3676f8acc6dba6b96bd8a1e7b78f is the only breaking change that needed to be fixed (`defmacro unless`)
- the rest is manual tweaks I did to improve over the auto-generated ones