### PR TITLE
Clarify that charlists cannot be used as logger metadata

### DIFF
--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -84,7 +84,7 @@ defmodule Logger.Formatter do
   >   * Be an atom
   >   * Be a reference
   >   * Be a port
-  >   * Implement the `String.Chars` protocol
+  >   * Implement the `String.Chars` protocol (except for charlists)
   >
   > If none of the conditions above are `true`, the given metadata get
   > discarded.


### PR DESCRIPTION
Clarifies the current behavior as pointed out in https://elixirforum.com/t/charlist-values-are-not-showing-up-in-logger-metadata/67256.

Alternatively, we could support it by removing [this line](https://github.com/elixir-lang/elixir/blob/main/lib/logger/lib/logger/formatter.ex#L537) (but it would crash on invalid charlists) or add a `try/rescue` with `List.to_string`?