### PR TITLE
:prune_metadata keeps delimiters

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -776,23 +776,23 @@ defmodule Macro do
 
   ## Options
 
-    * `:unquote` - when true, this function leaves `unquote/1` and
+    * `:unquote` - when `true`, this function leaves `unquote/1` and
       `unquote_splicing/1` expressions unescaped, effectively unquoting
       the contents on escape. This option is useful only when escaping
-      ASTs which may have quoted fragments in them. Defaults to false.
+      ASTs which may have quoted fragments in them. Defaults to `false`.
 
-    * `:prune_metadata` - when true, removes metadata from escaped AST
+    * `:prune_metadata` - when `true`, removes most metadata from escaped AST
       nodes. Note this option changes the semantics of escaped code and
-      it should only be used when escaping ASTs. Defaults to false.
+      it should only be used when escaping ASTs. Defaults to `false`.
 
-      As an example, `ExUnit` stores the AST of every assertion, so when
-      an assertion fails we can show code snippets to users. Without this
-      option, each time the test module is compiled, we get a different
-      MD5 of the module bytecode, because the AST contains metadata,
+      As an example for `:prune_metadata`, `ExUnit` stores the AST of every
+      assertion, so when an assertion fails we can show code snippets to users.
+      Without this option, each time the test module is compiled, we would get a
+      different MD5 of the module bytecode, because the AST contains metadata,
       such as counters, specific to the compilation environment. By pruning
       the metadata, we ensure that the module is deterministic and reduce
       the amount of data `ExUnit` needs to keep around. Only the minimal
-      amount of metadata is kept, such as `:line` and `:no_parens`.
+      amount of metadata is kept, such as `:line`, `:no_parens` and `:delimiter`.
 
   ## Comparison to `quote/2`
 

--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -140,7 +140,7 @@ escape(Expr, Op, Unquote) ->
   }).
 
 do_escape({Left, Meta, Right}, #elixir_quote{op=prune_metadata} = Q) when is_list(Meta) ->
-  TM = [{K, V} || {K, V} <- Meta, (K == no_parens) orelse (K == line)],
+  TM = [{K, V} || {K, V} <- Meta, (K == no_parens) orelse (K == line) orelse (K == delimiter)],
   TL = do_quote(Left, Q),
   TR = do_quote(Right, Q),
   {'{}', [], [TL, TM, TR]};

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -983,7 +983,7 @@ defmodule ExUnit.DocTestTest do
              8) doctest module ExUnit.DocTestTest.PatternMatching (8) (ExUnit.DocTestTest.PatternMatchingRunner)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 match (=) failed
-                code:  %{year: 2001, day: 1} = ~D"2000-01-01"
+                code:  %{year: 2001, day: 1} = ~D[2000-01-01]
                 left:  %{year: 2001, day: 1}
                 right: ~D[2000-01-01]
                 stacktrace:


### PR DESCRIPTION
As discussed [here](https://github.com/elixir-lang/elixir/pull/13905#issuecomment-2418081776).