### PR TITLE
Replace "dict" with "map" in Agents documentation page

### DIFF
--- a/lib/elixir/pages/mix-and-otp/agents.md
+++ b/lib/elixir/pages/mix-and-otp/agents.md
@@ -187,8 +187,8 @@ Before we move on to the next chapter, let's discuss the client/server dichotomy
 
 ```elixir
 def delete(bucket, key) do
-  Agent.get_and_update(bucket, fn dict ->
-    Map.pop(dict, key)
+  Agent.get_and_update(bucket, fn map ->
+    Map.pop(map, key)
   end)
 end
 ```
@@ -200,9 +200,9 @@ This distinction is important. If there are expensive actions to be done, you mu
 ```elixir
 def delete(bucket, key) do
   Process.sleep(1000) # puts client to sleep
-  Agent.get_and_update(bucket, fn dict ->
+  Agent.get_and_update(bucket, fn map ->
     Process.sleep(1000) # puts server to sleep
-    Map.pop(dict, key)
+    Map.pop(map, key)
   end)
 end
 ```


### PR DESCRIPTION
I think it is better to rename the variable in this case and avoid indirectly referring to a deprecated module.

> [!NOTE]
> The term "dict" or "dictionary" is still used in several areas in the project (not only documentation), is it better to handle all of them in a single PR?