### PR TITLE
Add visibility for flat_map filtering in docs

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1257,6 +1257,14 @@ defmodule Enum do
       iex> Enum.flat_map([:a, :b, :c], fn x -> [[x]] end)
       [[:a], [:b], [:c]]
 
+  This is frequently used to to transform and filter in one pass, returning empty
+  lists to exclude results:
+
+      iex> Enum.flat_map([4, 0, 2, 0], fn x ->
+      ...>   if x != 0, do: [1 / x], else: []
+      ...> end)
+      [0.25, 0.5]
+
   """
   @spec flat_map(t, (element -> t)) :: list
   def flat_map(enumerable, fun) when is_list(enumerable) do

--- a/lib/elixir/pages/cheatsheets/enum-cheat.cheatmd
+++ b/lib/elixir/pages/cheatsheets/enum-cheat.cheatmd
@@ -99,6 +99,19 @@ iex> Enum.reject(cart, &(&1.fruit =~ "o"))
 ]
 ```
 
+### [`flat_map(enum, fun)`](`Enum.flat_map/2`)
+
+This function (also listed [below](#concatenating-flattening)) can
+be used to transform and filter in one pass, returning empty lists
+to exclude results:
+
+```elixir
+iex> Enum.flat_map(cart, fn item ->
+...>   if item.count > 1, do: [item.fruit], else: []
+...> end)
+["apple", "orange"]
+```
+
 ### [`Comprehension`](`for/1`)
 
 Filtering can also be done with comprehensions:


### PR DESCRIPTION
- this common recipe is mentioned in [`filter`'s doc](https://hexdocs.pm/elixir/Enum.html#filter/2) but not in flat_map itself, it is probably worth mentioning it

- `flat_map` is already listed in the [cheatsheet](https://hexdocs.pm/elixir/enum-cheat.html#flat_map-enum-fun) under the flattening section, but it probably deserves to be also mentioned in the filtering section for better discoverability

<img width="853" alt="Screenshot 2024-08-26 at 20 04 14" src="https://github.com/user-attachments/assets/8362c76d-3f7f-4c2f-965d-56c7f69087d3">

<img width="1060" alt="Screenshot 2024-08-26 at 20 02 06" src="https://github.com/user-attachments/assets/cf1a29a2-3603-47ec-bc4b-c7e4f1463919">
