### PR TITLE
Wrap deps tasks in a lock

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -899,6 +899,20 @@ defmodule Mix.Project do
     Mix.Lock.with_lock(build_path, fun, on_taken: on_taken)
   end
 
+  @doc false
+  def with_deps_lock(config \\ config(), fun) do
+    # We wrap operations on the deps directory and on mix.lock to
+    # avoid write conflicts.
+
+    deps_path = deps_path(config)
+
+    on_taken = fn os_pid ->
+      Mix.shell().info("Waiting for lock on the deps directory (held by process #{os_pid})")
+    end
+
+    Mix.Lock.with_lock(deps_path, fun, on_taken: on_taken)
+  end
+
   # Loads mix.exs in the current directory or loads the project from the
   # mixfile cache and pushes the project onto the project stack.
   defp load_project(app, post_config) do

--- a/lib/mix/lib/mix/tasks/clean.ex
+++ b/lib/mix/lib/mix/tasks/clean.ex
@@ -30,6 +30,12 @@ defmodule Mix.Tasks.Clean do
 
     {opts, _, _} = OptionParser.parse(args, switches: @switches)
 
+    Mix.Project.with_build_lock(fn ->
+      do_run(opts)
+    end)
+  end
+
+  defp do_run(opts) do
     # First, we get the tasks. After that, we clean them.
     # This is to avoid a task cleaning a compiler module.
     tasks =

--- a/lib/mix/lib/mix/tasks/deps.clean.ex
+++ b/lib/mix/lib/mix/tasks/deps.clean.ex
@@ -130,8 +130,6 @@ defmodule Mix.Tasks.Deps.Clean do
   end
 
   defp clean_source(apps, deps, deps_path, build_only?) do
-    shell = Mix.shell()
-
     local = for %{scm: scm, app: app} <- deps, not scm.fetchable?(), do: Atom.to_string(app)
 
     Enum.each(apps, fn app ->

--- a/lib/mix/lib/mix/tasks/deps.clean.ex
+++ b/lib/mix/lib/mix/tasks/deps.clean.ex
@@ -29,6 +29,14 @@ defmodule Mix.Tasks.Deps.Clean do
     Mix.Project.get!()
     {opts, apps} = OptionParser.parse!(args, strict: @switches)
 
+    config = Mix.Project.config()
+
+    Mix.Project.with_deps_lock(config, fn ->
+      do_run(args, opts, apps)
+    end)
+  end
+
+  defp do_run(args, opts, apps) do
     build_path =
       Mix.Project.build_path()
       |> Path.dirname()

--- a/lib/mix/lib/mix/tasks/deps.clean.ex
+++ b/lib/mix/lib/mix/tasks/deps.clean.ex
@@ -29,10 +29,10 @@ defmodule Mix.Tasks.Deps.Clean do
     Mix.Project.get!()
     {opts, apps} = OptionParser.parse!(args, strict: @switches)
 
-    config = Mix.Project.config()
-
-    Mix.Project.with_deps_lock(config, fn ->
-      do_run(args, opts, apps)
+    Mix.Project.with_build_lock(fn ->
+      Mix.Project.with_deps_lock(fn ->
+        do_run(args, opts, apps)
+      end)
     end)
   end
 

--- a/lib/mix/lib/mix/tasks/deps.get.ex
+++ b/lib/mix/lib/mix/tasks/deps.get.ex
@@ -26,6 +26,14 @@ defmodule Mix.Tasks.Deps.Get do
     {opts, _, _} =
       OptionParser.parse(args, switches: [only: :string, target: :string, check_locked: :boolean])
 
+    config = Mix.Project.config()
+
+    Mix.Project.with_deps_lock(config, fn ->
+      do_run(opts)
+    end)
+  end
+
+  defp do_run(opts) do
     fetch_opts =
       for {switch, key} <- [only: :env, target: :target, check_locked: :check_locked],
           value = opts[switch],

--- a/lib/mix/lib/mix/tasks/deps.get.ex
+++ b/lib/mix/lib/mix/tasks/deps.get.ex
@@ -26,9 +26,7 @@ defmodule Mix.Tasks.Deps.Get do
     {opts, _, _} =
       OptionParser.parse(args, switches: [only: :string, target: :string, check_locked: :boolean])
 
-    config = Mix.Project.config()
-
-    Mix.Project.with_deps_lock(config, fn ->
+    Mix.Project.with_deps_lock(fn ->
       do_run(opts)
     end)
   end

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -27,6 +27,14 @@ defmodule Mix.Tasks.Deps.Unlock do
     Mix.Project.get!()
     {opts, apps, _} = OptionParser.parse(args, switches: @switches)
 
+    config = Mix.Project.config()
+
+    Mix.Project.with_deps_lock(config, fn ->
+      do_run(opts, apps)
+    end)
+  end
+
+  defp do_run(opts, apps) do
     cond do
       opts[:all] ->
         Mix.Dep.Lock.write(%{})

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -27,9 +27,7 @@ defmodule Mix.Tasks.Deps.Unlock do
     Mix.Project.get!()
     {opts, apps, _} = OptionParser.parse(args, switches: @switches)
 
-    config = Mix.Project.config()
-
-    Mix.Project.with_deps_lock(config, fn ->
+    Mix.Project.with_deps_lock(fn ->
       do_run(opts, apps)
     end)
   end

--- a/lib/mix/lib/mix/tasks/deps.update.ex
+++ b/lib/mix/lib/mix/tasks/deps.update.ex
@@ -45,6 +45,14 @@ defmodule Mix.Tasks.Deps.Update do
     {opts, rest, _} =
       OptionParser.parse(args, switches: [all: :boolean, only: :string, target: :string])
 
+    config = Mix.Project.config()
+
+    Mix.Project.with_deps_lock(config, fn ->
+      do_run(opts, rest)
+    end)
+  end
+
+  defp do_run(opts, rest) do
     fetch_opts =
       for {switch, key} <- [only: :env, target: :target],
           value = opts[switch],

--- a/lib/mix/lib/mix/tasks/deps.update.ex
+++ b/lib/mix/lib/mix/tasks/deps.update.ex
@@ -45,9 +45,7 @@ defmodule Mix.Tasks.Deps.Update do
     {opts, rest, _} =
       OptionParser.parse(args, switches: [all: :boolean, only: :string, target: :string])
 
-    config = Mix.Project.config()
-
-    Mix.Project.with_deps_lock(config, fn ->
+    Mix.Project.with_deps_lock(fn ->
       do_run(opts, rest)
     end)
   end


### PR DESCRIPTION
Wraps `mix deps.{get,update,unlock,clean}` in a lock to avoid conflicts with concurrent `deps/` and `mix.lock` writes.