### PR TITLE
Proposal: shallow validation of unquoted AST

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -814,7 +814,8 @@ defmodule Macro do
 
       iex> value = {:a, :b, :c}
       iex> quote do: unquote(value)
-      {:a, :b, :c}
+      ** (ArgumentError) tried to unquote invalid AST: {:a, :b, :c}
+      Did you forget to escape term using Macro.escape/1?
 
   `escape/2` is used to escape *values* (either directly passed or variable
   bound), while `quote/2` produces syntax trees for

--- a/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
@@ -405,12 +405,16 @@ defmodule Code.Normalizer.QuotedASTTest do
     end
 
     test "range" do
-      assert quoted_to_string(quote(do: unquote(-1..+2))) == "-1..2"
+      assert quoted_to_string(quote(do: -1..+2)) == "-1..+2"
       assert quoted_to_string(quote(do: Foo.integer()..3)) == "Foo.integer()..3"
-      assert quoted_to_string(quote(do: unquote(-1..+2//-3))) == "-1..2//-3"
+      assert quoted_to_string(quote(do: -1..+2//-3)) == "-1..+2//-3"
 
       assert quoted_to_string(quote(do: Foo.integer()..3//Bar.bat())) ==
                "Foo.integer()..3//Bar.bat()"
+
+      # invalid AST
+      assert quoted_to_string(-1..+2) == "-1..2"
+      assert quoted_to_string(-1..+2//-3) == "-1..2//-3"
     end
 
     test "when" do

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -2871,11 +2871,11 @@ defmodule Kernel.ExpansionTest do
 
   test "handles invalid expressions" do
     assert_compile_error(~r"invalid quoted expression: {1, 2, 3}", fn ->
-      expand_env(quote(do: unquote({1, 2, 3})), __ENV__)
+      expand_env({1, 2, 3}, __ENV__)
     end)
 
     assert_compile_error(~r"invalid quoted expression: #Function\<", fn ->
-      expand(quote(do: unquote({:sample, fn -> nil end})))
+      expand({:sample, fn -> nil end})
     end)
 
     assert_compile_error(~r"invalid pattern in match", fn ->

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -789,4 +789,26 @@ defmodule Kernel.QuoteTest.HasUnquoteTest do
 
     refute :elixir_quote.has_unquotes(ast)
   end
+
+  test "unquote with invalid AST (shallow check)" do
+    assert_raise ArgumentError, "tried to unquote invalid AST: %{unescaped: :map}", fn ->
+      quote do: unquote(%{unescaped: :map})
+    end
+
+    assert_raise ArgumentError, "tried to unquote invalid AST: {:bad_meta, nil, []}", fn ->
+      quote do: unquote({:bad_meta, nil, []})
+    end
+
+    assert_raise ArgumentError, "tried to unquote invalid AST: {:bad_arg, nil, 1}", fn ->
+      quote do: unquote({:bad_arg, nil, 1})
+    end
+
+    assert_raise ArgumentError, "tried to unquote invalid AST: {:bad_tuple}", fn ->
+      quote do: unquote({:bad_tuple})
+    end
+
+    assert_raise ArgumentError, ~r/tried to unquote invalid AST: #Reference</, fn ->
+      quote do: unquote(make_ref())
+    end
+  end
 end

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -839,7 +839,7 @@ defmodule MacroTest do
     end
 
     test "converts invalid AST with inspect" do
-      assert Macro.to_string(quote do: unquote(1..3)) == "1..3"
+      assert Macro.to_string(1..3) == "1..3"
     end
   end
 
@@ -1172,12 +1172,16 @@ defmodule MacroTest do
     end
 
     test "range" do
-      assert macro_to_string(quote(do: unquote(-1..+2))) == "-1..2"
+      assert macro_to_string(quote(do: -1..+2)) == "-1..+2"
       assert macro_to_string(quote(do: Foo.integer()..3)) == "Foo.integer()..3"
-      assert macro_to_string(quote(do: unquote(-1..+2//-3))) == "-1..2//-3"
+      assert macro_to_string(quote(do: -1..+2//-3)) == "-1..+2//-3"
 
       assert macro_to_string(quote(do: Foo.integer()..3//Bar.bat())) ==
                "Foo.integer()..3//Bar.bat()"
+
+      # invalid AST
+      assert macro_to_string(-1..+2) == "-1..2"
+      assert macro_to_string(-1..+2//-3) == "-1..2//-3"
     end
 
     test "when" do

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -63,7 +63,13 @@ defmodule Mix.Tasks.XrefTest do
       }
 
       output = [
-        %{callee: {A, :b, 1}, caller_module: B, file: "lib/b.ex", line: 3}
+        %{callee: {A, :b, 1}, caller_module: B, file: "lib/b.ex", line: 3},
+        %{
+          callee: {:elixir_quote, :shallow_validate_ast, 1},
+          caller_module: A,
+          file: "lib/a.ex",
+          line: 4
+        }
       ]
 
       assert_all_calls(files, output)


### PR DESCRIPTION
I didn't fix all tests yet, this is a proof of concept for discussion.

The idea is to introduce a shallow validation when using `unquote`, to give early feedback to meta-programmers when building obviously invalid AST which might fail later down the lane in a way that would then be non-obvious and harder to debug.

In order to avoid any slowdown especially when building complex ASTs, we do not loop on the whole AST (args just have to be a list), but this could catch many trivial errors e.g. forgetting to escape a map.
I had the idea on the back of my mind for a while, but https://github.com/elixir-lang/elixir/issues/13948 reminded me of it.

Note: This could perhaps just be a warning for now if we want to be conservative.