### PR TITLE
Add guards for `elem/2` and update `ArgumentError` messages

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1883,8 +1883,16 @@ defmodule Kernel do
   @doc guard: true
   @spec elem(tuple, non_neg_integer) :: term
   def elem(tuple, index) do
+    validate_tuple!(tuple)
+    validate_index!(index)
     :erlang.element(index + 1, tuple)
   end
+
+  defp validate_tuple!(tuple) when is_tuple(tuple), do: :ok
+  defp validate_tuple!(_tuple) when is_tuple(tuple), do: raise(ArgumentError, "1st argument: not a tuple")
+
+  defp validate_index(index) when is_integer(index) and index >= 0, do: :ok
+  defp validate_index(_index), do: raise(ArgumentError, "2nd argument: not a non_neg_integer")
 
   @doc """
   Puts `value` at the given zero-based `index` in `tuple`.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1889,10 +1889,10 @@ defmodule Kernel do
   end
 
   defp validate_tuple!(tuple) when is_tuple(tuple), do: :ok
-  defp validate_tuple!(_tuple) when is_tuple(tuple), do: raise(ArgumentError, "1st argument: not a tuple")
+  defp validate_tuple!(_tuple), do: Kernel.raise(ArgumentError, "1st argument: not a tuple")
 
-  defp validate_index(index) when is_integer(index) and index >= 0, do: :ok
-  defp validate_index(_index), do: raise(ArgumentError, "2nd argument: not a non_neg_integer")
+  defp validate_index!(index) when is_integer(index), do: :ok
+  defp validate_index!(_index), do: Kernel.raise(ArgumentError, "2nd argument: not an integer")
 
   @doc """
   Puts `value` at the given zero-based `index` in `tuple`.


### PR DESCRIPTION
The "problem" is that the argument order is swapped between Elixir's `Kernel.elem/2` and Erlang's `:erlang.element`

```elixir
def elem(tuple, index) do
  :erlang.element(index + 1, tuple)
end
```

If you pass something _other_ than a tuple to `Kernel.elem/2` as the first argument, that gets passed as the _second_ argument to `:erlang.element`, which throws an `ArgumentError` stating that the 2nd argument is not a tuple.

This PR adds some checks to the inputs of `Kernel.elem/2` such that you get correct positional information in the `ArgumentError` messages if you pass something other than a tuple as the first arg, and something other than a non neg integer as the 2nd arg.