### PR TITLE
Refactored `clean_man`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,11 +314,14 @@ endef
 
 $(foreach APP, elixir iex, $(eval $(BUILD_MANPAGES)))
 
+define RM_MANPAGES
+rm -f man/$1
+rm -f man/$1.bak
+endef
+
 clean_man:
-	rm -f man/elixir.1
-	rm -f man/elixir.1.bak
-	rm -f man/iex.1
-	rm -f man/iex.1.bak
+	$(call RM_MANPAGES,elixir.1)
+	$(call RM_MANPAGES,iex.1)
 
 install_man: build_man
 	$(Q) mkdir -p $(DESTDIR)$(MAN_PREFIX)/man1


### PR DESCRIPTION
Output is unchanged:

```shell
cat << _EOF | sh -
git switch makefile
make clean_man -n > /tmp/makefile
git log -n1 --oneline --pretty=short
git switch main
make clean_man -n > /tmp/main
git log -n1 --oneline --pretty=short
diff /tmp/makefile /tmp/main; echo $?
_EOF

Switched to branch 'makefile'
commit 31d71cf93 (HEAD -> makefile)
Author: Ariel Otilibili <otilibil@eurecom.fr>

    Refactored `clean_man`
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
commit 1f9233213 (HEAD -> main, origin/main, origin/HEAD)
Author: José Valim <jose.valim@dashbit.co>

    Improve error messages when matching on size
0
```