### PR TITLE
Add `project/0` warning

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -75,6 +75,14 @@ defmodule Mix.Project do
   the `:erlc_paths` configuration is used by `mix compile.erlang`, `mix compile.yecc`,
   and other tasks.
 
+  > #### Keep `project/0` fast {: .warning}
+  >
+  > `project/0` is called upon every Mix task invocation in your project, so
+  > heavy computation should be avoided. If a task requires a potentially
+  > complex configuration value, it should allow for lazy evaluation via a
+  > function configuration value that can be invoked only when needed by the
+  > task itself.
+
   ## CLI configuration
 
   Mix is most often invoked from the command line. For this purpose, you may define

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -77,11 +77,11 @@ defmodule Mix.Project do
 
   > #### Keep `project/0` fast {: .warning}
   >
-  > `project/0` is called upon every Mix task invocation in your project, so
-  > heavy computation should be avoided. If a task requires a potentially
-  > complex configuration value, it should allow for lazy evaluation via a
-  > function configuration value that can be invoked only when needed by the
-  > task itself.
+  > `project/0` is called whenever your `mix.exs` is loaded, so heavy
+  > computation should be avoided. If a task requires a potentially complex
+  > configuration value, it should allow its configuration to be set to an
+  > anonymous function or similar, so that it can be invoked only when
+  > needed by the task itself.
 
   ## CLI configuration
 


### PR DESCRIPTION
We were recently bit by costly code hiding in `project/0` config. Solved via moving to a lazy function `:docs` function value. Hoping to help others.