### PR TITLE
Use ~c to represent charlist arg for :gen_tcp.connect/3

### DIFF
--- a/lib/elixir/pages/mix-and-otp/docs-tests-and-with.md
+++ b/lib/elixir/pages/mix-and-otp/docs-tests-and-with.md
@@ -371,7 +371,7 @@ defmodule KVServerTest do
 
   setup do
     opts = [:binary, packet: :line, active: false]
-    {:ok, socket} = :gen_tcp.connect('localhost', 4040, opts)
+    {:ok, socket} = :gen_tcp.connect(~c"localhost", 4040, opts)
     %{socket: socket}
   end
 


### PR DESCRIPTION
Suppresses compiler warning about single quoted strings.


Before:
```
    warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
    │
 12 │     {:ok, socket} = :gen_tcp.connect('localhost', 4040, opts)
    │                                      ~
    │
    └─ test/kv_server_test.exs:12:38
```

After:
no warning emitted.