### PR TITLE
Use Float.{to_string/1, to_charlist/1} when possible

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -387,7 +387,7 @@ defimpl Inspect, for: Float do
       if abs >= 1.0 and abs < 1.0e16 and trunc(float) == float do
         [Integer.to_string(trunc(float)), ?., ?0]
       else
-        :erlang.float_to_list(float, [:short])
+        Float.to_charlist(float)
       end
 
     color(IO.iodata_to_binary(formatted), :number, opts)

--- a/lib/elixir/lib/list/chars.ex
+++ b/lib/elixir/lib/list/chars.ex
@@ -58,6 +58,6 @@ end
 
 defimpl List.Chars, for: Float do
   def to_charlist(term) do
-    :erlang.float_to_list(term, [:short])
+    Float.to_charlist(term)
   end
 end

--- a/lib/elixir/lib/string/chars.ex
+++ b/lib/elixir/lib/string/chars.ex
@@ -57,6 +57,6 @@ end
 
 defimpl String.Chars, for: Float do
   def to_string(term) do
-    :erlang.float_to_binary(term, [:short])
+    Float.to_string(term)
   end
 end


### PR DESCRIPTION
This is a suggestion to use the `Float.to_string/1` and `Float.to_charlist/1` functions in the `String.Chars` and `List.Chars` protocols. Furthermore, it also changes `Inspect` to use `Float.to_charlist/1`. The reasoning behind is consistency, so the functions match the others in the protocols.

This PR, updates the functions in the same places as updated in https://github.com/elixir-lang/elixir/pull/13046 except for in Float itself.

The changes all refer to these lines in Float:
https://github.com/elixir-lang/elixir/blob/ed75e6066cafe9feca5ca9d6894361a9745c1f95/lib/elixir/lib/float.ex#L602
https://github.com/elixir-lang/elixir/blob/ed75e6066cafe9feca5ca9d6894361a9745c1f95/lib/elixir/lib/float.ex#L631