### PR TITLE
Add metadata about single-expression block closing/opening

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -778,7 +778,7 @@ build_map_update(Left, {Pipe, Struct, Map}, Right, Extra) ->
 
 %% Blocks
 
-build_block(Exprs) -> build_block(Exprs, {}).
+build_block(Exprs) -> build_block(Exprs, none).
 
 build_block([{unquote_splicing, _, [_]}]=Exprs, BeforeAfter) ->
   {'__block__', block_meta(BeforeAfter), Exprs};
@@ -805,7 +805,7 @@ build_block([Expr], _BeforeAfter) ->
 build_block(Exprs, BeforeAfter) ->
   {'__block__', block_meta(BeforeAfter), Exprs}.
 
-block_meta({}) -> [];
+block_meta(none) -> [];
 block_meta({Before, After}) -> meta_from_token_with_closing(Before, After).
 
 %% Newlines

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -672,7 +672,7 @@ meta_from_location({Line, Column, _}) ->
 do_end_meta(Do, End) ->
   case ?token_metadata() of
     true ->
-      [{do, meta_from_location(?location(Do))}, {'end', meta_from_location(?location(End))}];
+      [{do, meta_from_token(Do)}, {'end', meta_from_token(End)}];
     false ->
       []
   end.
@@ -680,7 +680,7 @@ do_end_meta(Do, End) ->
 meta_from_token_with_closing(Begin, End) ->
   case ?token_metadata() of
     true ->
-      [{closing, meta_from_location(?location(End))} | meta_from_token(Begin)];
+      [{closing, meta_from_token(End)} | meta_from_token(Begin)];
     false ->
       meta_from_token(Begin)
   end.
@@ -778,46 +778,33 @@ build_map_update(Left, {Pipe, Struct, Map}, Right, Extra) ->
 
 %% Blocks
 
-build_block(Exprs) -> build_block(Exprs, []).
+build_block(Exprs) -> build_block(Exprs, {}).
 
-build_block([{unquote_splicing, _, [_]}]=Exprs, Meta) ->
-  {'__block__', Meta, Exprs};
-build_block([{Op, ExprMeta, Args}], Meta) ->
+build_block([{unquote_splicing, _, [_]}]=Exprs, BeforeAfter) ->
+  {'__block__', block_meta(BeforeAfter), Exprs};
+build_block([{Op, ExprMeta, Args}], {Before, After}) ->
   ExprMetaWithExtra =
     case ?token_metadata() of
-      true -> ExprMeta ++ block_meta(Meta);
-      false -> ExprMeta
+      true ->
+        ExprMeta ++ [{parens_opening, meta_from_token(Before)}, {parens_closing, meta_from_token(After)}];
+      false ->
+        ExprMeta
     end,
   {Op, ExprMetaWithExtra, Args};
-build_block([Expr], _Meta) ->
+build_block([Expr], _BeforeAfter) ->
   Expr;
-build_block(Exprs, Meta) ->
-  {'__block__', Meta, Exprs}.
+build_block(Exprs, BeforeAfter) ->
+  {'__block__', block_meta(BeforeAfter), Exprs}.
 
-block_meta(Meta) ->
-  block_meta(Meta, [], []).
-
-block_meta([], [], []) ->
-  [];
-block_meta([], [], Closing) ->
-  [{parens_closing, Closing}];
-block_meta([], Opening, Closing) ->
-  [{parens_opening, lists:reverse(Opening)} | block_meta([], [], Closing)];
-block_meta([{line, Line} | Meta], Opening, Closing) ->
-  block_meta(Meta, [{line, Line} | Opening], Closing);
-block_meta([{column, Column} | Meta], Opening, Closing) ->
-  block_meta(Meta, [{column, Column} | Opening], Closing);
-block_meta([{closing, Closing} | Meta], Opening, _Closing) ->
-  block_meta(Meta, Opening, Closing);
-block_meta([_ | Meta], Opening, Closing) ->
-  block_meta(Meta, Opening, Closing).
+block_meta({}) -> [];
+block_meta({Before, After}) -> meta_from_token_with_closing(Before, After).
 
 %% Newlines
 
 newlines_pair(Left, Right) ->
   case ?token_metadata() of
     true ->
-      newlines(?location(Left), [{closing, meta_from_location(?location(Right))}]);
+      newlines(?location(Left), [{closing, meta_from_token(Right)}]);
     false ->
       []
   end.
@@ -1089,7 +1076,7 @@ build_paren_stab(_Before, [{Op, _, [_]}]=Exprs, _After) when ?rearrange_uop(Op) 
   {'__block__', [], Exprs};
 build_paren_stab(Before, Stab, After) ->
   case check_stab(Stab, none) of
-    block -> build_block(reverse(Stab), meta_from_token_with_closing(Before, After));
+    block -> build_block(reverse(Stab), {Before, After});
     stab -> handle_literal(collect_stab(Stab, [], []), Before, newlines_pair(Before, After))
   end.
 

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -786,7 +786,16 @@ build_block([{Op, ExprMeta, Args}], {Before, After}) ->
   ExprMetaWithExtra =
     case ?token_metadata() of
       true ->
-        ExprMeta ++ [{parens_opening, meta_from_token(Before)}, {parens_closing, meta_from_token(After)}];
+        ParensEntry = meta_from_token(Before) ++ [{closing, meta_from_token(After)}],
+        case ExprMeta of
+          % If there are multiple parens, those will result in subsequent
+          % build_block/2 calls, so we can assume parens entry is first
+          [{parens, Parens} | Meta] ->
+            [{parens, [ParensEntry | Parens]} | Meta];
+
+          Meta ->
+            [{parens, [ParensEntry]} | Meta]
+        end;
       false ->
         ExprMeta
     end,

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -618,10 +618,26 @@ defmodule Kernel.ParserTest do
                   1,
                   {:+,
                    [
+                     parens: [[line: 1, column: 5, closing: [line: 1, column: 11]]],
                      line: 1,
-                     column: 8,
-                     parens_opening: [line: 1, column: 5],
-                     parens_closing: [line: 1, column: 11]
+                     column: 8
+                   ], [2, 3]}
+                ]}
+
+      file = "1 + ((2 + 3))"
+
+      assert Code.string_to_quoted!(file, token_metadata: true, columns: true) ==
+               {:+, [line: 1, column: 3],
+                [
+                  1,
+                  {:+,
+                   [
+                     parens: [
+                       [line: 1, column: 5, closing: [line: 1, column: 13]],
+                       [line: 1, column: 6, closing: [line: 1, column: 12]]
+                     ],
+                     line: 1,
+                     column: 9
                    ], [2, 3]}
                 ]}
     end
@@ -666,10 +682,9 @@ defmodule Kernel.ParserTest do
                      [
                        {:__block__,
                         [
+                          parens: [[line: 1, closing: [line: 1]]],
                           token: "1",
-                          line: 1,
-                          parens_opening: [line: 1],
-                          parens_closing: [line: 1]
+                          line: 1
                         ], [1]}
                      ],
                      {:__block__, [delimiter: "\"", line: 1], ["hello"]}
@@ -677,8 +692,7 @@ defmodule Kernel.ParserTest do
                 ]}
 
       assert string_to_quoted.("(1)") ==
-               {:__block__,
-                [token: "1", line: 1, parens_opening: [line: 1], parens_closing: [line: 1]], [1]}
+               {:__block__, [parens: [[line: 1, closing: [line: 1]]], token: "1", line: 1], [1]}
     end
 
     test "adds identifier_location for qualified identifiers" do

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -609,6 +609,23 @@ defmodule Kernel.ParserTest do
                 [[do: {:__block__, [], []}]]}
     end
 
+    test "adds opening and closing information for single-expression block" do
+      file = "1 + (2 + 3)"
+
+      assert Code.string_to_quoted!(file, token_metadata: true, columns: true) ==
+               {:+, [line: 1, column: 3],
+                [
+                  1,
+                  {:+,
+                   [
+                     line: 1,
+                     column: 8,
+                     parens_opening: [line: 1, column: 5],
+                     parens_closing: [line: 1, column: 11]
+                   ], [2, 3]}
+                ]}
+    end
+
     test "with :literal_encoder" do
       opts = [literal_encoder: &{:ok, {:__block__, &2, [&1]}}, token_metadata: true]
       string_to_quoted = &Code.string_to_quoted!(&1, opts)
@@ -646,10 +663,22 @@ defmodule Kernel.ParserTest do
                 [
                   {:->, [line: 1],
                    [
-                     [{:__block__, [token: "1", line: 1], [1]}],
+                     [
+                       {:__block__,
+                        [
+                          token: "1",
+                          line: 1,
+                          parens_opening: [line: 1],
+                          parens_closing: [line: 1]
+                        ], [1]}
+                     ],
                      {:__block__, [delimiter: "\"", line: 1], ["hello"]}
                    ]}
                 ]}
+
+      assert string_to_quoted.("(1)") ==
+               {:__block__,
+                [token: "1", line: 1, parens_opening: [line: 1], parens_closing: [line: 1]], [1]}
     end
 
     test "adds identifier_location for qualified identifiers" do


### PR DESCRIPTION
Blocks with a single expression are not present in the AST, so for expressions like `(1 + 2) * 2` there is no way to tell if the parentheses are in the source.

cc @mhanberg for Spitfire :D
cc @lukaszsamson