### PR TITLE
Make protocol errors pretty

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -346,7 +346,7 @@ defmodule Exception do
   defp rewrite_arg(arg) do
     Macro.prewalk(arg, fn
       {:%{}, meta, [__struct__: Range, first: first, last: last, step: step]} ->
-        {:..//, meta, [first, last, step]}
+        {:"..//", meta, [first, last, step]}
 
       other ->
         other
@@ -1997,11 +1997,11 @@ defmodule Protocol.UndefinedError do
 
   @impl true
   def message(%{protocol: protocol, value: value, description: description}) do
-    "protocol #{inspect(protocol)} not implemented for #{inspect(value)} of type " <>
+    "protocol #{inspect(protocol)} not implemented for #{inspect(value, pretty: true)} of type " <>
       value_type(value) <> maybe_description(description) <> maybe_available(protocol)
   end
 
-  defp value_type(%{__struct__: struct}), do: "#{inspect(struct)} (a struct)"
+  defp value_type(%{__struct__: struct}), do: "#{inspect(struct, pretty: true)} (a struct)"
   defp value_type(value) when is_atom(value), do: "Atom"
   defp value_type(value) when is_bitstring(value), do: "BitString"
   defp value_type(value) when is_float(value), do: "Float"


### PR DESCRIPTION
A common complaint I here from people is that error messages in Elixir are not pretty. Generally, this seems to be only the case when there are large structs in codebases that render in one line and are hard to read.

This PR changes the behavior to pretty inspect the structs in the case that a protocol is not implemented for some value.

The downside here is that the logging will no longer be in one line, but I think this is a fair tradeoff for legibility