### PR TITLE
Fix code example in GenServer docs

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -415,7 +415,7 @@ defmodule GenServer do
   Let's see how we could use those functions for debugging the stack server
   we defined earlier.
 
-      iex> {:ok, pid} = Stack.start_link([])
+      iex> {:ok, pid} = Stack.start_link("")
       iex> :sys.statistics(pid, true) # turn on collecting process statistics
       iex> :sys.trace(pid, true) # turn on event printing
       iex> Stack.push(pid, 1)


### PR DESCRIPTION
Fix the arg value in GenServer example. 

Related history pr code: https://github.com/elixir-lang/elixir/commit/9e8ae6efc50eedbc59a4a6583cada871e3c99be7#diff-07e9c029fa058bfd89482ef285ba58c16a3f3a64158a3267d8dea0391710da26L357