### PR TITLE
Update docs for mix test --slowest and --slowest-modules

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -188,11 +188,12 @@ defmodule Mix.Tasks.Test do
       `--seed 0` disables randomization so the tests in a single file will always be ran
       in the same order they were defined in
 
-    * `--slowest` - prints timing information for the N slowest tests.
-      Automatically sets `--trace` and `--preload-modules`
+    * `--slowest` - prints timing information for the N slowest tests. Includes time spent in
+     `ExUnit.Callbacks.setup/1`. Automatically sets `--trace` and `--preload-modules`
 
     * `--slowest-modules` *(since v1.17.0)* - prints timing information for the N slowest
-      modules. Automatically sets `--trace` and `--preload-modules`
+      modules. Includes time spent in `ExUnit.Callbacks.setup/1`. Automatically sets
+      `--trace` and `--preload-modules`
 
     * `--stale` - runs only tests which reference modules that changed since the
       last time tests were ran with `--stale`. You can read more about this option


### PR DESCRIPTION
I was hunting down a slow test and wasn't sure if `--slowest` and `--slowest-modules` considered time spent in `setup` and `setup_all`.  

After some testing, I found that they both count time spent in `setup` and neither counts the time spent in `setup_all`.  

Maybe this is obvious to other people, but it wasn't to me, and might be worth adding to the documentation. 

---

Here are the updated docs:

<img width="822" alt="image" src="https://github.com/user-attachments/assets/8002786b-264c-4fd2-b7f7-4edad26d0e3c">
