### PR TITLE
Simplify the explanation of a basic test case

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -13,7 +13,7 @@ defmodule ExUnit do
 
       # 2) Create a new test module and use "ExUnit.Case".
       defmodule AssertionTest do
-        # 3) Note that we pass "async: true", this runs tests in the
+        # 3) Note that we pass "async: true", this runs the tests in the
         #    test module concurrently with other test modules. The 
         #    individual tests within each test module are still run serially.
         use ExUnit.Case, async: true

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -11,11 +11,11 @@ defmodule ExUnit do
       # 1) Start ExUnit.
       ExUnit.start()
 
-      # 2) Create a new test module (test case) and use "ExUnit.Case".
+      # 2) Create a new test module and use "ExUnit.Case".
       defmodule AssertionTest do
-        # 3) Note that we pass "async: true", this runs the test case
-        #    concurrently with other test cases. The individual tests
-        #    within each test case are still run serially.
+        # 3) Note that we pass "async: true", this runs tests in the
+        #    test module concurrently with other test modules. The 
+        #    individual tests within each test module are still run serially.
         use ExUnit.Case, async: true
 
         # 4) Use the "test" macro instead of "def" for clarity.


### PR DESCRIPTION
Simplifies the language used to describe a "basic setup for ExUnit"

In particular, I removed the term "test case" which was an alias for a "test module". "test case" can easily be confused with a `test` block, so the explanation is something difficult to understand