### PR TITLE
Tweak `NaiveDateTime.from_erl` and `Time.from_erl` specs

### DIFF
--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -252,7 +252,7 @@ defmodule NaiveDateTime do
           Calendar.hour(),
           Calendar.minute(),
           Calendar.second(),
-          Calendar.microsecond() | non_neg_integer,
+          Calendar.microsecond() | non_neg_integer(),
           Calendar.calendar()
         ) :: {:ok, t} | {:error, atom}
   def new(year, month, day, hour, minute, second, microsecond \\ {0, 0}, calendar \\ Calendar.ISO)
@@ -317,7 +317,7 @@ defmodule NaiveDateTime do
           Calendar.hour(),
           Calendar.minute(),
           Calendar.second(),
-          Calendar.microsecond() | non_neg_integer,
+          Calendar.microsecond() | non_neg_integer(),
           Calendar.calendar()
         ) :: t
   def new!(
@@ -993,6 +993,8 @@ defmodule NaiveDateTime do
 
       iex> NaiveDateTime.from_erl({{2000, 1, 1}, {13, 30, 15}})
       {:ok, ~N[2000-01-01 13:30:15]}
+      iex> NaiveDateTime.from_erl({{2000, 1, 1}, {13, 30, 15}}, 5000)
+      {:ok, ~N[2000-01-01 13:30:15.005000]}
       iex> NaiveDateTime.from_erl({{2000, 1, 1}, {13, 30, 15}}, {5000, 3})
       {:ok, ~N[2000-01-01 13:30:15.005]}
       iex> NaiveDateTime.from_erl({{2000, 13, 1}, {13, 30, 15}})
@@ -1001,7 +1003,11 @@ defmodule NaiveDateTime do
       {:error, :invalid_date}
 
   """
-  @spec from_erl(:calendar.datetime(), Calendar.microsecond(), Calendar.calendar()) ::
+  @spec from_erl(
+          :calendar.datetime(),
+          Calendar.microsecond() | non_neg_integer(),
+          Calendar.calendar()
+        ) ::
           {:ok, t} | {:error, atom}
   def from_erl(tuple, microsecond \\ {0, 0}, calendar \\ Calendar.ISO)
 
@@ -1020,13 +1026,19 @@ defmodule NaiveDateTime do
 
       iex> NaiveDateTime.from_erl!({{2000, 1, 1}, {13, 30, 15}})
       ~N[2000-01-01 13:30:15]
+      iex> NaiveDateTime.from_erl!({{2000, 1, 1}, {13, 30, 15}}, 5000)
+      ~N[2000-01-01 13:30:15.005000]
       iex> NaiveDateTime.from_erl!({{2000, 1, 1}, {13, 30, 15}}, {5000, 3})
       ~N[2000-01-01 13:30:15.005]
       iex> NaiveDateTime.from_erl!({{2000, 13, 1}, {13, 30, 15}})
       ** (ArgumentError) cannot convert {{2000, 13, 1}, {13, 30, 15}} to naive datetime, reason: :invalid_date
 
   """
-  @spec from_erl!(:calendar.datetime(), Calendar.microsecond(), Calendar.calendar()) :: t
+  @spec from_erl!(
+          :calendar.datetime(),
+          Calendar.microsecond() | non_neg_integer(),
+          Calendar.calendar()
+        ) :: t
   def from_erl!(tuple, microsecond \\ {0, 0}, calendar \\ Calendar.ISO) do
     case from_erl(tuple, microsecond, calendar) do
       {:ok, value} ->

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -115,7 +115,7 @@ defmodule Time do
           Calendar.hour(),
           Calendar.minute(),
           Calendar.second(),
-          Calendar.microsecond() | non_neg_integer,
+          Calendar.microsecond() | non_neg_integer(),
           Calendar.calendar()
         ) :: {:ok, t} | {:error, atom}
   def new(hour, minute, second, microsecond \\ {0, 0}, calendar \\ Calendar.ISO)
@@ -355,13 +355,21 @@ defmodule Time do
 
   ## Examples
 
+      iex> Time.from_erl({23, 30, 15})
+      {:ok, ~T[23:30:15]}
+      iex> Time.from_erl({23, 30, 15}, 5000)
+      {:ok, ~T[23:30:15.005000]}
       iex> Time.from_erl({23, 30, 15}, {5000, 3})
       {:ok, ~T[23:30:15.005]}
       iex> Time.from_erl({24, 30, 15})
       {:error, :invalid_time}
 
   """
-  @spec from_erl(:calendar.time(), Calendar.microsecond(), Calendar.calendar()) ::
+  @spec from_erl(
+          :calendar.time(),
+          Calendar.microsecond() | non_neg_integer(),
+          Calendar.calendar()
+        ) ::
           {:ok, t} | {:error, atom}
   def from_erl(tuple, microsecond \\ {0, 0}, calendar \\ Calendar.ISO)
 
@@ -377,6 +385,8 @@ defmodule Time do
 
       iex> Time.from_erl!({23, 30, 15})
       ~T[23:30:15]
+      iex> Time.from_erl!({23, 30, 15}, 5000)
+      ~T[23:30:15.005000]
       iex> Time.from_erl!({23, 30, 15}, {5000, 3})
       ~T[23:30:15.005]
       iex> Time.from_erl!({24, 30, 15})


### PR DESCRIPTION
The changes align `NaiveDateTime.from_erl` and `Time.from_erl` specs with their corresponding `NaiveDateTime.new` and `Time.new` specs.

The `new` function specs accept a non-negative integer or a tuple of {seconds, precision} for microseconds.

Here's `NaiveDateTime.new/8`'s spec: https://github.com/elixir-lang/elixir/blob/cb2e03688ec699b79676c1925c86ac83cfaf0edf/lib/elixir/lib/calendar/naive_datetime.ex#L248-L257

And `NaiveDateTime.from_erl`'s spec + implementation: https://github.com/elixir-lang/elixir/blob/cb2e03688ec699b79676c1925c86ac83cfaf0edf/lib/elixir/lib/calendar/naive_datetime.ex#L1004-L1011

Here's the `Time.new/5` spec: https://github.com/elixir-lang/elixir/blob/cb2e03688ec699b79676c1925c86ac83cfaf0edf/lib/elixir/lib/calendar/time.ex#L114-L120

And the corresponding `from_erl`: https://github.com/elixir-lang/elixir/blob/cb2e03688ec699b79676c1925c86ac83cfaf0edf/lib/elixir/lib/calendar/time.ex#L364-L371

In both cases, the corresponding `new` functions handle `non_negative_integer` microseconds. I also added tests to confirm it.

---

Please notice that both `NaiveDateTime.t.microsecond` and `Time.t.microsecond` are of `Calendar.microsecond()` type, and it's okay because `new` functions set `microsecond: {microsecond, 6}` with default precision if none is provided.

