### PR TITLE
Refactor the current type checker for return type inference

### DIFF
--- a/lib/elixir/lib/module/behaviour.ex
+++ b/lib/elixir/lib/module/behaviour.ex
@@ -33,9 +33,7 @@ defmodule Module.Behaviour do
       module: module,
       file: file,
       line: line,
-      # Map containing the callbacks to be implemented
       callbacks: %{},
-      # list of warnings {message, env}
       warnings: []
     }
   end

--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -52,14 +52,9 @@ defmodule Module.Types do
   end
 
   defp warnings_from_clause(meta, args, guards, body, stack, context) do
-    case Pattern.of_head(args, guards, meta, stack, context) do
-      {:ok, _types, context} ->
-        {_type, context} = Expr.of_expr(body, stack, context)
-        context.warnings
-
-      {:error, context} ->
-        context.warnings
-    end
+    {_types, context} = Pattern.of_head(args, guards, meta, stack, context)
+    {_type, context} = Expr.of_expr(body, stack, context)
+    context.warnings
   end
 
   @doc false

--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -83,10 +83,12 @@ defmodule Module.Types do
     %{
       # A list of all warnings found so far
       warnings: [],
-      # Information about all vars and their types
+      # All vars and their types
       vars: %{},
-      # Information about variables and arguments from patterns
-      pattern_info: nil
+      # Variables and arguments from patterns
+      pattern_info: nil,
+      # If type checking has found an error/failure
+      failed: false
     }
   end
 end

--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -52,11 +52,13 @@ defmodule Module.Types do
   end
 
   defp warnings_from_clause(meta, args, guards, body, stack, context) do
-    with {:ok, _types, context} <- Pattern.of_head(args, guards, meta, stack, context),
-         {:ok, _type, context} <- Expr.of_expr(body, stack, context) do
-      context.warnings
-    else
-      {:error, context} -> context.warnings
+    case Pattern.of_head(args, guards, meta, stack, context) do
+      {:ok, _types, context} ->
+        {_type, context} = Expr.of_expr(body, stack, context)
+        context.warnings
+
+      {:error, context} ->
+        context.warnings
     end
   end
 

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -346,7 +346,7 @@ defmodule Module.Types.Expr do
         _ ->
           expected = if structs == [], do: @exception, else: Enum.reduce(structs, &union/2)
           formatter = fn expr -> {"rescue #{expr_to_string(expr)} ->", hints} end
-          {_type, context} = Of.refine_var(var, expected, expr, formatter, stack, context)
+          {_ok?, _type, context} = Of.refine_var(var, expected, expr, formatter, stack, context)
           context
       end
 

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -33,88 +33,78 @@ defmodule Module.Types.Expr do
 
   # :atom
   def of_expr(atom, _stack, context) when is_atom(atom),
-    do: {:ok, atom([atom]), context}
+    do: {atom([atom]), context}
 
   # 12
   def of_expr(literal, _stack, context) when is_integer(literal),
-    do: {:ok, integer(), context}
+    do: {integer(), context}
 
   # 1.2
   def of_expr(literal, _stack, context) when is_float(literal),
-    do: {:ok, float(), context}
+    do: {float(), context}
 
   # "..."
   def of_expr(literal, _stack, context) when is_binary(literal),
-    do: {:ok, binary(), context}
+    do: {binary(), context}
 
   # #PID<...>
   def of_expr(literal, _stack, context) when is_pid(literal),
-    do: {:ok, pid(), context}
+    do: {pid(), context}
 
   # []
   def of_expr([], _stack, context),
-    do: {:ok, empty_list(), context}
+    do: {empty_list(), context}
 
   # [expr, ...]
   def of_expr(list, stack, context) when is_list(list) do
     {prefix, suffix} = unpack_list(list, [])
-
-    with {:ok, prefix, context} <-
-           map_reduce_ok(prefix, context, &of_expr(&1, stack, &2)),
-         {:ok, suffix, context} <- of_expr(suffix, stack, context) do
-      {:ok, non_empty_list(Enum.reduce(prefix, &union/2), suffix), context}
-    end
+    {prefix, context} = Enum.map_reduce(prefix, context, &of_expr(&1, stack, &2))
+    {suffix, context} = of_expr(suffix, stack, context)
+    {non_empty_list(Enum.reduce(prefix, &union/2), suffix), context}
   end
 
   # {left, right}
   def of_expr({left, right}, stack, context) do
-    with {:ok, left, context} <- of_expr(left, stack, context),
-         {:ok, right, context} <- of_expr(right, stack, context) do
-      {:ok, tuple([left, right]), context}
-    end
+    {left, context} = of_expr(left, stack, context)
+    {right, context} = of_expr(right, stack, context)
+    {tuple([left, right]), context}
   end
 
   # <<...>>>
   def of_expr({:<<>>, _meta, args}, stack, context) do
     context = Of.binary(args, :expr, stack, context)
-    {:ok, binary(), context}
+    {binary(), context}
   end
 
-  def of_expr({:__CALLER__, _meta, var_context}, _stack, context)
-      when is_atom(var_context) do
-    {:ok, @caller, context}
+  def of_expr({:__CALLER__, _meta, var_context}, _stack, context) when is_atom(var_context) do
+    {@caller, context}
   end
 
   # TODO: __STACKTRACE__
   def of_expr({:__STACKTRACE__, _meta, var_context}, _stack, context)
       when is_atom(var_context) do
-    {:ok, list(term()), context}
+    {list(term()), context}
   end
 
   # {...}
   def of_expr({:{}, _meta, exprs}, stack, context) do
-    with {:ok, types, context} <- map_reduce_ok(exprs, context, &of_expr(&1, stack, &2)) do
-      {:ok, tuple(types), context}
-    end
+    {types, context} = Enum.map_reduce(exprs, context, &of_expr(&1, stack, &2))
+    {tuple(types), context}
   end
 
   # left = right
   def of_expr({:=, _meta, [left_expr, right_expr]} = expr, stack, context) do
-    with {:ok, right_type, context} <- of_expr(right_expr, stack, context) do
-      {type, context} = Pattern.of_match(left_expr, right_type, expr, stack, context)
-      {:ok, type, context}
-    end
+    {right_type, context} = of_expr(right_expr, stack, context)
+    Pattern.of_match(left_expr, right_type, expr, stack, context)
   end
 
   # %{map | ...}
   def of_expr({:%{}, _, [{:|, _, [map, args]}]}, stack, context) do
     {_args_type, context} = Of.closed_map(args, stack, context, &of_expr/3)
-
-    with {:ok, _map_type, context} <- of_expr(map, stack, context) do
-      # TODO: intersect map with keys of terms for args
-      # TODO: Merge args_type into map_type with dynamic/static key requirement
-      {:ok, dynamic(open_map()), context}
-    end
+    {_map_type, context} = of_expr(map, stack, context)
+    # TODO: intersect map with keys of terms for args
+    # TODO: Merge args_type into map_type with dynamic/static key requirement
+    {dynamic(open_map()), context}
   end
 
   # %Struct{map | ...}
@@ -123,90 +113,79 @@ defmodule Module.Types.Expr do
         stack,
         context
       ) do
-    with {:ok, args_types, context} <-
-           map_reduce_ok(args, context, fn {key, value}, context when is_atom(key) ->
-             with {:ok, type, context} <- of_expr(value, stack, context) do
-               {:ok, {key, type}, context}
-             end
-           end),
-         # TODO: args_types could be an empty list
-         {struct_type, context} =
-           Of.struct(module, args_types, :only_defaults, struct_meta, stack, context),
-         {:ok, map_type, context} <- of_expr(map, stack, context) do
-      if disjoint?(struct_type, map_type) do
-        warning = {:badupdate, :struct, expr, struct_type, map_type, context}
-        {:ok, error_type(), error(__MODULE__, warning, update_meta, stack, context)}
-      else
-        # TODO: Merge args_type into map_type with dynamic/static key requirement
-        {type, context} =
-          Of.struct(module, args_types, :merge_defaults, struct_meta, stack, context)
+    {args_types, context} =
+      Enum.map_reduce(args, context, fn {key, value}, context when is_atom(key) ->
+        {type, context} = of_expr(value, stack, context)
+        {{key, type}, context}
+      end)
 
-        {:ok, type, context}
-      end
+    # TODO: args_types could be an empty list
+    {struct_type, context} =
+      Of.struct(module, args_types, :only_defaults, struct_meta, stack, context)
+
+    {map_type, context} = of_expr(map, stack, context)
+
+    if disjoint?(struct_type, map_type) do
+      warning = {:badupdate, :struct, expr, struct_type, map_type, context}
+      {error_type(), error(__MODULE__, warning, update_meta, stack, context)}
+    else
+      # TODO: Merge args_type into map_type with dynamic/static key requirement
+      Of.struct(module, args_types, :merge_defaults, struct_meta, stack, context)
     end
   end
 
   # %{...}
   def of_expr({:%{}, _meta, args}, stack, context) do
-    {type, context} = Of.closed_map(args, stack, context, &of_expr/3)
-    {:ok, type, context}
+    Of.closed_map(args, stack, context, &of_expr/3)
   end
 
   # %Struct{}
   def of_expr({:%, _, [module, {:%{}, _, args}]} = expr, stack, context) do
     # TODO: We should not skip defaults
-    {type, context} = Of.struct(expr, module, args, :skip_defaults, stack, context, &of_expr/3)
-    {:ok, type, context}
+    Of.struct(expr, module, args, :skip_defaults, stack, context, &of_expr/3)
   end
 
   # ()
   def of_expr({:__block__, _meta, []}, _stack, context) do
-    {:ok, atom([nil]), context}
+    {atom([nil]), context}
   end
 
   # (expr; expr)
   def of_expr({:__block__, _meta, exprs}, stack, context) do
     {pre, [post]} = Enum.split(exprs, -1)
 
-    result =
-      map_reduce_ok(pre, context, fn expr, context ->
-        of_expr(expr, stack, context)
+    context =
+      Enum.reduce(pre, context, fn expr, context ->
+        {_, context} = of_expr(expr, stack, context)
+        context
       end)
 
-    case result do
-      {:ok, _, context} -> of_expr(post, stack, context)
-      {:error, context} -> {:error, context}
-    end
+    of_expr(post, stack, context)
   end
 
   # TODO: cond do pat -> expr end
   def of_expr({:cond, _meta, [[{:do, clauses}]]}, stack, context) do
-    {result, context} =
-      reduce_ok(clauses, context, fn {:->, _meta, [head, body]}, context ->
-        with {:ok, _, context} <- of_expr(head, stack, context),
-             {:ok, _, context} <- of_expr(body, stack, context),
-             do: {:ok, context}
+    context =
+      Enum.reduce(clauses, context, fn {:->, _meta, [head, body]}, context ->
+        {_, context} = of_expr(head, stack, context)
+        {_, context} = of_expr(body, stack, context)
+        context
       end)
 
-    case result do
-      :ok -> {:ok, dynamic(), context}
-      :error -> {:error, context}
-    end
+    {dynamic(), context}
   end
 
   # TODO: case expr do pat -> expr end
   def of_expr({:case, _meta, [case_expr, [{:do, clauses}]]}, stack, context) do
-    with {:ok, _expr_type, context} <- of_expr(case_expr, stack, context),
-         {:ok, context} <- of_clauses(clauses, stack, context),
-         do: {:ok, dynamic(), context}
+    {_expr_type, context} = of_expr(case_expr, stack, context)
+    context = of_clauses(clauses, stack, context)
+    {dynamic(), context}
   end
 
   # TODO: fn pat -> expr end
   def of_expr({:fn, _meta, clauses}, stack, context) do
-    case of_clauses(clauses, stack, context) do
-      {:ok, context} -> {:ok, fun(), context}
-      {:error, context} -> {:error, context}
-    end
+    context = of_clauses(clauses, stack, context)
+    {fun(), context}
   end
 
   @try_blocks [:do, :after]
@@ -214,10 +193,10 @@ defmodule Module.Types.Expr do
 
   # TODO: try do expr end
   def of_expr({:try, _meta, [blocks]}, stack, context) do
-    {result, context} =
-      reduce_ok(blocks, context, fn
+    context =
+      Enum.reduce(blocks, context, fn
         {:rescue, clauses}, context ->
-          reduce_ok(clauses, context, fn
+          Enum.reduce(clauses, context, fn
             {:->, _, [[{:in, meta, [var, exceptions]} = expr], body]}, context ->
               of_rescue(var, exceptions, body, expr, [], meta, stack, context)
 
@@ -232,97 +211,80 @@ defmodule Module.Types.Expr do
           of_clauses(clauses, stack, context)
       end)
 
-    case result do
-      :ok -> {:ok, dynamic(), context}
-      :error -> {:error, context}
-    end
+    {dynamic(), context}
   end
 
   # TODO: receive do pat -> expr end
   def of_expr({:receive, _meta, [blocks]}, stack, context) do
-    {result, context} =
-      reduce_ok(blocks, context, fn
+    context =
+      Enum.reduce(blocks, context, fn
         {:do, {:__block__, _, []}}, context ->
-          {:ok, context}
+          context
 
         {:do, clauses}, context ->
           of_clauses(clauses, stack, context)
 
         {:after, [{:->, _meta, [head, body]}]}, context ->
-          with {:ok, _type, context} <- of_expr(head, stack, context),
-               {:ok, _type, context} <- of_expr(body, stack, context),
-               do: {:ok, context}
+          {_type, context} = of_expr(head, stack, context)
+          {_type, context} = of_expr(body, stack, context)
+          context
       end)
 
-    case result do
-      :ok -> {:ok, dynamic(), context}
-      :error -> {:error, context}
-    end
+    {dynamic(), context}
   end
 
   # TODO: for pat <- expr do expr end
   def of_expr({:for, _meta, [_ | _] = args}, stack, context) do
     {clauses, [[{:do, block} | opts]]} = Enum.split(args, -1)
+    context = Enum.reduce(clauses, context, &for_clause(&1, stack, &2))
+    context = Enum.reduce(opts, context, &for_option(&1, stack, &2))
 
-    with {:ok, context} <- reduce_ok(clauses, context, &for_clause(&1, stack, &2)),
-         {:ok, context} <- reduce_ok(opts, context, &for_option(&1, stack, &2)) do
-      if Keyword.has_key?(opts, :reduce) do
-        with {:ok, context} <- of_clauses(block, stack, context) do
-          {:ok, dynamic(), context}
-        end
-      else
-        with {:ok, _type, context} <- of_expr(block, stack, context) do
-          {:ok, dynamic(), context}
-        end
-      end
+    if Keyword.has_key?(opts, :reduce) do
+      context = of_clauses(block, stack, context)
+      {dynamic(), context}
+    else
+      {_type, context} = of_expr(block, stack, context)
+      {dynamic(), context}
     end
   end
 
   # TODO: with pat <- expr do expr end
   def of_expr({:with, _meta, [_ | _] = clauses}, stack, context) do
-    case reduce_ok(clauses, context, &with_clause(&1, stack, &2)) do
-      {:ok, context} -> {:ok, dynamic(), context}
-      {:error, context} -> {:error, context}
-    end
+    {clauses, [options]} = Enum.split(clauses, -1)
+    context = Enum.reduce(clauses, context, &with_clause(&1, stack, &2))
+    context = Enum.reduce(options, context, &with_option(&1, stack, &2))
+    {dynamic(), context}
   end
 
   # TODO: fun.(args)
   def of_expr({{:., _meta1, [fun]}, _meta2, args}, stack, context) do
-    with {:ok, fun_type, context} <- of_expr(fun, stack, context),
-         {:ok, _args_types, context} <-
-           map_reduce_ok(args, context, &of_expr(&1, stack, &2)) do
-      context =
-        case fun_fetch(fun_type, length(args)) do
-          :ok -> context
-          :error -> Of.incompatible_error(fun, fun(), fun_type, stack, context)
-        end
+    {fun_type, context} = of_expr(fun, stack, context)
+    {_args_types, context} = Enum.map_reduce(args, context, &of_expr(&1, stack, &2))
 
-      {:ok, dynamic(), context}
+    case fun_fetch(fun_type, length(args)) do
+      :ok -> {dynamic(), context}
+      :error -> {dynamic(), Of.incompatible_error(fun, fun(), fun_type, stack, context)}
     end
   end
 
   def of_expr({{:., _, [callee, key_or_fun]}, meta, []} = expr, stack, context)
       when not is_atom(callee) and is_atom(key_or_fun) do
-    with {:ok, type, context} <- of_expr(callee, stack, context) do
-      if Keyword.get(meta, :no_parens, false) do
-        {type, context} = Of.map_fetch(expr, type, key_or_fun, stack, context)
-        {:ok, type, context}
-      else
-        {mods, context} = Of.remote(type, key_or_fun, 0, [:dot], expr, meta, stack, context)
-        {type, context} = apply_many(mods, key_or_fun, [], expr, stack, context)
-        {:ok, type, context}
-      end
+    {type, context} = of_expr(callee, stack, context)
+
+    if Keyword.get(meta, :no_parens, false) do
+      Of.map_fetch(expr, type, key_or_fun, stack, context)
+    else
+      {mods, context} = Of.remote(type, key_or_fun, 0, [:dot], expr, meta, stack, context)
+      apply_many(mods, key_or_fun, [], expr, stack, context)
     end
   end
 
   # TODO: expr.fun(arg)
   def of_expr({{:., _, [remote, name]}, meta, args} = expr, stack, context) do
-    with {:ok, remote_type, context} <- of_expr(remote, stack, context),
-         {:ok, args_types, context} <- map_reduce_ok(args, context, &of_expr(&1, stack, &2)) do
-      {mods, context} = Of.remote(remote_type, name, length(args), expr, meta, stack, context)
-      {type, context} = apply_many(mods, name, args_types, expr, stack, context)
-      {:ok, type, context}
-    end
+    {remote_type, context} = of_expr(remote, stack, context)
+    {args_types, context} = Enum.map_reduce(args, context, &of_expr(&1, stack, &2))
+    {mods, context} = Of.remote(remote_type, name, length(args), expr, meta, stack, context)
+    apply_many(mods, name, args_types, expr, stack, context)
   end
 
   # TODO: &Foo.bar/1
@@ -332,32 +294,29 @@ defmodule Module.Types.Expr do
         context
       )
       when is_atom(name) and is_integer(arity) do
-    with {:ok, remote_type, context} <- of_expr(remote, stack, context) do
-      # TODO: We cannot return the unions of functions. Do we forbid this?
-      # Do we check it is always the same return type? Do we simply say it is a function?
-      {_mods, context} = Of.remote(remote_type, name, arity, expr, meta, stack, context)
-      {:ok, fun(), context}
-    end
+    {remote_type, context} = of_expr(remote, stack, context)
+    # TODO: We cannot return the unions of functions. Do we forbid this?
+    # Do we check it is always the same return type? Do we simply say it is a function?
+    {_mods, context} = Of.remote(remote_type, name, arity, expr, meta, stack, context)
+    {fun(), context}
   end
 
   # &foo/1
   # TODO: & &1
   def of_expr({:&, _meta, _arg}, _stack, context) do
-    {:ok, fun(), context}
+    {fun(), context}
   end
 
   # TODO: local_call(arg)
   def of_expr({fun, _meta, args}, stack, context)
       when is_atom(fun) and is_list(args) do
-    with {:ok, _arg_types, context} <-
-           map_reduce_ok(args, context, &of_expr(&1, stack, &2)) do
-      {:ok, dynamic(), context}
-    end
+    {_arg_types, context} = Enum.map_reduce(args, context, &of_expr(&1, stack, &2))
+    {dynamic(), context}
   end
 
   # var
   def of_expr(var, _stack, context) when is_var(var) do
-    {:ok, Of.var(var, context), context}
+    {Of.var(var, context), context}
   end
 
   ## Try
@@ -365,57 +324,56 @@ defmodule Module.Types.Expr do
   defp of_rescue(var, exceptions, body, expr, hints, meta, stack, context) do
     args = [__exception__: @atom_true]
 
-    with {:ok, structs, context} <-
-           map_reduce_ok(exceptions, context, fn exception, context ->
-             # Exceptions are not validated in the compiler,
-             # to avoid export dependencies. So we do it here.
-             if Code.ensure_loaded?(exception) and function_exported?(exception, :__struct__, 0) do
-               {type, context} = Of.struct(exception, args, :merge_defaults, meta, stack, context)
-               {:ok, type, context}
-             else
-               # If the exception cannot be found or is invalid,
-               # we call Of.remote/5 to emit a warning.
-               context = Of.remote(exception, :__struct__, 0, meta, stack, context)
-               {:ok, error_type(), context}
-             end
-           end) do
-      context =
-        case var do
-          {:_, _, _} ->
-            context
-
-          _ ->
-            expected = if structs == [], do: @exception, else: Enum.reduce(structs, &union/2)
-            formatter = fn expr -> {"rescue #{expr_to_string(expr)} ->", hints} end
-            {_type, context} = Of.refine_var(var, expected, expr, formatter, stack, context)
-            context
+    {structs, context} =
+      Enum.map_reduce(exceptions, context, fn exception, context ->
+        # Exceptions are not validated in the compiler,
+        # to avoid export dependencies. So we do it here.
+        if Code.ensure_loaded?(exception) and function_exported?(exception, :__struct__, 0) do
+          Of.struct(exception, args, :merge_defaults, meta, stack, context)
+        else
+          # If the exception cannot be found or is invalid,
+          # we call Of.remote/5 to emit a warning.
+          context = Of.remote(exception, :__struct__, 0, meta, stack, context)
+          {error_type(), context}
         end
+      end)
 
-      of_expr_context(body, stack, context)
-    end
+    context =
+      case var do
+        {:_, _, _} ->
+          context
+
+        _ ->
+          expected = if structs == [], do: @exception, else: Enum.reduce(structs, &union/2)
+          formatter = fn expr -> {"rescue #{expr_to_string(expr)} ->", hints} end
+          {_type, context} = Of.refine_var(var, expected, expr, formatter, stack, context)
+          context
+      end
+
+    of_expr_context(body, stack, context)
   end
 
   ## Comprehensions
 
   defp for_clause({:<-, meta, [left, expr]}, stack, context) do
     {pattern, guards} = extract_head([left])
+    {_expr_type, context} = of_expr(expr, stack, context)
 
-    with {:ok, _expr_type, context} <- of_expr(expr, stack, context),
-         {:ok, _pattern_type, context} <-
-           Pattern.of_head([pattern], guards, meta, stack, context),
-         do: {:ok, context}
+    case Pattern.of_head([pattern], guards, meta, stack, context) do
+      {:ok, _, context} -> context
+      {:error, context} -> context
+    end
   end
 
   defp for_clause({:<<>>, _, [{:<-, meta, [left, right]}]}, stack, context) do
-    with {:ok, right_type, context} <- of_expr(right, stack, context) do
-      {_pattern_type, context} = Pattern.of_match(left, binary(), left, stack, context)
+    {right_type, context} = of_expr(right, stack, context)
+    {_pattern_type, context} = Pattern.of_match(left, binary(), left, stack, context)
 
-      if binary_type?(right_type) do
-        {:ok, context}
-      else
-        warning = {:badbinary, right_type, right, context}
-        {:ok, error(__MODULE__, warning, meta, stack, context)}
-      end
+    if binary_type?(right_type) do
+      context
+    else
+      warning = {:badbinary, right_type, right, context}
+      error(__MODULE__, warning, meta, stack, context)
     end
   end
 
@@ -432,7 +390,7 @@ defmodule Module.Types.Expr do
   end
 
   defp for_option({:uniq, _}, _stack, context) do
-    {:ok, context}
+    context
   end
 
   ## With
@@ -440,14 +398,14 @@ defmodule Module.Types.Expr do
   defp with_clause({:<-, meta, [left, expr]}, stack, context) do
     {pattern, guards} = extract_head([left])
 
-    with {:ok, _pattern_type, context} <-
-           Pattern.of_head([pattern], guards, meta, stack, context),
-         {:ok, _expr_type, context} <- of_expr(expr, stack, context),
-         do: {:ok, context}
-  end
+    case Pattern.of_head([pattern], guards, meta, stack, context) do
+      {:ok, _, context} ->
+        {_expr_type, context} = of_expr(expr, stack, context)
+        context
 
-  defp with_clause(list, stack, context) when is_list(list) do
-    reduce_ok(list, context, &with_option(&1, stack, &2))
+      {:error, context} ->
+        context
+    end
   end
 
   defp with_clause(expr, stack, context) do
@@ -463,8 +421,6 @@ defmodule Module.Types.Expr do
   end
 
   ## General helpers
-
-  defp error_type(), do: dynamic()
 
   defp apply_many([], _function, _args_types, _expr, _stack, context) do
     {dynamic(), context}
@@ -484,12 +440,17 @@ defmodule Module.Types.Expr do
   end
 
   defp of_clauses(clauses, stack, context) do
-    reduce_ok(clauses, context, fn {:->, meta, [head, body]}, context ->
+    Enum.reduce(clauses, context, fn {:->, meta, [head, body]}, context ->
       {patterns, guards} = extract_head(head)
 
-      with {:ok, _, context} <- Pattern.of_head(patterns, guards, meta, stack, context),
-           {:ok, _, context} <- of_expr(body, stack, context),
-           do: {:ok, context}
+      case Pattern.of_head(patterns, guards, meta, stack, context) do
+        {:ok, _, context} ->
+          {_, context} = of_expr(body, stack, context)
+          context
+
+        {:error, context} ->
+          context
+      end
     end)
   end
 
@@ -513,10 +474,8 @@ defmodule Module.Types.Expr do
   end
 
   defp of_expr_context(expr, stack, context) do
-    case of_expr(expr, stack, context) do
-      {:ok, _type, context} -> {:ok, context}
-      {:error, context} -> {:error, context}
-    end
+    {_type, context} = of_expr(expr, stack, context)
+    context
   end
 
   ## Warning formatting

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -376,14 +376,8 @@ defmodule Module.Types.Expr do
 
           _ ->
             expected = if structs == [], do: @exception, else: Enum.reduce(structs, &union/2)
-
-            formatter = fn expr ->
-              {"rescue #{expr_to_string(expr)} ->", hints}
-            end
-
-            {:ok, _type, context} =
-              Of.refine_var(var, expected, expr, formatter, stack, context)
-
+            formatter = fn expr -> {"rescue #{expr_to_string(expr)} ->", hints} end
+            {_type, context} = Of.refine_var(var, expected, expr, formatter, stack, context)
             context
         end
 

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -358,11 +358,8 @@ defmodule Module.Types.Expr do
   defp for_clause({:<-, meta, [left, expr]}, stack, context) do
     {pattern, guards} = extract_head([left])
     {_expr_type, context} = of_expr(expr, stack, context)
-
-    case Pattern.of_head([pattern], guards, meta, stack, context) do
-      {:ok, _, context} -> context
-      {:error, context} -> context
-    end
+    {[_type], context} = Pattern.of_head([pattern], guards, meta, stack, context)
+    context
   end
 
   defp for_clause({:<<>>, _, [{:<-, meta, [left, right]}]}, stack, context) do
@@ -398,14 +395,9 @@ defmodule Module.Types.Expr do
   defp with_clause({:<-, meta, [left, expr]}, stack, context) do
     {pattern, guards} = extract_head([left])
 
-    case Pattern.of_head([pattern], guards, meta, stack, context) do
-      {:ok, _, context} ->
-        {_expr_type, context} = of_expr(expr, stack, context)
-        context
-
-      {:error, context} ->
-        context
-    end
+    {[_type], context} = Pattern.of_head([pattern], guards, meta, stack, context)
+    {_expr_type, context} = of_expr(expr, stack, context)
+    context
   end
 
   defp with_clause(expr, stack, context) do
@@ -443,14 +435,9 @@ defmodule Module.Types.Expr do
     Enum.reduce(clauses, context, fn {:->, meta, [head, body]}, context ->
       {patterns, guards} = extract_head(head)
 
-      case Pattern.of_head(patterns, guards, meta, stack, context) do
-        {:ok, _, context} ->
-          {_, context} = of_expr(body, stack, context)
-          context
-
-        {:error, context} ->
-          context
-      end
+      {_types, context} = Pattern.of_head(patterns, guards, meta, stack, context)
+      {_, context} = of_expr(body, stack, context)
+      context
     end)
   end
 

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -305,7 +305,8 @@ defmodule Module.Types.Expr do
       when not is_atom(callee) and is_atom(key_or_fun) do
     with {:ok, type, context} <- of_expr(callee, stack, context) do
       if Keyword.get(meta, :no_parens, false) do
-        Of.map_fetch(expr, type, key_or_fun, stack, context)
+        {type, context} = Of.map_fetch(expr, type, key_or_fun, stack, context)
+        {:ok, type, context}
       else
         {mods, context} = Of.remote(type, key_or_fun, 0, [:dot], expr, meta, stack, context)
         {type, context} = apply_many(mods, key_or_fun, [], expr, stack, context)

--- a/lib/elixir/lib/module/types/helpers.ex
+++ b/lib/elixir/lib/module/types/helpers.ex
@@ -75,6 +75,10 @@ defmodule Module.Types.Helpers do
 
       {:error, reason} ->
         {:error, reason}
+
+      _ ->
+        IO.inspect({head, fun})
+        raise "oops"
     end
   end
 
@@ -269,6 +273,18 @@ defmodule Module.Types.Helpers do
       {fun, arity} = stack.function
       location = {stack.file, meta, {stack.module, fun, arity}}
       %{context | warnings: [{module, warning, location} | context.warnings]}
+    end
+  end
+
+  @doc """
+  Emits an error.
+
+  In practice an error is a warning that halts other errors from being collected.
+  """
+  def error(module, warning, meta, stack, context) do
+    case context do
+      %{failed: true} -> context
+      %{failed: false} -> warn(module, warning, meta, stack, %{context | failed: true})
     end
   end
 end

--- a/lib/elixir/lib/module/types/helpers.ex
+++ b/lib/elixir/lib/module/types/helpers.ex
@@ -38,52 +38,6 @@ defmodule Module.Types.Helpers do
   def get_meta({_, meta, _}), do: meta
   def get_meta(_other), do: []
 
-  ## Traversal helpers
-
-  @doc """
-  Like `Enum.reduce/3` but only continues while `fun` returns `{:ok, acc}`
-  and stops on `{:error, reason}`.
-  """
-  def reduce_ok(list, acc, fun) do
-    do_reduce_ok(list, acc, fun)
-  end
-
-  defp do_reduce_ok([head | tail], acc, fun) do
-    case fun.(head, acc) do
-      {:ok, acc} ->
-        do_reduce_ok(tail, acc, fun)
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  defp do_reduce_ok([], acc, _fun), do: {:ok, acc}
-
-  @doc """
-  Like `Enum.map_reduce/3` but only continues while `fun` returns `{:ok, elem, acc}`
-  and stops on `{:error, reason}`.
-  """
-  def map_reduce_ok(list, acc, fun) do
-    do_map_reduce_ok(list, [], acc, fun)
-  end
-
-  defp do_map_reduce_ok([head | tail], list, acc, fun) do
-    case fun.(head, acc) do
-      {:ok, elem, acc} ->
-        do_map_reduce_ok(tail, [elem | list], acc, fun)
-
-      {:error, reason} ->
-        {:error, reason}
-
-      _ ->
-        IO.inspect({head, fun})
-        raise "oops"
-    end
-  end
-
-  defp do_map_reduce_ok([], list, acc, _fun), do: {:ok, Enum.reverse(list), acc}
-
   ## Warnings
 
   @doc """
@@ -287,4 +241,9 @@ defmodule Module.Types.Helpers do
       %{failed: false} -> warn(module, warning, meta, stack, %{context | failed: true})
     end
   end
+
+  @doc """
+  The type to return when there is an error.
+  """
+  def error_type, do: Module.Types.Descr.dynamic()
 end

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -261,10 +261,7 @@ defmodule Module.Types.Of do
           Module.Types.Pattern.of_match_var(left, type, expr, stack, context)
 
         :guard ->
-          case Module.Types.Pattern.of_guard(left, type, expr, stack, context) do
-            {:ok, type, context} -> {type, context}
-            {:error, context} -> {dynamic(), context}
-          end
+          Module.Types.Pattern.of_guard(left, type, expr, stack, context)
 
         :expr ->
           case Module.Types.Expr.of_expr(left, stack, context) do
@@ -311,10 +308,8 @@ defmodule Module.Types.Of do
 
   defp specifier_size(_pattern_or_guard, {:size, _, [arg]}, expr, stack, context)
        when not is_integer(arg) do
-    case Module.Types.Pattern.of_guard(arg, integer(), expr, stack, context) do
-      {:ok, _, context} -> context
-      {:error, context} -> context
-    end
+    {_type, context} = Module.Types.Pattern.of_guard(arg, integer(), expr, stack, context)
+    context
   end
 
   defp specifier_size(_kind, _specifier, _expr, _stack, context) do

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -255,28 +255,24 @@ defmodule Module.Types.Of do
     type = specifier_type(kind, right)
     expr = {:<<>>, meta, args}
 
-    context =
+    {_type, context} =
       case kind do
         :match ->
-          case Module.Types.Pattern.of_match_var(left, type, expr, stack, context) do
-            {:ok, _type, context} -> context
-            {:error, context} -> context
-          end
+          Module.Types.Pattern.of_match_var(left, type, expr, stack, context)
 
         :guard ->
           case Module.Types.Pattern.of_guard(left, type, expr, stack, context) do
-            {:ok, _type, context} -> context
-            {:error, context} -> context
+            {:ok, type, context} -> {type, context}
+            {:error, context} -> {dynamic(), context}
           end
 
         :expr ->
           case Module.Types.Expr.of_expr(left, stack, context) do
             {:ok, actual, context} ->
-              {_type, context} = intersect(actual, type, expr, stack, context)
-              context
+              intersect(actual, type, expr, stack, context)
 
             {:error, context} ->
-              context
+              {dynamic(), context}
           end
       end
 

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -47,9 +47,10 @@ defmodule Module.Types.Of do
 
         # We need to return error otherwise it leads to cascading errors
         if empty?(new_type) do
-          {error_type(), error({:refine_var, old_type, type, var, context}, meta, stack, context)}
+          {:error, error_type(),
+           error({:refine_var, old_type, type, var, context}, meta, stack, context)}
         else
-          {new_type, context}
+          {:ok, new_type, context}
         end
 
       %{} ->
@@ -61,7 +62,7 @@ defmodule Module.Types.Of do
         }
 
         context = put_in(context.vars[version], data)
-        {type, context}
+        {:ok, type, context}
     end
   end
 

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -79,11 +79,10 @@ defmodule Module.Types.Of do
   def map_fetch(expr, type, field, stack, context) when is_atom(field) do
     case map_fetch(type, field) do
       {_optional?, value_type} ->
-        {:ok, value_type, context}
+        {value_type, context}
 
       reason ->
-        {:ok, dynamic(),
-         error({reason, expr, type, field, context}, elem(expr, 1), stack, context)}
+        {dynamic(), error({reason, expr, type, field, context}, elem(expr, 1), stack, context)}
     end
   end
 

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -336,10 +336,10 @@ defmodule Module.Types.Of do
       when is_integer(index) do
     case tuple_fetch(type, index - 1) do
       {_optional?, value_type} ->
-        {:ok, value_type, context}
+        {value_type, context}
 
       reason ->
-        {:ok, dynamic(), error({reason, expr, type, index - 1, context}, meta, stack, context)}
+        {dynamic(), error({reason, expr, type, index - 1, context}, meta, stack, context)}
     end
   end
 
@@ -351,24 +351,24 @@ defmodule Module.Types.Of do
       match?({false, _}, map_fetch(left, :__struct__)) or
           match?({false, _}, map_fetch(right, :__struct__)) ->
         warning = {:struct_comparison, expr, context}
-        {:ok, result, error(warning, elem(expr, 1), stack, context)}
+        {result, error(warning, elem(expr, 1), stack, context)}
 
       number_type?(left) and number_type?(right) ->
-        {:ok, result, context}
+        {result, context}
 
       disjoint?(left, right) ->
         warning = {:mismatched_comparison, expr, context}
-        {:ok, result, error(warning, elem(expr, 1), stack, context)}
+        {result, error(warning, elem(expr, 1), stack, context)}
 
       true ->
-        {:ok, result, context}
+        {result, context}
     end
   end
 
   def apply(mod, name, args, expr, stack, context) do
     case :elixir_rewrite.inline(mod, name, length(args)) do
       {mod, name} -> apply(mod, name, args, expr, stack, context)
-      false -> {:ok, dynamic(), context}
+      false -> {dynamic(), context}
     end
   end
 

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -47,9 +47,9 @@ defmodule Module.Types.Of do
 
         # We need to return error otherwise it leads to cascading errors
         if empty?(new_type) do
-          {:error, error({:refine_var, old_type, type, var, context}, meta, stack, context)}
+          {dynamic(), error({:refine_var, old_type, type, var, context}, meta, stack, context)}
         else
-          {:ok, new_type, context}
+          {new_type, context}
         end
 
       %{} ->
@@ -61,7 +61,7 @@ defmodule Module.Types.Of do
         }
 
         context = put_in(context.vars[version], data)
-        {:ok, type, context}
+        {type, context}
     end
   end
 

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -34,7 +34,7 @@ defmodule Module.Types.Pattern do
 
     {_trees, types, context} = of_pattern_args(patterns, expected_types, stack, context)
     {_, context} = Enum.map_reduce(guards, context, &of_guard(&1, @guard, &1, stack, &2))
-    {:ok, types, context}
+    {types, context}
   end
 
   defp of_pattern_args([], [], _stack, context) do

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -663,7 +663,8 @@ defmodule Module.Types.Pattern do
   def of_guard({{:., _, [callee, key]}, _, []} = map_fetch, _expected, expr, stack, context)
       when not is_atom(callee) do
     with {:ok, type, context} <- of_guard(callee, dynamic(), expr, stack, context) do
-      Of.map_fetch(map_fetch, type, key, stack, context)
+      {type, context} = Of.map_fetch(map_fetch, type, key, stack, context)
+      {:ok, type, context}
     end
   end
 

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -624,12 +624,14 @@ defmodule Module.Types.Pattern do
   def of_guard({:%, _, [module, {:%{}, _, args}]} = struct, _expected, _expr, stack, context)
       when is_atom(module) do
     fun = &of_guard(&1, dynamic(), struct, &2, &3)
-    Of.struct(struct, module, args, :skip_defaults, stack, context, fun)
+    {type, context} = Of.struct(struct, module, args, :skip_defaults, stack, context, fun)
+    {:ok, type, context}
   end
 
   # %{...}
   def of_guard({:%{}, _meta, args}, _expected, expr, stack, context) do
-    Of.closed_map(args, stack, context, &of_guard(&1, dynamic(), expr, &2, &3))
+    {type, context} = Of.closed_map(args, stack, context, &of_guard(&1, dynamic(), expr, &2, &3))
+    {:ok, type, context}
   end
 
   # <<>>

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -672,7 +672,8 @@ defmodule Module.Types.Pattern do
       when is_atom(function) do
     with {:ok, args_type, context} <-
            map_reduce_ok(args, context, &of_guard(&1, dynamic(), expr, stack, &2)) do
-      Of.apply(:erlang, function, args_type, expr, stack, context)
+      {type, context} = Of.apply(:erlang, function, args_type, expr, stack, context)
+      {:ok, type, context}
     end
   end
 

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -119,7 +119,7 @@ defmodule Module.Types.Pattern do
            end) do
       {type, merge_failed(init_context, context)}
     else
-      {:error, context} -> {dynamic(), context}
+      {:error, context} -> {error_type(), context}
     end
   end
 
@@ -544,7 +544,7 @@ defmodule Module.Types.Pattern do
     if atom_type?(expected, atom) do
       {atom([atom]), context}
     else
-      {dynamic(), Of.incompatible_error(expr, expected, atom([atom]), stack, context)}
+      {error_type(), Of.incompatible_error(expr, expected, atom([atom]), stack, context)}
     end
   end
 
@@ -553,7 +553,7 @@ defmodule Module.Types.Pattern do
     if integer_type?(expected) do
       {integer(), context}
     else
-      {dynamic(), Of.incompatible_error(expr, expected, integer(), stack, context)}
+      {error_type(), Of.incompatible_error(expr, expected, integer(), stack, context)}
     end
   end
 
@@ -562,7 +562,7 @@ defmodule Module.Types.Pattern do
     if float_type?(expected) do
       {float(), context}
     else
-      {dynamic(), Of.incompatible_error(expr, expected, float(), stack, context)}
+      {error_type(), Of.incompatible_error(expr, expected, float(), stack, context)}
     end
   end
 
@@ -571,7 +571,7 @@ defmodule Module.Types.Pattern do
     if binary_type?(expected) do
       {binary(), context}
     else
-      {dynamic(), Of.incompatible_error(expr, expected, binary(), stack, context)}
+      {error_type(), Of.incompatible_error(expr, expected, binary(), stack, context)}
     end
   end
 
@@ -580,7 +580,7 @@ defmodule Module.Types.Pattern do
     if empty_list_type?(expected) do
       {empty_list(), context}
     else
-      {dynamic(), Of.incompatible_error(expr, expected, empty_list(), stack, context)}
+      {error_type(), Of.incompatible_error(expr, expected, empty_list(), stack, context)}
     end
   end
 
@@ -618,7 +618,7 @@ defmodule Module.Types.Pattern do
       context = Of.binary(args, :guard, stack, context)
       {binary(), context}
     else
-      {dynamic(), Of.incompatible_error(expr, expected, binary(), stack, context)}
+      {error_type(), Of.incompatible_error(expr, expected, binary(), stack, context)}
     end
   end
 

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -279,7 +279,7 @@ defmodule Module.Types.ExprTest do
       assert typewarn!(elem({:ok, 123}, 2)) ==
                {dynamic(),
                 ~l"""
-                out of range index 2 in expression:
+                out of range tuple access at index 2 in expression:
 
                     elem({:ok, 123}, 2)
 

--- a/lib/elixir/test/elixir/module/types/type_helper.exs
+++ b/lib/elixir/test/elixir/module/types/type_helper.exs
@@ -59,32 +59,35 @@ defmodule TypeHelper do
   end
 
   @doc false
-  def __typecheck__!({:ok, type, %{warnings: []}}), do: type
+  def __typecheck__!({type, %{warnings: []}}), do: type
 
-  def __typecheck__!({:ok, _type, %{warnings: warnings}}),
+  def __typecheck__!({_type, %{warnings: warnings, failed: false}}),
     do: raise("type checking ok but with warnings: #{inspect(warnings)}")
 
-  def __typecheck__!({:error, %{warnings: warnings}}),
+  def __typecheck__!({_type, %{warnings: warnings, failed: true}}),
     do: raise("type checking errored with warnings: #{inspect(warnings)}")
 
   @doc false
-  def __typeerror__!({:error, %{warnings: [{module, warning, _locs} | _]}}),
+  def __typeerror__!({_type, %{warnings: [{module, warning, _locs} | _], failed: true}}),
     do: module.format_diagnostic(warning).message
 
-  def __typeerror__!({:ok, type, _context}),
+  def __typeerror__!({_type, %{warnings: warnings, failed: false}}),
+    do: raise("type checking with warnings but expected error: #{inspect(warnings)}")
+
+  def __typeerror__!({type, _}),
     do: raise("type checking ok but expected error: #{Descr.to_quoted_string(type)}")
 
   @doc false
-  def __typediag__!({:ok, type, %{warnings: [{module, warning, _locs}]}}),
+  def __typediag__!({type, %{warnings: [{module, warning, _locs}]}}),
     do: {type, module.format_diagnostic(warning)}
 
-  def __typediag__!({:ok, type, %{warnings: []}}),
+  def __typediag__!({type, %{warnings: []}}),
     do: raise("type checking ok without warnings: #{Descr.to_quoted_string(type)}")
 
-  def __typediag__!({:ok, _type, %{warnings: warnings}}),
+  def __typediag__!({_type, %{warnings: warnings, failed: false}}),
     do: raise("type checking ok but many warnings: #{inspect(warnings)}")
 
-  def __typediag__!({:error, %{warnings: warnings}}),
+  def __typediag__!({:error, %{warnings: warnings, failed: true}}),
     do: raise("type checking errored with warnings: #{inspect(warnings)}")
 
   @doc false
@@ -129,9 +132,9 @@ defmodule TypeHelper do
   def __typecheck__(patterns, guards, body) do
     stack = new_stack()
 
-    with {:ok, _types, context} <- Pattern.of_head(patterns, guards, [], stack, new_context()),
-         {:ok, type, context} <- Expr.of_expr(body, stack, context) do
-      {:ok, type, context}
+    case Pattern.of_head(patterns, guards, [], stack, new_context()) do
+      {:ok, _types, context} -> Expr.of_expr(body, stack, context)
+      {:error, context} -> {Module.Types.Descr.dynamic(), context}
     end
   end
 

--- a/lib/elixir/test/elixir/module/types/type_helper.exs
+++ b/lib/elixir/test/elixir/module/types/type_helper.exs
@@ -131,11 +131,8 @@ defmodule TypeHelper do
 
   def __typecheck__(patterns, guards, body) do
     stack = new_stack()
-
-    case Pattern.of_head(patterns, guards, [], stack, new_context()) do
-      {:ok, _types, context} -> Expr.of_expr(body, stack, context)
-      {:error, context} -> {Module.Types.Descr.dynamic(), context}
-    end
+    {_types, context} = Pattern.of_head(patterns, guards, [], stack, new_context())
+    Expr.of_expr(body, stack, context)
   end
 
   defp expand_and_unpack(patterns, guards, body, env) do


### PR DESCRIPTION
The main goal is to allow checking to continue even if it finds typing violations, so we can infer return types. The violations are replaced by `dynamic()`. Only the first violation is reported to avoid cascading failures.