### PR TITLE
Improve error message on empty "mix do"

### DIFF
--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -58,12 +58,25 @@ defmodule Mix.Tasks.Do do
     {apps, args} = extract_apps_from_args(args)
     show_forgotten_apps_warning(apps)
 
-    Enum.each(gather_commands(args), fn [task | args] ->
-      if apps == [] do
-        Mix.Task.run(task, args)
-      else
-        Mix.Task.run_in_apps(task, apps, args)
-      end
+    Enum.each(gather_commands(args), fn
+      [task | args] ->
+        if apps == [] do
+          Mix.Task.run(task, args)
+        else
+          Mix.Task.run_in_apps(task, apps, args)
+        end
+
+      [] ->
+        Mix.raise("""
+        One of the commands passed to "mix do" is empty. Each command passed to "mix do" must \
+        have at least the task name. These are all invalid:
+
+          mix do
+          mix do my_task +
+          mix do + my_task
+
+        Run "mix help do" for more information.
+        """)
     end)
   end
 

--- a/lib/mix/test/mix/tasks/do_test.exs
+++ b/lib/mix/test/mix/tasks/do_test.exs
@@ -13,6 +13,14 @@ defmodule Mix.Tasks.DoTest do
     end)
   end
 
+  test "raises if a task is empty" do
+    for args <- [~w(), ~w(+), ~w(help +), ~w(+ help)] do
+      assert_raise Mix.Error, ~r"^One of the commands passed to \"mix do\" is empty", fn ->
+        Mix.Tasks.Do.run(args)
+      end
+    end
+  end
+
   test "gather_command returns a list of commands" do
     assert gather_commands(["help", "+", "compile"]) ==
              [["help"], ["compile"]]


### PR DESCRIPTION
Yucksies!

```
→ mix do
** (FunctionClauseError) no function clause matching in anonymous fn/1 in Mix.Tasks.Do.run/1    
    
    The following arguments were given to anonymous fn/1 in Mix.Tasks.Do.run/1:
    
        # 1
        []
    
    (mix 1.17.3) lib/mix/tasks/do.ex:61: anonymous fn/1 in Mix.Tasks.Do.run/1
    (elixir 1.17.3) lib/enum.ex:987: Enum."-each/2-lists^foreach/1-0-"/2
    (mix 1.17.3) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.17.3) lib/mix/cli.ex:96: Mix.CLI.run_task/2
    /Users/andrea/.asdf/installs/elixir/1.17.3/bin/mix:2: (file)
```