### PR TITLE
Fix typo in Access.get_and_update/3 error message

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -418,8 +418,8 @@ defmodule Access do
 
     Accessing a list by index is typically discouraged in Elixir, \
     instead we prefer to use the Enum module to manipulate lists \
-    as a whole. If you really must mostify a list element by index, \
-    you can Access.at/1 or the functions in the List module\
+    as a whole. If you really must modify a list element by index, \
+    you can use Access.at/1 or the functions in the List module\
     """
   end
 


### PR DESCRIPTION
Thank you for putting the time and effort in these informative error messages.

This PR fixes a typo in the error raised by `Access.get_and_update/3`