### PR TITLE
Add token metadata to distinguish between :nil and nil

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -283,10 +283,10 @@ access_expr -> bin_heredoc : build_bin_heredoc('$1').
 access_expr -> list_heredoc : build_list_heredoc('$1').
 access_expr -> bitstring : '$1'.
 access_expr -> sigil : build_sigil('$1').
-access_expr -> atom : handle_literal(?exprs('$1'), '$1').
-access_expr -> atom_quoted : handle_literal(?exprs('$1'), '$1', atom_delimiter('$1')).
-access_expr -> atom_safe : build_quoted_atom('$1', true, atom_delimiter('$1')).
-access_expr -> atom_unsafe : build_quoted_atom('$1', false, atom_delimiter('$1')).
+access_expr -> atom : handle_literal(?exprs('$1'), '$1', atom_colon_meta('$1')).
+access_expr -> atom_quoted : handle_literal(?exprs('$1'), '$1', atom_delimiter_meta('$1')).
+access_expr -> atom_safe : build_quoted_atom('$1', true, atom_delimiter_meta('$1')).
+access_expr -> atom_unsafe : build_quoted_atom('$1', false, atom_delimiter_meta('$1')).
 access_expr -> dot_alias : '$1'.
 access_expr -> parens_call : '$1'.
 
@@ -1029,7 +1029,12 @@ build_quoted_atom({_, Location, Args}, Safe, ExtraMeta) ->
 binary_to_atom_op(true)  -> binary_to_existing_atom;
 binary_to_atom_op(false) -> binary_to_atom.
 
-atom_delimiter({_Kind, {_Line, _Column, Delimiter}, _Args}) ->
+atom_colon_meta({atom, _Location, Atom}) when Atom =:= true orelse Atom =:= false orelse Atom =:= nil ->
+  [{format, atom}];
+atom_colon_meta(_) ->
+  [].
+
+atom_delimiter_meta({_Kind, {_Line, _Column, Delimiter}, _Args}) ->
   case ?token_metadata() of
     true -> [{delimiter, <<Delimiter>>}];
     false -> []

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -795,6 +795,9 @@ defmodule Kernel.ParserTest do
       assert string_to_quoted.("nil") == {:__block__, [line: 1], [nil]}
       assert string_to_quoted.(":one") == {:__block__, [line: 1], [:one]}
 
+      assert string_to_quoted.("true") == {:__block__, [line: 1], [true]}
+      assert string_to_quoted.(":true") == {:__block__, [format: :atom, line: 1], [true]}
+
       assert string_to_quoted.("[one: :two]") == {
                :__block__,
                [{:closing, [line: 1]}, {:line, 1}],


### PR DESCRIPTION
Edge case, but preferably we want to avoid loosing information.