### PR TITLE
Send warnings to stderr and in yellow color in test and compiler.erlang tasks

### DIFF
--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -313,7 +313,9 @@ defmodule Mix.Compilers.Erlang do
     for {_, warnings} <- entries,
         {file, issues} <- warnings,
         {location, module, message} <- issues do
-      IO.puts("#{file}:#{location_to_string(location)} warning: #{module.format_error(message)}")
+      message = "#{file}:#{location_to_string(location)} warning: #{module.format_error(message)}"
+
+      IO.puts(:stderr, IO.ANSI.format([:yellow, :bright, message]))
     end
   end
 

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -683,9 +683,7 @@ defmodule Mix.Tasks.Test do
     files = Mix.Utils.extract_files(test_files, warn_test_pattern) -- matched_test_files
 
     for file <- files do
-      Mix.shell().info(
-        "warning: #{file} does not match #{inspect(test_pattern)} and won't be loaded"
-      )
+      warning("warning: #{file} does not match #{inspect(test_pattern)} and won't be loaded")
     end
   end
 
@@ -878,5 +876,16 @@ defmodule Mix.Tasks.Test do
     else
       []
     end
+  end
+
+  # Prints the given ANSI warning to the shell followed by a newline.
+  defp warning(message) do
+    Mix.shell().print_app()
+
+    IO.puts(:stderr, IO.ANSI.format(yellow(message)))
+  end
+
+  defp yellow(message) do
+    [:yellow, :bright, message]
   end
 end

--- a/lib/mix/test/mix/tasks/compile.erlang_test.exs
+++ b/lib/mix/test/mix/tasks/compile.erlang_test.exs
@@ -161,13 +161,13 @@ defmodule Mix.Tasks.Compile.ErlangTest do
 
       capture_io(fn -> Mix.Tasks.Compile.Erlang.run([]) end)
 
-      assert capture_io(fn ->
+      assert capture_io(:stderr, fn ->
                assert {:noop, _} = Mix.Tasks.Compile.Erlang.run([])
-             end) =~ ~r"has_warning.erl:2:(1:)? warning: function my_fn/0 is unused\n"
+             end) =~ ~r"has_warning.erl:2:(1:)? warning: function my_fn/0 is unused"
 
-      assert capture_io(fn ->
+      assert capture_io(:stderr, fn ->
                assert {:noop, _} = Mix.Tasks.Compile.Erlang.run([])
-             end) =~ ~r"has_warning.erl:2:(1:)? warning: function my_fn/0 is unused\n"
+             end) =~ ~r"has_warning.erl:2:(1:)? warning: function my_fn/0 is unused"
 
       # Should not print old warnings after fixing
       File.write!(file, """


### PR DESCRIPTION
There warnings were being sent to stdio. I am redirecting them to stderr and with yellow color.