### PR TITLE
Fix parsing of fractional durations

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -715,7 +715,15 @@ defmodule Calendar.ISO do
       {second, <<delimiter, _::binary>> = rest} when delimiter in [?., ?,] ->
         case parse_microsecond(rest) do
           {{ms, precision}, "S"} ->
-            ms = if second > 0, do: ms, else: -ms
+            ms =
+              case string do
+                "-" <> _ ->
+                  -ms
+
+                _ ->
+                  ms
+              end
+
             {:ok, [second: second, microsecond: {ms, precision}] ++ acc}
 
           _ ->

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -264,7 +264,7 @@ defmodule DurationTest do
     assert Duration.from_iso8601!("PT6S") == %Duration{second: 6}
     assert Duration.from_iso8601!("PT1,6S") == %Duration{second: 1, microsecond: {600_000, 1}}
     assert Duration.from_iso8601!("PT-1.6S") == %Duration{second: -1, microsecond: {-600_000, 1}}
-    assert _faulty = Duration.from_iso8601!("PT0,6S") == %Duration{second: 0, microsecond: {-600_000, 1}}
+    assert Duration.from_iso8601!("PT0,6S") == %Duration{second: 0, microsecond: {600_000, 1}}
     assert Duration.from_iso8601!("PT-0,6S") == %Duration{second: 0, microsecond: {-600_000, 1}}
     assert Duration.from_iso8601!("-PT-0,6S") == %Duration{second: 0, microsecond: {600_000, 1}}
     assert Duration.from_iso8601!("-P10DT4H") == %Duration{day: -10, hour: -4}

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -237,8 +237,10 @@ defmodule DurationTest do
     assert Duration.from_iso8601("P4Y2W3Y") == {:error, :invalid_date_component}
     assert Duration.from_iso8601("P5HT4MT3S") == {:error, :invalid_date_component}
     assert Duration.from_iso8601("P5H3HT4M") == {:error, :invalid_date_component}
+    assert Duration.from_iso8601("P0.5Y") == {:error, :invalid_date_component}
     assert Duration.from_iso8601("PT1D") == {:error, :invalid_time_component}
     assert Duration.from_iso8601("PT.6S") == {:error, :invalid_time_component}
+    assert Duration.from_iso8601("PT0.5H") == {:error, :invalid_time_component}
     assert Duration.from_iso8601("invalid") == {:error, :invalid_duration}
   end
 

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -264,6 +264,9 @@ defmodule DurationTest do
     assert Duration.from_iso8601!("PT6S") == %Duration{second: 6}
     assert Duration.from_iso8601!("PT1,6S") == %Duration{second: 1, microsecond: {600_000, 1}}
     assert Duration.from_iso8601!("PT-1.6S") == %Duration{second: -1, microsecond: {-600_000, 1}}
+    assert _faulty = Duration.from_iso8601!("PT0,6S") == %Duration{second: 0, microsecond: {-600_000, 1}}
+    assert Duration.from_iso8601!("PT-0,6S") == %Duration{second: 0, microsecond: {-600_000, 1}}
+    assert Duration.from_iso8601!("-PT-0,6S") == %Duration{second: 0, microsecond: {600_000, 1}}
     assert Duration.from_iso8601!("-P10DT4H") == %Duration{day: -10, hour: -4}
     assert Duration.from_iso8601!("-P10DT-4H") == %Duration{day: -10, hour: 4}
     assert Duration.from_iso8601!("P-10D") == %Duration{day: -10}


### PR DESCRIPTION
The parsing of fractional durations checked for non-negativity by testing `second > 0`, which reports `false` for not only negative integers but also for 0.


The JavaScript libraries that I tested disagree whether "-PT-0,6S" represents a positive or negative duration, "moment" and "tinyduration" reported positive, "luxon" (the successor to moment) reported negative. My reading of the specification gives me no reason to doubt that a double negative should result in anything but a positive total result.

It is worth mentioning that as the scale units are represented as integers, there is no clean way to implement fractional parsing of non-second units. Currently, fractional non-second durations simply fail to parse. [Wikipedia](https://en.wikipedia.org/wiki/ISO_8601#Durations) gives "0.5Y" as an example.