### PR TITLE
Notify each dep compilation from deps.compile

### DIFF
--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -55,13 +55,28 @@ defmodule Mix.Task.Compiler do
 
         * `:app` - app which modules have been compiled.
 
-        * `:build_scm` - the SCM module of the compiled project.
+        * `:scm` - the SCM module of the compiled project.
 
         * `:modules_diff` - information about the compiled modules. The
           value is a map with keys: `:added`, `:changed`, `:removed`,
           where each holds a list of modules. There is also a `:timestamp`
           key, which matches the modification time of all the compiled
           module files.
+
+        * `:os_pid` - the operating system PID of the process that run
+          the compilation. The value is a string and it can be compared
+          with `System.pid/0` to determine if compilation happened in
+          the same OS process as the listener.
+
+    * `{:dep_compiled, info}` - delivered after a dependency is compiled.
+      `info` is a map with the following keys:
+
+        * `:app` - the dependency app.
+
+        * `:scm` - the SCM module of the dependency.
+
+        * `:manager` - the dependency project management, possible values:
+          `:rebar3`, `:mix`, `:make`, `nil`.
 
         * `:os_pid` - the operating system PID of the process that run
           the compilation. The value is a string and it can be compared
@@ -222,7 +237,7 @@ defmodule Mix.Task.Compiler do
     lazy_message = fn ->
       info = %{
         app: config[:app],
-        build_scm: config[:build_scm],
+        scm: config[:build_scm],
         modules_diff: lazy_modules_diff.(),
         os_pid: System.pid()
       }

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -106,6 +106,23 @@ defmodule Mix.Tasks.Deps.Compile do
               false
           end
 
+        if compiled? do
+          build_path = Mix.Project.build_path(config)
+
+          lazy_message = fn ->
+            info = %{
+              app: dep.app,
+              scm: dep.scm,
+              manager: dep.manager,
+              os_pid: System.pid()
+            }
+
+            {:dep_compiled, info}
+          end
+
+          Mix.Sync.PubSub.broadcast(build_path, lazy_message)
+        end
+
         # We should touch fetchable dependencies even if they
         # did not compile otherwise they will always be marked
         # as stale, even when there is nothing to do.

--- a/lib/mix/test/fixtures/compile_listeners/deps/reloader/lib/reloader.ex
+++ b/lib/mix/test/fixtures/compile_listeners/deps/reloader/lib/reloader.ex
@@ -15,7 +15,7 @@ defmodule Reloader do
     %{
       modules_diff: %{added: added, changed: changed, removed: removed, timestamp: _timestamp},
       app: app,
-      build_scm: build_scm,
+      scm: scm,
       os_pid: os_pid
     } = info
 
@@ -23,7 +23,26 @@ defmodule Reloader do
     Received :modules_compiled with
       added: #{inspect(Enum.sort(added))}, changed: #{inspect(Enum.sort(changed))}, removed: #{inspect(Enum.sort(removed))}
       app: #{inspect(app)}
-      build_scm: #{inspect(build_scm)}
+      scm: #{inspect(scm)}
+      os_pid: #{inspect(os_pid)}
+    """)
+
+    {:noreply, state}
+  end
+
+  def handle_info({:dep_compiled, info}, state) do
+    %{
+      app: app,
+      scm: scm,
+      manager: manager,
+      os_pid: os_pid
+    } = info
+
+    IO.write("""
+    Received :dep_compiled with
+      app: #{inspect(app)}
+      scm: #{inspect(scm)}
+      manager: #{inspect(manager)}
       os_pid: #{inspect(os_pid)}
     """)
 


### PR DESCRIPTION
Sends `{:dep_compiled, info}` after every dependency compiled with `deps.compile`. This can be used to detect when rebar/make dependencies are recompiled (in which case the listener may want to purge all modules from that dependency).