### PR TITLE
added more checksum types

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -595,7 +595,7 @@ defmodule Mix.Utils do
     end
   end
 
-  @checksums [:sha512]
+  @checksums [:sha224, :sha256, :sha384, :sha512, :sha3_224, :sha3_256, :sha3_384, :sha3_512]
 
   defp require_checksum(opts) do
     cond do
@@ -615,7 +615,7 @@ defmodule Mix.Utils do
       with expected when expected != nil <- opts[hash],
            actual when actual != expected <- hexhash(binary, hash) do
         message = """
-        Data does not match the given SHA-512 checksum.
+        Data does not match the given #{hash_name(hash)} checksum.
 
         Expected: #{expected}
           Actual: #{actual}
@@ -627,6 +627,15 @@ defmodule Mix.Utils do
       end
     end)
   end
+
+  defp hash_name(:sha224), do: "SHA-224"
+  defp hash_name(:sha256), do: "SHA-256"
+  defp hash_name(:sha384), do: "SHA-384"
+  defp hash_name(:sha512), do: "SHA-512"
+  defp hash_name(:sha3_224), do: "SHA3-224"
+  defp hash_name(:sha3_256), do: "SHA3-256"
+  defp hash_name(:sha3_384), do: "SHA3-384"
+  defp hash_name(:sha3_512), do: "SHA3-512"
 
   defp hexhash(binary, hash) do
     Base.encode16(:crypto.hash(hash, binary), case: :lower)


### PR DESCRIPTION
Added more checksum types to the list so libraries can make use of `Mix.Utils.read_path/2` at compile-time to download resources and verify the integrity (without having to calculate SHA512 if the original source only gives SHA256 or some other hash values.)

For example, currently in torchx we rely on external tools (curl, wget) to download the lib torch archive in its [mix.exs](https://github.com/elixir-nx/nx/blob/main/torchx/mix.exs) while we could have used this helper function and verify the checksum. 