### PR TITLE
Move fun/arity explanation later in getting started

### DIFF
--- a/lib/elixir/pages/getting-started/anonymous-functions.md
+++ b/lib/elixir/pages/getting-started/anonymous-functions.md
@@ -4,11 +4,11 @@ Anonymous functions allow us to store and pass executable code around as if it w
 
 ## Identifying functions and documentation
 
-Before we move on to the next data type, let's talk about how Elixir identifies functions.
+Before we move on to discuss anonymous functions, let's talk about how Elixir identifies named functions.
 
 Functions in Elixir are identified by both their name and their arity. The arity of a function describes the number of arguments that the function takes. From this point on we will use both the function name and its arity to describe functions throughout the documentation. `trunc/1` identifies the function which is named `trunc` and takes `1` argument, whereas `trunc/2` identifies a different (nonexistent) function with the same name but with an arity of `2`.
 
-We can also use this syntax to access documentation. The Elixir shell defines the `h` function, which you can use to access documentation for any function. For example, typing `h trunc/1` is going to print the documentation for the `trunc/1` function:
+We can also use this syntax to access documentation. The Elixir shell defines the [`h`](`IEx.Helpers.h/1`) function, which you can use to access documentation for any function. For example, typing `h trunc/1` is going to print the documentation for the `trunc/1` function:
 
 ```elixir
 iex> h trunc/1
@@ -26,7 +26,7 @@ iex> h Kernel.trunc/1
 Returns the integer part of number.
 ```
 
-You can use the module+function to lookup for anything, including operators (try `h Kernel.+/2`). Invoking `h` without arguments displays the documentation for `IEx.Helpers`, which is where `h` and other functionality is defined.
+You can use the module+function to lookup for anything, including operators (try `h Kernel.+/2`). Invoking [`h`](`IEx.Helpers.h/1`) without arguments displays the documentation for `IEx.Helpers`, which is where `h` and other functionalities are defined.
 
 ## Defining anonymous functions
 

--- a/lib/elixir/pages/getting-started/anonymous-functions.md
+++ b/lib/elixir/pages/getting-started/anonymous-functions.md
@@ -2,6 +2,32 @@
 
 Anonymous functions allow us to store and pass executable code around as if it was an integer or a string. Let's learn more.
 
+## Identifying functions and documentation
+
+Before we move on to the next data type, let's talk about how Elixir identifies functions.
+
+Functions in Elixir are identified by both their name and their arity. The arity of a function describes the number of arguments that the function takes. From this point on we will use both the function name and its arity to describe functions throughout the documentation. `trunc/1` identifies the function which is named `trunc` and takes `1` argument, whereas `trunc/2` identifies a different (nonexistent) function with the same name but with an arity of `2`.
+
+We can also use this syntax to access documentation. The Elixir shell defines the `h` function, which you can use to access documentation for any function. For example, typing `h trunc/1` is going to print the documentation for the `trunc/1` function:
+
+```elixir
+iex> h trunc/1
+                             def trunc(number)
+
+Returns the integer part of number.
+```
+
+`h trunc/1` works because it is defined in the `Kernel` module. All functions in the `Kernel` module are automatically imported into our namespace. Most often you will also include the module name when looking up the documentation for a given function:
+
+```elixir
+iex> h Kernel.trunc/1
+                             def trunc(number)
+
+Returns the integer part of number.
+```
+
+You can use the module+function to lookup for anything, including operators (try `h Kernel.+/2`). Invoking `h` without arguments displays the documentation for `IEx.Helpers`, which is where `h` and other functionality is defined.
+
 ## Defining anonymous functions
 
 Anonymous functions in Elixir are delimited by the keywords `fn` and `end`:

--- a/lib/elixir/pages/getting-started/basic-types.md
+++ b/lib/elixir/pages/getting-started/basic-types.md
@@ -81,32 +81,6 @@ false
 
 You can also use [`is_float`](`is_float/1`) or [`is_number`](`is_number/1`) to check, respectively, if an argument is a float, or either an integer or float.
 
-## Identifying functions and documentation
-
-Before we move on to the next data type, let's talk about how Elixir identifies functions.
-
-Functions in Elixir are identified by both their name and their arity. The arity of a function describes the number of arguments that the function takes. From this point on we will use both the function name and its arity to describe functions throughout the documentation. `trunc/1` identifies the function which is named `trunc` and takes `1` argument, whereas `trunc/2` identifies a different (nonexistent) function with the same name but with an arity of `2`.
-
-We can also use this syntax to access documentation. The Elixir shell defines the `h` function, which you can use to access documentation for any function. For example, typing `h trunc/1` is going to print the documentation for the `trunc/1` function:
-
-```elixir
-iex> h trunc/1
-                             def trunc(number)
-
-Returns the integer part of number.
-```
-
-`h trunc/1` works because it is defined in the `Kernel` module. All functions in the `Kernel` module are automatically imported into our namespace. Most often you will also include the module name when looking up the documentation for a given function:
-
-```elixir
-iex> h Kernel.trunc/1
-                             def trunc(number)
-
-Returns the integer part of number.
-```
-
-You can use the module+function to lookup for anything, including operators (try `h Kernel.+/2`). Invoking `h` without arguments displays the documentation for `IEx.Helpers`, which is where `h` and other functionality is defined.
-
 ## Booleans and `nil`
 
 Elixir supports `true` and `false` as booleans:


### PR DESCRIPTION
From this [page](https://hexdocs.pm/elixir/1.17.3/basic-types.html#identifying-functions-and-documentation) to this [one](https://hexdocs.pm/elixir/1.17.3/anonymous-functions.html), as previously suggested in https://github.com/elixir-lang/elixir/pull/13885.

I think it is quite natural, since this page relies on the concept of arity, and we don't need it up to this point.

Split the commit into move & (minor) edit for easier review.