### PR TITLE
Document new unused `...` operator in correct place in operators.md

### DIFF
--- a/lib/elixir/pages/references/operators.md
+++ b/lib/elixir/pages/references/operators.md
@@ -131,6 +131,7 @@ The following is a table of all the operators that Elixir is capable of parsing,
   * `<~>`
   * `+++`
   * `---`
+  * `...`
 
 The following operators are used by the `Bitwise` module when imported: [`&&&`](`Bitwise.&&&/2`), [`<<<`](`Bitwise.<<</2`), [`>>>`](`Bitwise.>>>/2`), and [`|||`](`Bitwise.|||/2`). See the `Bitwise` documentation for more information.
 


### PR DESCRIPTION
[The new `...` operator](https://github.com/elixir-lang/elixir/commit/d68c8d6cddadd8ec5995dddaf4cee0e22e4ca440#diff-7e4167a9de48e2dcae64fae18a5b2ddad1d4aeff8f2dde274eb6f127ef65ac11R148) snuck by me, and it's perfect for something I've wanted to do in Matcha for a while. This PR documents it in the [Operators reference > Custom and overridden operators > Defining custom operators](https://hexdocs.pm/elixir/operators.html#defining-custom-operators) listing to increase visibility.