### PR TITLE
Add test for call with thai atom

### DIFF
--- a/lib/elixir/test/elixir/kernel/string_tokenizer_test.exs
+++ b/lib/elixir/test/elixir/kernel/string_tokenizer_test.exs
@@ -70,6 +70,14 @@ defmodule Kernel.StringTokenizerTest do
     assert {:error, _} = Code.string_to_quoted("Ola!")
   end
 
+  test "tokenizes calls with thai atom" do
+    assert {{:., _, [:foo, :บูมเมอแรง]}, _, []} =
+             Code.string_to_quoted!(":foo.บูมเมอแรง()")
+
+    assert {{:., _, [:foo, :บูมเมอแรง]}, _, []} =
+             Code.string_to_quoted!(":foo.\"บูมเมอแรง\"()")
+  end
+
   describe "script mixing" do
     test "prevents Restricted codepoints in identifiers" do
       exception = assert_raise SyntaxError, fn -> Code.string_to_quoted!("_shibㅤ = 1") end

--- a/lib/elixir/test/elixir/kernel/string_tokenizer_test.exs
+++ b/lib/elixir/test/elixir/kernel/string_tokenizer_test.exs
@@ -70,7 +70,8 @@ defmodule Kernel.StringTokenizerTest do
     assert {:error, _} = Code.string_to_quoted("Ola!")
   end
 
-  test "tokenizes calls with thai atom" do
+  test "tokenizes remote calls" do
+    # We chose the atom below because Erlang represents it using nested lists
     assert {{:., _, [:foo, :บูมเมอแรง]}, _, []} =
              Code.string_to_quoted!(":foo.บูมเมอแรง()")
 


### PR DESCRIPTION
Close #13951

As discussed in the issue, this is already fixed in main, but I thought perhaps adding a test to prevent future regressions would be beneficial? 🪃

<img width="632" alt="Screenshot 2024-11-03 at 9 31 17" src="https://github.com/user-attachments/assets/48447425-5023-47c7-9444-955305565e47">
