### PR TITLE
Moving to good directory with good drive on windows

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -301,8 +301,9 @@ defmodule Mix.Tasks.Release.Init do
     setlocal enabledelayedexpansion
 
     pushd .
-    cd "%~dp0\.."
+    pushd "%~dp0\.."
     set RELEASE_ROOT=%cd%
+    popd
     popd
 
     if not defined RELEASE_NAME (set RELEASE_NAME=<%= @release.name %>)


### PR DESCRIPTION
Using pushd that takes consideration for the drive in the path, when it is different form where the command is launch.

Reference to #13820 