### PR TITLE
Fix warning when dbg with/1 with catch-all clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ TODO.
   * [Kernel] Now verify the type of the binary generators
   * [Kernel] Track the type of tuples in patterns and inside `elem/2`
   * [List] Add `List.ends_with?/2`
-  * [Macro] Improve `dbg` handling of `if/2` and of code blocks
+  * [Macro] Improve `dbg` handling of `if/2`, `with/1` and of code blocks
   * [Process] Handle arbitrarily high integer values in `Process.sleep/1`
   * [String] Inspect special whitespace and zero-width characters using their Unicode representation
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2731,7 +2731,7 @@ defmodule Macro do
             end)
 
           error_clause =
-            quote do
+            quote generated: true do
               {other, _acc} -> raise WithClauseError, term: other
             end
 


### PR DESCRIPTION
Fixes the following:
<img width="687" alt="Screenshot 2024-10-14 at 10 03 53" src="https://github.com/user-attachments/assets/cca35f44-4d9d-4bd4-a68f-22329bf30811">
