### PR TITLE
Use `for..end` in some cases for simplicity

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3321,21 +3321,17 @@ defmodule Enum do
   list of IDs. You want to keep all products that are in the given IDs and
   return their names sorted by their price. You could write it like this:
 
-      for(
-        product <- products,
-        product.id in ids,
-        do: product
-      )
+      for product <- products, product.id in ids do
+        product
+      end
       |> Enum.sort_by(& &1.price)
       |> Enum.map(& &1.name)
 
   However, you could also write it like this:
 
-      for(
-        product <- products,
-        product.id in ids,
-        do: {product.name, product.price}
-      )
+      for product <- products, product.id in ids do
+        {product.name, product.price}
+      end
       |> List.keysort(1)
       |> Enum.map(&elem(&1, 0))
 

--- a/lib/elixir/scripts/docs_config.exs
+++ b/lib/elixir/scripts/docs_config.exs
@@ -5,13 +5,12 @@
 skipped = Version.parse!("1.0.3")
 
 list_contents =
-  for(
-    "v" <> rest <- String.split(text_tags),
-    not String.ends_with?(rest, "-latest"),
-    version = Version.parse!(rest),
-    Version.compare(version, skipped) == :gt,
-    do: version
-  )
+  for "v" <> rest <- String.split(text_tags),
+      not String.ends_with?(rest, "-latest"),
+      version = Version.parse!(rest),
+      Version.compare(version, skipped) == :gt do
+    version
+  end
   |> Enum.sort({:desc, Version})
   |> Enum.map_intersperse(", ", fn version ->
     version_string = Version.to_string(version)

--- a/lib/mix/lib/mix/compilers/test.ex
+++ b/lib/mix/lib/mix/compilers/test.ex
@@ -136,17 +136,14 @@ defmodule Mix.Compilers.Test do
 
         # Otherwise let's start with the new sources
         # Plus the sources that have changed in disk
-        for(
-          source <- matched_test_files,
-          not is_map_key(test_sources, source),
-          do: source
-        ) ++
-          for(
-            {source, source(external: external)} <- test_sources,
-            times = Enum.map([source | external], &Map.fetch!(sources_mtimes, &1)),
-            Mix.Utils.stale?(times, [modified]),
-            do: source
-          )
+        for source <- matched_test_files, not is_map_key(test_sources, source) do
+          source
+        end ++
+          for {source, source(external: external)} <- test_sources,
+              times = Enum.map([source | external], &Map.fetch!(sources_mtimes, &1)),
+              Mix.Utils.stale?(times, [modified]) do
+            source
+          end
       end
 
     stale = MapSet.new(changed -- removed)


### PR DESCRIPTION
I found the usage of `for` was not the most common one in the docs for `Enum.sort_by/2`, so I changed it there, and in some other parts of the code.