### PR TITLE
Replace any -> term in modules or functions mixing them

### DIFF
--- a/lib/elixir/lib/agent.ex
+++ b/lib/elixir/lib/agent.ex
@@ -284,7 +284,7 @@ defmodule Agent do
   instead of an anonymous function; `fun` in `module` will be called with the
   given arguments `args` to initialize the state.
   """
-  @spec start_link(module, atom, [any], GenServer.options()) :: on_start
+  @spec start_link(module, atom, [term], GenServer.options()) :: on_start
   def start_link(module, fun, args, options \\ []) do
     GenServer.start_link(Agent.Server, {module, fun, args}, options)
   end
@@ -311,7 +311,7 @@ defmodule Agent do
 
   See `start_link/4` for more information.
   """
-  @spec start(module, atom, [any], GenServer.options()) :: on_start
+  @spec start(module, atom, [term], GenServer.options()) :: on_start
   def start(module, fun, args, options \\ []) do
     GenServer.start(Agent.Server, {module, fun, args}, options)
   end
@@ -348,7 +348,7 @@ defmodule Agent do
   instead of an anonymous function. The state is added as first
   argument to the given list of arguments.
   """
-  @spec get(agent, module, atom, [term], timeout) :: any
+  @spec get(agent, module, atom, [term], timeout) :: term
   def get(agent, module, fun, args, timeout \\ 5000) do
     GenServer.call(agent, {:get, {module, fun, args}}, timeout)
   end
@@ -389,7 +389,7 @@ defmodule Agent do
   instead of an anonymous function. The state is added as first
   argument to the given list of arguments.
   """
-  @spec get_and_update(agent, module, atom, [term], timeout) :: any
+  @spec get_and_update(agent, module, atom, [term], timeout) :: term
   def get_and_update(agent, module, fun, args, timeout \\ 5000) do
     GenServer.call(agent, {:get_and_update, {module, fun, args}}, timeout)
   end

--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -46,8 +46,8 @@ defmodule GenEvent do
   @callback init(args :: term) ::
               {:ok, state}
               | {:ok, state, :hibernate}
-              | {:error, reason :: any}
-            when state: any
+              | {:error, reason :: term}
+            when state: term
 
   @callback handle_event(event :: term, state :: term) ::
               {:ok, new_state}

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -523,8 +523,8 @@ defmodule GenServer do
               {:ok, state}
               | {:ok, state, timeout | :hibernate | {:continue, continue_arg :: term}}
               | :ignore
-              | {:stop, reason :: any}
-            when state: any
+              | {:stop, reason :: term}
+            when state: term
 
   @doc """
   Invoked to handle synchronous `call/3` messages. `call/3` will block until a
@@ -1018,7 +1018,7 @@ defmodule GenServer do
   or `:ignore`, the process is terminated and this function returns
   `{:error, reason}` or `:ignore`, respectively.
   """
-  @spec start_link(module, any, options) :: on_start
+  @spec start_link(module, term, options) :: on_start
   def start_link(module, init_arg, options \\ []) when is_atom(module) and is_list(options) do
     do_start(:link, module, init_arg, options)
   end
@@ -1028,7 +1028,7 @@ defmodule GenServer do
 
   See `start_link/3` for more information.
   """
-  @spec start(module, any, options) :: on_start
+  @spec start(module, term, options) :: on_start
   def start(module, init_arg, options \\ []) when is_atom(module) and is_list(options) do
     do_start(:nolink, module, init_arg, options)
   end

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -438,7 +438,7 @@ defmodule Inspect.Algebra do
 
   """
   @doc since: "1.6.0"
-  @spec container_doc(t, [any], t, Inspect.Opts.t(), (term, Inspect.Opts.t() -> t), keyword()) ::
+  @spec container_doc(t, [term], t, Inspect.Opts.t(), (term, Inspect.Opts.t() -> t), keyword()) ::
           t
   def container_doc(left, collection, right, inspect_opts, fun, opts \\ [])
       when is_doc(left) and is_list(collection) and is_doc(right) and is_function(fun, 2) and

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -630,7 +630,7 @@ defmodule Kernel do
 
   """
   @doc guard: true
-  @spec hd(nonempty_maybe_improper_list(elem, any)) :: elem when elem: term
+  @spec hd(nonempty_maybe_improper_list(elem, term)) :: elem when elem: term
   def hd(list) do
     :erlang.hd(list)
   end
@@ -2973,7 +2973,7 @@ defmodule Kernel do
           (term | nil -> {current_value, new_value} | :pop)
         ) :: {current_value, new_structure :: structure}
         when structure: Access.t(),
-             keys: nonempty_list(any),
+             keys: nonempty_list(term),
              current_value: Access.value(),
              new_value: Access.value()
   def get_and_update_in(data, keys, fun)

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -401,7 +401,7 @@ defmodule MapSet do
 
   """
   @doc since: "1.15.0"
-  @spec split_with(MapSet.t(), (any() -> as_boolean(term))) :: {MapSet.t(), MapSet.t()}
+  @spec split_with(MapSet.t(), (term() -> as_boolean(term))) :: {MapSet.t(), MapSet.t()}
   def split_with(%MapSet{map: map}, fun) when is_function(fun, 1) do
     {while_true, while_false} = Map.split_with(map, fn {key, _} -> fun.(key) end)
     {%MapSet{map: while_true}, %MapSet{map: while_false}}

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -222,7 +222,7 @@ defmodule Regex do
       {:ok, Regex.compile!("foo", [:caseless])}
 
   """
-  @spec compile(binary, binary | [term]) :: {:ok, t} | {:error, any}
+  @spec compile(binary, binary | [term]) :: {:ok, t} | {:error, term}
   def compile(source, opts \\ "") when is_binary(source) do
     compile(source, opts, version())
   end

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -471,7 +471,7 @@ defmodule Registry do
   """
   @doc since: "1.4.0"
   @spec dispatch(registry, key, dispatcher, keyword) :: :ok
-        when dispatcher: (entries :: [{pid, value}] -> term) | {module(), atom(), [any()]}
+        when dispatcher: (entries :: [{pid, value}] -> term) | {module(), atom(), [term()]}
   def dispatch(registry, key, mfa_or_fun, opts \\ [])
       when is_atom(registry) and is_function(mfa_or_fun, 1)
       when is_atom(registry) and tuple_size(mfa_or_fun) == 3 do

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -878,7 +878,7 @@ defmodule Stream do
   """
   @spec transform(Enumerable.t(), acc, fun) :: Enumerable.t()
         when fun: (element, acc -> {Enumerable.t(), acc} | {:halt, acc}),
-             acc: any
+             acc: term
   def transform(enum, acc, reducer) when is_function(reducer, 2) do
     &do_transform(enum, fn -> acc end, reducer, &1, &2, nil, fn acc -> acc end)
   end
@@ -893,7 +893,7 @@ defmodule Stream do
         when start_fun: (-> acc),
              reducer: (element, acc -> {Enumerable.t(), acc} | {:halt, acc}),
              after_fun: (acc -> term),
-             acc: any
+             acc: term
   def transform(enum, start_fun, reducer, after_fun)
       when is_function(start_fun, 0) and is_function(reducer, 2) and is_function(after_fun, 1) do
     &do_transform(enum, start_fun, reducer, &1, &2, nil, after_fun)
@@ -920,7 +920,7 @@ defmodule Stream do
              reducer: (element, acc -> {Enumerable.t(), acc} | {:halt, acc}),
              last_fun: (acc -> {Enumerable.t(), acc} | {:halt, acc}),
              after_fun: (acc -> term),
-             acc: any
+             acc: term
   def transform(enum, start_fun, reducer, last_fun, after_fun)
       when is_function(start_fun, 0) and is_function(reducer, 2) and is_function(last_fun, 1) and
              is_function(after_fun, 1) do


### PR DESCRIPTION
Some functions are using a mix of `any` and `term` within the same signature, which somebody pointed out to me is confusing as it seems to indicate some kind of nuance.

I know that specs are not meant to stay forever, so I gave up fixing all instances of `any`, but I searched for these mixed specs and replaced `any` by `term` (sometimes in other functions of the same module too) for consistency.

```elixir
# quick-and-dirty one-liner for reference:
Path.wildcard("lib/**/*.ex") |> Enum.flat_map(fn file -> File.read!(file) |> Code.string_to_quoted() |> Macro.prewalker() |> Stream.filter(&match?({:@, _, [{x, _, _} | _]} when x in [:spec, :callback], &1)) |> Stream.map(&Macro.to_string/1) |> Stream.filter(& &1 =~ ~r/\bany\b/ && &1 =~ "term") |> Stream.map(& file <> "\t" <> &1)  end) |> Enum.each(&IO.puts/1)
```