### PR TITLE
Support min and max in guards

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -972,7 +972,7 @@ defmodule Kernel do
   comparison"](#module-structural-comparison) section
   for more information.
 
-  Inlined by the compiler.
+  Allowed in guard tests. Inlined by the compiler.
 
   ## Examples
 
@@ -982,6 +982,7 @@ defmodule Kernel do
       "b"
 
   """
+  @doc guard: true
   @spec max(first, second) :: first | second when first: term, second: term
   def max(first, second) do
     :erlang.max(first, second)
@@ -998,7 +999,7 @@ defmodule Kernel do
   comparison"](#module-structural-comparison) section
   for more information.
 
-  Inlined by the compiler.
+  Allowed in guard tests. Inlined by the compiler.
 
   ## Examples
 
@@ -1008,6 +1009,7 @@ defmodule Kernel do
       "bar"
 
   """
+  @doc guard: true
   @spec min(first, second) :: first | second when first: term, second: term
   def min(first, second) do
     :erlang.min(first, second)


### PR DESCRIPTION
Support min and max in guards, for: https://github.com/elixir-lang/elixir/issues/11985

How would you prefer this to be tested? I've looked through `kernel_test.exs` and `guard_test.exs` and I'm not seeing anything specific for guards that delegate to the Erlang builtin guards.

Thank you!