### PR TITLE
Notify modules diff from compile.erlang

### DIFF
--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -332,11 +332,17 @@ defmodule Mix.Compilers.Erlang do
 
   defp modules_diff(added, changed, removed, timestamp) do
     %{
-      added: Enum.map(added, &module_from_path/1),
-      changed: Enum.map(changed, &module_from_path/1),
-      removed: Enum.map(removed, &module_from_path/1),
+      added: modules_from_paths(added),
+      changed: modules_from_paths(changed),
+      removed: modules_from_paths(removed),
       timestamp: timestamp
     }
+  end
+
+  defp modules_from_paths(paths) do
+    for path <- paths, String.ends_with?(path, ".beam") do
+      module_from_path(path)
+    end
   end
 
   defp module_from_path(path) do

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -127,22 +127,15 @@ defmodule Mix.Tasks.Compile.Elixir do
 
     with_logger_app(project, fn ->
       Mix.Project.with_build_lock(project, fn ->
-        {status, warnings, lazy_modules_diff} =
-          Mix.Compilers.Elixir.compile(
-            manifest,
-            srcs,
-            dest,
-            cache_key,
-            Mix.Tasks.Compile.Erlang.manifests(),
-            Mix.Tasks.Compile.Erlang.modules(),
-            opts
-          )
-
-        if lazy_modules_diff do
-          Mix.Task.Compiler.notify_modules_compiled(lazy_modules_diff)
-        end
-
-        {status, warnings}
+        Mix.Compilers.Elixir.compile(
+          manifest,
+          srcs,
+          dest,
+          cache_key,
+          Mix.Tasks.Compile.Erlang.manifests(),
+          Mix.Tasks.Compile.Erlang.modules(),
+          opts
+        )
       end)
     end)
   end

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -84,7 +84,7 @@ defmodule Mix.Tasks.Compile.Erlang do
 
     opts = [parallel: MapSet.new(find_parallel(erls))] ++ opts
 
-    Erlang.compile(manifest(), tuples, opts, fn input, _output ->
+    Erlang.compile_entries(manifest(), tuples, :erl, :beam, opts, fn input, _output ->
       # We're purging the module because a previous compiler (for example, Phoenix)
       # might have already loaded the previous version of it.
       module = input |> Path.basename(".erl") |> String.to_atom()

--- a/lib/mix/test/mix/sync/pubsub_test.exs
+++ b/lib/mix/test/mix/sync/pubsub_test.exs
@@ -75,16 +75,16 @@ defmodule Mix.Sync.PubSubTest do
       %{event: "event1"}
     end
 
-    PubSub.broadcast(@pubsub_key, lazy_message)
+    PubSub.broadcast([@pubsub_key, "lazy"], lazy_message)
 
-    PubSub.subscribe(@pubsub_key)
+    PubSub.subscribe([@pubsub_key, "lazy"])
 
     lazy_message = fn ->
       send(self(), :lazy2)
       %{event: "event2"}
     end
 
-    PubSub.broadcast(@pubsub_key, lazy_message)
+    PubSub.broadcast([@pubsub_key, "lazy"], lazy_message)
 
     refute_received :lazy1
     assert_received :lazy2


### PR DESCRIPTION
Follow up to #13896.

One thing to note is that `:compile.file` removes the file and if the compilation fails, there is no .beam file. This means that a module may be notified as changed, but it has no file on the disk. Not sure if we should convert such entries as deleted, or ignore them, or perhaps keep as changed.