### PR TITLE
Fix formatter adding extra escapes to remote call functions

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -2438,8 +2438,7 @@ defmodule Code.Formatter do
   end
 
   defp escape_atom(string, char) do
-    char = List.to_string([char])
-    String.replace(string, char, "\\#{char}")
+    String.replace(string, <<char>>, <<?\\, char>>)
   end
 
   ## Algebra helpers

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -126,13 +126,13 @@ defmodule Code.Normalizer do
     {:., meta, [Access, :get]}
   end
 
-  # Only normalize the left side of the dot operator
   # The right hand side is an atom in the AST but it's not an atom literal, so
-  # it should not be wrapped
-  defp do_normalize({:., meta, [left, right]}, state) do
+  # it should not be wrapped. However, it should be escaped if applicable.
+  defp do_normalize({:., meta, [left, right]}, state) when is_atom(right) do
     meta = patch_meta_line(meta, state.parent_meta)
 
     left = do_normalize(left, %{state | parent_meta: meta})
+    right = maybe_escape_literal(right, state)
 
     {:., meta, [left, right]}
   end

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2328,6 +2328,15 @@ defmodule Macro do
   as a key (`:key`), or as the function name of a remote call
   (`:remote_call`).
 
+  ## Options
+
+    * `:escape` - a two-arity function used to escape a quoted
+      atom content, if necessary. The function receives the atom
+      content as string and a quote delimiter character, which
+      should always be escaped. By default the content is escaped
+      such that the inspected sequence would be parsed as the
+      given atom.
+
   ## Examples
 
   ### As a literal
@@ -2376,14 +2385,19 @@ defmodule Macro do
 
   """
   @doc since: "1.14.0"
-  @spec inspect_atom(:literal | :key | :remote_call, atom) :: binary
-  def inspect_atom(source_format, atom)
+  @spec inspect_atom(:literal | :key | :remote_call, atom, keyword) :: binary
+  def inspect_atom(source_format, atom, opts \\ []) do
+    opts = Keyword.validate!(opts, [:escape])
 
-  def inspect_atom(:literal, atom) when is_nil(atom) or is_boolean(atom) do
+    escape = Keyword.get(opts, :escape, &inspect_atom_escape/2)
+    do_inspect_atom(source_format, atom, escape)
+  end
+
+  def do_inspect_atom(:literal, atom, _escape) when is_nil(atom) or is_boolean(atom) do
     Atom.to_string(atom)
   end
 
-  def inspect_atom(:literal, atom) when is_atom(atom) do
+  def do_inspect_atom(:literal, atom, escape) when is_atom(atom) do
     binary = Atom.to_string(atom)
 
     case classify_atom(atom) do
@@ -2395,7 +2409,7 @@ defmodule Macro do
         end
 
       :quoted ->
-        {escaped, _} = Code.Identifier.escape(binary, ?")
+        escaped = escape.(binary, ?")
         IO.iodata_to_binary([?:, ?", escaped, ?"])
 
       _ ->
@@ -2403,7 +2417,7 @@ defmodule Macro do
     end
   end
 
-  def inspect_atom(:key, atom) when is_atom(atom) do
+  def do_inspect_atom(:key, atom, escape) when is_atom(atom) do
     binary = Atom.to_string(atom)
 
     case classify_atom(atom) do
@@ -2411,7 +2425,7 @@ defmodule Macro do
         IO.iodata_to_binary([?", binary, ?", ?:])
 
       :quoted ->
-        {escaped, _} = Code.Identifier.escape(binary, ?")
+        escaped = escape.(binary, ?")
         IO.iodata_to_binary([?", escaped, ?", ?:])
 
       _ ->
@@ -2419,7 +2433,7 @@ defmodule Macro do
     end
   end
 
-  def inspect_atom(:remote_call, atom) when is_atom(atom) do
+  def do_inspect_atom(:remote_call, atom, escape) when is_atom(atom) do
     binary = Atom.to_string(atom)
 
     case inner_classify(atom) do
@@ -2431,11 +2445,16 @@ defmodule Macro do
           if type in [:not_callable, :alias] do
             binary
           else
-            elem(Code.Identifier.escape(binary, ?"), 0)
+            escape.(binary, ?")
           end
 
         IO.iodata_to_binary([?", escaped, ?"])
     end
+  end
+
+  defp inspect_atom_escape(string, char) do
+    {escaped, _} = Code.Identifier.escape(string, char)
+    escaped
   end
 
   # Classifies the given atom into one of the following categories:

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2386,18 +2386,13 @@ defmodule Macro do
   """
   @doc since: "1.14.0"
   @spec inspect_atom(:literal | :key | :remote_call, atom, keyword) :: binary
-  def inspect_atom(source_format, atom, opts \\ []) do
-    opts = Keyword.validate!(opts, [:escape])
+  def inspect_atom(source_format, atom, opts \\ [])
 
-    escape = Keyword.get(opts, :escape, &inspect_atom_escape/2)
-    do_inspect_atom(source_format, atom, escape)
-  end
-
-  def do_inspect_atom(:literal, atom, _escape) when is_nil(atom) or is_boolean(atom) do
+  def inspect_atom(:literal, atom, _opts) when is_nil(atom) or is_boolean(atom) do
     Atom.to_string(atom)
   end
 
-  def do_inspect_atom(:literal, atom, escape) when is_atom(atom) do
+  def inspect_atom(:literal, atom, opts) when is_atom(atom) do
     binary = Atom.to_string(atom)
 
     case classify_atom(atom) do
@@ -2409,7 +2404,7 @@ defmodule Macro do
         end
 
       :quoted ->
-        escaped = escape.(binary, ?")
+        escaped = inspect_atom_escape(opts, binary, ?")
         IO.iodata_to_binary([?:, ?", escaped, ?"])
 
       _ ->
@@ -2417,7 +2412,7 @@ defmodule Macro do
     end
   end
 
-  def do_inspect_atom(:key, atom, escape) when is_atom(atom) do
+  def inspect_atom(:key, atom, opts) when is_atom(atom) do
     binary = Atom.to_string(atom)
 
     case classify_atom(atom) do
@@ -2425,7 +2420,7 @@ defmodule Macro do
         IO.iodata_to_binary([?", binary, ?", ?:])
 
       :quoted ->
-        escaped = escape.(binary, ?")
+        escaped = inspect_atom_escape(opts, binary, ?")
         IO.iodata_to_binary([?", escaped, ?", ?:])
 
       _ ->
@@ -2433,7 +2428,7 @@ defmodule Macro do
     end
   end
 
-  def do_inspect_atom(:remote_call, atom, escape) when is_atom(atom) do
+  def inspect_atom(:remote_call, atom, opts) when is_atom(atom) do
     binary = Atom.to_string(atom)
 
     case inner_classify(atom) do
@@ -2445,16 +2440,20 @@ defmodule Macro do
           if type in [:not_callable, :alias] do
             binary
           else
-            escape.(binary, ?")
+            inspect_atom_escape(opts, binary, ?")
           end
 
         IO.iodata_to_binary([?", escaped, ?"])
     end
   end
 
-  defp inspect_atom_escape(string, char) do
-    {escaped, _} = Code.Identifier.escape(string, char)
-    escaped
+  defp inspect_atom_escape(opts, string, char) do
+    if escape = opts[:escape] do
+      escape.(string, char)
+    else
+      {escaped, _} = Code.Identifier.escape(string, char)
+      escaped
+    end
   end
 
   # Classifies the given atom into one of the following categories:

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -918,7 +918,7 @@ handle_dot([$., H | T] = Original, Line, Column, DotInfo, Scope, Tokens) when ?i
 
       case unsafe_to_atom(UnescapedPart, Line, Column, NewScope) of
         {ok, Atom} ->
-          Token = check_call_identifier(Line, Column, UnescapedPart, Atom, Rest),
+          Token = check_call_identifier(Line, Column, Part, Atom, Rest),
           TokensSoFar = add_token_with_eol({'.', DotInfo}, Tokens),
           tokenize(Rest, NewLine, NewColumn, NewScope, [Token | TokensSoFar]);
 

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -914,9 +914,11 @@ handle_dot([$., H | T] = Original, Line, Column, DotInfo, Scope, Tokens) when ?i
           InterScope
       end,
 
-      case unsafe_to_atom(Part, Line, Column, NewScope) of
+      {ok, [UnescapedPart]} = unescape_tokens([Part], Line, Column, NewScope),
+
+      case unsafe_to_atom(UnescapedPart, Line, Column, NewScope) of
         {ok, Atom} ->
-          Token = check_call_identifier(Line, Column, Part, Atom, Rest),
+          Token = check_call_identifier(Line, Column, UnescapedPart, Atom, Rest),
           TokensSoFar = add_token_with_eol({'.', DotInfo}, Tokens),
           tokenize(Rest, NewLine, NewColumn, NewScope, [Token | TokensSoFar]);
 

--- a/lib/elixir/test/elixir/code_formatter/calls_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/calls_test.exs
@@ -595,6 +595,7 @@ defmodule Code.Formatter.CallsTest do
       assert_same ~S[Kernel.+(1, 2)]
       assert_same ~S[:erlang.+(1, 2)]
       assert_same ~S[foo."bar baz"(1, 2)]
+      assert_same ~S[foo."bar\nbaz"(1, 2)]
     end
 
     test "splits on arguments and dot on line limit" do

--- a/lib/elixir/test/elixir/code_formatter/operators_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/operators_test.exs
@@ -948,6 +948,7 @@ defmodule Code.Formatter.OperatorsTest do
       assert_format "&(Mod.foo/1)", "&Mod.foo/1"
       assert_format "&(Mod.++/1)", "&Mod.++/1"
       assert_format ~s[&(Mod."foo bar"/1)], ~s[&Mod."foo bar"/1]
+      assert_format ~S[&(Mod."foo\nbar"/1)], ~S[&Mod."foo\nbar"/1]
 
       # Invalid
       assert_format "& Mod.foo/bar", "&(Mod.foo() / bar)"


### PR DESCRIPTION
Currently given a code `Foo."bar\nbaz"(1, 2)`, the formatter would keep adding extra `\` on every format.