### PR TITLE
Code.Fragment.surround_context/2 handles &123 as :capture_arg

### DIFF
--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -1091,6 +1091,38 @@ defmodule CodeFragmentTest do
       end
     end
 
+    test "capture operator" do
+      assert CF.surround_context("& &123 + 1", {1, 1}) == %{
+               context: {:operator, ~c"&"},
+               begin: {1, 1},
+               end: {1, 2}
+             }
+
+      for i <- 3..6 do
+        assert CF.surround_context("& &123 + 1", {1, i}) == %{
+                 context: {:capture_arg, ~c"&123"},
+                 begin: {1, 3},
+                 end: {1, 7}
+               }
+      end
+    end
+
+    test "capture operator false positive" do
+      assert CF.surround_context("1&&2", {1, 3}) == %{
+               context: {:operator, ~c"&&"},
+               begin: {1, 2},
+               end: {1, 4}
+             }
+
+      assert CF.surround_context("1&&2", {1, 4}) == :none
+
+      assert CF.surround_context("&a", {1, 2}) == %{
+               context: {:local_or_var, ~c"a"},
+               begin: {1, 2},
+               end: {1, 3}
+             }
+    end
+
     test "unquoted atom" do
       for i <- 1..10 do
         assert CF.surround_context(":hello_wor", {1, i}) == %{


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/13818

There is a precedent for the name `capture_arg` is used [here](https://github.com/elixir-lang/elixir/blob/5902c29ad5f264021a9a9b447a25e2d8b4c45ea4/lib/elixir/src/elixir_fn.erl#L198-L201), so I thought it would be clear, but happy to rename it.