### PR TITLE
Format inserted/deleted maps in list assertions 

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -398,9 +398,7 @@ defmodule ExUnit.Diff do
 
   defp diff_improper([], right, env) when is_list(right) do
     equivalent? = right == []
-
     right = right |> escape() |> update_diff_meta(not equivalent?)
-
     {%__MODULE__{equivalent?: equivalent?, right: right, left: []}, env}
   end
 

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -1142,12 +1142,11 @@ defmodule ExUnit.Diff do
   defp maybe_escape(other, %{context: :match}), do: other
   defp maybe_escape(other, _env), do: escape(other)
 
-  # We escape container types to make a distinction between AST
-  # and values that should be inspected. All other values have no
-  # special AST representation, so we can keep them as is.
-  # Maps should be formatted not inspected.
+  # We escape container types to make a distinction between AST and values that
+  # should be inspected. Maps should not be inspected, convert it to ast.
+  # All other values have no special AST representation, so we can keep them as is.
   defp escape(other) when is_struct(other), do: other
-  defp escape(elem) when is_map(elem), do: {:%{}, [], Map.to_list(elem)}
+  defp escape(other) when is_map(other), do: {:%{}, [], Map.to_list(other)}
   defp escape(other) when is_list(other) or is_tuple(other), do: {other}
   defp escape(other), do: other
 

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -1143,10 +1143,21 @@ defmodule ExUnit.Diff do
   defp maybe_escape(other, _env), do: escape(other)
 
   # We escape container types to make a distinction between AST and values that
-  # should be inspected. Maps should not be inspected, convert it to ast.
+  # should be inspected. Maps and structs without custom inspect implementation
+  # should not be inspected, convert it to ast.
   # All other values have no special AST representation, so we can keep them as is.
-  defp escape(other) when is_struct(other), do: other
-  defp escape(other) when is_map(other), do: {:%{}, [], Map.to_list(other)}
+  defp escape(other) when is_map(other) do
+    struct = maybe_struct(other)
+
+    if struct && Inspect.impl_for(other) not in [Inspect.Any, Inspect.Map] do
+      other
+    else
+      other
+      |> Map.to_list()
+      |> build_map_or_struct(struct)
+    end
+  end
+
   defp escape(other) when is_list(other) or is_tuple(other), do: {other}
   defp escape(other), do: other
 

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -398,6 +398,7 @@ defmodule ExUnit.Diff do
 
   defp diff_improper([], right, env) when is_list(right) do
     equivalent? = right == []
+
     right = right |> escape() |> update_diff_meta(not equivalent?)
 
     {%__MODULE__{equivalent?: equivalent?, right: right, left: []}, env}
@@ -763,10 +764,6 @@ defmodule ExUnit.Diff do
   rescue
     _ -> :error
   end
-
-  def build_quoted(elem) when is_struct(elem), do: elem
-  def build_quoted(elem) when is_map(elem), do: {:%{}, [], Map.to_list(elem)}
-  def build_quoted(elem), do: elem
 
   defp maybe_struct(%name{}), do: name
   defp maybe_struct(_), do: nil

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -398,7 +398,13 @@ defmodule ExUnit.Diff do
 
   defp diff_improper([], right, env) when is_list(right) do
     equivalent? = right == []
-    right = right |> escape() |> update_diff_meta(not equivalent?)
+
+    right =
+      right
+      |> Enum.map(&build_elem/1)
+      |> escape()
+      |> update_diff_meta(not equivalent?)
+
     {%__MODULE__{equivalent?: equivalent?, right: right, left: []}, env}
   end
 
@@ -558,7 +564,7 @@ defmodule ExUnit.Diff do
   end
 
   defp move_right({y, list1, [elem2 | rest2], {edit1, edit2, env}}) do
-    {y, list1, rest2, {edit1, [{:ins, build_elem(elem2)} | edit2], env}}
+    {y, list1, rest2, {edit1, [{:ins, elem2} | edit2], env}}
   end
 
   defp move_right({y, list1, [], edits}) do

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -398,12 +398,7 @@ defmodule ExUnit.Diff do
 
   defp diff_improper([], right, env) when is_list(right) do
     equivalent? = right == []
-
-    right =
-      right
-      |> Enum.map(&build_quoted/1)
-      |> escape()
-      |> update_diff_meta(not equivalent?)
+    right = right |> escape() |> update_diff_meta(not equivalent?)
 
     {%__MODULE__{equivalent?: equivalent?, right: right, left: []}, env}
   end
@@ -624,12 +619,12 @@ defmodule ExUnit.Diff do
   end
 
   defp list_script_to_diff([{:del, elem1} | rest1], rest2, _, left, right, env) do
-    diff_left = elem1 |> build_quoted() |> maybe_escape(env) |> update_diff_meta(true)
+    diff_left = elem1 |> maybe_escape(env) |> update_diff_meta(true)
     list_script_to_diff(rest1, rest2, false, [diff_left | left], right, env)
   end
 
   defp list_script_to_diff(rest1, [{:ins, elem2} | rest2], _, left, right, env) do
-    diff_right = elem2 |> build_quoted() |> escape() |> update_diff_meta(true)
+    diff_right = elem2 |> escape() |> update_diff_meta(true)
     list_script_to_diff(rest1, rest2, false, left, [diff_right | right], env)
   end
 
@@ -1157,7 +1152,7 @@ defmodule ExUnit.Diff do
   # special AST representation, so we can keep them as is.
   # Maps should be formatted not inspected.
   defp escape(other) when is_struct(other), do: {other}
-  defp escape({:%{}, _, _} = other), do: other
+  defp escape(elem) when is_map(elem), do: {:%{}, [], Map.to_list(elem)}
   defp escape(other) when is_list(other) or is_tuple(other), do: {other}
   defp escape(other), do: other
 

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -1146,7 +1146,7 @@ defmodule ExUnit.Diff do
   # and values that should be inspected. All other values have no
   # special AST representation, so we can keep them as is.
   # Maps should be formatted not inspected.
-  defp escape(other) when is_struct(other), do: {other}
+  defp escape(other) when is_struct(other), do: other
   defp escape(elem) when is_map(elem), do: {:%{}, [], Map.to_list(elem)}
   defp escape(other) when is_list(other) or is_tuple(other), do: {other}
   defp escape(other), do: other

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -558,7 +558,7 @@ defmodule ExUnit.Diff do
   end
 
   defp move_right({y, list1, [elem2 | rest2], {edit1, edit2, env}}) do
-    {y, list1, rest2, {edit1, [{:ins, elem2} | edit2], env}}
+    {y, list1, rest2, {edit1, [{:ins, build_elem(elem2)} | edit2], env}}
   end
 
   defp move_right({y, list1, [], edits}) do
@@ -566,7 +566,7 @@ defmodule ExUnit.Diff do
   end
 
   defp move_down({y, [elem1 | rest1], list2, {edit1, edit2, env}}) do
-    {y + 1, rest1, list2, {[{:del, elem1} | edit1], edit2, env}}
+    {y + 1, rest1, list2, {[{:del, build_elem(elem1)} | edit1], edit2, env}}
   end
 
   defp move_down({y, [], list2, edits}) do
@@ -762,6 +762,10 @@ defmodule ExUnit.Diff do
   rescue
     _ -> :error
   end
+
+  def build_elem(elem) when is_struct(elem), do: elem
+  def build_elem(elem) when is_map(elem), do: {:%{}, [], Map.to_list(elem)}
+  def build_elem(elem), do: elem
 
   defp maybe_struct(%name{}), do: name
   defp maybe_struct(_), do: nil
@@ -1145,6 +1149,9 @@ defmodule ExUnit.Diff do
   # We escape container types to make a distinction between AST
   # and values that should be inspected. All other values have no
   # special AST representation, so we can keep them as is.
+  # Maps should be formatted not inspected.
+  defp escape(other) when is_struct(other), do: {other}
+  defp escape({:%{}, _, _} = other), do: other
   defp escape(other) when is_list(other) or is_tuple(other), do: {other}
   defp escape(other), do: other
 

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -401,7 +401,7 @@ defmodule ExUnit.Diff do
 
     right =
       right
-      |> Enum.map(&build_elem/1)
+      |> Enum.map(&build_quoted/1)
       |> escape()
       |> update_diff_meta(not equivalent?)
 
@@ -572,7 +572,7 @@ defmodule ExUnit.Diff do
   end
 
   defp move_down({y, [elem1 | rest1], list2, {edit1, edit2, env}}) do
-    {y + 1, rest1, list2, {[{:del, build_elem(elem1)} | edit1], edit2, env}}
+    {y + 1, rest1, list2, {[{:del, elem1} | edit1], edit2, env}}
   end
 
   defp move_down({y, [], list2, edits}) do
@@ -624,12 +624,12 @@ defmodule ExUnit.Diff do
   end
 
   defp list_script_to_diff([{:del, elem1} | rest1], rest2, _, left, right, env) do
-    diff_left = elem1 |> maybe_escape(env) |> update_diff_meta(true)
+    diff_left = elem1 |> build_quoted() |> maybe_escape(env) |> update_diff_meta(true)
     list_script_to_diff(rest1, rest2, false, [diff_left | left], right, env)
   end
 
   defp list_script_to_diff(rest1, [{:ins, elem2} | rest2], _, left, right, env) do
-    diff_right = elem2 |> escape() |> update_diff_meta(true)
+    diff_right = elem2 |> build_quoted() |> escape() |> update_diff_meta(true)
     list_script_to_diff(rest1, rest2, false, left, [diff_right | right], env)
   end
 
@@ -769,9 +769,9 @@ defmodule ExUnit.Diff do
     _ -> :error
   end
 
-  def build_elem(elem) when is_struct(elem), do: elem
-  def build_elem(elem) when is_map(elem), do: {:%{}, [], Map.to_list(elem)}
-  def build_elem(elem), do: elem
+  def build_quoted(elem) when is_struct(elem), do: elem
+  def build_quoted(elem) when is_map(elem), do: {:%{}, [], Map.to_list(elem)}
+  def build_quoted(elem), do: elem
 
   defp maybe_struct(%name{}), do: name
   defp maybe_struct(_), do: nil

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -922,6 +922,8 @@ defmodule ExUnit.DiffTest do
       ]\
       """
     )
+
+    assert_diff([map] == [map], [])
   end
 
   test "maps and structs with escaped values" do

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -1200,7 +1200,16 @@ defmodule ExUnit.DiffTest do
 
     refute_diff(ref1 == :a, "-#{inspect_ref1}-", "+:a+")
     refute_diff({ref1, ref2} == :a, "-{#{inspect_ref1}, #{inspect_ref2}}", "+:a+")
-    refute_diff(%{ref1 => ref2} == :a, "-%{#{inspect_ref1} => #{inspect_ref2}}", "+:a+")
+
+    refute_diff(
+      %{ref1 => ref2} == :a,
+      """
+      -%{
+        #{inspect_ref1} => #{inspect_ref2}
+      }\
+      """,
+      "+:a+"
+    )
 
     refute_diff(
       %Opaque{data: ref1} == :a,
@@ -1241,7 +1250,16 @@ defmodule ExUnit.DiffTest do
     refute_diff(identity == :a, "-#{inspect}-", "+:a+")
     refute_diff({identity, identity} == :a, "-{#{inspect}, #{inspect}}", "+:a+")
     refute_diff({identity, :a} == {:a, identity}, "{-#{inspect}-, -:a-}", "{+:a+, +#{inspect}+}")
-    refute_diff(%{identity => identity} == :a, "-%{#{inspect} => #{inspect}}", "+:a+")
+
+    refute_diff(
+      %{identity => identity} == :a,
+      """
+      -%{
+        #{inspect} => #{inspect}
+      }-\
+      """,
+      "+:a+"
+    )
 
     refute_diff(
       (&String.to_charlist/1) == (&String.unknown/1),

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -126,12 +126,11 @@ defmodule ExUnit.DiffTest do
     assert env_binding == expected_binding
   end
 
+  @terminal_width 80
   defp to_diff(side, sign) do
-    terminal_width = 80
-
     side
     |> Diff.to_algebra(&diff_wrapper(&1, sign))
-    |> Algebra.format(terminal_width)
+    |> Algebra.format(@terminal_width)
     |> IO.iodata_to_binary()
   end
 

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -10,6 +10,10 @@ defmodule ExUnit.DiffTest do
     defstruct [:name, :age]
   end
 
+  defmodule Customer do
+    defstruct [:address, :age, :first_name, :language, :last_name, :notifications]
+  end
+
   defmodule Person do
     defstruct [:age]
   end
@@ -875,17 +879,17 @@ defmodule ExUnit.DiffTest do
 
   test "maps in lists" do
     map = %{
-      first_name: "John",
-      last_name: "Doe",
-      age: 30,
-      notifications: true,
-      language: "en-US",
       address: %{
         street: "123 Main St",
         city: "Springfield",
         state: "IL",
         zip: "62701"
-      }
+      },
+      age: 30,
+      first_name: "John",
+      language: "en-US",
+      last_name: "Doe",
+      notifications: true
     }
 
     refute_diff(
@@ -893,12 +897,12 @@ defmodule ExUnit.DiffTest do
       """
       [
         -%{
-          address: %{state: \"IL\", zip: \"62701\", street: \"123 Main St\", city: \"Springfield\"},
+          address: %{state: "IL", zip: "62701", street: "123 Main St", city: "Springfield"},
           age: 30,
-          first_name: \"John\",
-          last_name: \"Doe\",
-          notifications: true,
-          language: \"en-US\"
+          first_name: "John",
+          language: "en-US",
+          last_name: "Doe",
+          notifications: true
         }-
       ]\
       """,
@@ -911,18 +915,70 @@ defmodule ExUnit.DiffTest do
       """
       [
         +%{
-          address: %{state: \"IL\", zip: \"62701\", street: \"123 Main St\", city: \"Springfield\"},
+          address: %{state: "IL", zip: "62701", street: "123 Main St", city: "Springfield"},
           age: 30,
-          first_name: \"John\",
-          last_name: \"Doe\",
-          notifications: true,
-          language: \"en-US\"
+          first_name: "John",
+          language: "en-US",
+          last_name: "Doe",
+          notifications: true
         }+
       ]\
       """
     )
 
     assert_diff([map] == [map], [])
+  end
+
+  test "structs in lists" do
+    customer = %Customer{
+      address: %{
+        street: "123 Main St",
+        city: "Springfield",
+        state: "IL",
+        zip: "62701"
+      },
+      age: 30,
+      first_name: "John",
+      language: "en-US",
+      last_name: "Doe",
+      notifications: true
+    }
+
+    refute_diff(
+      [customer] == [],
+      """
+      [
+        -%ExUnit.DiffTest.Customer{
+          address: %{state: "IL", zip: "62701", street: "123 Main St", city: "Springfield"},
+          age: 30,
+          first_name: "John",
+          language: "en-US",
+          last_name: "Doe",
+          notifications: true
+        }-
+      ]\
+      """,
+      "[]"
+    )
+
+    refute_diff(
+      [] == [customer],
+      "[]",
+      """
+      [
+        +%ExUnit.DiffTest.Customer{
+          address: %{state: "IL", zip: "62701", street: "123 Main St", city: "Springfield"},
+          age: 30,
+          first_name: "John",
+          language: "en-US",
+          last_name: "Doe",
+          notifications: true
+        }+
+      ]\
+      """
+    )
+
+    assert_diff([customer] == [customer], [])
   end
 
   test "maps and structs with escaped values" do

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -469,6 +469,58 @@ defmodule ExUnit.FormatterTest do
            """
   end
 
+  test "formats nested maps with column limit" do
+    map =
+      %{
+        microsecond: {1, 2},
+        second: 3,
+        month: 4,
+        day: 5,
+        year: 2024,
+        minute: 6,
+        hour: 7
+      }
+
+    failure = [{:error, catch_assertion(assert [map, %{map | hour: 8}] == [map]), []}]
+
+    assert format_test_all_failure(test_module(), failure, 1, 80, &formatter/2) == """
+             1) Hello: failure on setup_all callback, all tests have been invalidated
+                Assertion with == failed
+                code:  assert [map, %{map | hour: 8}] == [map]
+                left:  [
+                         %{
+                           microsecond: {1, 2},
+                           second: 3,
+                           month: 4,
+                           day: 5,
+                           year: 2024,
+                           minute: 6,
+                           hour: 7
+                         },
+                         %{
+                           microsecond: {1, 2},
+                           second: 3,
+                           month: 4,
+                           day: 5,
+                           year: 2024,
+                           minute: 6,
+                           hour: 8
+                         }
+                       ]
+                right: [
+                         %{
+                           microsecond: {1, 2},
+                           second: 3,
+                           month: 4,
+                           day: 5,
+                           year: 2024,
+                           minute: 6,
+                           hour: 7
+                         }
+                       ]
+           """
+  end
+
   test "formats assertions with complex function call arguments" do
     failure = [{:error, catch_assertion(assert is_list(List.to_tuple([1, 2, 3]))), []}]
 

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -469,58 +469,6 @@ defmodule ExUnit.FormatterTest do
            """
   end
 
-  test "formats nested maps with column limit" do
-    map =
-      %{
-        microsecond: {1, 2},
-        second: 3,
-        month: 4,
-        day: 5,
-        year: 2024,
-        minute: 6,
-        hour: 7
-      }
-
-    failure = [{:error, catch_assertion(assert [map, %{map | hour: 8}] == [map]), []}]
-
-    assert format_test_all_failure(test_module(), failure, 1, 80, &formatter/2) == """
-             1) Hello: failure on setup_all callback, all tests have been invalidated
-                Assertion with == failed
-                code:  assert [map, %{map | hour: 8}] == [map]
-                left:  [
-                         %{
-                           microsecond: {1, 2},
-                           second: 3,
-                           month: 4,
-                           day: 5,
-                           year: 2024,
-                           minute: 6,
-                           hour: 7
-                         },
-                         %{
-                           microsecond: {1, 2},
-                           second: 3,
-                           month: 4,
-                           day: 5,
-                           year: 2024,
-                           minute: 6,
-                           hour: 8
-                         }
-                       ]
-                right: [
-                         %{
-                           microsecond: {1, 2},
-                           second: 3,
-                           month: 4,
-                           day: 5,
-                           year: 2024,
-                           minute: 6,
-                           hour: 7
-                         }
-                       ]
-           """
-  end
-
   test "formats assertions with complex function call arguments" do
     failure = [{:error, catch_assertion(assert is_list(List.to_tuple([1, 2, 3]))), []}]
 


### PR DESCRIPTION
Solves #13624 When the elements are equal then we pass them as ast, when deleted or inserted we pass maps as `%{a: 1, b: 2}` and fall into inspect in safe_to_algebra. This pr changes maps to ast representation so it's formatted correctly in the function that handles maps.
I wrote a test, but I couldn't make it fail initially. However, it did fail when I added a regular assertion in my code. There are likely similar issues with other data structure, but now that I know what to change, it should be easier to extend the fix. It wasn't easy to find the issue with all the pattern matching in function heads and the single-element tuple which is not that easy to spot. It would be helpful to have a `dbg` implementation for multiple function heads.