### PR TITLE
Fix bug with schemaless URI in `URI.merge/2`

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -907,7 +907,7 @@ defmodule URI do
     %{rel | path: remove_dot_segments_from_path(rel.path)}
   end
 
-  def merge(base, %URI{host: host} = rel) when host != nil do
+  def merge(%URI{} = base, %URI{host: host} = rel) when host != nil do
     %{rel | scheme: base.scheme, path: remove_dot_segments_from_path(rel.path)}
   end
 

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -387,6 +387,9 @@ defmodule URITest do
     assert URI.merge("http://google.com/foo", "//example.com/baz")
            |> to_string == "http://example.com/baz"
 
+    assert URI.merge("http://google.com/foo", URI.new!("//example.com/baz"))
+           |> to_string == "http://example.com/baz"
+
     assert URI.merge("http://google.com/foo", "//example.com/.././bar/../../../baz")
            |> to_string == "http://example.com/baz"
 


### PR DESCRIPTION
Only occurs when mixing strings and URIs, but the docs seem to encourage that.

Without the fix the test results in the following error:

```
  1) test merge/2 (URITest)
     test/elixir/uri_test.exs:376
     ** (KeyError) key :scheme not found in: "http://google.com/foo"

     If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
     code: assert URI.merge("http://google.com/foo", URI.new!("//example.com/baz"))
     stacktrace:
       (elixir 1.18.0-dev) lib/uri.ex:911: URI.merge/2
       test/elixir/uri_test.exs:390: (test)
```

That's because that (one) particular clause didn't check for the base to be a `%URI{}`.

Happy to also backport it to the 1.17 branch (should be easy/ probably cherry-pickable) but:
1. seems like an extreme edge case
2. a workaround is available (use URI/URI or String/String as args)

Thank you all for your excellent work! :green_heart: :rocket: 