### PR TITLE
Add tuple type operators for insertion and deletion

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -1369,61 +1369,6 @@ defmodule Module.Types.Descr do
     end
   end
 
-  # defp tuple_values(dnf) do
-  #   Enum.reduce(dnf, none(), fn {tag, elements, negs}, acc ->
-  #     union(tuple_values(tag, elements, negs, []), acc)
-  #   end)
-  # end
-
-  # defp tuple_values(:open, _, [], _), do: term()
-  # defp tuple_values(:closed, elements, [], acc) do
-  #   Enum.reduce(elements, none(), &union/2)
-  #   |> union(Enum.reduce(acc, none(), fn {
-  # end
-
-  # defp tuple_values(
-
-  # defp tuple_values(tag, elements, negs, acc) do
-  # end
-
-  # # Transforms a tuple dnf into a union of tuple literals.
-  # defp tuple_normalize(dnf) do
-  #   Enum.flat_map(dnf, fn {tag, elements, negs} -> tuple_normalize([{tag, elements}], negs) end)
-  # end
-
-  # defp tuple_normalize(acc, [], acc), do: acc
-
-  # defp tuple_normalize(acc, [{neg_tag, neg_elements} | negs]) do
-  # end
-
-  # defp expand_negation(tag, elements, neg_tag, neg_elements) do
-  #   n = length(elements)
-  #   m = length(neg_elements)
-
-  #   # Scenarios where the difference is guaranteed to be empty:
-  #   # 1. When removing larger tuples from a fixed-size positive tuple
-  #   # 2. When removing smaller tuples from larger tuples
-  #   if (tag == :closed and n < m) or (neg_tag == :closed and n > m) do
-  #     []
-  #   else
-  #     expand_elements(acc, tag, elements, neg_tag, neg_elements) ++
-  #       expand_compatibility(n, m, tag, elements, neg_tag, neg_elements)
-  #   end
-  # end
-
-  # Expand the negation of a tuple, considering the terms where one element
-  # in the positive tuple is not in the negative tuple.
-  # defp expand_elements(acc, tag, elements, neg_tag, [neg_type | neg_elements]) do
-  #   {ty, elements} = List.pop_at(elements, 0, term())
-  #   diff = difference(ty, neg_type)
-
-  #   if empty?(diff) do
-  #     expand_elements([ty acc, tag, elements, neg_tag, neg_elements)
-  #   else
-  #     expand_elements([ty | acc], tag, elements, neg_tag, neg_elements)
-  #   end
-  # end
-
   # Check if a tuple represented in DNF is empty
   defp tuple_empty?(dnf) do
     Enum.all?(dnf, fn {tag, pos, negs} -> tuple_empty?(tag, pos, negs) end)

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -1571,15 +1571,15 @@ defmodule Module.Types.Descr do
 
         cond do
           is_proper_tuple? and is_proper_size? ->
+            static_result = tuple_delete_static(static, index)
             # Prune for dynamic values make the intersection succeed
             dynamic_result =
               intersection(dynamic, tuple_of_size_at_least(index))
               |> tuple_delete_static(index)
 
-            static_result = tuple_delete_static(static, index)
-
             union(dynamic(dynamic_result), static_result)
 
+          # Highlight the case where the issue is an index out of range from the tuple
           is_proper_tuple? ->
             :badrange
 
@@ -1625,15 +1625,15 @@ defmodule Module.Types.Descr do
 
         cond do
           is_proper_tuple? and is_proper_size? ->
+            static_result = insert_element(static, index, type)
             # Prune for dynamic values that make the intersection succeed
             dynamic_result =
               intersection(dynamic, tuple_of_size_at_least(index))
               |> insert_element(index, type)
 
-            static_result = insert_element(static, index, type)
-
             union(dynamic(dynamic_result), static_result)
 
+          # Highlight the case where the issue is an index out of range from the tuple
           is_proper_tuple? ->
             :badrange
 

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -496,13 +496,13 @@ defmodule Module.Types.DescrTest do
                union(tuple([integer()]), tuple([float()]))
 
       # Test deleting with an out-of-bounds index
-      assert tuple_delete_at(tuple([integer(), atom()]), 3) == :outofrange
+      assert tuple_delete_at(tuple([integer(), atom()]), 3) == :badrange
 
       # Test deleting with a negative index
       assert tuple_delete_at(tuple([integer(), atom()]), -1) == :badindex
 
       # Test deleting from an empty tuple
-      assert tuple_delete_at(empty_tuple(), 0) == :outofrange
+      assert tuple_delete_at(empty_tuple(), 0) == :badrange
 
       # Test deleting from a non-tuple type
       assert tuple_delete_at(integer(), 0) == :badtuple
@@ -558,11 +558,11 @@ defmodule Module.Types.DescrTest do
                union(tuple([boolean(), integer()]), tuple([boolean(), atom()]))
 
       # Test inserting with an out-of-bounds index
-      assert tuple_insert_at(tuple([integer(), atom()]), 3, boolean()) == :outofrange
+      assert tuple_insert_at(tuple([integer(), atom()]), 3, boolean()) == :badrange
 
       # Out-of-bounds in a union
       assert union(tuple([integer(), atom()]), tuple([float()]))
-             |> tuple_insert_at(2, boolean()) == :outofrange
+             |> tuple_insert_at(2, boolean()) == :badrange
 
       # Inserting with a negative index
       assert tuple_insert_at(tuple([integer(), atom()]), -1, boolean()) == :badindex
@@ -592,45 +592,6 @@ defmodule Module.Types.DescrTest do
                  dynamic(tuple([float(), boolean(), binary()]))
                )
              )
-    end
-
-    test "tuple_values" do
-      # Test with a closed tuple
-      assert tuple_values(tuple([integer(), atom(), boolean()])) ==
-               union(integer(), union(atom(), boolean()))
-
-      # Test with an empty tuple
-      assert tuple_values(empty_tuple()) == none()
-
-      # Test with a dynamic tuple
-      assert tuple_values(dynamic(tuple([integer(), atom()]))) ==
-               dynamic(union(integer(), atom()))
-
-      # Test with an open tuple
-      assert tuple_values(open_tuple([integer(), atom()])) == term()
-
-      # Test with a union of tuples
-      assert tuple_values(union(tuple([integer(), atom()]), tuple([float(), binary()]))) ==
-               union(integer(), union(float(), union(atom(), binary())))
-
-      # Test with an intersection of tuples
-      assert tuple_values(intersection(tuple([term(), atom()]), tuple([integer(), term()]))) ==
-               union(integer(), atom())
-
-      # Test with a difference of tuples
-      assert tuple_values(
-               difference(tuple([integer(), atom(), boolean()]), tuple([term(), term()]))
-             ) == union(integer(), union(atom(), boolean()))
-
-      # Test with a complex union involving dynamic
-      assert tuple_values(union(tuple([integer(), atom()]), dynamic(tuple([float(), binary()]))))
-             |> equal?(union(union(integer(), atom()), dynamic(union(float(), binary()))))
-
-      # Test with a non-tuple type
-      assert tuple_values(integer()) == :badtuple
-
-      # Test with term()
-      assert tuple_values(term()) == :badtuple
     end
 
     test "map_fetch" do

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -475,6 +475,12 @@ defmodule Module.Types.DescrTest do
     end
 
     test "tuple_delete_at" do
+      assert tuple_delete_at(tuple([integer(), atom()]), 3) == :badrange
+      assert tuple_delete_at(tuple([integer(), atom()]), -1) == :badindex
+      assert tuple_delete_at(empty_tuple(), 0) == :badrange
+      assert tuple_delete_at(integer(), 0) == :badtuple
+      assert tuple_delete_at(term(), 0) == :badtuple
+
       # Test deleting an element from a closed tuple
       assert tuple_delete_at(tuple([integer(), atom(), boolean()]), 1) ==
                tuple([integer(), boolean()])
@@ -495,21 +501,6 @@ defmodule Module.Types.DescrTest do
       assert tuple_delete_at(union(tuple([integer(), atom()]), tuple([float(), binary()])), 1) ==
                union(tuple([integer()]), tuple([float()]))
 
-      # Test deleting with an out-of-bounds index
-      assert tuple_delete_at(tuple([integer(), atom()]), 3) == :badrange
-
-      # Test deleting with a negative index
-      assert tuple_delete_at(tuple([integer(), atom()]), -1) == :badindex
-
-      # Test deleting from an empty tuple
-      assert tuple_delete_at(empty_tuple(), 0) == :badrange
-
-      # Test deleting from a non-tuple type
-      assert tuple_delete_at(integer(), 0) == :badtuple
-
-      # Test deleting from a term()
-      assert tuple_delete_at(term(), 0) == :badtuple
-
       # Test deleting from an intersection of tuples
       assert intersection(tuple([integer(), atom()]), tuple([term(), boolean()]))
              |> tuple_delete_at(1) == tuple([integer()])
@@ -524,8 +515,6 @@ defmodule Module.Types.DescrTest do
              |> tuple_delete_at(1)
              |> equal?(union(tuple([integer()]), dynamic(tuple([float()]))))
 
-      assert tuple_delete_at(open_tuple([term()]), 0) == tuple()
-
       # Succesfully deleting at position `index` in a tuple means that the dynamic
       # values that succeed are intersected with tuples of size at least `index`
       assert dynamic(tuple()) |> tuple_delete_at(0) == dynamic(tuple())
@@ -536,6 +525,15 @@ defmodule Module.Types.DescrTest do
     end
 
     test "tuple_insert_at" do
+      assert tuple_insert_at(tuple([integer(), atom()]), 3, boolean()) == :badrange
+      assert tuple_insert_at(tuple([integer(), atom()]), -1, boolean()) == :badindex
+      assert tuple_insert_at(integer(), 0, boolean()) == :badtuple
+      assert tuple_insert_at(term(), 0, boolean()) == :badtuple
+
+      # Out-of-bounds in a union
+      assert union(tuple([integer(), atom()]), tuple([float()]))
+             |> tuple_insert_at(2, boolean()) == :badrange
+
       # Test inserting into a closed tuple
       assert tuple_insert_at(tuple([integer(), atom()]), 1, boolean()) ==
                tuple([integer(), boolean(), atom()])
@@ -566,27 +564,6 @@ defmodule Module.Types.DescrTest do
       # Test inserting into a union of tuples
       assert tuple_insert_at(union(tuple([integer()]), tuple([atom()])), 0, boolean()) ==
                union(tuple([boolean(), integer()]), tuple([boolean(), atom()]))
-
-      # Test inserting with an out-of-bounds index
-      assert tuple_insert_at(tuple([integer(), atom()]), 3, boolean()) == :badrange
-
-      # Out-of-bounds in a union
-      assert union(tuple([integer(), atom()]), tuple([float()]))
-             |> tuple_insert_at(2, boolean()) == :badrange
-
-      # Inserting with a negative index
-      assert tuple_insert_at(tuple([integer(), atom()]), -1, boolean()) == :badindex
-
-      # Inserting into a non-tuple type
-      assert tuple_insert_at(integer(), 0, boolean()) == :badtuple
-
-      # Inserting into a term()
-      assert tuple_insert_at(term(), 0, boolean()) == :badtuple
-
-      # Test inserting into an intersection of tuples
-      assert tuple([integer(), atom()])
-             |> tuple_insert_at(1, float())
-             |> equal?(tuple([integer(), float(), atom()]))
 
       # Test inserting into a difference of tuples
       assert difference(tuple([integer(), atom(), boolean()]), tuple([term(), term()]))

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -523,6 +523,16 @@ defmodule Module.Types.DescrTest do
       assert union(tuple([integer(), atom()]), dynamic(tuple([float(), binary()])))
              |> tuple_delete_at(1)
              |> equal?(union(tuple([integer()]), dynamic(tuple([float()]))))
+
+      assert tuple_delete_at(open_tuple([term()]), 0) == tuple()
+
+      # Succesfully deleting at position `index` in a tuple means that the dynamic
+      # values that succeed are intersected with tuples of size at least `index`
+      assert dynamic(tuple()) |> tuple_delete_at(0) == dynamic(tuple())
+
+      assert dynamic(union(tuple(), integer()))
+             |> tuple_delete_at(1)
+             |> equal?(dynamic(tuple_of_size_at_least(1)))
     end
 
     test "tuple_insert_at" do
@@ -592,6 +602,12 @@ defmodule Module.Types.DescrTest do
                  dynamic(tuple([float(), boolean(), binary()]))
                )
              )
+
+      # If you succesfully intersect at position index in a type, then the dynamic values
+      # that succeed are intersected with tuples of size at least index
+      assert dynamic(union(tuple(), integer()))
+             |> tuple_insert_at(1, boolean())
+             |> equal?(dynamic(open_tuple([term(), boolean()])))
     end
 
     test "map_fetch" do


### PR DESCRIPTION
Add type safe operators to perform tuple insertion and deletion at a given integer index.

Deals with dynamic by considering which values make the operation succeed (e.g., inserting at position 2 into a tuple requires tuples of size at least 2)