### PR TITLE
Support `:group` option in ExUnit

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -299,7 +299,7 @@ defmodule ExUnit.Case do
 
   @type env :: module() | Macro.Env.t()
   @compile {:no_warn_undefined, [IEx.Pry]}
-  @reserved [:module, :file, :line, :test, :async, :group, :registered, :describe]
+  @reserved [:module, :file, :line, :test, :async, :registered, :describe]
 
   @doc false
   defmacro __using__(opts) do

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -562,10 +562,6 @@ defmodule ExUnit.Case do
     async_partition_key = Keyword.get(opts, :async_partition_key, nil)
     parameterize = Keyword.get(opts, :parameterize, nil)
 
-    if async_partition_key != nil and async? == false do
-      raise ArgumentError, ":async_partition_key is only a valid option when async: true"
-    end
-
     if not (parameterize == nil or (is_list(parameterize) and Enum.all?(parameterize, &is_map/1))) do
       raise ArgumentError, ":parameterize must be a list of maps, got: #{inspect(parameterize)}"
     end

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -12,11 +12,9 @@ defmodule ExUnit.Case do
       It should be enabled only if tests do not change any global state.
       Defaults to `false`.
 
-    * `:async_partition_key` - configures async tests in this module to run
-      within an async partition denoted by the provided key. Tests in the same
-      async partition never run concurrently. Tests from different partitions
-      can run concurrently. This option is only valid when the :async option
-      is set to true.
+    * `:group` - configures async tests in this module to run within a group.
+      Tests in the same group never run concurrently. Tests from different
+      groups can run concurrently with `async: true`.
       Defaults to `nil`.
 
     * `:register` - when `false`, does not register this module within
@@ -301,7 +299,7 @@ defmodule ExUnit.Case do
 
   @type env :: module() | Macro.Env.t()
   @compile {:no_warn_undefined, [IEx.Pry]}
-  @reserved [:module, :file, :line, :test, :async, :async_partition_key, :registered, :describe]
+  @reserved [:module, :file, :line, :test, :async, :group, :registered, :describe]
 
   @doc false
   defmacro __using__(opts) do
@@ -324,7 +322,7 @@ defmodule ExUnit.Case do
     end
 
     {register?, opts} = Keyword.pop(opts, :register, true)
-    {next_opts, opts} = Keyword.split(opts, [:async, :async_partition_key, :parameterize])
+    {next_opts, opts} = Keyword.split(opts, [:async, :group, :parameterize])
 
     if opts != [] do
       IO.warn("unknown options given to ExUnit.Case: #{inspect(opts)}")
@@ -559,7 +557,7 @@ defmodule ExUnit.Case do
 
     opts = Module.get_attribute(module, :ex_unit_module, [])
     async? = Keyword.get(opts, :async, false)
-    async_partition_key = Keyword.get(opts, :async_partition_key, nil)
+    group = Keyword.get(opts, :group, nil)
     parameterize = Keyword.get(opts, :parameterize, nil)
 
     if not (parameterize == nil or (is_list(parameterize) and Enum.all?(parameterize, &is_map/1))) do
@@ -579,7 +577,7 @@ defmodule ExUnit.Case do
       def __ex_unit__(:config) do
         %{
           async?: unquote(async?),
-          async_partition_key: unquote(Macro.escape(async_partition_key)),
+          group: unquote(Macro.escape(group)),
           parameterize: unquote(Macro.escape(parameterize))
         }
       end

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -583,7 +583,7 @@ defmodule ExUnit.Case do
       def __ex_unit__(:config) do
         %{
           async?: unquote(async?),
-          async_partition_key: unquote(async_partition_key),
+          async_partition_key: unquote(Macro.escape(async_partition_key)),
           parameterize: unquote(Macro.escape(parameterize))
         }
       end

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -12,10 +12,10 @@ defmodule ExUnit.Case do
       It should be enabled only if tests do not change any global state.
       Defaults to `false`.
 
-    * `:group` - configures async tests in this module to run within a group.
+    * `:group` - configures the group this module belongs to.
       Tests in the same group never run concurrently. Tests from different
-      groups can run concurrently with `async: true`.
-      Defaults to `nil`.
+      groups (or with no groups) can run concurrently when `async: true`
+      is given. By default, belongs to no group (defaults to `nil`).
 
     * `:register` - when `false`, does not register this module within
       ExUnit server. This means the module won't run when ExUnit suite runs.

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -12,6 +12,13 @@ defmodule ExUnit.Case do
       It should be enabled only if tests do not change any global state.
       Defaults to `false`.
 
+    * `:async_partition_key` - configures async tests in this module to run
+      within an async partition denoted by the provided key. Tests in the same
+      async partition never run concurrently. Tests from different partitions
+      can run concurrently. This option is only valid when the :async option
+      is set to true.
+      Defaults to `nil`.
+
     * `:register` - when `false`, does not register this module within
       ExUnit server. This means the module won't run when ExUnit suite runs.
 

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -164,7 +164,7 @@ defmodule ExUnit.Runner do
   defp spawn_modules(
          config,
          [{_group, group_modules} | modules],
-         true = async?,
+         async?,
          running
        ) do
     if max_failures_reached?(config) do
@@ -177,15 +177,6 @@ defmodule ExUnit.Runner do
           end)
         end)
 
-      spawn_modules(config, modules, async?, Map.put(running, ref, pid))
-    end
-  end
-
-  defp spawn_modules(config, [{_group, [{module, params}]} | modules], async?, running) do
-    if max_failures_reached?(config) do
-      running
-    else
-      {pid, ref} = spawn_monitor(fn -> run_module(config, module, async?, params) end)
       spawn_modules(config, modules, async?, Map.put(running, ref, pid))
     end
   end

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -106,9 +106,9 @@ defmodule ExUnit.Runner do
         async_loop(config, running, async_once?, modules_to_restore)
 
       # Slots are available, start with async modules
-      async_modules = ExUnit.Server.take_async_modules(available) ->
-        running = spawn_modules(config, async_modules, true, running)
-        modules_to_restore = maybe_store_modules(modules_to_restore, :async, async_modules)
+      async_partitions = ExUnit.Server.take_async_partitions(available) ->
+        running = spawn_modules(config, async_partitions, true, running)
+        modules_to_restore = maybe_store_modules(modules_to_restore, :async, async_partitions)
         async_loop(config, running, true, modules_to_restore)
 
       true ->
@@ -159,6 +159,27 @@ defmodule ExUnit.Runner do
 
   defp spawn_modules(_config, [], _async, running) do
     running
+  end
+
+  defp spawn_modules(
+         config,
+         [{_partition_key, partition_modules} | modules],
+         true = async?,
+         running
+       )
+       when is_list(partition_modules) do
+    if max_failures_reached?(config) do
+      running
+    else
+      {pid, ref} =
+        spawn_monitor(fn ->
+          Enum.each(partition_modules, fn {module, params} ->
+            run_module(config, module, async?, params)
+          end)
+        end)
+
+      spawn_modules(config, modules, async?, Map.put(running, ref, pid))
+    end
   end
 
   defp spawn_modules(config, [{module, params} | modules], async?, running) do

--- a/lib/ex_unit/lib/ex_unit/server.ex
+++ b/lib/ex_unit/lib/ex_unit/server.ex
@@ -108,20 +108,18 @@ defmodule ExUnit.Server do
       when is_integer(loaded) do
     state =
       if uniq? do
-        async_modules =
-          state.async_modules
-          |> :queue.to_list()
-          |> Enum.uniq()
-          |> Enum.map(fn {group, modules} ->
+        async_groups =
+          Map.new(state.async_groups, fn {group, modules} ->
             {group, Enum.uniq(modules)}
           end)
-          |> :queue.from_list()
 
+        async_modules = :queue.to_list(state.async_modules) |> Enum.uniq() |> :queue.from_list()
         sync_modules = :queue.to_list(state.sync_modules) |> Enum.uniq() |> :queue.from_list()
 
         %{
           state
-          | async_modules: async_modules,
+          | async_groups: async_groups,
+            async_modules: async_modules,
             sync_modules: sync_modules
         }
       else

--- a/lib/ex_unit/lib/ex_unit/server.ex
+++ b/lib/ex_unit/lib/ex_unit/server.ex
@@ -12,7 +12,7 @@ defmodule ExUnit.Server do
   def add_module(name, config) do
     %{
       async?: async?,
-      async_partition_key: async_partition_key,
+      group: group,
       parameterize: parameterize
     } = config
 
@@ -23,7 +23,7 @@ defmodule ExUnit.Server do
         [{name, %{}}]
       end
 
-    case GenServer.call(@name, {:add, {async?, async_partition_key}, modules}, @timeout) do
+    case GenServer.call(@name, {:add, {async?, group}, modules}, @timeout) do
       :ok ->
         :ok
 

--- a/lib/ex_unit/lib/ex_unit/server.ex
+++ b/lib/ex_unit/lib/ex_unit/server.ex
@@ -152,13 +152,13 @@ defmodule ExUnit.Server do
   def handle_call({:add, {true = _async, group}, names}, _from, %{loaded: loaded} = state)
       when is_integer(loaded) do
     state =
-    case state.async_groups do
-      %{^group => entries} ->
-        {%{async_groups | group => names ++ entries}, state.async_modules}
-      %{} ->
-        {Map.put(async_groups, group, names),
-         :queue.in({:group, group}, state.async_modules)}
-    end
+      case state.async_groups do
+        %{^group => entries} = async_groups ->
+          {%{async_groups | group => names ++ entries}, state.async_modules}
+
+        %{} = async_groups ->
+          {Map.put(async_groups, group, names), :queue.in({:group, group}, state.async_modules)}
+      end
 
     {:reply, :ok, state}
   end

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -715,6 +715,123 @@ defmodule ExUnitTest do
     assert_receive {:tmp_dir, tmp_dir2} when tmp_dir1 != tmp_dir2
   end
 
+  test "async tests run concurrently" do
+    Process.register(self(), :async_tests)
+
+    defmodule FirstAsyncTest do
+      use ExUnit.Case, async: true
+
+      test "first test" do
+        send(:async_tests, {:first_test, :started})
+        Process.sleep(10)
+        assert true
+        send(:async_tests, {:first_test, :finished})
+      end
+    end
+
+    defmodule SecondAsyncTest do
+      use ExUnit.Case, async: true
+
+      test "second test" do
+        send(:async_tests, {:second_test, :started})
+        Process.sleep(15)
+        assert true
+        send(:async_tests, {:second_test, :finished})
+      end
+    end
+
+    configure_and_reload_on_exit(max_cases: 2)
+
+    test_task =
+      Task.async(fn ->
+        capture_io(fn -> ExUnit.run() end)
+      end)
+
+    # Expected test distribution through time
+    #
+    # Time (ms): 0    10    20
+    #            |-----|-----|
+    # CPU0:      (  1  )
+    # CPU1:      (   2    )
+    assert_receive({:first_test, :started}, 5)
+    assert_receive({:second_test, :started}, 5)
+
+    # make sure we don't leave the task running after the outer test finishes
+    Task.await(test_task)
+  end
+
+  test "async tests run concurrently respecting partition keys" do
+    Process.register(self(), :async_partitioned_tests)
+
+    defmodule RedOneTest do
+      use ExUnit.Case, async: true, async_partition_key: :red
+
+      test "red one test" do
+        send(:async_partitioned_tests, {:red_one, :started})
+        Process.sleep(30)
+        assert true
+        send(:async_partitioned_tests, {:red_one, :finished})
+      end
+    end
+
+    defmodule RedTwoTest do
+      use ExUnit.Case, async: true, async_partition_key: :red
+
+      test "red two test" do
+        send(:async_partitioned_tests, {:red_two, :started})
+        Process.sleep(10)
+        assert true
+        send(:async_partitioned_tests, {:red_two, :finished})
+      end
+    end
+
+    defmodule BlueOneTest do
+      use ExUnit.Case, async: true, async_partition_key: :blue
+
+      test "blue one test" do
+        send(:async_partitioned_tests, {:blue_one, :started})
+        Process.sleep(10)
+        assert true
+        send(:async_partitioned_tests, {:blue_one, :finished})
+      end
+    end
+
+    defmodule BlueTwoTest do
+      use ExUnit.Case, async: true, async_partition_key: :blue
+
+      test "blue two test" do
+        send(:async_partitioned_tests, {:blue_two, :started})
+        Process.sleep(10)
+        assert true
+        send(:async_partitioned_tests, {:blue_two, :finished})
+      end
+    end
+
+    configure_and_reload_on_exit(max_cases: 4)
+
+    test_task =
+      Task.async(fn ->
+        capture_io(fn -> ExUnit.run() end)
+      end)
+
+    # Expected test distribution through time
+    #
+    # Time (ms): 0    10    20    30    40
+    #            |-----|-----|-----|-----|
+    # CPU0:      (      R1         )( R2 )
+    # CPU1:      ( B1 )( B2 )
+    assert_receive({:red_one, :started}, 5)
+    assert_receive({:blue_one, :started}, 5)
+    refute_receive({:red_two, :started}, 25)
+    assert_received({:blue_one, :finished})
+    assert_received({:blue_two, :started})
+    assert_receive({:blue_two, :finished}, 15)
+    assert_receive({:red_two, :started}, 15)
+
+    # make sure we don't leave the task running after the outer test finishes
+    Task.await(test_task)
+  end
+
   describe "after_suite/1" do
     test "executes all callbacks set in reverse order" do
       Process.register(self(), :after_suite_test_process)

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -760,50 +760,50 @@ defmodule ExUnitTest do
     Task.await(test_task)
   end
 
-  test "async tests run concurrently respecting partition keys" do
-    Process.register(self(), :async_partitioned_tests)
+  test "async tests run concurrently respecting groups" do
+    Process.register(self(), :async_grouped_tests)
 
     defmodule RedOneTest do
-      use ExUnit.Case, async: true, async_partition_key: :red
+      use ExUnit.Case, async: true, group: :red
 
       test "red one test" do
-        send(:async_partitioned_tests, {:red_one, :started})
+        send(:async_grouped_tests, {:red_one, :started})
         Process.sleep(30)
         assert true
-        send(:async_partitioned_tests, {:red_one, :finished})
+        send(:async_grouped_tests, {:red_one, :finished})
       end
     end
 
     defmodule RedTwoTest do
-      use ExUnit.Case, async: true, async_partition_key: :red
+      use ExUnit.Case, async: true, group: :red
 
       test "red two test" do
-        send(:async_partitioned_tests, {:red_two, :started})
+        send(:async_grouped_tests, {:red_two, :started})
         Process.sleep(10)
         assert true
-        send(:async_partitioned_tests, {:red_two, :finished})
+        send(:async_grouped_tests, {:red_two, :finished})
       end
     end
 
     defmodule BlueOneTest do
-      use ExUnit.Case, async: true, async_partition_key: :blue
+      use ExUnit.Case, async: true, group: :blue
 
       test "blue one test" do
-        send(:async_partitioned_tests, {:blue_one, :started})
+        send(:async_grouped_tests, {:blue_one, :started})
         Process.sleep(10)
         assert true
-        send(:async_partitioned_tests, {:blue_one, :finished})
+        send(:async_grouped_tests, {:blue_one, :finished})
       end
     end
 
     defmodule BlueTwoTest do
-      use ExUnit.Case, async: true, async_partition_key: :blue
+      use ExUnit.Case, async: true, group: :blue
 
       test "blue two test" do
-        send(:async_partitioned_tests, {:blue_two, :started})
+        send(:async_grouped_tests, {:blue_two, :started})
         Process.sleep(10)
         assert true
-        send(:async_partitioned_tests, {:blue_two, :finished})
+        send(:async_grouped_tests, {:blue_two, :finished})
       end
     end
 
@@ -1218,9 +1218,9 @@ defmodule ExUnitTest do
     assert third =~ "ThirdTestFIFO"
   end
 
-  test "async test partitions are run in compile order (FIFO)" do
+  test "async test groups are run in compile order (FIFO)" do
     defmodule RedOneFIFO do
-      use ExUnit.Case, async: true, async_partition_key: :red
+      use ExUnit.Case, async: true, group: :red
 
       test "red one test" do
         assert true
@@ -1228,7 +1228,7 @@ defmodule ExUnitTest do
     end
 
     defmodule BlueOneFIFO do
-      use ExUnit.Case, async: true, async_partition_key: :blue
+      use ExUnit.Case, async: true, group: :blue
 
       test "blue one test" do
         assert true
@@ -1236,7 +1236,7 @@ defmodule ExUnitTest do
     end
 
     defmodule RedTwoFIFO do
-      use ExUnit.Case, async: true, async_partition_key: :red
+      use ExUnit.Case, async: true, group: :red
 
       test "red two test" do
         assert true
@@ -1244,7 +1244,7 @@ defmodule ExUnitTest do
     end
 
     defmodule BlueTwoFIFO do
-      use ExUnit.Case, async: true, async_partition_key: :blue
+      use ExUnit.Case, async: true, group: :blue
 
       test "blue two test" do
         assert true


### PR DESCRIPTION
This is a proposal to add a new `ExUnit.Case` option to support more use cases for running tests concurrently.

## Motivation

This addresses situations like the following example.

Imagine you have several test modules that depend on resources which can't be used concurrently.

These test modules depend on `MockServiceA`:
- `ServiceA.Module1Test`
- `ServiceA.Module2Test`

And these test modules depend on `MockServiceB`:
- `ServiceB.Module1Test`
- `ServiceB.Module2Test`

Because access to the two mock services needs to be serialized, we can't use the `:async` option and that means all tests are executed sequentially even though tests that only depend on one of the services can run concurrently with other tests that don't depend on it.

```
CPU0: ServiceA.Module1Test -> ServiceA.Module2Test -> ServiceB.Module1Test -> ServiceB.Module2Test
CPU1: -
```

The goal of this work is to make it possible to run tests concurrently like so:

```
CPU0: ServiceA.Module1Test -> ServiceA.Module2Test
CPU1: ServiceB.Module1Test -> ServiceB.Module2Test
```

As the number of services and tests grows, the opportunity to decrease the time it takes to run the test suite grows dramatically.

## Interface

<s>
The proposed code uses the name `:async_partition_key` for the option because the concepts of partitioning  and partition keys should be familiar to a lot of people already and seems to fit well for this functionality.
</s>


We agreed on the name `group` to avoid confusion with test-suite partitioning.

Here's the example from above:

```elixir
defmodule ServiceA.Module1Test do
  use ExUnit.Case, async: true, group: :service_a
end

defmodule ServiceA.Module2Test do
  use ExUnit.Case, async: true, group: :service_a
end

defmodule ServiceB.Module1Test do
  use ExUnit.Case, async: true, group: :service_b
end

defmodule ServiceB.Module2Test do
  use ExUnit.Case, async: true, group: :service_b
end
```

That being said, I'm open to other suggestions on the interface and naming.

## Implementation details

I tried to keep the properties of the existing code (e.g. using :queue to make the test runs deterministic when run in compilation order).

For parameterized tests, if you specify a `group`, all the parameters run in the same group. If you don't specify it, then they run concurrently as the docs already state.

I also added tests for this functionality, though I'm not sure if there is a better way to test it.