### PR TITLE
Do not allow guards in assert/1

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -363,11 +363,20 @@ defmodule ExUnit.Assertions do
   end
 
   @doc false
-  def __match__({:when, _, _} = left, _, _, _, _) do
-    raise ArgumentError, """
-    invalid pattern in assert/1: #{Macro.to_string(left)}
+  def __match__({:when, _, _} = left, right, _, _, _) do
+    suggestion =
+      quote do
+        assert match?(unquote(left), unquote(right))
+      end
 
-    Use assert match?(... when ...) if you need to assert with a guard.
+    raise ArgumentError, """
+    invalid pattern in assert/1:
+
+    #{Macro.to_string(left) |> Inspect.Error.pad(2)}
+
+    To assert with guards, use match?/2:
+
+    #{Macro.to_string(suggestion) |> Inspect.Error.pad(2)}
     """
   end
 

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -357,6 +357,14 @@ defmodule ExUnit.Assertions do
   end
 
   @doc false
+  def __match__({:when, _, _} = left, _, _, _, _) do
+    raise ArgumentError, """
+    invalid pattern in assert/1: #{Macro.to_string(left)}
+
+    Use assert match?(... when ...) if you need to assert with a guard.
+    """
+  end
+
   def __match__(left, right, code, check, caller) do
     left = __expand_pattern__(left, caller)
     vars = collect_vars_from_pattern(left)

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -121,6 +121,11 @@ defmodule ExUnit.Assertions do
 
   Even though the match works, `assert` still expects a truth
   value. In such cases, simply use `==/2` or `match?/2`.
+
+  If you need more complex pattern matching using guards, you
+  need to use `match?/2`:
+
+      assert match?([%{id: id} | _] when is_integer(id), records)
   """
   defmacro assert({:=, meta, [left, right]} = assertion) do
     code = escape_quoted(:assert, meta, assertion)

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -126,6 +126,7 @@ defmodule ExUnit.Assertions do
   need to use `match?/2`:
 
       assert match?([%{id: id} | _] when is_integer(id), records)
+
   """
   defmacro assert({:=, meta, [left, right]} = assertion) do
     code = escape_quoted(:assert, meta, assertion)

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -257,7 +257,17 @@ defmodule ExUnit.AssertionsTest do
   end
 
   test "assert match with `when` in the pattern fails" do
-    assert_raise ArgumentError, ~r/invalid pattern in assert\/1: x when is_map\(x\)/, fn ->
+    message = """
+    invalid pattern in assert\/1:
+
+      x when is_map(x)
+
+    To assert with guards, use match?/2:
+
+      assert match?(x when is_map(x), %{})
+    """
+
+    assert_raise ArgumentError, message, fn ->
       Code.eval_string("""
       defmodule AssertGuard do
         import ExUnit.Assertions

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -256,6 +256,23 @@ defmodule ExUnit.AssertionsTest do
     end
   end
 
+  test "assert match with `when` in the pattern fails" do
+    assert_raise ArgumentError, ~r/invalid pattern in assert\/1: x when is_map\(x\)/, fn ->
+      Code.eval_string("""
+      defmodule AssertGuard do
+        import ExUnit.Assertions
+
+        def run do
+          assert (x when is_map(x)) = %{}
+        end
+      end
+      """)
+    end
+  after
+    :code.purge(AssertGuard)
+    :code.delete(AssertGuard)
+  end
+
   test "assert match with __ENV__ in the pattern" do
     message =
       ExUnit.CaptureIO.capture_io(:stderr, fn ->


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/13814

Indeed as pointed out by José guards being able were a side effect of the shared implementation between `match?` and regular `=`.

The `match?` version would not be strictly equivalent, since there is no way to to reuse extracted variables after matches, but this is probably an OK limitation in practice.