### PR TITLE
Make Mix.Project.with_build_lock/2 public

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -890,7 +890,7 @@ defmodule Mix.Project do
   This function can also be called if this process already has the
   lock. In such case the function is executed immediately.
 
-  This lock is primarily useful by compiler tasks that alter the build
+  This lock is primarily useful for compiler tasks that alter the build
   artifacts to avoid conflicts with a concurrent compilation.
   """
   @spec with_build_lock(keyword, (-> term())) :: term()

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -882,7 +882,18 @@ defmodule Mix.Project do
     end
   end
 
-  @doc false
+  @doc """
+  Acquires a lock on the project build path and runs the given function.
+
+  When another process (across all OS processes) is holding the lock,
+  a message is printed and this call blocks until the lock is acquired.
+  This function can also be called if this process already has the
+  lock. In such case the function is executed immediately.
+
+  This lock is primarily useful by compiler tasks that alter the build
+  artifacts to avoid conflicts with a concurrent compilation.
+  """
+  @spec with_build_lock(keyword, (-> term())) :: term()
   def with_build_lock(config \\ config(), fun) do
     # To avoid duplicated compilation, we wrap compilation tasks, such
     # as compile.all, deps.compile, compile.elixir, compile.erlang in


### PR DESCRIPTION
The lock can be useful in other projects. For example in the Phoenix code reloader we want to implement a mix listener and purge stale modules before compilation, which should happen within a lock, as we do in `IEx.Helpers.recompile/1`:

https://github.com/elixir-lang/elixir/blob/f17fc8b4c30c7143a527ceacf8d9a603ae14f54a/lib/iex/lib/iex/helpers.ex#L139-L142