### PR TITLE
dbg for with expressions

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2676,7 +2676,8 @@ defmodule Macro do
 
   defp dbg_ast_to_debuggable({:with, meta, args} = ast, _env) do
     {opts, clauses} = List.pop_at(args, -1)
-    unmatched_ast_var = unique_var(:unmatched_ast_var, __MODULE__)
+    unmatched_ast_var = unique_var(:unmatched_ast, __MODULE__)
+    result_var = unique_var(:result, __MODULE__)
 
     modified_clauses =
       Enum.flat_map(clauses, fn
@@ -2702,8 +2703,8 @@ defmodule Macro do
             quote do
               [
                 unquote(:->)(
-                  [{unquote(unmatched_ast_var), unquote({:result, [], Elixir})}],
-                  {:__else__, unquote(unmatched_ast_var), unquote({:result, [], Elixir})}
+                  [{unquote(unmatched_ast_var), unquote(result_var)}],
+                  {:__else__, unquote(unmatched_ast_var), unquote(result_var)}
                 )
               ]
             end

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2675,8 +2675,8 @@ defmodule Macro do
   end
 
   defp dbg_ast_to_debuggable({:with, meta, args} = ast, _env) do
-    {opts, clauses} =
-      List.pop_at(args, -1)
+    {opts, clauses} = List.pop_at(args, -1)
+    unmatched_ast_var = unique_var(:unmatched_ast_var, __MODULE__)
 
     modified_clauses =
       Enum.flat_map(clauses, fn
@@ -2702,9 +2702,8 @@ defmodule Macro do
             quote do
               [
                 unquote(:->)(
-                  [{unquote({:unmatched_ast, [], Elixir}), unquote({:result, [], Elixir})}],
-                  {:__else__, unquote({:unmatched_ast, [], Elixir}),
-                   unquote({:result, [], Elixir})}
+                  [{unquote(unmatched_ast_var), unquote({:result, [], Elixir})}],
+                  {:__else__, unquote(unmatched_ast_var), unquote({:result, [], Elixir})}
                 )
               ]
             end
@@ -2717,8 +2716,8 @@ defmodule Macro do
               {:->, meta, [[left], right]} = else_clause ->
                 quote do
                   unquote(:->)(
-                    [{unquote({:unmatched_ast, [], Elixir}), unquote(left)}],
-                    {:__else__, unquote({:unmatched_ast, [], Elixir}),
+                    [{unquote(unmatched_ast_var), unquote(left)}],
+                    {:__else__, unquote(unmatched_ast_var),
                      {Keyword.get(unquote(meta), :line), unquote(Macro.escape(else_clause))},
                      unquote(right)}
                   )


### PR DESCRIPTION
My take on the `dbg` for `with` - previous discussion is here: https://github.com/elixir-lang/elixir/pull/12477 
I feel that without `dbg` for `with` clauses the dbg feature is incomplete:
I started off with @sabiwara code but I took a different approach.
A with clause can have 3 possible ways of finishing:
- do block is executed
- one of the else blocks is executed
- no else block is specified but value is unmatched 

In with expression only the lines with `<-` can be unmatched so I focused only on these:
Example code:
```elixir
            with {:ok, width} <- Map.fetch(opts, :width),                                                                                                                     
                 {:ok, height} <- Map.fetch(opts, :height) do                                                                                                                 
              width * height                                                                                                                                                  
            else                                                                                                                                                              
              :error -> 0                                                                                                                                                     
            end 
  ```
Currently the dbg does not print the whole code, just the important parts so the result is quite short:

- do block is executed
```
All with clauses matched, result:                                                                                                                                                                                                                            
{:ok, 300}
```             
- no else block is specified - I'm adding one in this case to catch the result and the printed result is
```                                                                                                                                       
With clause unmatched on line 398                                                                                                                              
{:ok, height} <- Map.fetch(opts, :height) #=> :error
```
- one of the else blocks is executed - we need to know where it was unmatched in the `<-` section and then when it matched in `->` section - the printed result in this case is:
```                                                                                                   
With clause unmatched on line 419                                                                                                                              
{:ok, height} <- Map.fetch(opts, :height) #=> :error                                                                                                           
Then else clause matched on line 423                                                                                                                   
->(:error, 0) #=> 0
```
The last one should be `:error -> 0` - I need to check how to format this prorperly.