### PR TITLE
Remove GITHUB_TOKEN out of attest-build-provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,15 +81,11 @@ jobs:
           build_docs: ${{ matrix.build_docs }}
 
       - uses: actions/attest-build-provenance@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           subject-path: 'elixir-otp-${{ matrix.otp }}.*'
 
       - uses: actions/attest-build-provenance@v1
         if: ${{ matrix.build_docs }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           subject-path: 'Docs.*'
 


### PR DESCRIPTION
I see that we've already requested a token with attestation permission. So the GITHUB_TOKEN environment variable might not be necessary anymore. 

Here is the test removed from my fork repository https://github.com/wingyplus/elixir/actions/runs/10907530737.