### PR TITLE
Remove not needed macrocallback code

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -635,7 +635,6 @@ defmodule IEx.Introspection do
   defp format_callback({{kind, name, _arity}, specs}) do
     Enum.map(specs, fn spec ->
       Typespec.spec_to_quoted(name, spec)
-      |> Macro.prewalk(&drop_macro_env/1)
       |> format_typespec(kind, 0)
     end)
   end
@@ -663,11 +662,6 @@ defmodule IEx.Introspection do
   defp format_optional_callbacks(callbacks) do
     format_typespec(callbacks, :optional_callbacks, 0)
   end
-
-  defp drop_macro_env({name, meta, [{:"::", _, [_, {{:., _, [Macro.Env, :t]}, _, _}]} | args]}),
-    do: {name, meta, args}
-
-  defp drop_macro_env(other), do: other
 
   @doc """
   Prints the types for the given module and type documentation.


### PR DESCRIPTION
This code added in 6951f0cd2af548fedb212d6c9b1284bc861841df was made obsolete in aee7fbc0dc3cdee77fbe3d4a6442b2e0b53afe5d (v1.1). Correct macrocallback handling was added in 04f151b68b0dc1e5679cda3fa66b70fe3e07579a (v1.10) and since then macro caller arg is passed to typespecs as `term()` instead of `Macro.Env.t()`