### PR TITLE
Fix broken/outdated erlang doc links

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1598,7 +1598,7 @@ defmodule Kernel do
 
   This function is optimized so the complexity of `a -- b` is proportional
   to `length(a) * log(length(b))`. See also the [Erlang efficiency
-  guide](https://www.erlang.org/doc/efficiency_guide/retired_myths.html).
+  guide](https://www.erlang.org/doc/system/efficiency_guide.html).
 
   Inlined by the compiler.
 

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -306,7 +306,7 @@ defmodule ExUnit do
     * `:rand_algorithm` - algorithm to be used when generating the test seed.
       Available algorithms can be found in Erlang's
       [`:rand`](https://www.erlang.org/doc/man/rand.html) documentation (see
-      [`:rand.builting_arg/0`](https://www.erlang.org/doc/man/rand.html#type-builtin_alg)).
+      [`:rand.builting_arg/0`](https://www.erlang.org/doc/apps/stdlib/rand.html#t:builtin_alg/0)).
       Available since v1.16.0. Before v1.16.0, the algorithm was hard-coded to
       `:exs1024`. On Elixir v1.16.0 and after, the default changed to `:exsss`;
 

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -379,7 +379,7 @@ defmodule Mix do
 
     * `HEX_CACERTS_PATH` - use specified CA certificate file instead of default
       system CA certificates. This configures how HTTPS calls are made via
-      [Erlang `ssl` module](https://www.erlang.org/doc/man/ssl#type-client_cafile)
+      [Erlang `ssl` module](https://www.erlang.org/doc/apps/ssl/ssl.html#t:client_option_cert/0)
       to fetch remote archives and packages. For more details, see
       [`mix hex.config`](https://hexdocs.pm/hex/Mix.Tasks.Hex.Config.html#module-config-keys).
   """

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -167,7 +167,7 @@ defmodule Mix.Tasks.Release do
       $ bin/RELEASE_NAME daemon
 
   In daemon mode, the system is started on the background via
-  [`run_erl`](https://www.erlang.org/doc/man/run_erl.html). You may also
+  [`run_erl`](https://www.erlang.org/doc/apps/erts/run_erl_cmd.html). You may also
   want to enable [`heart`](https://www.erlang.org/doc/man/heart.html)
   in daemon mode so it automatically restarts the system in case
   of crashes. See the generated `releases/RELEASE_VSN/env.sh` file.
@@ -191,8 +191,8 @@ defmodule Mix.Tasks.Release do
 
   While daemons are not available on Windows, it is possible to install a
   released system as a service on Windows with the help of
-  [`erlsrv`](https://www.erlang.org/doc/man/erlsrv.html). This can be done by
-  running:
+  [`erlsrv`](https://www.erlang.org/doc/apps/erts/erlsrv_cmd.html).
+  This can be done by running:
 
       $ bin/RELEASE_NAME install
 


### PR DESCRIPTION
Docs only changes. Some links were 404, some having obsolete anchors. Quickly checked other links as well, everything else should be fine.