### PR TITLE
Fix duplicated :parens and :end_of_expression metadata for nested blocks

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -791,15 +791,7 @@ build_block([{Op, ExprMeta, Args}], {Before, After}) ->
     case ?token_metadata() of
       true ->
         ParensEntry = meta_from_token(Before) ++ [{closing, meta_from_token(After)}],
-        case ExprMeta of
-          % If there are multiple parens, those will result in subsequent
-          % build_block/2 calls, so we can assume parens entry is first
-          [{parens, Parens} | Meta] ->
-            [{parens, [ParensEntry | Parens]} | Meta];
-
-          Meta ->
-            [{parens, [ParensEntry]} | Meta]
-        end;
+        add_parens_meta(ExprMeta, ParensEntry);
       false ->
         ExprMeta
     end,
@@ -811,6 +803,13 @@ build_block(Exprs, BeforeAfter) ->
 
 block_meta(none) -> [];
 block_meta({Before, After}) -> meta_from_token_with_closing(Before, After).
+
+add_parens_meta([{parens, Parens} | Meta], ParensEntry) ->
+  [{parens, [ParensEntry | Parens]} | Meta];
+add_parens_meta([MetaEntry | Meta], ParensEntry) ->
+  [MetaEntry | add_parens_meta(Meta, ParensEntry)];
+add_parens_meta([], ParensEntry) ->
+  [{parens, [ParensEntry]}].
 
 %% Newlines
 

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -841,10 +841,10 @@ annotate_eoe(Token, Stack) ->
     true ->
       case {Token, Stack} of
         {{_, Location}, [{'->', StabMeta, [StabArgs, {Left, Meta, Right}]} | Rest]} when is_list(Meta) ->
-          [{'->', StabMeta, [StabArgs, {Left, [{end_of_expression, end_of_expression(Location)} | Meta], Right}]} | Rest];
+          [{'->', StabMeta, [StabArgs, {Left, add_eoe_meta(Meta, end_of_expression(Location)), Right}]} | Rest];
 
         {{_, Location}, [{Left, Meta, Right} | Rest]} when is_list(Meta), Left =/= '->' ->
-          [{Left, [{end_of_expression, end_of_expression(Location)} | Meta], Right} | Rest];
+          [{Left, add_eoe_meta(Meta, end_of_expression(Location)), Right} | Rest];
 
         _ ->
           Stack
@@ -857,6 +857,13 @@ end_of_expression({_, _, Count} = Location) when is_integer(Count) ->
   [{newlines, Count} | meta_from_location(Location)];
 end_of_expression(Location) ->
   meta_from_location(Location).
+
+add_eoe_meta([{end_of_expression, _Entry} | Meta], Entry) ->
+  [{end_of_expression, Entry} | Meta];
+add_eoe_meta([MetaEntry | Meta], Entry) ->
+  [MetaEntry | add_eoe_meta(Meta, Entry)];
+add_eoe_meta([], Entry) ->
+  [{end_of_expression, Entry}].
 
 %% Dots
 

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -468,38 +468,38 @@ defmodule Kernel.ParserTest do
       args = [
         {:one,
          [
-           end_of_expression: [newlines: 0, line: 1, column: 6],
            closing: [line: 1, column: 5],
            line: 1,
-           column: 1
+           column: 1,
+           end_of_expression: [newlines: 0, line: 1, column: 6]
          ], []},
         {:two,
          [
-           end_of_expression: [newlines: 1, line: 1, column: 12],
            closing: [line: 1, column: 11],
            line: 1,
-           column: 7
+           column: 7,
+           end_of_expression: [newlines: 1, line: 1, column: 12]
          ], []},
         {:three,
          [
-           end_of_expression: [newlines: 2, line: 2, column: 8],
            closing: [line: 2, column: 7],
            line: 2,
-           column: 1
+           column: 1,
+           end_of_expression: [newlines: 2, line: 2, column: 8]
          ], []},
         {:four,
          [
-           end_of_expression: [newlines: 3, line: 4, column: 7],
            closing: [line: 4, column: 6],
            line: 4,
-           column: 1
+           column: 1,
+           end_of_expression: [newlines: 3, line: 4, column: 7]
          ], []},
         {:five,
          [
-           end_of_expression: [newlines: 1, line: 7, column: 7],
            closing: [line: 7, column: 6],
            line: 7,
-           column: 1
+           column: 1,
+           end_of_expression: [newlines: 1, line: 7, column: 7]
          ], []}
       ]
 
@@ -518,10 +518,10 @@ defmodule Kernel.ParserTest do
       assert Code.string_to_quoted!(file, token_metadata: true) ==
                {:case,
                 [
-                  end_of_expression: [newlines: 1, line: 4],
                   do: [line: 1],
                   end: [line: 4],
-                  line: 1
+                  line: 1,
+                  end_of_expression: [newlines: 1, line: 4]
                 ],
                 [
                   true,
@@ -534,15 +534,15 @@ defmodule Kernel.ParserTest do
                           [
                             {:bar,
                              [
-                               end_of_expression: [newlines: 0, line: 2],
                                closing: [line: 2],
-                               line: 2
+                               line: 2,
+                               end_of_expression: [newlines: 0, line: 2]
                              ], []},
                             {:two,
                              [
-                               end_of_expression: [newlines: 1, line: 2],
                                closing: [line: 2],
-                               line: 2
+                               line: 2,
+                               end_of_expression: [newlines: 1, line: 2]
                              ], []}
                           ]}
                        ]},
@@ -551,9 +551,9 @@ defmodule Kernel.ParserTest do
                          [:baz],
                          {:bat,
                           [
-                            end_of_expression: [newlines: 1, line: 3],
                             closing: [line: 3],
-                            line: 3
+                            line: 3,
+                            end_of_expression: [newlines: 1, line: 3]
                           ], []}
                        ]}
                     ]
@@ -577,10 +577,10 @@ defmodule Kernel.ParserTest do
              ) ==
                {:a,
                 [
-                  end_of_expression: [newlines: 1, line: 6],
                   do: [line: 1],
                   end: [line: 6],
-                  line: 1
+                  line: 1,
+                  end_of_expression: [newlines: 1, line: 6]
                 ],
                 [
                   [
@@ -591,17 +591,17 @@ defmodule Kernel.ParserTest do
                           [{:d, [line: 2], nil}],
                           {:__block__,
                            [
-                             end_of_expression: [newlines: 1, line: 5],
                              newlines: 1,
                              closing: [line: 5],
-                             line: 3
+                             line: 3,
+                             end_of_expression: [newlines: 1, line: 5]
                            ],
                            [
                              [
                                {:->, [line: 4],
                                 [
                                   [{:b, [line: 4], nil}],
-                                  {:c, [end_of_expression: [newlines: 1, line: 4], line: 4], nil}
+                                  {:c, [line: 4, end_of_expression: [newlines: 1, line: 4]], nil}
                                 ]}
                              ]
                            ]}
@@ -713,11 +713,11 @@ defmodule Kernel.ParserTest do
       assert string_to_quoted.(file) ==
                {:__block__,
                 [
-                  end_of_expression: [newlines: 1, line: 6, column: 2],
                   parens: [
                     [line: 1, column: 1, closing: [line: 6, column: 1]],
-                    [line: 3, column: 3, closing: [line: 5, column: 3]],
-                  ]
+                    [line: 3, column: 3, closing: [line: 5, column: 3]]
+                  ],
+                  end_of_expression: [newlines: 1, line: 6, column: 2]
                 ], []}
     end
 

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -657,9 +657,9 @@ defmodule Kernel.ParserTest do
                   1,
                   {:+,
                    [
-                     parens: [[line: 1, column: 5, closing: [line: 1, column: 11]]],
                      line: 1,
-                     column: 8
+                     column: 8,
+                     parens: [[line: 1, column: 5, closing: [line: 1, column: 11]]]
                    ], [2, 3]}
                 ]}
 
@@ -671,12 +671,12 @@ defmodule Kernel.ParserTest do
                   1,
                   {:+,
                    [
+                     line: 1,
+                     column: 9,
                      parens: [
                        [line: 1, column: 5, closing: [line: 1, column: 13]],
                        [line: 1, column: 6, closing: [line: 1, column: 12]]
-                     ],
-                     line: 1,
-                     column: 9
+                     ]
                    ], [2, 3]}
                 ]}
     end
@@ -698,6 +698,25 @@ defmodule Kernel.ParserTest do
                   parens: [
                     [line: 1, column: 1, closing: [line: 1, column: 4]],
                     [line: 1, column: 2, closing: [line: 1, column: 3]]
+                  ]
+                ], []}
+
+      file = """
+      (
+        # Foo
+        (
+          # Bar
+        )
+      )
+      """
+
+      assert string_to_quoted.(file) ==
+               {:__block__,
+                [
+                  end_of_expression: [newlines: 1, line: 6, column: 2],
+                  parens: [
+                    [line: 1, column: 1, closing: [line: 6, column: 1]],
+                    [line: 3, column: 3, closing: [line: 5, column: 3]],
                   ]
                 ], []}
     end
@@ -807,9 +826,9 @@ defmodule Kernel.ParserTest do
                      [
                        {:__block__,
                         [
-                          parens: [[line: 1, closing: [line: 1]]],
                           token: "1",
-                          line: 1
+                          line: 1,
+                          parens: [[line: 1, closing: [line: 1]]]
                         ], [1]}
                      ],
                      {:__block__, [delimiter: "\"", line: 1], ["hello"]}
@@ -817,7 +836,7 @@ defmodule Kernel.ParserTest do
                 ]}
 
       assert string_to_quoted.("(1)") ==
-               {:__block__, [parens: [[line: 1, closing: [line: 1]]], token: "1", line: 1], [1]}
+               {:__block__, [token: "1", line: 1, parens: [[line: 1, closing: [line: 1]]]], [1]}
     end
 
     test "adds identifier_location for qualified identifiers" do


### PR DESCRIPTION
```elixir
Code.string_to_quoted!(
  ~S"""
  (
    # Foo
    (
      # Bar
    )
  )
  """,
  token_metadata: true
)
```

Before:

```
{:__block__,
 [
   end_of_expression: [newlines: 1, line: 6],
   parens: [[line: 1, closing: [line: 6]]],
   end_of_expression: [newlines: 1, line: 5],
   parens: [[line: 3, closing: [line: 5]]]
 ], []}
```

After:

```
{:__block__,
 [
   parens: [[line: 1, closing: [line: 6]], [line: 3, closing: [line: 5]]],
   end_of_expression: [newlines: 1, line: 6]
 ], []}
```