### PR TITLE
Improve validation of unquote_splicing AST

### DIFF
--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -531,11 +531,12 @@ tail_list(Left, Right, Tail) when is_list(Left) ->
   [H | T] = lists:reverse(Tail ++ Left),
   lists:reverse([{'|', [], [H, Right]} | T]).
 
-validate_list(List) when is_list(List) ->
-  ok;
-validate_list(List) when not is_list(List) ->
-  argument_error(<<"expected a list with quoted expressions in unquote_splicing/1, got: ",
-                   ('Elixir.Kernel':inspect(List))/binary>>).
+validate_list(List) ->
+  case valid_ast_list(List) of
+    true -> ok;
+    false -> argument_error(<<"expected a list with quoted expressions in unquote_splicing/1, got: ",
+                   ('Elixir.Kernel':inspect(List))/binary>>)
+  end.
 
 argument_error(Message) ->
   error('Elixir.ArgumentError':exception([{message, Message}])).

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -814,4 +814,23 @@ defmodule Kernel.QuoteTest.HasUnquoteTest do
     assert quote do: unquote(foo: [1 | 2]) == [foo: [1 | 2]]
     assert quote do: unquote(foo: [bar: %{}]) == [foo: [bar: %{}]]
   end
+
+  test "unquote_splicing with invalid AST" do
+    for args <- [
+          "not_a_list",
+          [:improper | :list],
+          [%{unescaped: :map}],
+          [1..10],
+          [{:bad_meta, nil, []}],
+          [{:bad_arg, nil, 1}],
+          [{:bad_tuple}],
+          [make_ref()],
+          [nested: {}]
+        ] do
+      message =
+        "expected a list with quoted expressions in unquote_splicing/1, got: #{inspect(args)}"
+
+      assert_raise ArgumentError, message, fn -> quote do: [unquote_splicing(args)] end
+    end
+  end
 end


### PR DESCRIPTION
Extending https://github.com/elixir-lang/elixir/pull/13950 to `unquote_splicing`, which was just checking `is_list`.