### PR TITLE
Add AST metadata about assoc operator location

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -610,10 +610,10 @@ map_base_expr -> ellipsis_op map_base_expr : build_unary_op('$1', '$2').
 assoc_op_eol -> assoc_op : '$1'.
 assoc_op_eol -> assoc_op eol : '$1'.
 
-assoc_expr -> matched_expr assoc_op_eol matched_expr : {'$1', '$3'}.
-assoc_expr -> unmatched_expr assoc_op_eol unmatched_expr : {'$1', '$3'}.
-assoc_expr -> matched_expr assoc_op_eol unmatched_expr : {'$1', '$3'}.
-assoc_expr -> unmatched_expr assoc_op_eol matched_expr : {'$1', '$3'}.
+assoc_expr -> matched_expr assoc_op_eol matched_expr : {with_assoc_meta('$1', '$2'), '$3'}.
+assoc_expr -> unmatched_expr assoc_op_eol unmatched_expr : {with_assoc_meta('$1', '$2'), '$3'}.
+assoc_expr -> matched_expr assoc_op_eol unmatched_expr : {with_assoc_meta('$1', '$2'), '$3'}.
+assoc_expr -> unmatched_expr assoc_op_eol matched_expr : {with_assoc_meta('$1', '$2'), '$3'}.
 assoc_expr -> map_base_expr : '$1'.
 
 assoc_update -> matched_expr pipe_op_eol assoc_expr : {'$2', '$1', ['$3']}.
@@ -1154,6 +1154,15 @@ parens_meta({Open, Close}) ->
 parens_meta({Open, _Args, Close}) ->
   parens_meta({Open, Close}).
 
+with_assoc_meta({Target, Meta, Args}, AssocToken) ->
+  case ?token_metadata() of
+    true ->
+      {Target, [{assoc, meta_from_token(AssocToken)} | Meta], Args};
+    false ->
+      {Target, Meta, Args}
+  end;
+
+with_assoc_meta(Left, _AssocToken) -> Left.
 
 %% Warnings and errors
 

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -856,6 +856,38 @@ defmodule Kernel.ParserTest do
       assert string_to_quoted.("foo.\nBar\n.\nBaz") ==
                {:__aliases__, [last: [line: 4], line: 1], [{:foo, [line: 1], nil}, :Bar, :Baz]}
     end
+
+    test "adds metadata about assoc operator position in maps" do
+      opts = [
+        literal_encoder: &{:ok, {:__block__, &2, [&1]}},
+        token_metadata: true,
+        columns: true
+      ]
+
+      string_to_quoted = &Code.string_to_quoted!(&1, opts)
+
+      file = "%{:key => 1, {} => {}}"
+
+      assert string_to_quoted.(file) ==
+               {
+                 :%{},
+                 [closing: [line: 1, column: 22], line: 1, column: 1],
+                 [
+                   {{:__block__, [assoc: [line: 1, column: 8], line: 1, column: 3], [:key]},
+                    {:__block__, [token: "1", line: 1, column: 11], [1]}},
+                   {
+                     {:{},
+                      [
+                        assoc: [line: 1, column: 17],
+                        closing: [line: 1, column: 15],
+                        line: 1,
+                        column: 14
+                      ], []},
+                     {:{}, [closing: [line: 1, column: 21], line: 1, column: 20], []}
+                   }
+                 ]
+               }
+    end
   end
 
   describe "syntax errors" do


### PR DESCRIPTION
Once we parse

```elixir
%{:key1 => 1, :key2 => 2}
```

the entries become `[{:key1, 1}, {:key2, 2}]` in the AST and there is no information about `=>`. This adds a `assoc: [line: ..., column: ...]` to the key AST nodes.

cc @mhanberg