### PR TITLE
Formatter fix: next_break_fits respects line_length

### DIFF
--- a/lib/elixir/test/elixir/code_formatter/calls_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/calls_test.exs
@@ -165,6 +165,11 @@ defmodule Code.Formatter.CallsTest do
 
       assert_format bad, good, @short_length
     end
+
+    test "for maps" do
+      assert_same "a(%{x: 1})", @short_length
+      assert_format "ab(%{x: 1})", "ab(%{\n  x: 1\n})", @short_length
+    end
   end
 
   describe "local calls" do

--- a/lib/elixir/test/elixir/config/provider_test.exs
+++ b/lib/elixir/test/elixir/config/provider_test.exs
@@ -41,8 +41,9 @@ defmodule Config.ProviderTest do
              {:elixir, [:unknown, :nested, :key], {:ok, :value}}
            ]) == :ok
 
-    assert Config.Provider.validate_compile_env([{:elixir, [:unknown, :nested, :unknown], :error}]) ==
-             :ok
+    assert Config.Provider.validate_compile_env([
+             {:elixir, [:unknown, :nested, :unknown], :error}
+           ]) == :ok
 
     assert {:error, msg} =
              Config.Provider.validate_compile_env([{:elixir, [:unknown, :nested], :error}])


### PR DESCRIPTION
Tentative fix for https://github.com/elixir-lang/elixir/issues/13775

The problem is that the closing bracket `")"` is ignored when evaluating the nested group for which fitting is enabled.

```elixir
["f" · disable([
  ²⟨"(" · _⟩ · ²⟨enable([
    ²⟨"%" · ∅ · "{" · _ · ["x"]⟩ · _ · "}"
  ])⟩ · _ · ")" · ∅
])]
```

The approach:
- `fits?` doesn't return a bool anymore, but `:fit | :no_fit | :break_next`, `:break_next` meaning that we wouldn't actually fit without breaking within the nested `:enabled`
- add more modes to `format` to make sure we break in the nested `:enabled`