### PR TITLE
Add separate metadata entry for every block parens

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -791,15 +791,7 @@ build_block([{Op, ExprMeta, Args}], {Before, After}) ->
     case ?token_metadata() of
       true ->
         ParensEntry = meta_from_token(Before) ++ [{closing, meta_from_token(After)}],
-        case ExprMeta of
-          % If there are multiple parens, those will result in subsequent
-          % build_block/2 calls, so we can assume parens entry is first
-          [{parens, Parens} | Meta] ->
-            [{parens, [ParensEntry | Parens]} | Meta];
-
-          Meta ->
-            [{parens, [ParensEntry]} | Meta]
-        end;
+        [{parens, ParensEntry} | ExprMeta];
       false ->
         ExprMeta
     end,
@@ -1147,7 +1139,7 @@ parens_meta({Open, Close}) ->
   case ?token_metadata() of
     true ->
       ParensEntry = meta_from_token(Open) ++ [{closing, meta_from_token(Close)}],
-      [{parens, [ParensEntry]}];
+      [{parens, ParensEntry}];
     false ->
       []
   end;

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -657,7 +657,7 @@ defmodule Kernel.ParserTest do
                   1,
                   {:+,
                    [
-                     parens: [[line: 1, column: 5, closing: [line: 1, column: 11]]],
+                     parens: [line: 1, column: 5, closing: [line: 1, column: 11]],
                      line: 1,
                      column: 8
                    ], [2, 3]}
@@ -671,10 +671,8 @@ defmodule Kernel.ParserTest do
                   1,
                   {:+,
                    [
-                     parens: [
-                       [line: 1, column: 5, closing: [line: 1, column: 13]],
-                       [line: 1, column: 6, closing: [line: 1, column: 12]]
-                     ],
+                     parens: [line: 1, column: 5, closing: [line: 1, column: 13]],
+                     parens: [line: 1, column: 6, closing: [line: 1, column: 12]],
                      line: 1,
                      column: 9
                    ], [2, 3]}
@@ -688,17 +686,33 @@ defmodule Kernel.ParserTest do
       file = "()"
 
       assert string_to_quoted.(file) ==
-               {:__block__, [parens: [[line: 1, column: 1, closing: [line: 1, column: 2]]]], []}
+               {:__block__, [parens: [line: 1, column: 1, closing: [line: 1, column: 2]]], []}
 
       file = "(())"
 
       assert string_to_quoted.(file) ==
                {:__block__,
                 [
-                  parens: [
-                    [line: 1, column: 1, closing: [line: 1, column: 4]],
-                    [line: 1, column: 2, closing: [line: 1, column: 3]]
-                  ]
+                  parens: [line: 1, column: 1, closing: [line: 1, column: 4]],
+                  parens: [line: 1, column: 2, closing: [line: 1, column: 3]]
+                ], []}
+
+      file = """
+      (
+        # Foo
+        (
+          # Bar
+        )
+      )
+      """
+
+      assert string_to_quoted.(file) ==
+               {:__block__,
+                [
+                  end_of_expression: [newlines: 1, line: 6, column: 2],
+                  parens: [line: 1, column: 1, closing: [line: 6, column: 1]],
+                  end_of_expression: [newlines: 1, line: 5, column: 4],
+                  parens: [line: 3, column: 3, closing: [line: 5, column: 3]]
                 ], []}
     end
 
@@ -710,7 +724,7 @@ defmodule Kernel.ParserTest do
                 [
                   {:->,
                    [
-                     parens: [[line: 1, column: 4, closing: [line: 1, column: 5]]],
+                     parens: [line: 1, column: 4, closing: [line: 1, column: 5]],
                      line: 1,
                      column: 7
                    ], [[], {:x, [line: 1, column: 10], nil}]}
@@ -725,7 +739,7 @@ defmodule Kernel.ParserTest do
                  [
                    {:->,
                     [
-                      parens: [[line: 1, column: 4, closing: [line: 1, column: 9]]],
+                      parens: [line: 1, column: 4, closing: [line: 1, column: 9]],
                       line: 1,
                       column: 11
                     ],
@@ -753,7 +767,7 @@ defmodule Kernel.ParserTest do
                      do: [
                        {:->,
                         [
-                          parens: [[line: 1, column: 12, closing: [line: 1, column: 17]]],
+                          parens: [line: 1, column: 12, closing: [line: 1, column: 17]],
                           line: 1,
                           column: 19
                         ],
@@ -807,7 +821,7 @@ defmodule Kernel.ParserTest do
                      [
                        {:__block__,
                         [
-                          parens: [[line: 1, closing: [line: 1]]],
+                          parens: [line: 1, closing: [line: 1]],
                           token: "1",
                           line: 1
                         ], [1]}
@@ -817,7 +831,7 @@ defmodule Kernel.ParserTest do
                 ]}
 
       assert string_to_quoted.("(1)") ==
-               {:__block__, [parens: [[line: 1, closing: [line: 1]]], token: "1", line: 1], [1]}
+               {:__block__, [parens: [line: 1, closing: [line: 1]], token: "1", line: 1], [1]}
     end
 
     test "adds identifier_location for qualified identifiers" do


### PR DESCRIPTION
Supersedes #13995 to avoid traversing meta.

This changes the `:parens` meta from #13940, so that instead of

```elixir
[
  parens: [
    [line: 1, column: 5, closing: [line: 1, column: 13]],
    [line: 1, column: 6, closing: [line: 1, column: 12]]
  ]
]
```

we do

```elixir
[
  parens: [line: 1, column: 5, closing: [line: 1, column: 13]],
  parens: [line: 1, column: 6, closing: [line: 1, column: 12]]
]
```

The list can still be retrieved easily by calling `Keyword.get_values/2`.

cc @mhanberg