### PR TITLE
Fetch tags before building docs

### DIFF
--- a/.github/workflows/release_pre_built/action.yml
+++ b/.github/workflows/release_pre_built/action.yml
@@ -64,6 +64,7 @@ runs:
       if: ${{ inputs.build_docs }}
       shell: bash
       run: |
+        git fetch --tags
         make Docs.zip
         shasum -a 1 Docs.zip > Docs.zip.sha1sum
         shasum -a 256 Docs.zip > Docs.zip.sha256sum


### PR DESCRIPTION
This is regression by https://github.com/elixir-lang/elixir/pull/13845. Docs artifact needs to fetch the tags before start building it to make version selection works.

Fixes #13892