### PR TITLE
Add a rule of thumb to the guide.

### DIFF
--- a/lib/elixir/pages/getting-started/basic-types.md
+++ b/lib/elixir/pages/getting-started/basic-types.md
@@ -169,6 +169,8 @@ true
 
 Similarly, values like `0` and `""`, which some other programming languages consider to be "falsy", are also "truthy" in Elixir.
 
+As a rule of thumb, use `and`, `or` and `not` when you are expecting booleans. If any of the arguments are non-boolean, use `&&`, `||` and `!`.
+
 ## Atoms
 
 An atom is a constant whose value is its own name. Some other languages call these symbols. They are often useful to enumerate over distinct values, such as:


### PR DESCRIPTION
This rule of thumb used to in the getting started page, but it got dropped when moved to hexdocs, I'm not sure if it was intentional.

It was helpful to point new devs to the suggestion when onboarding to elixir.