### PR TITLE
fix(formatter): fix small issue where there was only one newline added

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -638,7 +638,7 @@ defmodule Code.Formatter do
 
   defp block_args_to_algebra(args, min_line, max_line, state) do
     quoted_to_algebra = fn {kind, meta, _} = arg, args, state ->
-      newlines = maybe_add_newlines({kind, args}, meta)
+      newlines = handle_newlines(arg, args, meta[:end_of_expression][:newlines] || 1)
       {doc, state} = quoted_to_algebra(arg, :block, state)
       {{doc, block_next_line(kind), newlines}, state}
     end
@@ -656,12 +656,12 @@ defmodule Code.Formatter do
   defp block_next_line(:@), do: @empty
   defp block_next_line(_), do: break("")
 
-  defp maybe_add_newlines({:def, [{:@, _, _} = _next | _]}, _meta) do
-    @newlines
+  defp handle_newlines({current, _, _}, [{:@, _, _} = _next | _], newlines) when current != :@ do
+    max(newlines, 2)
   end
 
-  defp maybe_add_newlines(_, meta) do
-    meta[:end_of_expression][:newlines] || 1
+  defp handle_newlines(_, _, newlines) do
+    newlines
   end
 
   ## Operators

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -637,8 +637,8 @@ defmodule Code.Formatter do
   end
 
   defp block_args_to_algebra(args, min_line, max_line, state) do
-    quoted_to_algebra = fn {kind, meta, _} = arg, _args, state ->
-      newlines = meta[:end_of_expression][:newlines] || 1
+    quoted_to_algebra = fn {kind, meta, _} = arg, args, state ->
+      newlines = maybe_add_newlines({kind, args}, meta)
       {doc, state} = quoted_to_algebra(arg, :block, state)
       {{doc, block_next_line(kind), newlines}, state}
     end
@@ -655,6 +655,14 @@ defmodule Code.Formatter do
 
   defp block_next_line(:@), do: @empty
   defp block_next_line(_), do: break("")
+
+  defp maybe_add_newlines({:def, [{:@, _, _} = _next | _]}, _meta) do
+    @newlines
+  end
+
+  defp maybe_add_newlines(_, meta) do
+    meta[:end_of_expression][:newlines] || 1
+  end
 
   ## Operators
 

--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -869,6 +869,56 @@ defmodule Code.Formatter.GeneralTest do
       assert_format bad, good
     end
 
+    test "with def followed by module attribute" do
+      bad = """
+      defmodule Example do
+        @impl FooA
+        def a(), do: :something
+        @impl FooB
+        def b() do
+          :something_else
+        end
+      end
+      """
+
+      good = """
+      defmodule Example do
+        @impl FooA
+        def a(), do: :something
+
+        @impl FooB
+        def b() do
+          :something_else
+        end
+      end
+      """
+
+      assert_format bad, good
+    end
+
+    test "with def followed by def" do
+      bad = """
+      defmodule Example do
+        def a(), do: :something
+        def b() do
+          :something_else
+        end
+      end
+      """
+
+      good = """
+      defmodule Example do
+        def a(), do: :something
+
+        def b() do
+          :something_else
+        end
+      end
+      """
+
+      assert_format bad, good
+    end
+
     test "with multiple defs" do
       assert_same """
       def foo(:one), do: 1


### PR DESCRIPTION
to a def that is followed by a module attribute.

Closes  #13866

--------------------------

I'm not sure this implementation is the best, but it seems to do the job. I wouldn't be surprised if there is a better way to solve it though. This was my naive approach.

The test cases show the current behavior (def + def works, but def + mod attr doesn't).

Feel free to adjust/modify/close/do whatever you'd like to it if you see it fit.

Thank you for all of your work as usual! ❤️ 