### PR TITLE
Update docs_config.exs Generate version-based links for app documentation

### DIFF
--- a/lib/elixir/scripts/docs_config.exs
+++ b/lib/elixir/scripts/docs_config.exs
@@ -1,17 +1,21 @@
-# Generate docs_config.js for version chooser in ExDoc
-[app] = System.argv()
+app =
+  case System.argv() do
+    [app] -> app
+    _ -> raise "Expected a single argument for the app name"
+  end
 
 {text_tags, 0} = System.cmd("git", ["tag"])
+
 skipped = Version.parse!("1.0.3")
 
 list_contents =
-  for(
-    "v" <> rest <- String.split(text_tags),
-    not String.ends_with?(rest, "-latest"),
-    version = Version.parse!(rest),
-    Version.compare(version, skipped) == :gt,
-    do: version
-  )
+  text_tags
+  |> String.split()
+  |> Enum.filter(fn tag ->
+    String.starts_with?(tag, "v") and not String.ends_with?(tag, "-latest")
+  end)
+  |> Enum.map(fn "v" <> rest -> Version.parse!(rest) end)
+  |> Enum.filter(fn version -> Version.compare(version, skipped) == :gt end)
   |> Enum.sort({:desc, Version})
   |> Enum.map_intersperse(", ", fn version ->
     version_string = Version.to_string(version)
@@ -20,3 +24,4 @@ list_contents =
 
 File.mkdir_p!("doc/#{app}")
 File.write!("doc/#{app}/docs_config.js", ["var versionNodes = [", list_contents, "];\n"])
+ 


### PR DESCRIPTION
- Process git tags to create a version list
- Skip versions <= 1.0.3 and exclude '-latest' tags
- Output version nodes in docs_config.js for the specified app