### PR TITLE
Clarify `struct!/2` update behavior

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2449,8 +2449,9 @@ defmodule Kernel do
     * when updating a struct, as in `struct!(%SomeStruct{}, key: :value)`,
       it is equivalent to `%SomeStruct{struct | key: :value}` and therefore this
       function will check if every given key-value belongs to the struct.
-      However, updating structs does not enforce keys, as keys are enforced
-      only when building;
+      Updating structs does not enforce keys, as keys are enforced
+      only when building. This is relevant if a struct is created in a way that
+      avoids key enforcement.
 
   """
   @spec struct!(module | struct, Enumerable.t()) :: struct

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2449,9 +2449,6 @@ defmodule Kernel do
     * when updating a struct, as in `struct!(%SomeStruct{}, key: :value)`,
       it is equivalent to `%SomeStruct{struct | key: :value}` and therefore this
       function will check if every given key-value belongs to the struct.
-      Updating structs does not enforce keys, as keys are enforced
-      only when building. This is relevant if a struct is created in a way that
-      avoids key enforcement.
 
   """
   @spec struct!(module | struct, Enumerable.t()) :: struct


### PR DESCRIPTION
This is a bit of a speculative PR. I'm not sure what the proper wording should be, but after a bit of discussion on Discord, this seems maybe okay.

My general complaint about the current text is that it's not very obvious why it's even there. The sentence starting with "However" seems like it may be better to remove entirely. However (heh), it seems like this can be improved. Really, there's a kind of strange table of behaviors possible for struct construction and updating, especially when involving `@enforce_keys`. Part of me feels like this can be ignored until potential improvements to the static type system, but I think it is and will still be somewhat relevant for runtime behavior.

I considered specifying that `struct/2` can produce results that don't exactly honor `@enforce_keys`, but due to the dynamic nature of Elixir, it's not entirely true. Dialyzer makes this more complicated, since it will enforce keys better when using constructor functions, but you can also always do `%{__struct__: Foo}` to create a malformed struct.