### PR TITLE
Clarify the interplay of `Stream` and `Enum`

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -31,11 +31,9 @@ defmodule Stream do
   Due to their laziness, streams are useful when working with large
   (or even infinite) collections. When chaining many operations with `Enum`,
   intermediate lists are created, while `Stream` creates a recipe of
-  computations that are executed at a later moment.
-  Notably, the issue with using `Enum` in this context is with the
-  intermediate lists that are created as their result. An `Enum` function
-  used on a stream will still process the elements one by one as they are
-  emitted by the stream.
+  computations that are executed at a later moment. Then when the
+  stream is consumed later on, most commonly by using a function in
+  the `Enum` module, the stream will emit its elements one by one.
 
   Let's see another example:
 

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -31,8 +31,13 @@ defmodule Stream do
   Due to their laziness, streams are useful when working with large
   (or even infinite) collections. When chaining many operations with `Enum`,
   intermediate lists are created, while `Stream` creates a recipe of
-  computations that are executed at a later moment. Let's see another
-  example:
+  computations that are executed at a later moment.
+  Notably, the issue with using `Enum` in this context is with the
+  intermediate lists that are created as their result. An `Enum` function
+  used on a stream will still process the elements one by one as they are
+  emitted by the stream.
+
+  Let's see another example:
 
       1..3
       |> Enum.map(&IO.inspect(&1))


### PR DESCRIPTION
This is based on trying to clarify/make more obvious a missunderstanding I held until ~yesterday.

Namely I thought that calling an `Enum` function on a stream would result in the equivalent of `Enum.to_list` and hence all stream benefits would be forfeit. Yes, it should be clear seeing `Enum.take` work that this isn't the case, but it's not always so easy.

This turned out wrong as @benwilson512 pointed out eloquently here: https://elixirforum.com/t/why-is-stream-reduce-while-missing/34422/2

Not sure if this is the best place or way to highlight this in the docs, but I thought I'd give it a shot. One could argue that this documentation belongs in the `Enum` module, but for `Stream` documentation that module is the primary source - plus it's more about `Stream`s implementation of `Enumerable`.