### PR TITLE
test Mix task should exit with 1 when --warnings-as-errors opt is used

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -608,7 +608,25 @@ defmodule Mix.Tasks.Test do
       |> filter_to_allowed_files(allowed_files)
       |> filter_by_partition(shell, partitions)
 
-    display_warn_test_pattern(test_files, test_pattern, unfiltered_test_files, warn_test_pattern)
+    warnings =
+      display_warn_test_pattern(
+        test_files,
+        test_pattern,
+        unfiltered_test_files,
+        warn_test_pattern
+      )
+
+    if warnings != [] and Keyword.get(opts, :warnings_as_errors) do
+      System.at_exit(fn _ ->
+        message =
+          "\nERROR! Test suite aborted after successful execution due to " <>
+            "warnings while using the --warnings-as-errors option"
+
+        Mix.shell().error(message)
+
+        exit({:shutdown, 1})
+      end)
+    end
 
     try do
       Enum.each(test_paths, &require_test_helper(shell, &1))


### PR DESCRIPTION
Previously some warnings were not detected as errors, exiting the command with 1.

A real case example is wrongly naming a test file with the extension .ex instead of .exs. This was making the CI flow not to fail because of this.

A test app has been uploaded to: https://github.com/eksperimental-debug/debug_elixir_test_wrong_ext

Previously:

    ❯ mix test --warnings-as-errors; echo $?
    Compiling 1 file (.ex)
    Generated debug_elixir_test_wrong_ext app
    warning: test/foo_test.ex does not match "*_test.exs" and won't be loaded
    Running ExUnit with seed: 194476, max_cases: 20

    ..
    Finished in 0.00 seconds (0.00s async, 0.00s sync)
    1 doctest, 1 test, 0 failures
    0

Now:

    ❯ mix test --warnings-as-errors; echo $?
    Compiling 1 file (.ex)
    Generated debug_elixir_test_wrong_ext app
    warning: test/foo_test.ex does not match "*_test.exs" and won't be loaded
    Running ExUnit with seed: 560339, max_cases: 20

    ..
    Finished in 0.00 seconds (0.00s async, 0.00s sync)
    1 doctest, 1 test, 0 failures

    ERROR! Test suite aborted after successful execution due to warnings while using the --warnings-as-errors option
    1

All tests will be executed, the warning is printed, but it prints an error message and exits with 1.

Screenshot with this fix:
<img width="865" alt="image" src="https://github.com/user-attachments/assets/422dd220-4509-4ab5-98f3-d2d6139233b7">
