### PR TITLE
Provide some more pointers for logger overload protection

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -19,9 +19,12 @@ defmodule Logger do
     * Formats and truncates messages on the client
       to avoid clogging `Logger` handlers.
 
-    * Alternates between sync and async modes to remain
-      performant when required but also apply back-pressure
-      when under stress.
+    * Provides multiple forms of [overload protection](https://www.erlang.org/doc/apps/kernel/logger_chapter.html#protecting-the-handler-from-overload):
+      * keeps track of its message queue and switches to sync mode to apply
+        back pressure or even drop messages
+      * limits the number of logs emitted defaulting to 500 per second
+      * optionally allows to terminate & restart it if message queue length
+        or memory thresholds are exceeded
 
     * Allows overriding the logging level for a specific module,
       application or process.

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -23,7 +23,7 @@ defmodule Logger do
       * keeps track of its message queue and switches to sync mode to apply
         back pressure or even drop messages
       * limits the number of logs emitted defaulting to 500 per second
-      * optionally allows to terminate & restart it if message queue length
+      * optionally allows to terminate and restart it if the message queue length
         or memory thresholds are exceeded
 
     * Allows overriding the logging level for a specific module,


### PR DESCRIPTION
The previous docs didn't mention that logger may drop messages entirely, which I think is important to call out (and not just because I finished a long debugging journey to find these :) ).

This should give a fair overview of the built-in overload protections, similar to what I tried to do in erlang/otp#8855

I think this can really help folks be aware of some of these.

As always, thank you a lot for all your work :green_heart: 