### PR TITLE
unless rewrites: don't use `Kernel.!` in conditions in the head

### DIFF
--- a/lib/elixir/test/elixir/code_formatter/migration_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/migration_test.exs
@@ -242,6 +242,11 @@ defmodule Code.Formatter.MigrationTest do
       good = "x |> foo() |> Kernel.!() |> if(do: y)"
 
       assert_format bad, good, @opts
+
+      bad = "unless x |> foo(), do: y"
+      good = "if !(x |> foo()), do: y"
+
+      assert_format bad, good, @opts
     end
 
     test "rewrites in as not in" do


### PR DESCRIPTION
[See conversation here](https://github.com/elixir-lang/elixir/pull/13844#discussion_r1771993140)

```elixir
# given:
unless Widget |> where(foo: ^bar) |> Repo.exists?(), do: ...
# before this change
if Widget |> where(foo: ^bar) |> Repo.exists?() |> Kernel.!(), do: ...
# after this change
if !(Widget |> where(foo: ^bar) |> Repo.exists?()), do:
```

this behaviour is unchanged. any desire for consistency across all pipes, rather than different behaviour with 1-vs-2+?
```elixir
# given
a |> unless(...)
# get
!a |> if(...)
# given
a |> b() |> unless(...)
# get
a |> b() |> Kernel.!() |> if(...)
```