### PR TITLE
Bump ci (OTP 27.1 and Ubuntu 24.04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   test_linux:
-    name: Ubuntu 20.04, Erlang/OTP ${{ matrix.otp_version }}
+    name: Ubuntu 24.04, Erlang/OTP ${{ matrix.otp_version }}
     strategy:
       fail-fast: false
       matrix:
@@ -35,7 +35,7 @@ jobs:
             development: true
           - otp_version: maint
             development: true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     # Earlier Erlang/OTP versions ignored compiler directives
     # when using warnings_as_errors. So we only set ERLC_OPTS
     # from Erlang/OTP 27+.
@@ -111,7 +111,7 @@ jobs:
 
   check_posix_compliant:
     name: Check POSIX-compliant
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - otp_version: "27.0"
+          - otp_version: "27.1"
             otp_latest: true
+            erlc_opts: "warnings_as_errors"
+          - otp_version: "27.0"
             erlc_opts: "warnings_as_errors"
           - otp_version: "26.0"
           - otp_version: "25.3"


### PR DESCRIPTION
Hey there lovely folks! :green_heart: 

Commits should speak for themselves, only include a new OTP version and bump Ubuntu to 24.04 (20.04 will be EOL soon) both _should_ work but as usual the CI may foil my plans :)

Thanks for all your amazing work! :green_heart: 