### PR TITLE
Deprecate single quites in quoted atoms and calls, refs #13958

### DIFF
--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -201,6 +201,42 @@ defmodule Kernel.WarningTest do
     end
   end
 
+  describe "deprecated single quotes in atoms" do
+    test "warns for single quotes in atoms" do
+      assert_warn_eval(
+        [
+          "nofile:1:1",
+          "single quotes around atoms are deprecated. Use double quotes instead"
+        ],
+        ~s/:'a+b'/
+      )
+    end
+
+    test "warns twice for single and unnecessary atom quotes" do
+      assert_warn_eval(
+        [
+          "nofile:1:1",
+          "single quotes around atoms are deprecated. Use double quotes instead",
+          "nofile:1:1",
+          "found quoted atom \"ab\" but the quotes are not required"
+        ],
+        ~s/:'ab'/
+      )
+    end
+
+    test "warns twice for single and unnecessary call quotes" do
+      assert_warn_eval(
+        [
+          "nofile:1:9",
+          "single quotes around calls are deprecated. Use double quotes instead",
+          "nofile:1:9",
+          "found quoted call \"length\" but the quotes are not required"
+        ],
+        ~s/[Kernel.'length'([])]/
+      )
+    end
+  end
+
   test "warns on :: as atom" do
     assert_warn_eval(
       [

--- a/lib/elixir/test/erlang/atom_test.erl
+++ b/lib/elixir/test/erlang/atom_test.erl
@@ -17,7 +17,7 @@ atom_with_punctuation_test() ->
   {'...', []} = eval(":...").
 
 atom_quoted_call_test() ->
-  {3, []} = eval("Kernel.'+'(1, 2)").
+  {3, []} = eval("Kernel.\"+\"(1, 2)").
 
 kv_with_quotes_test() ->
   {'foo bar', []} = eval(":atom_test.kv(\"foo bar\": nil)").
@@ -29,7 +29,6 @@ kv_with_interpolation_test() ->
 
 quoted_atom_test() ->
   {'+', []} = eval(":\"+\""),
-  {'+', []} = eval(":'+'"),
   {'foo bar', []} = eval(":\"foo bar\"").
 
 atom_with_interpolation_test() ->


### PR DESCRIPTION
Since this is my first contribution to Elixir (which I always loved), I am not really sure about the process :)

Should I also add a `CHANGELOG` entry? From the history it seems that not all people do that.

One extra question: now tests start to show warnings:

```
» make test
Generated elixir app
==> elixir (eunit)
warning: single quotes around calls are deprecated. Use double quotes instead.
└─ nofile:1:8

warning: single quotes around atoms are deprecated. Use double quotes instead.
└─ nofile:1:1

  All 126 tests passed.
```

But, I fail to find the source code for them. Any ideas?

Closes https://github.com/elixir-lang/elixir/issues/13958
