### PR TITLE
Give prevalence to process level over primary/module levels

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -939,8 +939,14 @@ defmodule Logger do
   def __should_log__(level, module) do
     level = elixir_level_to_erlang_level(level)
 
-    if :logger_config.allow(level, module) do
-      level
+    case get_process_level(self()) do
+      nil ->
+        if :logger_config.allow(level, module) do
+          level
+        end
+
+      process_level ->
+        process_level
     end
   end
 

--- a/lib/logger/test/test_helper.exs
+++ b/lib/logger/test/test_helper.exs
@@ -41,14 +41,17 @@ defmodule Logger.Case do
     end
   end
 
-  def capture_log(level \\ :debug, fun) do
+  def capture_log(level \\ Logger.level(), fun) do
+    previous_level = Logger.level()
     Logger.configure(level: level)
 
-    capture_io(:user, fn ->
-      fun.()
-      Logger.flush()
-    end)
-  after
-    Logger.configure(level: :debug)
+    try do
+      capture_io(:user, fn ->
+        fun.()
+        Logger.flush()
+      end)
+    after
+      Logger.configure(level: previous_level)
+    end
   end
 end


### PR DESCRIPTION
The docs incorrectly implied that `Logger.put_process_level/2` allowed one to decrease the logger level for a process. This is not possible with this function.