### PR TITLE
docs: reword similarity between receive/1 and case/2 in getting-started/processes

### DIFF
--- a/lib/elixir/pages/getting-started/processes.md
+++ b/lib/elixir/pages/getting-started/processes.md
@@ -53,7 +53,7 @@ iex> receive do
 "world"
 ```
 
-When a message is sent to a process, the message is stored in the process mailbox. The `receive/1` block goes through the current process mailbox searching for a message that matches any of the given patterns. `receive/1` supports guards and many clauses, such as `case/2`.
+When a message is sent to a process, the message is stored in the process mailbox. The `receive/1` block goes through the current process mailbox searching for a message that matches any of the given patterns. `receive/1` supports guards and many clauses, exactly as `case/2`.
 
 The process that sends the message does not block on `send/2`, it puts the message in the recipient's mailbox and continues. In particular, a process can send messages to itself.
 


### PR DESCRIPTION
As it stands, it could be interpreted as if one of the clauses supported is `case/2` which isn't the intent.

Reworded to use `exactly` instead of `such` to match the wording in https://hexdocs.pm/elixir/Kernel.SpecialForms.html#receive/1-variable-handling