### PR TITLE
Add `Kernel.maybe_then/3`

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2745,6 +2745,37 @@ defmodule Kernel do
   end
 
   @doc """
+  If the third argument, `condition` evaluates to `true`, it pipes the first
+  argument, `value`, into the third argument, a function `fun`, and returns
+  the result of calling `fun`. Otherwise, if `condition` evaluates to `false`,
+  it returns `value` unchanged.
+
+  In other words, if `condition` is `true`, it is the same as calling
+  `then(value, fun)` (see `then/2`); if `conidition` is `false`, it is the same
+  as calling `Function.identity(value)`.
+
+  It can be used in pipelines, using the `|>/2` operator, to execute some step
+  only in case a certain condition is met.
+
+  ### Examples
+
+      iex> 1 |> maybe_then(_some_condition = true, fn x -> x * 2 end)
+      2
+
+      iex> 1 |> maybe_then(_some_condition = false, fn x -> x * 2 end)
+      1
+
+      iex> ["abc", "beam"]
+      ...> |> maybe_then(upcase? = true, Enum.map(&String.upcase/1))
+      ["ABC", "BEAM"]
+  """
+  defmacro maybe_then(value, condition, fun) do
+    quote do
+      if unquote(condition), do: unquote(fun).(unquote(value)), else: unquote(value)
+    end
+  end
+
+  @doc """
   Gets a value from a nested structure with nil-safe handling.
 
   Uses the `Access` module to traverse the structures

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -450,6 +450,15 @@ defmodule KernelTest do
     end
   end
 
+  test "maybe_then/3" do
+    assert 1 |> maybe_then(true, fn x -> x * 2 end) == 2
+    assert 1 |> maybe_then(false, fn x -> x * 2 end) == 1
+
+    assert_raise BadArityError, fn ->
+      1 |> maybe_then(true, fn x, y -> x * y end)
+    end
+  end
+
   test "if/2 boolean optimization does not leak variables during expansion" do
     if false do
       :ok


### PR DESCRIPTION
I sometimes find myself writing things like this when building Ecto queries:
```elixir
q = 
  from(u in Users)
  |> where([u], u.home_town = ^home_town)

q =
  if only_legal_age? do
    where(q, [u], u.age >= 18)
  else
    q
  end
```
or
```elixir
from(u in Users)
|> where([u], u.home_town = ^home_town)
|> then(fn q ->
  if only_legal_age? do
    where(q, [u], u.age >= 18)
  else
    q
  end
)
```
Neither of these options is really nice, I think. With this proposal, it would become:
```elixir
from(u in Users)
|> where([u], u.home_town = ^home_town)
|> maybe_then(
  only_legal_age?,
  &where(&1, [u], u.age >= 18)
)
```

It's similar to and inspired by [the conditional `when` clauses from Laravel/Eloquent](https://laravel.com/docs/11.x/queries#conditional-clauses).

I'm looking forward to hearing your thoughts!