### PR TITLE
Add @doc false to Inspect.Algebra.no_limit/1

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -588,6 +588,7 @@ defmodule Inspect.Algebra do
     doc_cons(doc1, doc2)
   end
 
+  @doc false
   def no_limit(doc) do
     doc_limit(doc, :infinity)
   end

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -589,7 +589,7 @@ defmodule Inspect.Algebra do
   end
 
   @doc ~S"""
-  Prevents breaks inside the document.
+  Disable any rendering limit while rendering the given document.
 
   ## Examples
 

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -588,7 +588,21 @@ defmodule Inspect.Algebra do
     doc_cons(doc1, doc2)
   end
 
-  @doc false
+  @doc ~S"""
+  Prevents breaks inside the document.
+
+  ## Examples
+
+      iex> doc = Inspect.Algebra.glue("hello", "world") |> Inspect.Algebra.group()
+      iex> Inspect.Algebra.format(doc, 10)
+      ["hello", "\n", "world"]
+      iex> doc = Inspect.Algebra.no_limit(doc)
+      iex> Inspect.Algebra.format(doc, 10)
+      ["hello", " ", "world"]
+
+  """
+  @doc since: "1.14.0"
+  @spec no_limit(t) :: t
   def no_limit(doc) do
     doc_limit(doc, :infinity)
   end


### PR DESCRIPTION
I noticed this function was public without a doc, should we document it or hide it?

It was added in the context of a [formatter bug fix](https://github.com/elixir-lang/elixir/commit/4212fbf36e65b062430877cdadee5c1f33e10ae0#diff-c39f084ee74a44527298ef9e4b035e263913b9f07dc9940823bb1b8504fad600R585), so probably the latter?