### PR TITLE
Switching to good drive before moving in directory

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -301,6 +301,7 @@ defmodule Mix.Tasks.Release.Init do
     setlocal enabledelayedexpansion
 
     pushd .
+    %~d0
     cd "%~dp0\.."
     set RELEASE_ROOT=%cd%
     popd


### PR DESCRIPTION
To be able to run batch file from another drive, we must siwtch to the good one before "cd" into a directory.

As explained in #13820 