### PR TITLE
Add list types

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -29,6 +29,8 @@ defmodule Module.Types.Descr do
   @bit_optional 1 <<< 8
 
   @empty_list %{bitmap: @bit_empty_list}
+  # A definition of non empty list that does not use negation. 
+  @not_non_empty_list %{bitmap: @bit_top, atom: @atom_top, tuple: @tuple_top, map: @map_top}
 
   @atom_top {:negation, :sets.new(version: 2)}
   @tuple_top [{:open, [], []}]
@@ -66,9 +68,6 @@ defmodule Module.Types.Descr do
   def integer(), do: %{bitmap: @bit_integer}
   def float(), do: %{bitmap: @bit_float}
   def fun(), do: %{bitmap: @bit_fun}
-
-  # A definition of non empty list that does not use negation. 
-  @not_non_empty_list %{bitmap: @bit_top, atom: @atom_top, tuple: @tuple_top, map: @map_top}
 
   # TODO: check emptiness here?
   def list(type \\ :term, last_type \\ @empty_list) do

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -28,15 +28,14 @@ defmodule Module.Types.Descr do
   @bit_number @bit_integer ||| @bit_float
   @bit_optional 1 <<< 8
 
-  @empty_list %{bitmap: @bit_empty_list}
-  # A definition of non empty list that does not use negation. 
-  @not_non_empty_list %{bitmap: @bit_top, atom: @atom_top, tuple: @tuple_top, map: @map_top}
-
   @atom_top {:negation, :sets.new(version: 2)}
   @tuple_top [{:open, [], []}]
   @map_top [{:open, %{}, []}]
   @map_empty [{:closed, %{}, []}]
   @none %{}
+  @empty_list %{bitmap: @bit_empty_list}
+  # A definition of non empty list that does not use negation. Includes empty list. 
+  @not_non_empty_list %{bitmap: @bit_top, atom: @atom_top, tuple: @tuple_top, map: @map_top}
   @non_empty_list_top [{:term, @not_non_empty_list, []}]
 
   # Type definitions


### PR DESCRIPTION
Proper list types: 
- `list()` 
- `list(integer())` a (possibly empty) list of integers

Improper lists:
- `list(integer(), atom())` (a list of integers, with an atom at the tail)

A type like `list(term(), term()` includes both propers lists and improper lists (since `term()` includes `empty_list()`)

Also includes `hd` and `tl` operators, type-safe so using those on lists that may be empty will error

Using `tl` on a improper list like `list(integer(), atom())` will return either a list of integers or an `atom()`.

The addition creates some warning for the compiler on patterns not matching, to be fixed :)