### PR TITLE
Refactored pre-requisites of `build_man`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,17 +304,15 @@ dialyze: compile $(PLT)
 
 build_man: man/iex.1 man/elixir.1
 
-man/iex.1:
-	$(Q) cp man/iex.1.in man/iex.1
-	$(Q) sed -i.bak "/{COMMON}/r man/common" man/iex.1
-	$(Q) sed -i.bak "/{COMMON}/d" man/iex.1
-	$(Q) rm -f man/iex.1.bak
+define BUILD_MANPAGES
+man/$(APP).1:
+	$(Q) cp man/$(APP).1.in man/$(APP).1
+	$(Q) sed -i.bak "/{COMMON}/r man/common" man/$(APP).1
+	$(Q) sed -i.bak "/{COMMON}/d" man/$(APP).1
+	$(Q) rm -f man/$(APP).1.bak
+endef
 
-man/elixir.1:
-	$(Q) cp man/elixir.1.in man/elixir.1
-	$(Q) sed -i.bak "/{COMMON}/r man/common" man/elixir.1
-	$(Q) sed -i.bak "/{COMMON}/d" man/elixir.1
-	$(Q) rm -f man/elixir.1.bak
+$(foreach APP, elixir iex, $(eval $(BUILD_MANPAGES)))
 
 clean_man:
 	rm -f man/elixir.1


### PR DESCRIPTION
* `man/iex.1` & `man/elixir.1` are evaluated from `BUILD_MANPAGES`
* no diff in output of `build_man`.

```shell
# git log -n1 --oneline --pretty=short
commit 458a00b2a (HEAD -> makefile)
Author: Ariel Otilibili <otilibil@eurecom.fr>

    Refactored pre-requisites of `build_man`

# make build_man -n > /tmp/makefile; echo $?
0

# git switch main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.

# git log -n1 --oneline --pretty=short
commit b5282802a (HEAD -> main, origin/main, origin/HEAD)
Author: Jean Klingler <sabiwara@gmail.com>

    Disable migrate_unless within defmacro and remove dbg for unless (#13850)

# make build_man -n > /tmp/main; echo $?
0

# diff /tmp/makefile /tmp/main; echo $?
0
```