### PR TITLE
Fix logger translator tests under erlang 27.1

### DIFF
--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -948,13 +948,13 @@ defmodule Logger.TranslatorTest do
   test "translates Supervisor progress" do
     {:ok, pid} = Supervisor.start_link([], strategy: :one_for_one)
 
-    assert capture_log(:info, fn ->
+    assert capture_log(:debug, fn ->
              ref = Process.monitor(pid)
              Supervisor.start_child(pid, worker(Task, [__MODULE__, :sleep, [self()]]))
              Process.exit(pid, :normal)
              receive do: ({:DOWN, ^ref, _, _, _} -> :ok)
            end) =~ ~r"""
-           \[info\] Child Task of Supervisor #PID<\d+\.\d+\.\d+> \(Supervisor\.Default\) started
+           \[(debug|info)\] Child Task of Supervisor #PID<\d+\.\d+\.\d+> \(Supervisor\.Default\) started
            Pid: #PID<\d+\.\d+\.\d+>
            Start Call: Task.start_link\(Logger.TranslatorTest, :sleep, \[#PID<\d+\.\d+\.\d+>\]\)
            """
@@ -963,36 +963,36 @@ defmodule Logger.TranslatorTest do
   test "translates Supervisor progress with name" do
     {:ok, pid} = Supervisor.start_link([], strategy: :one_for_one, name: __MODULE__)
 
-    assert capture_log(:info, fn ->
+    assert capture_log(:debug, fn ->
              ref = Process.monitor(pid)
              Supervisor.start_child(pid, worker(Task, [__MODULE__, :sleep, [self()]]))
              Process.exit(pid, :normal)
              receive do: ({:DOWN, ^ref, _, _, _} -> :ok)
            end) =~ ~r"""
-           \[info\] Child Task of Supervisor Logger.TranslatorTest started
+           \[(debug|info)\] Child Task of Supervisor Logger.TranslatorTest started
            """
 
     {:ok, pid} = Supervisor.start_link([], strategy: :one_for_one, name: {:global, __MODULE__})
 
-    assert capture_log(:info, fn ->
+    assert capture_log(:debug, fn ->
              ref = Process.monitor(pid)
              Supervisor.start_child(pid, worker(Task, [__MODULE__, :sleep, [self()]]))
              Process.exit(pid, :normal)
              receive do: ({:DOWN, ^ref, _, _, _} -> :ok)
            end) =~ ~r"""
-           \[info\] Child Task of Supervisor Logger.TranslatorTest started
+           \[(debug|info)\] Child Task of Supervisor Logger.TranslatorTest started
            """
 
     {:ok, pid} =
       Supervisor.start_link([], strategy: :one_for_one, name: {:via, :global, __MODULE__})
 
-    assert capture_log(:info, fn ->
+    assert capture_log(:debug, fn ->
              ref = Process.monitor(pid)
              Supervisor.start_child(pid, worker(Task, [__MODULE__, :sleep, [self()]]))
              Process.exit(pid, :normal)
              receive do: ({:DOWN, ^ref, _, _, _} -> :ok)
            end) =~ ~r"""
-           \[info\] Child Task of Supervisor Logger.TranslatorTest started
+           \[(debug|info)\] Child Task of Supervisor Logger.TranslatorTest started
            """
   end
 


### PR DESCRIPTION
This patch fixes logger tests when running with Erlang 27.1. I have also made backward compatibility, which at least works with Erlang 27.0.1.

Have tested `v1.17` and `main` branches with Erlang 27.1 and 27.0.1.

Based on forum discussion: https://elixirforum.com/t/elixir-v1-17-3-released/66156/2
