### PR TITLE
Fix typo

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -705,7 +705,7 @@ defmodule Logger do
   This guarantees all logger handlers flush to disk or storage.
   This is useful for testing but it should be avoided in production,
   as it could force logger handlers to drop whatever they are doing
-  and flush, even if continuing to buffer would be the most peformant
+  and flush, even if continuing to buffer would be the most performant
   option.
   """
   @spec flush :: :ok


### PR DESCRIPTION
Just introduced in https://github.com/elixir-lang/elixir/commit/b75cccc8df0b6664ce7f8a3b3efe13183e3b9ae9

peformant -> performant