### PR TITLE
more specific error message on invalid deps given to `mix deps.update`

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.update.ex
+++ b/lib/mix/lib/mix/tasks/deps.update.ex
@@ -61,6 +61,20 @@ defmodule Mix.Tasks.Deps.Update do
         Mix.Dep.Fetcher.all(Mix.Dep.Lock.read(), %{}, fetch_opts)
 
       rest != [] ->
+        invalid =
+          Enum.find(rest, fn name ->
+            !String.match?(name, ~r/^[a-zA-Z0-9_]+$/)
+          end)
+
+        if invalid do
+          Mix.raise("""
+          Invalid dependency name given to \"mix deps.update\": `#{invalid}`
+
+          Dependency names always start with a lowercase ASCII letter,
+          followed by lowercase ASCII letters, numbers, or underscores
+          """)
+        end
+
         {old, new} = Map.split(Mix.Dep.Lock.read(), to_app_names(rest))
         Mix.Dep.Fetcher.by_name(rest, old, new, fetch_opts)
 

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -417,6 +417,18 @@ defmodule Mix.Tasks.DepsTest do
     end)
   end
 
+  test "raises an error on invalid names being given" do
+    in_fixture("deps_status", fn ->
+      Mix.Project.push(CustomDepsEnvApp)
+
+      assert_raise Mix.Error,
+                   ~r/Invalid dependency name given to "mix deps.update": `:foobar`/,
+                   fn ->
+                     Mix.Tasks.Deps.Update.run([":foobar"])
+                   end
+    end)
+  end
+
   test "can customize environment" do
     in_fixture("deps_status", fn ->
       Mix.Project.push(CustomDepsEnvApp)


### PR DESCRIPTION
A client of mine had a confusing error where they ran `mix deps.update :dep`. This produced an error like so:

```
Unknown dependency :dep for environment dev
```

It is not obvious what the error that they made was, and this PR provides a more explicit error message in cases where an impossible dependency name is given

```
Invalid dependency name given to "mix deps.update": `:bar`
```