### PR TITLE
Update .gitignore generated by 'mix new'

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -311,9 +311,6 @@ defmodule Mix.Tasks.New do
   # Where third-party dependencies like ExDoc output generated docs.
   /doc/
 
-  # Ignore .fetch files in case you like to edit your project deps locally.
-  /.fetch
-
   # If the VM crashes, it generates a dump, let's ignore it too.
   erl_crash.dump
 


### PR DESCRIPTION
The .gitignore file would reference '/.fetch' files, which caused some confusion (cf.
https://elixir-lang.slack.com/archives/C03EPRA3B/p1727706411018609).

Some research suggests that these files are no longer generated as of commit 59b6e2ee8bce86b424a9825915f6d91f81d8e770 so let's stop mentioning them in the .gitignore, too.