### PR TITLE
fixes Logger docs layout

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -198,7 +198,7 @@ defmodule Logger do
     * `:metadata` - key-value pairs of global primary metadata to be included
       in all log messages. Defaults to `[]`. The default formatter writes to
       standard out and therefore cannot print all metadata. See
-      [`Logger.Formatter`'s documentation](Logger.Formatter.html#module-metadata)
+      [`Logger.Formatter`'s documentation](`m:Logger.Formatter#module-metadata`)
       for more information.
 
   For example, to configure `Logger` to redirect all Erlang messages using a

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -198,7 +198,7 @@ defmodule Logger do
     * `:metadata` - key-value pairs of global primary metadata to be included
       in all log messages. Defaults to `[]`. The default formatter writes to
       standard out and therefore cannot print all metadata. See
-      [`Logger.Formatter`'s documentation](Logger.Formatter.html#module-metadata`)
+      [`Logger.Formatter`'s documentation](Logger.Formatter.html#module-metadata)
       for more information.
 
   For example, to configure `Logger` to redirect all Erlang messages using a


### PR DESCRIPTION
Hi,

This is causing layout issue in [main](https://hexdocs.pm/logger/main/Logger.html) docs

![image](https://github.com/user-attachments/assets/47f0670c-b4e4-4b9e-b9a4-ba5036b2488f)

Thanks.