### PR TITLE
Bump Windows Runner & add more OTP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
     name: Windows Server 2019, Erlang/OTP ${{ matrix.otp_version }}
     strategy:
       matrix:
-        otp_version: ["25.3", "26.0"]
-    runs-on: windows-2019
+        otp_version: ["25.3", "26.3", "27.1"]
+    runs-on: windows-2022
     steps:
       - name: Configure Git
         run: git config --global core.autocrlf input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     name: Windows Server 2019, Erlang/OTP ${{ matrix.otp_version }}
     strategy:
       matrix:
-        otp_version: ["25.3", "26.3", "27.1"]
+        otp_version: ["25.3", "26.2", "27.1"]
     runs-on: windows-2022
     steps:
       - name: Configure Git


### PR DESCRIPTION
During #13969 I saw that Windows also seemed a bit outdated but didn't wanna touch it yet (as less trust in Windows/experience with OTP testing on it)

According to setup-beam this should be possible:
https://github.com/erlef/setup-beam?tab=readme-ov-file#compatibility-between-operating-system-and-erlangotp

Unsure what the testing strategy for Windows is, but I went with "newest OTP minor for all supported OTP majors".

Thank you for all your work!