### PR TITLE
Provide a more expressive error with a suggestion.

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1614,7 +1614,7 @@ defmodule UndefinedFunctionError do
   defp message(:"module could not be loaded", module, function, arity) do
     formatted_fun = Exception.format_mfa(module, function, arity)
 
-    {"function #{formatted_fun} is undefined (module #{inspect(module)} is not available)",
+    {"function #{formatted_fun} is undefined (module #{inspect(module)} is not available). Did you forget to alias a module?",
      :suggest_module}
   end
 


### PR DESCRIPTION
**This is not from a seasoned elixir programmer but a relatively new Elixir programmer perspective**

I was trying to call a function inside a module. "MyApp.MyModule". I forgot to alias the module that contained the function and so I received the following error saying 

`[error] GenServer #PID<0.995.0> terminating
** (UndefinedFunctionError) function Game.find_active_game_for_user/1 is undefined (module Game is not available)`

Now, I got confused because I know the function exists. The issue is that I forgot to alias it. My mental process then went to why is this compiler not finding my function which I just checked that it's there inside "MyApp.Game". Eventually, I realized I forgot to alias it. Very dumb mistake but time consuming 

**Solution**
I think it would be nice if the compiler throws a better error and try to help with a suggestion like `Did you forget to alias the Game module?`. Now I understand the module is "MyApp.Game" and not "Game" but just the hint of alias is good enough for me to understand I missed that step.