### PR TITLE
fix  #13864: `typedoc` for `init_option`

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -595,7 +595,7 @@ defmodule Supervisor do
   @typedoc "The supervisor reference."
   @type supervisor :: pid | name | {atom, node}
 
-  @typedoc "Options given to `start_link/2` and `c:init/1`."
+  @typedoc "Options given to `start_link/2` and `init/2`."
   @type init_option ::
           {:strategy, strategy}
           | {:max_restarts, non_neg_integer}


### PR DESCRIPTION
change `c:init/1` to`init/2` in the `typedoc`'s text