### PR TITLE
Fix signature of trunc/1 in guide

### DIFF
--- a/lib/elixir/pages/getting-started/basic-types.md
+++ b/lib/elixir/pages/getting-started/basic-types.md
@@ -91,7 +91,7 @@ We can also use this syntax to access documentation. The Elixir shell defines th
 
 ```elixir
 iex> h trunc/1
-                             def trunc()
+                             def trunc(number)
 
 Returns the integer part of number.
 ```
@@ -100,7 +100,7 @@ Returns the integer part of number.
 
 ```elixir
 iex> h Kernel.trunc/1
-                             def trunc()
+                             def trunc(number)
 
 Returns the integer part of number.
 ```


### PR DESCRIPTION
This might be confusing otherwise especially for an [explanation about arity](https://hexdocs.pm/elixir/1.17.3/basic-types.html#identifying-functions-and-documentation).