### PR TITLE
docs: add link to capture syntax

### DIFF
--- a/lib/elixir/pages/getting-started/recursion.md
+++ b/lib/elixir/pages/getting-started/recursion.md
@@ -128,7 +128,7 @@ iex> Enum.map([1, 2, 3], fn x -> x * 2 end)
 [2, 4, 6]
 ```
 
-Or, using the capture syntax:
+Or, using the [capture syntax](`Kernel.SpecialForms.&/1`):
 
 ```elixir
 iex> Enum.reduce([1, 2, 3], 0, &+/2)


### PR DESCRIPTION
This should provide a link for a reader to investigate more about that new syntax shown in the example.
