### PR TITLE
Add a human readable representation of duration

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1030,9 +1030,12 @@ defmodule DateTime do
   By default, `DateTime.to_iso8601/2` returns datetimes formatted in the "extended"
   format, for human readability. It also supports the "basic" format through passing the `:basic` option.
 
-  Only supports converting datetimes which are in the ISO calendar,
-  attempting to convert datetimes from other calendars will raise.
   You can also optionally specify an offset for the formatted string.
+  If none is given, the one in the given `datetime` is used.
+
+  Only supports converting datetimes which are in the ISO calendar.
+  If another calendar is given, it is automatically converted to ISO.
+  It raises if not possible.
 
   WARNING: the ISO 8601 datetime format does not contain the time zone nor
   its abbreviation, which means information is lost when converting to such
@@ -1345,6 +1348,11 @@ defmodule DateTime do
 
   @doc """
   Converts the given `datetime` to a string according to its calendar.
+
+  Unfortunately, there is no standard that specifies rendering of a
+  datetime with its complete time zone information, so Elixir uses a
+  custom (but relatively common) representation which appends the time
+  zone abbreviation and full name to the datetime.
 
   ### Examples
 

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -373,7 +373,7 @@ defmodule Duration do
             second: "s"
           ]
 
-    * `:separator` - how to separate the distinct components
+    * `:separator` - a string used to separate the distinct components. Defaults to `" "`.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -759,6 +759,9 @@ defmodule NaiveDateTime do
   @doc """
   Converts the given naive datetime to a string according to its calendar.
 
+  For redability, this function follows the RFC3339 suggestion of removing
+  the "T" separator between the date and time components.
+
   ### Examples
 
       iex> NaiveDateTime.to_string(~N[2000-02-28 23:00:13])

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -358,4 +358,69 @@ defmodule DurationTest do
     assert %Duration{microsecond: {-800_000, 0}} |> Duration.to_iso8601() == "PT0S"
     assert %Duration{microsecond: {-1_200_000, 2}} |> Duration.to_iso8601() == "PT-1.20S"
   end
+
+  test "to_string/1" do
+    assert Duration.to_string(%Duration{year: 1, month: 2, day: 3, hour: 4, minute: 5, second: 6}) ==
+             "1 year, 2 months, 3 days, 4 hours, 5 minutes, 6 seconds"
+
+    assert Duration.to_string(%Duration{week: 3, hour: 5, minute: 3}) ==
+             "3 weeks, 5 hours, 3 minutes"
+
+    assert Duration.to_string(%Duration{hour: 5, minute: 3}) ==
+             "5 hours, 3 minutes"
+
+    assert Duration.to_string(%Duration{year: 1, month: 2, day: 3}) ==
+             "1 year, 2 months, 3 days"
+
+    assert Duration.to_string(%Duration{hour: 4, minute: 5, second: 6}) ==
+             "4 hours, 5 minutes, 6 seconds"
+
+    assert Duration.to_string(%Duration{year: 1, month: 2}) ==
+             "1 year, 2 months"
+
+    assert Duration.to_string(%Duration{day: 3}) ==
+             "3 days"
+
+    assert Duration.to_string(%Duration{hour: 4, minute: 5}) ==
+             "4 hours, 5 minutes"
+
+    assert Duration.to_string(%Duration{second: 6}) ==
+             "6 seconds"
+
+    assert Duration.to_string(%Duration{second: 1, microsecond: {600_000, 1}}) ==
+             "1.6 seconds"
+
+    assert Duration.to_string(%Duration{second: -1, microsecond: {-600_000, 1}}) ==
+             "-1.6 seconds"
+
+    assert Duration.to_string(%Duration{second: -1, microsecond: {-234_567, 6}}) ==
+             "-1.234567 seconds"
+
+    assert Duration.to_string(%Duration{second: 1, microsecond: {123_456, 6}}) ==
+             "1.123456 seconds"
+
+    assert Duration.to_string(%Duration{year: 3, week: 4, day: -3, second: -6}) ==
+             "3 years, 4 weeks, -3 days, -6 seconds"
+
+    assert Duration.to_string(%Duration{second: -4, microsecond: {-230_000, 2}}) ==
+             "-4.23 seconds"
+
+    assert Duration.to_string(%Duration{second: -4, microsecond: {230_000, 2}}) ==
+             "-3.77 seconds"
+
+    assert Duration.to_string(%Duration{second: 2, microsecond: {-1_200_000, 4}}) ==
+             "0.8000 seconds"
+
+    assert Duration.to_string(%Duration{second: 1, microsecond: {-1_200_000, 3}}) ==
+             "-0.200 seconds"
+
+    assert Duration.to_string(%Duration{microsecond: {-800_000, 2}}) ==
+             "-0.80 seconds"
+
+    assert Duration.to_string(%Duration{microsecond: {-800_000, 0}}) ==
+             "0 seconds"
+
+    assert Duration.to_string(%Duration{microsecond: {-1_200_000, 2}}) ==
+             "-1.20 seconds"
+  end
 end

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -361,66 +361,72 @@ defmodule DurationTest do
 
   test "to_string/1" do
     assert Duration.to_string(%Duration{year: 1, month: 2, day: 3, hour: 4, minute: 5, second: 6}) ==
-             "1 year, 2 months, 3 days, 4 hours, 5 minutes, 6 seconds"
+             "1a 2mo 3d 4h 5min 6s"
 
     assert Duration.to_string(%Duration{week: 3, hour: 5, minute: 3}) ==
-             "3 weeks, 5 hours, 3 minutes"
+             "3wk 5h 3min"
 
     assert Duration.to_string(%Duration{hour: 5, minute: 3}) ==
-             "5 hours, 3 minutes"
+             "5h 3min"
 
     assert Duration.to_string(%Duration{year: 1, month: 2, day: 3}) ==
-             "1 year, 2 months, 3 days"
+             "1a 2mo 3d"
 
     assert Duration.to_string(%Duration{hour: 4, minute: 5, second: 6}) ==
-             "4 hours, 5 minutes, 6 seconds"
+             "4h 5min 6s"
 
     assert Duration.to_string(%Duration{year: 1, month: 2}) ==
-             "1 year, 2 months"
+             "1a 2mo"
 
     assert Duration.to_string(%Duration{day: 3}) ==
-             "3 days"
+             "3d"
 
     assert Duration.to_string(%Duration{hour: 4, minute: 5}) ==
-             "4 hours, 5 minutes"
+             "4h 5min"
 
     assert Duration.to_string(%Duration{second: 6}) ==
-             "6 seconds"
+             "6s"
 
     assert Duration.to_string(%Duration{second: 1, microsecond: {600_000, 1}}) ==
-             "1.6 seconds"
+             "1.6s"
 
     assert Duration.to_string(%Duration{second: -1, microsecond: {-600_000, 1}}) ==
-             "-1.6 seconds"
+             "-1.6s"
 
     assert Duration.to_string(%Duration{second: -1, microsecond: {-234_567, 6}}) ==
-             "-1.234567 seconds"
+             "-1.234567s"
 
     assert Duration.to_string(%Duration{second: 1, microsecond: {123_456, 6}}) ==
-             "1.123456 seconds"
+             "1.123456s"
 
     assert Duration.to_string(%Duration{year: 3, week: 4, day: -3, second: -6}) ==
-             "3 years, 4 weeks, -3 days, -6 seconds"
+             "3a 4wk -3d -6s"
 
     assert Duration.to_string(%Duration{second: -4, microsecond: {-230_000, 2}}) ==
-             "-4.23 seconds"
+             "-4.23s"
 
     assert Duration.to_string(%Duration{second: -4, microsecond: {230_000, 2}}) ==
-             "-3.77 seconds"
+             "-3.77s"
 
     assert Duration.to_string(%Duration{second: 2, microsecond: {-1_200_000, 4}}) ==
-             "0.8000 seconds"
+             "0.8000s"
 
     assert Duration.to_string(%Duration{second: 1, microsecond: {-1_200_000, 3}}) ==
-             "-0.200 seconds"
+             "-0.200s"
 
     assert Duration.to_string(%Duration{microsecond: {-800_000, 2}}) ==
-             "-0.80 seconds"
+             "-0.80s"
 
     assert Duration.to_string(%Duration{microsecond: {-800_000, 0}}) ==
-             "0 seconds"
+             "0s"
 
     assert Duration.to_string(%Duration{microsecond: {-1_200_000, 2}}) ==
-             "-1.20 seconds"
+             "-1.20s"
+
+    assert Duration.to_string(%Duration{year: 1, month: 2, day: 3, hour: 4, minute: 5, second: 6},
+             units: [year: "year", month: "month", day: "day"],
+             separator: "-"
+           ) ==
+             "1year-2month-3day-4h-5min-6s"
   end
 end


### PR DESCRIPTION
Without this function, projects like Phoenix.HTML, Postgrex, and similar would have to implement this function over and over.