### PR TITLE
Fix docs for Process.monitor/2

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -569,10 +569,15 @@ defmodule Process do
 
       send(pid, {:ping, ref_and_alias})
 
-      receive do: msg -> msg
+      receive do: (msg -> msg)
       #=> :pong
 
-      receive do: msg -> msg
+      ref_and_alias = Process.monitor(pid, alias: :reply_demonitor)
+      #=> #Reference<0.906660723.3006791681.40191>
+
+      send(pid, {:ping, ref_and_alias})
+
+      receive do: (msg -> msg)
       #=> {:DOWN, #Reference<0.906660723.3006791681.40191>, :process, #PID<0.118.0>, :noproc}
 
   """


### PR DESCRIPTION
Previously, the example contained 2 issues.

1. A syntax error on `receive` as there were no parens.
2. The example was incomplete, and would hang on the 2nd receive

This commit updates the example to reflect the original intent, by sending 2 messages and getting a `:noproc` on the 2nd `receive`.

This was originally added in https://github.com/elixir-lang/elixir/commit/65829ef4e80406a30ddaaa27e92bdcbb4292a069#diff-8041c84ced048086c5c0b41e19df8d1ed59f0fdd769487a656ddac42f928d213R554