### PR TITLE
Add releases for main & maintenance branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
           git push origin $ref_name --force
           gh release create \
             $ref_name \
+            —-latest=false \
             --title $ref_name \
             --notes "Automated release for latest ${{ github.ref_name }}." \
             || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: Release
 
 on:
   push:
+    branches:
+      - main
+      - v*.*
     tags:
       - v*
 
@@ -22,6 +25,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Create draft release
+        if: github.ref_type != 'branch'
         run: |
           gh release create \
             --repo ${{ github.repository }} \
@@ -29,6 +33,24 @@ jobs:
             --notes '' \
             --draft \
             ${{ github.ref_name }}
+
+      - uses: actions/checkout@v4
+        if: github.ref_type == 'branch'
+        with:
+          fetch-depth: 50
+
+      - name: Update ${{ github.ref_name }}-latest
+        if: github.ref_type == 'branch'
+        run: |
+          ref_name=${{ github.ref_name }}-latest
+          git tag $ref_name --force
+          git push origin $ref_name --force
+          gh release create \
+            $ref_name \
+            --title $ref_name \
+            --notes "Automated release for latest ${{ github.ref_name }}." \
+            || true
+
   release_pre_built:
     needs: create_draft_release
     strategy:
@@ -65,6 +87,7 @@ jobs:
           subject-path: 'Docs.*'
 
       - name: "Sign files with Trusted Signing"
+        if: github.repository == 'elixir-lang/elixir'
         uses: azure/trusted-signing-action@v0.4.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -83,16 +106,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload --clobber "${{ github.ref_name }}" \
+          if [ "${{ github.ref_type }}" == "branch" ]; then
+            tag=${{ github.ref_name }}-latest
+          else
+            tag="${{ github.ref_name }}"
+          fi
+
+          gh release upload --clobber "$tag" \
             elixir-otp-${{ matrix.otp }}.zip \
             elixir-otp-${{ matrix.otp }}.zip.sha{1,256}sum \
             elixir-otp-${{ matrix.otp }}.exe \
             elixir-otp-${{ matrix.otp }}.exe.sha{1,256}sum
-      - name: Upload Docs to GitHub
-        if: ${{ matrix.build_docs }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload --clobber "${{ github.ref_name }}" \
-            Docs.zip \
-            Docs.zip.sha{1,256}sum
+
+          if [ "${{ matrix.build_docs }}" == "build_docs" ]; then
+            gh release upload --clobber "$tag" \
+              Docs.zip \
+              Docs.zip.sha{1,256}sum
+          fi


### PR DESCRIPTION
Before this patch, release.yml workflow was only compiling and publishing builds on tag pushes.

This patch additionally handles branch pushes (main, v1.17, etc) and publishes them to corresponding releases (main-latest, v1.17-latest, etc).

When we first looked at using GitHub releases for main builds, we discarded the idea because we didn't want to keep re-creating (and thus sending out notifications) releases. There was no API to update the SHA the release was pointing to either. It's obvious in hindsight but all we need to do is to update the _tag_ with the latest SHA and force-push the tag that the release is pointing to. So it is logically the same release but we update the SHA (through tag) and upload updated release assets.

Demo:

![image](https://github.com/user-attachments/assets/f1ea9e80-633f-4785-a24d-3b9a88939b65)

We now have two places where we build main and maintenance branches, release.yml and builds.hex.pm.yml, so in future commits we should look into unifying the two.