### PR TITLE
dbg for function calls.

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1495,7 +1495,7 @@ defmodule Macro do
     :error
   end
 
-  defp op_call({:"..//", _, [left, middle, right]} = ast, fun) do
+  defp op_call({:..//, _, [left, middle, right]} = ast, fun) do
     left = op_to_string(left, fun, :.., :left)
     middle = op_to_string(middle, fun, :.., :right)
     right = op_to_string(right, fun, :"//", :right)
@@ -1946,7 +1946,7 @@ defmodule Macro do
   @spec operator?(name :: atom(), arity()) :: boolean()
   def operator?(name, arity)
 
-  def operator?(:"..//", 3),
+  def operator?(:..//, 3),
     do: true
 
   # Code.Identifier treats :// as a binary operator for precedence
@@ -2482,7 +2482,7 @@ defmodule Macro do
   #
   defp inner_classify(atom) when is_atom(atom) do
     cond do
-      atom in [:%, :%{}, :{}, :<<>>, :..., :.., :., :"..//", :->] ->
+      atom in [:%, :%{}, :{}, :<<>>, :..., :.., :., :..//, :->] ->
         :not_callable
 
       # <|>, ^^^, and ~~~ are deprecated

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -803,8 +803,7 @@ defmodule MacroTest do
               true
             else
               :error -> false
-            end,
-            print_location: false
+            end
           )
         end
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -915,6 +915,26 @@ defmodule MacroTest do
              """
     end
 
+    test "with anonymous function" do
+      add = fn a, b -> a + b end
+      {a, b} = {1, 2}
+
+      {result, formatted} =
+        dbg_format(add.(a, b))
+
+      assert result == 3
+      assert formatted =~ "macro_test.exs"
+
+      assert formatted =~ """
+             Function arguments:
+             a #=> 1
+             b #=> 2
+
+             Function result:
+             add.(a, b) #=> 3
+             """
+    end
+
     test "with \"syntax_colors: []\" it doesn't print any color sequences" do
       {_result, formatted} = dbg_format("hello")
       refute formatted =~ "\e["


### PR DESCRIPTION
aoc is not that far away :)
I wanted to see the input params to a function call and I was pretty sure this is implemented.
I know that there could be macros but with pattern matching we can just skip it.
Any other edge cases that I should cover?.

![image](https://github.com/user-attachments/assets/c4736689-0476-4585-aa13-ba73ccda8a0a)
```elixir
number = 1
list =
1..15
  |> Enum.filter(fn x -> rem(x, 2) == 0 end)
  |> Enum.map(& &1 + 1)

Enum.reduce(list, number, fn x, acc -> x + acc end)
|> dbg()


Function arguments:
list #=> [3, 5, 7, 9, 11, 13, 15]
number #=> 1
fn x, acc -> x + acc end #=> #Function<2.29434556 in file:test.exs>

Function result:
Enum.reduce(list, number, fn x, acc -> x + acc end) #=> 64
```

