### PR TITLE
Fix typos

### DIFF
--- a/lib/elixir/lib/module/parallel_checker.ex
+++ b/lib/elixir/lib/module/parallel_checker.ex
@@ -503,8 +503,8 @@ defmodule Module.ParallelChecker do
 
   def handle_call({:lock, module}, from, %{waiting: waiting} = state) do
     case waiting do
-      %{^module => froms} ->
-        waiting = Map.put(state.waiting, module, [from | froms])
+      %{^module => from_list} ->
+        waiting = Map.put(state.waiting, module, [from | from_list])
         {:noreply, %{state | waiting: waiting}}
 
       %{} ->
@@ -514,8 +514,8 @@ defmodule Module.ParallelChecker do
   end
 
   def handle_call({:unlock, module}, _from, %{waiting: waiting} = state) do
-    froms = Map.fetch!(waiting, module)
-    Enum.each(froms, &:gen_server.reply(&1, false))
+    from_list = Map.fetch!(waiting, module)
+    Enum.each(from_list, &:gen_server.reply(&1, false))
     waiting = Map.delete(waiting, module)
     {:reply, :ok, %{state | waiting: waiting}}
   end

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -160,7 +160,7 @@ defmodule Module.Types.Descr do
   def gradual?(descr), do: is_map_key(descr, :dynamic)
 
   @doc """
-  Returns true if hte type only has a gradual part.
+  Returns true if the type only has a gradual part.
   """
   def only_gradual?(%{dynamic: _} = descr), do: map_size(descr) == 1
   def only_gradual?(_), do: false

--- a/lib/elixir/pages/references/gradual-set-theoretic-types.md
+++ b/lib/elixir/pages/references/gradual-set-theoretic-types.md
@@ -4,7 +4,7 @@ Elixir is in the process of incorporating set-theoretic types into the compiler.
 
   * **sound** - the inferred and assigned by the type system align with the behaviour of the program
 
-  * **gradual** - Elixir's type system includes the `dynamic()` type, which can be used when the type of a varible or expression is checked at runtime. In the absense of `dynamic()`, Elixir's type system behaves as a static one
+  * **gradual** - Elixir's type system includes the `dynamic()` type, which can be used when the type of a variable or expression is checked at runtime. In the absence of `dynamic()`, Elixir's type system behaves as a static one
 
   * **developer friendly** - the types are described, implemented, and composed using basic set operations: unions, intersections, and negation (hence it is a set-theoretic type system)
 
@@ -104,7 +104,7 @@ Once Elixir introduces typed function signatures (see "Roadmap"), any function w
 
 ## Roadmap
 
-The current milestone is to implement type inference of patterns and guards, as well as type checking of all language contructs, without changes to the Elixir language. At this stage, we want to collect feedback on the quality of error messages and performance, and therefore the type system has no user facing API. Full type inference of patterns was released in Elixir v1.18, and inference of guards is expected as part of Elixir v1.19.
+The current milestone is to implement type inference of patterns and guards, as well as type checking of all language constructs, without changes to the Elixir language. At this stage, we want to collect feedback on the quality of error messages and performance, and therefore the type system has no user facing API. Full type inference of patterns was released in Elixir v1.18, and inference of guards is expected as part of Elixir v1.19.
 
 If the results are satisfactory, the next milestone will include a mechanism for defining typed structs. Elixir programs frequently pattern match on structs, which reveals information about the struct fields, but it knows nothing about their respective types. By propagating types from structs and their fields throughout the program, we will increase the type system’s ability to find errors while further straining our type system implementation. Proposals including the required changes to the language surface will be sent to the community once we reach this stage.
 

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1449,7 +1449,7 @@ check_terminator({End, {EndLine, EndColumn, _}}, [{Start, {StartLine, StartColum
 check_terminator({'end', {Line, Column, _}}, [], #elixir_tokenizer{mismatch_hints=Hints}) ->
   Suffix =
     case lists:keyfind('end', 1, Hints) of
-      {'end', HintLine, _Identation} ->
+      {'end', HintLine, _Indentation} ->
         io_lib:format("\n~ts the \"end\" on line ~B may not have a matching \"do\" "
                       "defined before it (based on indentation)", [elixir_errors:prefix(hint), HintLine]);
       false ->

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -100,7 +100,7 @@ defmodule CodeTest do
       end
       """
 
-      assert {_, [%{position: {3, 18}}]} =
+      assert {_, [%{position: {3, 19}}]} =
                Code.with_diagnostics(fn ->
                  quoted = Code.string_to_quoted!(sample, columns: true)
                  Code.eval_quoted(quoted, [])

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -95,7 +95,7 @@ defmodule CodeTest do
       sample = """
       defmodule CodeTest.UnknownRemoteCall do
         def perform do
-          UnkownModule.foo()
+          UnknownModule.foo()
         end
       end
       """

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -782,7 +782,7 @@ defmodule Module.Types.DescrTest do
              |> tuple_delete_at(1)
              |> equal?(union(tuple([integer()]), dynamic(tuple([float()]))))
 
-      # Succesfully deleting at position `index` in a tuple means that the dynamic
+      # Successfully deleting at position `index` in a tuple means that the dynamic
       # values that succeed are intersected with tuples of size at least `index`
       assert dynamic(tuple()) |> tuple_delete_at(0) == dynamic(tuple())
       assert dynamic(term()) |> tuple_delete_at(0) == dynamic(tuple())
@@ -848,7 +848,7 @@ defmodule Module.Types.DescrTest do
                )
              )
 
-      # If you succesfully intersect at position index in a type, then the dynamic values
+      # If you successfully intersect at position index in a type, then the dynamic values
       # that succeed are intersected with tuples of size at least index
       assert dynamic(union(tuple(), integer()))
              |> tuple_insert_at(1, boolean())

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -234,8 +234,8 @@ defmodule PathTest do
 
     assert Path.relative_to_cwd(Path.dirname(File.cwd!()), force: true) == ".."
 
-    [slash | splitted_cwd] = Path.split(File.cwd!())
-    relative_to_root = List.duplicate("..", length(splitted_cwd))
+    [slash | split_cwd] = Path.split(File.cwd!())
+    relative_to_root = List.duplicate("..", length(split_cwd))
 
     assert Path.relative_to_cwd(slash) == slash
     assert Path.relative_to_cwd(slash, force: true) == Path.join(relative_to_root)


### PR DESCRIPTION
The typos were detected by this app: https://pypi.org/project/typos/ running the following command

    typos --exclude "lib/elixir/unicode/" --exclude "man/" --exclude "typos"  --format brief