### PR TITLE
Disable migrate_unless within defmacro

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -487,6 +487,16 @@ defmodule Code.Formatter do
     binary_op_to_algebra(:in, "not in", meta, left, right, context, state)
   end
 
+  # disable migrate_unless within defmacro
+  defp quoted_to_algebra(
+         {atom, _, [{:unless, _, _}, _]} = ast,
+         context,
+         %{migrate_unless: true} = state
+       )
+       when atom in [:defmacro, :defmacrop] do
+    quoted_to_algebra(ast, context, %{state | migrate_unless: false})
+  end
+
   # rewrite unless as if!
   defp quoted_to_algebra(
          {:unless, meta, [condition, block]},

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2652,17 +2652,16 @@ defmodule Macro do
     end
   end
 
-  defp dbg_ast_to_debuggable({op, meta, [condition_ast, clauses]} = ast, env)
-       when op in [:if, :unless] do
-    case Macro.Env.lookup_import(env, {op, 2}) do
+  defp dbg_ast_to_debuggable({:if, meta, [condition_ast, clauses]} = ast, env) do
+    case Macro.Env.lookup_import(env, {:if, 2}) do
       [macro: Kernel] ->
         condition_result_var = unique_var(:condition_result, __MODULE__)
 
         quote do
           unquote(condition_result_var) = unquote(condition_ast)
-          result = unquote({op, meta, [condition_result_var, clauses]})
+          result = unquote({:if, meta, [condition_result_var, clauses]})
 
-          {unquote(op), unquote(escape(ast)), unquote(escape(condition_ast)),
+          {:if, unquote(escape(ast)), unquote(escape(condition_ast)),
            unquote(condition_result_var), result}
         end
 
@@ -2809,18 +2808,15 @@ defmodule Macro do
   end
 
   defp dbg_format_ast_to_debug(
-         {op, ast, condition_ast, condition_result, result},
+         {:if, ast, condition_ast, condition_result, result},
          options
-       )
-       when op in [:if, :unless] do
-    op_name = String.capitalize(Atom.to_string(op))
-
+       ) do
     formatted = [
-      dbg_maybe_underline("#{op_name} condition", options),
+      dbg_maybe_underline("If condition", options),
       ":\n",
       dbg_format_ast_with_value(condition_ast, condition_result, options),
       ?\n,
-      dbg_maybe_underline("#{op_name} expression", options),
+      dbg_maybe_underline("If expression", options),
       ":\n",
       dbg_format_ast_with_value(ast, result, options)
     ]

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -652,36 +652,6 @@ defmodule MacroTest do
              """
     end
 
-    test "unless expression" do
-      x = false
-      map = %{a: 5, b: 1}
-
-      {result, formatted} =
-        dbg_format(
-          unless true and x do
-            map[:a] * 2
-          else
-            map[:b]
-          end
-        )
-
-      assert result == 10
-
-      assert formatted =~ "macro_test.exs"
-
-      assert formatted =~ """
-             Unless condition:
-             true and x #=> false
-
-             Unless expression:
-             unless true and x do
-               map[:a] * 2
-             else
-               map[:b]
-             end #=> 10
-             """
-    end
-
     test "with \"syntax_colors: []\" it doesn't print any color sequences" do
       {_result, formatted} = dbg_format("hello")
       refute formatted =~ "\e["


### PR DESCRIPTION
Running `format --migrate` would break the Elixir codebase as of now, this PR fixes it:
- by avoiding formatting unless within `defmacro` - we can resue this approach for the pipe operator for [this](https://github.com/elixir-lang/elixir/issues/12122#issuecomment-2366508169)
- removing a test for `dbg` since we plan to deprecate - or is that too early? I can perhaps try to find a workaround using `Code.eval_string` in this case