### PR TITLE
Fix relative path resolution in "mix release" for symlinked scripts

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -87,10 +87,17 @@ defmodule Mix.Tasks.Release.Init do
     #!/bin/sh
     set -e
 
-    SELF=$(readlink -f "$0" || true)
-    if [ -z "$SELF" ]; then SELF="$0"; fi
-    if [ "${SELF#/}" = "$SELF" ]; then SELF="$(cd "$(dirname "$0")" && pwd -P)/$(basename "$SELF")"; fi
-    SELF=$(cd "$(dirname "$SELF")" && pwd -P)/$(basename "$SELF")
+    readlink_f () {
+      cd "$(dirname "$1")" > /dev/null
+      filename="$(basename "$1")"
+      if [ -h "$filename" ]; then
+        readlink_f "$(readlink "$filename")"
+      else
+        echo "$(pwd -P)/$filename"
+      fi
+    }
+
+    SELF=$(readlink_f "$0")
     RELEASE_ROOT="$(CDPATH='' cd "$(dirname "$SELF")/.." && pwd -P)"
     export RELEASE_ROOT
     RELEASE_NAME="${RELEASE_NAME:-"<%= @release.name %>"}"

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -88,13 +88,16 @@ defmodule Mix.Tasks.Release.Init do
     set -e
 
     readlink_f () {
+      original_dir=$(pwd)
       cd "$(dirname "$1")" > /dev/null
       filename="$(basename "$1")"
       if [ -h "$filename" ]; then
-        readlink_f "$(readlink "$filename")"
+        result=$(readlink_f "$(readlink "$filename")")
       else
-        echo "$(pwd -P)/$filename"
+        result="$(pwd -P)/$filename"
       fi
+      cd "$original_dir" > /dev/null
+      echo "$result"
     }
 
     SELF=$(readlink_f "$0")

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -88,16 +88,13 @@ defmodule Mix.Tasks.Release.Init do
     set -e
 
     readlink_f () {
-      original_dir=$(pwd)
       cd "$(dirname "$1")" > /dev/null
       filename="$(basename "$1")"
       if [ -h "$filename" ]; then
-        result=$(readlink_f "$(readlink "$filename")")
+        readlink_f "$(readlink "$filename")"
       else
-        result="$(pwd -P)/$filename"
+        echo "$(pwd -P)/$filename"
       fi
-      cd "$original_dir" > /dev/null
-      echo "$result"
     }
 
     SELF=$(readlink_f "$0")

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -87,8 +87,10 @@ defmodule Mix.Tasks.Release.Init do
     #!/bin/sh
     set -e
 
-    SELF=$(readlink "$0" || true)
+    SELF=$(readlink -f "$0" || true)
     if [ -z "$SELF" ]; then SELF="$0"; fi
+    if [ "${SELF#/}" = "$SELF" ]; then SELF="$(cd "$(dirname "$0")" && pwd -P)/$(basename "$SELF")"; fi
+    SELF=$(cd "$(dirname "$SELF")" && pwd -P)/$(basename "$SELF")
     RELEASE_ROOT="$(CDPATH='' cd "$(dirname "$SELF")/.." && pwd -P)"
     export RELEASE_ROOT
     RELEASE_NAME="${RELEASE_NAME:-"<%= @release.name %>"}"

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -786,6 +786,42 @@ defmodule Mix.Tasks.ReleaseTest do
     end)
   end
 
+  test "works properly with an absolute symlink to release" do
+    in_fixture("release_test", fn ->
+      Mix.Project.in_project(:release_test, ".", fn _ ->
+        Mix.Task.run("release")
+
+        File.ln_s!(
+          "_build/dev/rel/release_test/bin/release_test",
+          "release_test"
+        )
+
+        script = Path.absname("release_test")
+        {hello_world, 0} = System.cmd(script, ["eval", "IO.puts :hello_world"])
+        assert String.trim_trailing(hello_world) == "hello_world"
+      end)
+    end)
+  end
+
+  test "works properly with a relative symlink to release" do
+    in_fixture("release_test", fn ->
+      Mix.Project.in_project(:release_test, ".", fn _ ->
+        Mix.Task.run("release")
+
+        File.mkdir!("bin")
+
+        File.ln_s!(
+          "../_build/dev/rel/release_test/bin/release_test",
+          "bin/release_test"
+        )
+
+        script = Path.absname("bin/release_test")
+        {hello_world, 0} = System.cmd(script, ["eval", "IO.puts :hello_world"])
+        assert String.trim_trailing(hello_world) == "hello_world"
+      end)
+    end)
+  end
+
   defp open_port(command, args, env \\ []) do
     env = for {k, v} <- env, do: {to_charlist(k), to_charlist(v)}
     Port.open({:spawn_executable, to_charlist(command)}, [:hide, args: args, env: env])

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -786,14 +786,15 @@ defmodule Mix.Tasks.ReleaseTest do
     end)
   end
 
+  @tag :unix
   test "works properly with an absolute symlink to release" do
     in_fixture("release_test", fn ->
       Mix.Project.in_project(:release_test, ".", fn _ ->
         Mix.Task.run("release")
 
         File.ln_s!(
-          "_build/dev/rel/release_test/bin/release_test",
-          "release_test"
+          Path.absname("_build/#{Mix.env()}/rel/release_test/bin/release_test"),
+          Path.absname("release_test")
         )
 
         script = Path.absname("release_test")
@@ -803,17 +804,14 @@ defmodule Mix.Tasks.ReleaseTest do
     end)
   end
 
+  @tag :unix
   test "works properly with a relative symlink to release" do
     in_fixture("release_test", fn ->
       Mix.Project.in_project(:release_test, ".", fn _ ->
         Mix.Task.run("release")
 
         File.mkdir!("bin")
-
-        File.ln_s!(
-          "../_build/dev/rel/release_test/bin/release_test",
-          "bin/release_test"
-        )
+        File.ln_s!("../_build/#{Mix.env()}/rel/release_test/bin/release_test", "bin/release_test")
 
         script = Path.absname("bin/release_test")
         {hello_world, 0} = System.cmd(script, ["eval", "IO.puts :hello_world"])

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -791,14 +791,23 @@ defmodule Mix.Tasks.ReleaseTest do
       Mix.Project.in_project(:release_test, ".", fn _ ->
         Mix.Task.run("release")
 
+        script_name = "release_test"
+
+        script_name =
+          if match?({:win32, _}, :os.type()), do: "#{script_name}.bat", else: script_name
+
         File.ln_s!(
-          "_build/dev/rel/release_test/bin/release_test",
-          "release_test"
+          Path.join("_build/dev/rel/release_test/bin", script_name),
+          script_name
         )
 
-        script = Path.absname("release_test")
-        {hello_world, 0} = System.cmd(script, ["eval", "IO.puts :hello_world"])
-        assert String.trim_trailing(hello_world) == "hello_world"
+        try do
+          script = Path.absname(script_name)
+          {hello_world, 0} = System.cmd(script, ["eval", "IO.puts :hello_world"])
+          assert String.trim_trailing(hello_world) == "hello_world"
+        after
+          File.rm!(script_name)
+        end
       end)
     end)
   end
@@ -808,16 +817,25 @@ defmodule Mix.Tasks.ReleaseTest do
       Mix.Project.in_project(:release_test, ".", fn _ ->
         Mix.Task.run("release")
 
+        script_name = "release_test"
+
+        script_name =
+          if match?({:win32, _}, :os.type()), do: "#{script_name}.bat", else: script_name
+
         File.mkdir!("bin")
 
         File.ln_s!(
-          "../_build/dev/rel/release_test/bin/release_test",
-          "bin/release_test"
+          Path.join("../_build/dev/rel/release_test/bin", script_name),
+          Path.join("bin", script_name)
         )
 
-        script = Path.absname("bin/release_test")
-        {hello_world, 0} = System.cmd(script, ["eval", "IO.puts :hello_world"])
-        assert String.trim_trailing(hello_world) == "hello_world"
+        try do
+          script = Path.absname(Path.join("bin", script_name))
+          {hello_world, 0} = System.cmd(script, ["eval", "IO.puts :hello_world"])
+          assert String.trim_trailing(hello_world) == "hello_world"
+        after
+          File.rm_rf!("bin")
+        end
       end)
     end)
   end

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -791,23 +791,14 @@ defmodule Mix.Tasks.ReleaseTest do
       Mix.Project.in_project(:release_test, ".", fn _ ->
         Mix.Task.run("release")
 
-        script_name = "release_test"
-
-        script_name =
-          if match?({:win32, _}, :os.type()), do: "#{script_name}.bat", else: script_name
-
         File.ln_s!(
-          Path.join("_build/dev/rel/release_test/bin", script_name),
-          script_name
+          "_build/dev/rel/release_test/bin/release_test",
+          "release_test"
         )
 
-        try do
-          script = Path.absname(script_name)
-          {hello_world, 0} = System.cmd(script, ["eval", "IO.puts :hello_world"])
-          assert String.trim_trailing(hello_world) == "hello_world"
-        after
-          File.rm!(script_name)
-        end
+        script = Path.absname("release_test")
+        {hello_world, 0} = System.cmd(script, ["eval", "IO.puts :hello_world"])
+        assert String.trim_trailing(hello_world) == "hello_world"
       end)
     end)
   end
@@ -817,25 +808,16 @@ defmodule Mix.Tasks.ReleaseTest do
       Mix.Project.in_project(:release_test, ".", fn _ ->
         Mix.Task.run("release")
 
-        script_name = "release_test"
-
-        script_name =
-          if match?({:win32, _}, :os.type()), do: "#{script_name}.bat", else: script_name
-
         File.mkdir!("bin")
 
         File.ln_s!(
-          Path.join("../_build/dev/rel/release_test/bin", script_name),
-          Path.join("bin", script_name)
+          "../_build/dev/rel/release_test/bin/release_test",
+          "bin/release_test"
         )
 
-        try do
-          script = Path.absname(Path.join("bin", script_name))
-          {hello_world, 0} = System.cmd(script, ["eval", "IO.puts :hello_world"])
-          assert String.trim_trailing(hello_world) == "hello_world"
-        after
-          File.rm_rf!("bin")
-        end
+        script = Path.absname("bin/release_test")
+        {hello_world, 0} = System.cmd(script, ["eval", "IO.puts :hello_world"])
+        assert String.trim_trailing(hello_world) == "hello_world"
       end)
     end)
   end


### PR DESCRIPTION
This PR addresses an issue (#13672) with path resolution in `mix release` when scripts are executed via relative symlinks.

The original script did not correctly resolve paths, leading to errors when the release script was invoked through a symlink that pointed to a relative path.

The fix ensures that **SELF** is always resolved to an absolute path, regardless of how the script is invoked.

This update improves the reliability of release scripts in environments where symlinks are used. Additionally, tests have been added to verify that both absolute and relative symlinks work correctly with the updated path resolution logic.