### PR TITLE
adds test_pid field in the test metadata

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -103,6 +103,8 @@ defmodule ExUnit do
       * `:logs` - the captured logs
       * `:parameters` - the test parameters
 
+    When a test has finished, the following fields are added for consumption by `ExUnit.Formatter` callbacks:
+      * `:test_pid` - the pid that the test was running on
     """
     defstruct [:name, :case, :module, :state, time: 0, tags: %{}, logs: "", parameters: %{}]
 

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -104,7 +104,7 @@ defmodule ExUnit do
       * `:parameters` - the test parameters
 
     When a test has finished, the following fields are added for consumption by `ExUnit.Formatter` callbacks:
-      * `:test_pid` - the pid that the test was running on
+      * `:test_pid` - the PID that the test was running on
     """
     defstruct [:name, :case, :module, :state, time: 0, tags: %{}, logs: "", parameters: %{}]
 

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -456,6 +456,7 @@ defmodule ExUnit.Runner do
   end
 
   defp receive_test_reply(test, test_pid, test_ref, timeout) do
+    test = Map.put(test, :test_pid, test_pid)
     receive do
       {^test_pid, :test_finished, test} ->
         Process.demonitor(test_ref, [:flush])


### PR DESCRIPTION
this enhancement adds a `test_pid` field into the test context metadata.  This is useful for backtracking which test is responsible when a ecto sandbox or mox allowance has triggered after the parent test has finished.  For now, one will have to write a custom `ExUnit.Formatter` to take advantage of this extra metadata.