### PR TITLE
Add --migrate flag to mix format

### DIFF
--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -403,10 +403,13 @@ format_error({undefined_bittype, Expr}) ->
   io_lib:format("unknown bitstring specifier: ~ts", ['Elixir.Macro':to_string(Expr)]);
 format_error({unknown_bittype, Name}) ->
   io_lib:format("bitstring specifier \"~ts\" does not exist and is being expanded to \"~ts()\","
-                " please use parentheses to remove the ambiguity", [Name, Name]);
+                " please use parentheses to remove the ambiguity.\n"
+                "You may run mix format --migrate to fix this warning automatically.", [Name, Name]);
 format_error({parens_bittype, Name}) ->
     io_lib:format("extra parentheses on a bitstring specifier \"~ts()\" have been deprecated. "
-    "Please remove the parentheses: \"~ts\"",
+    "Please remove the parentheses: \"~ts\".\n"
+    "You may run mix format --migrate to fix this warning automatically."
+    ,
     [Name, Name]);
 format_error({bittype_mismatch, Val1, Val2, Where}) ->
   io_lib:format("conflicting ~ts specification for bit field: \"~p\" and \"~p\"", [Where, Val1, Val2]);

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -404,11 +404,11 @@ format_error({undefined_bittype, Expr}) ->
 format_error({unknown_bittype, Name}) ->
   io_lib:format("bitstring specifier \"~ts\" does not exist and is being expanded to \"~ts()\","
                 " please use parentheses to remove the ambiguity.\n"
-                "You may run mix format --migrate to fix this warning automatically.", [Name, Name]);
+                "You may run \"mix format --migrate\" to fix this warning automatically.", [Name, Name]);
 format_error({parens_bittype, Name}) ->
     io_lib:format("extra parentheses on a bitstring specifier \"~ts()\" have been deprecated. "
     "Please remove the parentheses: \"~ts\".\n"
-    "You may run mix format --migrate to fix this warning automatically."
+    "You may run \"mix format --migrate\" to fix this warning automatically."
     ,
     [Name, Name]);
 format_error({bittype_mismatch, Val1, Val2, Where}) ->

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -269,7 +269,7 @@ tokenize([$" | T], Line, Column, Scope, Tokens) ->
 tokenize([$' | T], Line, Column, Scope, Tokens) ->
   Message = "single-quoted strings represent charlists. "
     "Use ~c\"\" if you indeed want a charlist or use \"\" instead.\n"
-    "You may run mix format --migrate to fix this warning automatically.",
+    "You may run \"mix format --migrate\" to fix this warning automatically.",
   NewScope = prepend_warning(Line, Column, Message, Scope),
   handle_strings(T, Line, Column + 1, $', NewScope, Tokens);
 

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -267,7 +267,10 @@ tokenize([$" | T], Line, Column, Scope, Tokens) ->
 
 %% TODO: Remove me in Elixir v2.0
 tokenize([$' | T], Line, Column, Scope, Tokens) ->
-  NewScope = prepend_warning(Line, Column, "single-quoted strings represent charlists. Use ~c\"\" if you indeed want a charlist or use \"\" instead", Scope),
+  Message = "single-quoted strings represent charlists. "
+    "Use ~c\"\" if you indeed want a charlist or use \"\" instead.\n"
+    "You may run mix format --migrate to fix this warning automatically.",
+  NewScope = prepend_warning(Line, Column, Message, Scope),
   handle_strings(T, Line, Column + 1, $', NewScope, Tokens);
 
 % Operator atoms

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -534,6 +534,18 @@ defmodule Mix.Tasks.FormatTest do
     end)
   end
 
+  test "respects the --migrate flag", context do
+    in_tmp(context.test, fn ->
+      File.write!("a.ex", "unless foo, do: 'bar'\n")
+
+      Mix.Tasks.Format.run(["a.ex"])
+      assert File.read!("a.ex") == "unless foo, do: 'bar'\n"
+
+      Mix.Tasks.Format.run(["a.ex", "--migrate"])
+      assert File.read!("a.ex") == "if !foo, do: ~c\"bar\"\n"
+    end)
+  end
+
   test "uses inputs and configuration from --dot-formatter", context do
     in_tmp(context.test, fn ->
       File.write!("custom_formatter.exs", """


### PR DESCRIPTION
The second commit is suggesting to run `mix --format` as previously suggested - open to more suggestions about the wording or formatting of the message.

<img width="962" alt="Screenshot 2024-09-21 at 14 02 18" src="https://github.com/user-attachments/assets/786b89e5-fe5b-42e1-80ba-91e90914a742">
