### PR TITLE
Detect unused clauses and matches

### DIFF
--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -53,7 +53,9 @@ defmodule Module.Types do
   end
 
   defp warnings_from_clause(meta, args, guards, body, stack, context) do
-    {_types, context} = Pattern.of_head(args, guards, meta, stack, context)
+    dynamic = Module.Types.Descr.dynamic()
+    expected = Enum.map(args, fn _ -> dynamic end)
+    {_types, context} = Pattern.of_head(args, guards, expected, :default, meta, stack, context)
     {_type, context} = Expr.of_expr(body, stack, context)
     context.warnings
   end

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -582,6 +582,15 @@ defmodule Module.Types.Descr do
   def number_type?(%{bitmap: bitmap}) when (bitmap &&& @bit_number) != 0, do: true
   def number_type?(_), do: false
 
+  @doc """
+  Optimized version of `not empty?(intersection(atom(), type))`.
+  """
+  def atom_type?(:term), do: true
+  def atom_type?(%{dynamic: :term}), do: true
+  def atom_type?(%{dynamic: %{atom: _}}), do: true
+  def atom_type?(%{atom: _}), do: true
+  def atom_type?(_), do: false
+
   ## Bitmaps
 
   defp bitmap_to_quoted(val) do

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -121,7 +121,7 @@ defmodule Module.Types.Of do
     {dynamic?, fallback, single, multiple, assert, context} =
       Enum.reduce(pairs, {false, none(), [], [], [], context}, fn
         {key, value}, {dynamic?, fallback, single, multiple, assert, context} ->
-          {dynamic_key?, keys, context} = of_finite_key_type(key, stack, context, of_fun)
+          {dynamic_key?, keys, context} = finite_key_type(key, stack, context, of_fun)
           {value_type, context} = of_fun.(value, stack, context)
           dynamic? = dynamic? or dynamic_key? or gradual?(value_type)
 
@@ -164,11 +164,11 @@ defmodule Module.Types.Of do
     if dynamic?, do: {dynamic(map), context}, else: {map, context}
   end
 
-  defp of_finite_key_type(key, _stack, context, _of_fun) when is_atom(key) do
+  defp finite_key_type(key, _stack, context, _of_fun) when is_atom(key) do
     {false, [key], context}
   end
 
-  defp of_finite_key_type(key, stack, context, of_fun) do
+  defp finite_key_type(key, stack, context, of_fun) do
     {key_type, context} = of_fun.(key, stack, context)
 
     case atom_fetch(key_type) do

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -25,29 +25,25 @@ defmodule Module.Types.Pattern do
      is refined, we restart at step 2.
 
   """
-  # TODO: The expected types for patterns/guards must always given as arguments.
-  # TODO: Perform full guard inference
-  def of_head(patterns, guards, meta, stack, context) do
+  def of_head(patterns, guards, expected, tag, meta, stack, context) do
     stack = %{stack | meta: meta}
-    dynamic = dynamic()
-    expected_types = Enum.map(patterns, fn _ -> dynamic end)
 
-    {_trees, types, context} = of_pattern_args(patterns, expected_types, stack, context)
+    {_trees, types, context} = of_pattern_args(patterns, expected, tag, stack, context)
     {_, context} = Enum.map_reduce(guards, context, &of_guard(&1, @guard, &1, stack, &2))
     {types, context}
   end
 
-  defp of_pattern_args([], [], _stack, context) do
+  defp of_pattern_args([], [], _tag, _stack, context) do
     {[], [], context}
   end
 
-  defp of_pattern_args(patterns, expected_types, stack, context) do
+  defp of_pattern_args(patterns, expected, tag, stack, context) do
     context = init_pattern_info(context)
-    {trees, context} = of_pattern_args_index(patterns, expected_types, 0, [], stack, context)
+    {trees, context} = of_pattern_args_index(patterns, expected, 0, [], stack, context)
 
     {types, context} =
-      of_pattern_recur(expected_types, stack, context, fn types, changed, context ->
-        of_pattern_args_tree(trees, types, changed, 0, [], stack, context)
+      of_pattern_recur(expected, tag, stack, context, fn types, changed, context ->
+        of_pattern_args_tree(trees, types, changed, 0, [], tag, stack, context)
       end)
 
     {trees, types, context}
@@ -75,11 +71,13 @@ defmodule Module.Types.Pattern do
          [index | changed],
          index,
          acc,
+         tag,
          stack,
          context
        ) do
-    with {:ok, type, context} <- of_pattern_intersect(tree, type, pattern, stack, context) do
-      of_pattern_args_tree(tail, expected_types, changed, index + 1, [type | acc], stack, context)
+    with {:ok, type, context} <- of_pattern_intersect(tree, type, pattern, tag, stack, context) do
+      acc = [type | acc]
+      of_pattern_args_tree(tail, expected_types, changed, index + 1, acc, tag, stack, context)
     end
   end
 
@@ -89,35 +87,41 @@ defmodule Module.Types.Pattern do
          changed,
          index,
          acc,
+         tag,
          stack,
          context
        ) do
-    of_pattern_args_tree(tail, expected_types, changed, index + 1, [type | acc], stack, context)
+    acc = [type | acc]
+    of_pattern_args_tree(tail, expected_types, changed, index + 1, acc, tag, stack, context)
   end
 
-  defp of_pattern_args_tree([], [], [], _index, acc, _stack, context) do
+  defp of_pattern_args_tree([], [], [], _index, acc, _tag, _stack, context) do
     {:ok, Enum.reverse(acc), context}
   end
 
   @doc """
-  Return the type and typing context of a pattern expression with
-  the given expected and expr or an error in case of a typing conflict.
+  A simplified version of `of_head` used by `=` and `<-`.
+
+  This version tracks the whole expression in tracing,
+  instead of only the pattern.
   """
-  def of_match(pattern, expected, expr, stack, context) do
+  def of_match(pattern, guards \\ [], expected, expr, tag, stack, context) do
     context = init_pattern_info(context)
     {tree, context} = of_pattern(pattern, [{:arg, 0, expected, expr}], stack, context)
 
     {[type], context} =
-      of_pattern_recur([expected], stack, context, fn [type], [0], context ->
-        with {:ok, type, context} <- of_pattern_intersect(tree, type, expr, stack, context) do
+      of_pattern_recur([expected], tag, stack, context, fn [type], [0], context ->
+        with {:ok, type, context} <-
+               of_pattern_intersect(tree, type, expr, tag, stack, context) do
           {:ok, [type], context}
         end
       end)
 
+    {_, context} = Enum.map_reduce(guards, context, &of_guard(&1, @guard, &1, stack, &2))
     {type, context}
   end
 
-  defp of_pattern_recur(types, stack, context, callback) do
+  defp of_pattern_recur(types, tag, stack, context, callback) do
     %{pattern_info: {pattern_vars, pattern_info, _counter}} = context
     context = nilify_pattern_info(context)
     pattern_vars = Map.to_list(pattern_vars)
@@ -126,7 +130,7 @@ defmodule Module.Types.Pattern do
     try do
       case callback.(types, changed, context) do
         {:ok, types, context} ->
-          of_pattern_recur(types, pattern_vars, pattern_info, stack, context, callback)
+          of_pattern_recur(types, pattern_vars, pattern_info, tag, stack, context, callback)
 
         {:error, context} ->
           {types, error_vars(pattern_vars, context)}
@@ -136,7 +140,7 @@ defmodule Module.Types.Pattern do
     end
   end
 
-  defp of_pattern_recur(types, vars, info, stack, context, callback) do
+  defp of_pattern_recur(types, vars, info, tag, stack, context, callback) do
     %{vars: context_vars} = context
 
     {changed, context} =
@@ -161,9 +165,9 @@ defmodule Module.Types.Pattern do
                   end
 
                 :error ->
-                  # TODO: This should be precised about the operation (case/=/try/etc)
-                  context = Of.incompatible_error(expr, expected, actual, stack, context)
-                  throw({types, context})
+                  meta = get_meta(expr) || stack.meta
+                  error = {:badpattern, expr, tag, context}
+                  throw({types, error(__MODULE__, error, meta, stack, context)})
               end
           end)
 
@@ -195,9 +199,14 @@ defmodule Module.Types.Pattern do
       changed ->
         case callback.(types, changed, context) do
           # A simple structural comparison for optimization
-          {:ok, ^types, context} -> {types, context}
-          {:ok, types, context} -> of_pattern_recur(types, vars, info, stack, context, callback)
-          {:error, context} -> {types, error_vars(vars, context)}
+          {:ok, ^types, context} ->
+            {types, context}
+
+          {:ok, types, context} ->
+            of_pattern_recur(types, vars, info, tag, stack, context, callback)
+
+          {:error, context} ->
+            {types, error_vars(vars, context)}
         end
     end
   end
@@ -208,22 +217,15 @@ defmodule Module.Types.Pattern do
     end)
   end
 
-  defp of_pattern_intersect(tree, expected, expr, stack, context) do
+  defp of_pattern_intersect(tree, expected, expr, tag, stack, context) do
     actual = of_pattern_tree(tree, context)
     type = intersection(actual, expected)
 
-    cond do
-      not empty?(type) ->
-        {:ok, type, context}
-
-      empty?(actual) ->
-        # The pattern itself is invalid
-        meta = get_meta(expr) || stack.meta
-        {:error, error(__MODULE__, {:invalid_pattern, expr, context}, meta, stack, context)}
-
-      true ->
-        # TODO: This should be precised about the operation (case/=/try/etc)
-        {:error, Of.incompatible_error(expr, expected, actual, stack, context)}
+    if empty?(type) do
+      meta = get_meta(expr) || stack.meta
+      {:error, error(__MODULE__, {:badpattern, expr, tag, context}, meta, stack, context)}
+    else
+      {:ok, type, context}
     end
   end
 
@@ -325,7 +327,7 @@ defmodule Module.Types.Pattern do
   end
 
   def of_match_var(ast, expected, expr, stack, context) do
-    of_match(ast, expected, expr, stack, context)
+    of_match(ast, expected, expr, :default, stack, context)
   end
 
   ## Patterns
@@ -697,13 +699,22 @@ defmodule Module.Types.Pattern do
     Of.map_fetch(map_fetch, type, key, stack, context)
   end
 
-  # Remote
+  # Comparison operators
   def of_guard({{:., _, [:erlang, function]}, _, args}, _expected, expr, stack, context)
+      when function in [:==, :"/=", :"=:=", :"=/="] do
+    {_args_type, context} =
+      Enum.map_reduce(args, context, &of_guard(&1, dynamic(), expr, stack, &2))
+
+    {boolean(), context}
+  end
+
+  # Remote
+  def of_guard({{:., _, [:erlang, function]}, _, args} = call, _expected, expr, stack, context)
       when is_atom(function) do
     {args_type, context} =
       Enum.map_reduce(args, context, &of_guard(&1, dynamic(), expr, stack, &2))
 
-    Of.apply(:erlang, function, args_type, expr, stack, context)
+    Of.apply(:erlang, function, args_type, call, stack, context)
   end
 
   # var
@@ -725,7 +736,8 @@ defmodule Module.Types.Pattern do
     %{context | pattern_info: nil}
   end
 
-  def format_diagnostic({:invalid_pattern, expr, context}) do
+  # TODO: Decide if we need expected in here
+  def format_diagnostic({:badpattern, expr, tag, context}) do
     traces = collect_traces(expr, context)
 
     %{

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -732,7 +732,15 @@ expand_case(Meta, Expr, Opts, S, E) ->
     end,
 
   {EOpts, SO, EO} = elixir_clauses:'case'(Meta, ROpts, SE, EE),
-  {{'case', Meta, [EExpr, EOpts]}, SO, EO}.
+
+  case prune_case_clauses(EExpr, EOpts) of
+    {ok, Pruned} -> {Pruned, SO, EO};
+    error -> {{'case', Meta, [EExpr, EOpts]}, SO, EO}
+  end.
+
+prune_case_clauses(false, [{do, [{'->', _, [[false], Body]}, {'->', _, [[true], _]}]}]) -> {ok, Body};
+prune_case_clauses(true, [{do, [{'->', _, [[false], _]}, {'->', _, [[true], Body]}]}]) -> {ok, Body};
+prune_case_clauses(_, _) -> error.
 
 rewrite_case_clauses([{do, [
   {'->', FalseMeta, [

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -143,7 +143,7 @@ defmodule Module.Types.ExprTest do
       assert typewarn!(URI.unknown("foo")) ==
                {dynamic(), "URI.unknown/1 is undefined or private"}
 
-      assert typewarn!(if(true, do: URI.unknown("foo"))) ==
+      assert typewarn!(if(:rand.uniform() > 0.5, do: URI.unknown("foo"))) ==
                {dynamic() |> union(atom([nil])), "URI.unknown/1 is undefined or private"}
 
       assert typewarn!(try(do: :ok, after: URI.unknown("foo"))) ==

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -755,9 +755,9 @@ defmodule Module.Types.ExprTest do
     end
 
     test "accessing an unknown field on struct with diagnostic" do
-      {type, diagnostic} = typediag!(%Point{}.foo_bar)
+      {type, [diagnostic]} = typediag!(%Point{}.foo_bar)
       assert type == dynamic()
-      assert diagnostic.span == {__ENV__.line - 2, 54}
+      assert diagnostic.span == {__ENV__.line - 2, 56}
 
       assert diagnostic.message == ~l"""
              unknown key .foo_bar in expression:
@@ -771,9 +771,9 @@ defmodule Module.Types.ExprTest do
     end
 
     test "accessing an unknown field on struct in a var with diagnostic" do
-      {type, diagnostic} = typediag!([x = %URI{}], x.foo_bar)
+      {type, [diagnostic]} = typediag!([x = %URI{}], x.foo_bar)
       assert type == dynamic()
-      assert diagnostic.span == {__ENV__.line - 2, 61}
+      assert diagnostic.span == {__ENV__.line - 2, 63}
 
       assert diagnostic.message == ~l"""
              unknown key .foo_bar in expression:
@@ -792,7 +792,7 @@ defmodule Module.Types.ExprTest do
                    scheme: term(),
                    userinfo: term()
                  })
-                 # from: types_test.ex:LINE-4:41
+                 # from: types_test.ex:LINE-4:43
                  x = %URI{}
              """
 
@@ -1014,6 +1014,41 @@ defmodule Module.Types.ExprTest do
                end
              ) == dynamic(atom([:ok, :error]))
     end
+
+    test "reports error from clause that will never match" do
+      assert typeerror!(
+               [x],
+               case Atom.to_string(x) do
+                 :error -> :error
+                 x -> x
+               end
+             ) == ~l"""
+             the following clause will never match:
+
+                 :error
+
+             because it attempts to match on the result of:
+
+                 Atom.to_string(x)
+
+             which has type:
+
+                 binary()
+             """
+    end
+
+    test "reports errors from multiple clauses" do
+      {type, [_, _]} =
+        typediag!(
+          [x],
+          case Atom.to_string(x) do
+            :ok -> :ok
+            :error -> :error
+          end
+        )
+
+      assert type == atom([:ok, :error])
+    end
   end
 
   describe "receive" do
@@ -1093,6 +1128,28 @@ defmodule Module.Types.ExprTest do
                  _ -> :else2
                end
              ) == atom([:caught1, :caught2, :rescue, :else1, :else2])
+    end
+
+    test "reports error from clause that will never match" do
+      assert typeerror!(
+               [x],
+               try do
+                 Atom.to_string(x)
+               rescue
+                 _ -> :ok
+               else
+                 :error -> :error
+                 x -> x
+               end
+             ) == ~l"""
+             the following clause will never match:
+
+                 :error
+
+             it attempts to match on the result of the try do-block which has incompatible type:
+
+                 binary()
+             """
     end
 
     test "warns on undefined exceptions" do

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -1051,6 +1051,16 @@ defmodule Module.Types.ExprTest do
     end
   end
 
+  describe "conditionals" do
+    test "if does not report on literal booleans" do
+      assert typecheck!(
+               if true do
+                 :ok
+               end
+             ) == atom([:ok])
+    end
+  end
+
   describe "receive" do
     test "returns unions of all clauses" do
       assert typecheck!(

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -76,11 +76,31 @@ defmodule Module.Types.PatternTest do
                  [info | _] = __ENV__.function
                  info
                )
-             ) =~ "incompatible types in expression"
+             ) =~ "the following pattern will never match"
     end
 
     test "does not check underscore" do
       assert typecheck!(_ = raise("oops")) == none()
+    end
+  end
+
+  describe "=" do
+    test "reports incompatible types" do
+      assert typeerror!([x = {:ok, _}], [_ | _] = x) == ~l"""
+             the following pattern will never match:
+
+                 [_ | _] = x
+
+             because the right-hand side has type:
+
+                 dynamic({:ok, term()})
+
+             where "x" was given the type:
+
+                 # type: dynamic({:ok, term()})
+                 # from: types_test.ex:LINE
+                 x = {:ok, _}
+             """
     end
   end
 

--- a/lib/elixir/test/elixir/module/types/type_helper.exs
+++ b/lib/elixir/test/elixir/module/types/type_helper.exs
@@ -92,14 +92,11 @@ defmodule TypeHelper do
     do: raise("type checking ok but expected error: #{Descr.to_quoted_string(type)}")
 
   @doc false
-  def __typediag__!({type, %{warnings: [{module, warning, _locs}]}}),
-    do: {type, module.format_diagnostic(warning)}
+  def __typediag__!({type, %{warnings: [_ | _] = warnings}}),
+    do: {type, for({module, arg, _} <- warnings, do: module.format_diagnostic(arg))}
 
   def __typediag__!({type, %{warnings: []}}),
-    do: raise("type checking without warnings/errors: #{Descr.to_quoted_string(type)}")
-
-  def __typediag__!({_type, %{warnings: warnings}}),
-    do: raise("type checking with too many warnings/errors: #{inspect(warnings)}")
+    do: raise("type checking without diagnostics: #{Descr.to_quoted_string(type)}")
 
   @doc false
   def __typewarn__!({type, %{warnings: [{module, warning, _locs}], failed: false}}),

--- a/lib/elixir/test/elixir/module/types/type_helper.exs
+++ b/lib/elixir/test/elixir/module/types/type_helper.exs
@@ -126,7 +126,8 @@ defmodule TypeHelper do
   end
 
   def __typeinfer__(patterns, guards) do
-    Pattern.of_head(patterns, guards, [], new_stack(:infer), new_context())
+    expected = Enum.map(patterns, fn _ -> Module.Types.Descr.dynamic() end)
+    Pattern.of_head(patterns, guards, expected, :default, [], new_stack(:infer), new_context())
   end
 
   defp typecheck(mode, patterns, guards, body, env) do
@@ -144,7 +145,11 @@ defmodule TypeHelper do
 
   def __typecheck__(mode, patterns, guards, body) do
     stack = new_stack(mode)
-    {_types, context} = Pattern.of_head(patterns, guards, [], stack, new_context())
+    expected = Enum.map(patterns, fn _ -> Module.Types.Descr.dynamic() end)
+
+    {_types, context} =
+      Pattern.of_head(patterns, guards, expected, :default, [], stack, new_context())
+
     Expr.of_expr(body, stack, context)
   end
 


### PR DESCRIPTION
I need to fix the tests as they have a bunch of warnings because we often test on obvious errors to validate error messages.