### PR TITLE
Add doc to explain return value with after clauses

### DIFF
--- a/lib/elixir/pages/getting-started/try-catch-and-rescue.md
+++ b/lib/elixir/pages/getting-started/try-catch-and-rescue.md
@@ -232,7 +232,7 @@ cleaning up!
 ** (RuntimeError) oops
 ```
 
-Elixir will automatically wrap the function body in a `try` whenever one of `after`, `rescue` or `catch` is specified.
+Elixir will automatically wrap the function body in a `try` whenever one of `after`, `rescue` or `catch` is specified. The `after` block handles side effects and does not supersede the return value from the clauses above it.
 
 ## Else
 

--- a/lib/elixir/pages/getting-started/try-catch-and-rescue.md
+++ b/lib/elixir/pages/getting-started/try-catch-and-rescue.md
@@ -232,7 +232,7 @@ cleaning up!
 ** (RuntimeError) oops
 ```
 
-Elixir will automatically wrap the function body in a `try` whenever one of `after`, `rescue` or `catch` is specified. The `after` block handles side effects and does not supersede the return value from the clauses above it.
+Elixir will automatically wrap the function body in a `try` whenever one of `after`, `rescue` or `catch` is specified. The `after` block handles side effects and does not change the return value from the clauses above it.
 
 ## Else
 


### PR DESCRIPTION
I really enjoy this functionality and find it helpful but I believe it's the only time in the language when the final executed expression doesn't determine the return value. Making this explicit in the docs could help clarify any confusion. 