### PR TITLE
Explicitly mention trimming in String.split/1 doc

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -375,6 +375,11 @@ defmodule String do
       iex> String.split("no\u00a0break")
       ["no\u00a0break"]
 
+  Removes empty strings, like when using `trim: true` in `String.split/3`.
+
+      iex> String.split(" ")
+      []
+
   """
   @spec split(t) :: [t]
   defdelegate split(binary), to: String.Break

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -357,9 +357,10 @@ defmodule String do
 
   @doc ~S"""
   Divides a string into substrings at each Unicode whitespace
-  occurrence with leading and trailing whitespace ignored. Groups
-  of whitespace are treated as a single occurrence. Divisions do
-  not occur on non-breaking whitespace.
+  occurrence with leading and trailing whitespace ignored.
+
+  Groups of whitespace are treated as a single occurrence.
+  Divisions do not occur on non-breaking whitespace.
 
   ## Examples
 


### PR DESCRIPTION
Makes this explicit since it was deemed surprising in https://github.com/elixir-lang/elixir-lang.github.com/pull/1768
