### PR TITLE
Add :migrate_call_parens_on_pipe formatter option

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1913,7 +1913,7 @@ defmodule DateTime do
     if Calendar.compatible_calendars?(dt_calendar, calendar) do
       result_datetime =
         datetime
-        |> to_iso_days
+        |> to_iso_days()
         |> from_iso_days(datetime, calendar, precision)
 
       {:ok, result_datetime}

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -1296,7 +1296,7 @@ defmodule NaiveDateTime do
     if Calendar.compatible_calendars?(ndt_calendar, calendar) do
       result_naive_datetime =
         naive_datetime
-        |> to_iso_days
+        |> to_iso_days()
         |> from_iso_days(calendar, precision)
 
       {:ok, result_naive_datetime}

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -696,6 +696,13 @@ defmodule Code do
       modifiers, where `<<foo::custom_type>>` becomes `<<foo::custom_type()>>`.
       Defaults to the value of the `:migrate` option. This option changes the AST.
 
+    * `:migrate_call_parens_on_pipe` (since v1.19.0) - when `true`,
+      formats local calls on the right-hand side of the pipe operator to always
+      include parentheses, for example `foo |> bar` becomes `foo |> bar()`.
+      Parentheses are always added for qualified calls like `foo |> Bar.bar`
+      disregarding of this option.
+      Defaults to the value of the `:migrate` option. This option changes the AST.
+
     * `:migrate_charlists_as_sigils` (since v1.18.0) - when `true`,
       formats charlists as [`~c`](`Kernel.sigil_c/2`) sigils, for example
       `'foo'` becomes `~c"foo"`.

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -697,10 +697,11 @@ defmodule Code do
       Defaults to the value of the `:migrate` option. This option changes the AST.
 
     * `:migrate_call_parens_on_pipe` (since v1.19.0) - when `true`,
-      formats local calls on the right-hand side of the pipe operator to always
-      include parentheses, for example `foo |> bar` becomes `foo |> bar()`.
-      Parentheses are always added for qualified calls like `foo |> Bar.bar`
-      disregarding of this option.
+      formats calls on the right-hand side of the pipe operator to always include
+      parentheses, for example `foo |> bar` becomes `foo |> bar()` and
+      `foo |> mod.fun` becomes `foo |> mod.fun()`.
+      Parentheses are always added for qualified calls like `foo |> Bar.bar` even
+      when this option is `false`.
       Defaults to the value of the `:migrate` option. This option changes the AST.
 
     * `:migrate_charlists_as_sigils` (since v1.18.0) - when `true`,

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -437,7 +437,7 @@ defmodule IO.ANSI.Docs do
       col
       |> String.trim()
       |> String.replace("\\\|", "|")
-      |> handle_links
+      |> handle_links()
       |> handle_inline(options)
 
     {col, length_without_escape(col, 0)}
@@ -610,8 +610,8 @@ defmodule IO.ANSI.Docs do
 
   defp handle_links(text) do
     text
-    |> remove_square_brackets_in_link
-    |> escape_underlines_in_link
+    |> remove_square_brackets_in_link()
+    |> escape_underlines_in_link()
   end
 
   defp escape_underlines_in_link(text) do

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -155,7 +155,7 @@ defmodule System do
     ~c"git rev-parse --short=7 HEAD 2> "
     |> Kernel.++(null)
     |> :os.cmd()
-    |> strip
+    |> strip()
   end
 
   defp revision, do: get_revision()

--- a/lib/elixir/test/elixir/code_formatter/migration_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/migration_test.exs
@@ -27,6 +27,24 @@ defmodule Code.Formatter.MigrationTest do
     end
   end
 
+  describe "migrate_call_parens_on_pipe: true" do
+    @opts [migrate_call_parens_on_pipe: true]
+
+    test "adds parentheses on the right operand" do
+      assert_format "x |> y", "x |> y()", @opts
+      assert_format "x |> y |> z", "x |> y() |> z()", @opts
+    end
+
+    test "does nothing within defmacro" do
+      assert_same "defmacro left |> right, do: ...", @opts
+    end
+
+    test "does nothing without the migrate_unless option" do
+      assert_same "x |> y"
+      assert_same "x |> y |> z"
+    end
+  end
+
   describe "migrate_charlists_as_sigils: true" do
     @opts [migrate_charlists_as_sigils: true]
 
@@ -279,6 +297,14 @@ defmodule Code.Formatter.MigrationTest do
   describe "migrate: true" do
     test "enables :migrate_bitstring_modifiers" do
       assert_format "<<foo::binary()>>", "<<foo::binary>>", migrate: true
+    end
+
+    test "enables :migrate_call_parens_on_pipe" do
+      bad = "x |> y"
+
+      good = "x |> y()"
+
+      assert_format bad, good, migrate: true
     end
 
     test "enables :migrate_charlists_as_sigils" do

--- a/lib/elixir/test/elixir/code_formatter/migration_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/migration_test.exs
@@ -33,6 +33,8 @@ defmodule Code.Formatter.MigrationTest do
     test "adds parentheses on the right operand" do
       assert_format "x |> y", "x |> y()", @opts
       assert_format "x |> y |> z", "x |> y() |> z()", @opts
+      assert_format "x |> y.z", "x |> y.z()", @opts
+      assert_format "x |> y.z.t", "x |> y.z.t()", @opts
     end
 
     test "does nothing within defmacro" do
@@ -42,6 +44,7 @@ defmodule Code.Formatter.MigrationTest do
     test "does nothing without the migrate_unless option" do
       assert_same "x |> y"
       assert_same "x |> y |> z"
+      assert_same "x |> y.z"
     end
   end
 

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -894,68 +894,68 @@ defmodule ExceptionTest do
     import Exception, only: [message: 1]
 
     test "RuntimeError" do
-      assert %RuntimeError{} |> message == "runtime error"
-      assert %RuntimeError{message: "unexpected roquefort"} |> message == "unexpected roquefort"
+      assert %RuntimeError{} |> message() == "runtime error"
+      assert %RuntimeError{message: "unexpected roquefort"} |> message() == "unexpected roquefort"
     end
 
     test "ArithmeticError" do
-      assert %ArithmeticError{} |> message == "bad argument in arithmetic expression"
+      assert %ArithmeticError{} |> message() == "bad argument in arithmetic expression"
 
       assert %ArithmeticError{message: "unexpected camembert"}
-             |> message == "unexpected camembert"
+             |> message() == "unexpected camembert"
     end
 
     test "ArgumentError" do
-      assert %ArgumentError{} |> message == "argument error"
-      assert %ArgumentError{message: "unexpected comté"} |> message == "unexpected comté"
+      assert %ArgumentError{} |> message() == "argument error"
+      assert %ArgumentError{message: "unexpected comté"} |> message() == "unexpected comté"
     end
 
     test "KeyError" do
-      assert %KeyError{} |> message == "key nil not found"
-      assert %KeyError{message: "key missed"} |> message == "key missed"
+      assert %KeyError{} |> message() == "key nil not found"
+      assert %KeyError{message: "key missed"} |> message() == "key missed"
     end
 
     test "Enum.OutOfBoundsError" do
-      assert %Enum.OutOfBoundsError{} |> message == "out of bounds error"
+      assert %Enum.OutOfBoundsError{} |> message() == "out of bounds error"
 
       assert %Enum.OutOfBoundsError{message: "the brie is not on the table"}
-             |> message == "the brie is not on the table"
+             |> message() == "the brie is not on the table"
     end
 
     test "Enum.EmptyError" do
-      assert %Enum.EmptyError{} |> message == "empty error"
+      assert %Enum.EmptyError{} |> message() == "empty error"
 
       assert %Enum.EmptyError{message: "there is no saint-nectaire left!"}
-             |> message == "there is no saint-nectaire left!"
+             |> message() == "there is no saint-nectaire left!"
     end
 
     test "UndefinedFunctionError" do
-      assert %UndefinedFunctionError{} |> message == "undefined function"
+      assert %UndefinedFunctionError{} |> message() == "undefined function"
 
       assert %UndefinedFunctionError{module: Kernel, function: :bar, arity: 1}
-             |> message == "function Kernel.bar/1 is undefined or private"
+             |> message() == "function Kernel.bar/1 is undefined or private"
 
       assert %UndefinedFunctionError{module: Foo, function: :bar, arity: 1}
-             |> message ==
+             |> message() ==
                "function Foo.bar/1 is undefined (module Foo is not available). " <>
                  "Make sure the module name is correct and has been specified in full (or that an alias has been defined)"
 
       assert %UndefinedFunctionError{module: nil, function: :bar, arity: 3}
-             |> message == "function nil.bar/3 is undefined"
+             |> message() == "function nil.bar/3 is undefined"
 
       assert %UndefinedFunctionError{module: nil, function: :bar, arity: 0}
-             |> message == "function nil.bar/0 is undefined"
+             |> message() == "function nil.bar/0 is undefined"
     end
 
     test "FunctionClauseError" do
-      assert %FunctionClauseError{} |> message == "no function clause matches"
+      assert %FunctionClauseError{} |> message() == "no function clause matches"
 
       assert %FunctionClauseError{module: Foo, function: :bar, arity: 1}
-             |> message == "no function clause matching in Foo.bar/1"
+             |> message() == "no function clause matching in Foo.bar/1"
     end
 
     test "ErlangError" do
-      assert %ErlangError{original: :sample} |> message == "Erlang error: :sample"
+      assert %ErlangError{original: :sample} |> message() == "Erlang error: :sample"
     end
 
     test "MissingApplicationsError" do
@@ -963,7 +963,7 @@ defmodule ExceptionTest do
                apps: [{:logger, "~> 1.18"}, {:ex_unit, Version.parse_requirement!(">= 0.0.0")}],
                description: "applications are required"
              }
-             |> message == """
+             |> message() == """
              applications are required
 
              To address this, include these applications as your dependencies:

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -560,7 +560,7 @@ defmodule FileTest do
 
       try do
         File.touch!(dest)
-        assert File.cp_r(src, dest) |> io_error?
+        assert File.cp_r(src, dest) |> io_error?()
       after
         File.rm_rf(dest)
       end
@@ -686,8 +686,8 @@ defmodule FileTest do
     end
 
     test "cp_r with src dir and dest dir using lists" do
-      src = fixture_path("cp_r") |> to_charlist
-      dest = tmp_path("tmp") |> to_charlist
+      src = fixture_path("cp_r") |> to_charlist()
+      dest = tmp_path("tmp") |> to_charlist()
 
       File.mkdir(dest)
 
@@ -1012,7 +1012,7 @@ defmodule FileTest do
     end
 
     test "mkdir with list" do
-      fixture = tmp_path("tmp_test") |> to_charlist
+      fixture = tmp_path("tmp_test") |> to_charlist()
 
       try do
         refute File.exists?(fixture)
@@ -1083,7 +1083,7 @@ defmodule FileTest do
     end
 
     test "mkdir_p with nested directory and list" do
-      base = tmp_path("tmp_test") |> to_charlist
+      base = tmp_path("tmp_test") |> to_charlist()
       fixture = Path.join(base, "test")
       refute File.exists?(base)
 
@@ -1287,7 +1287,7 @@ defmodule FileTest do
     end
 
     test "rm_rf with charlist" do
-      fixture = tmp_path("tmp") |> to_charlist
+      fixture = tmp_path("tmp") |> to_charlist()
       File.mkdir(fixture)
       File.cp_r!(fixture_path("cp_r"), fixture)
 

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -27,7 +27,7 @@ defmodule IO.ANSI.DocsTest do
 
     test "multiple entries formatted" do
       result = format_headings(["foo", "bar"])
-      assert :binary.matches(result, "\e[0m\n\e[7m\e[33m") |> length == 2
+      assert :binary.matches(result, "\e[0m\n\e[7m\e[33m") |> length() == 2
       assert String.starts_with?(result, "\e[0m\n\e[7m\e[33m")
       assert String.ends_with?(result, "\e[0m\n\e[0m")
       assert String.contains?(result, " foo ")
@@ -36,7 +36,7 @@ defmodule IO.ANSI.DocsTest do
 
     test "is correctly formatted when newline character is present" do
       result = format_headings(["foo\nbar"])
-      assert :binary.matches(result, "\e[0m\n\e[7m\e[33m") |> length == 2
+      assert :binary.matches(result, "\e[0m\n\e[7m\e[33m") |> length() == 2
       assert ["\e[0m", foo_line, bar_line, "\e[0m"] = String.split(result, "\n")
       assert Regex.match?(~r/\e\[7m\e\[33m +foo +\e\[0m/, foo_line)
       assert Regex.match?(~r/\e\[7m\e\[33m +bar +\e\[0m/, bar_line)

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -157,7 +157,7 @@ defmodule Kernel.CLI.ExecutableTest do
   end
 
   test "parses paths", %{cli_extension: cli_extension} do
-    root = fixture_path("../../..") |> to_charlist
+    root = fixture_path("../../..") |> to_charlist()
 
     args =
       ~c"-pa \"#{root}/*\" -pz \"#{root}/lib/*\" -e \"IO.inspect(:code.get_path(), limit: :infinity)\""

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1213,11 +1213,11 @@ defmodule KernelTest do
     end
 
     test "local call" do
-      assert [1, [2], 3] |> List.flatten() |> local == [2, 4, 6]
+      assert [1, [2], 3] |> List.flatten() |> local() == [2, 4, 6]
     end
 
     test "with capture" do
-      assert Enum.map([1, 2, 3], &(&1 |> twice |> twice)) == [4, 8, 12]
+      assert Enum.map([1, 2, 3], &(&1 |> twice() |> twice())) == [4, 8, 12]
     end
 
     test "with anonymous functions" do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -1540,7 +1540,7 @@ defmodule MacroTest do
   test "generate_arguments/2" do
     assert Macro.generate_arguments(0, __MODULE__) == []
     assert Macro.generate_arguments(1, __MODULE__) == [{:arg1, [], __MODULE__}]
-    assert Macro.generate_arguments(4, __MODULE__) |> length == 4
+    assert Macro.generate_arguments(4, __MODULE__) |> length() == 4
   end
 
   defp postwalk(ast) do

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -309,7 +309,7 @@ defmodule Module.Types.DescrTest do
 
       refute difference(tuple(), empty_tuple())
              |> difference(open_tuple([term(), term()]))
-             |> empty?
+             |> empty?()
 
       assert difference(open_tuple([term()]), open_tuple([term(), term()]))
              |> difference(tuple([term()]))

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -242,12 +242,12 @@ defmodule PathTest do
   end
 
   test "absname/1,2" do
-    assert Path.absname("/") |> strip_drive_letter_if_windows == "/"
-    assert Path.absname("/foo") |> strip_drive_letter_if_windows == "/foo"
-    assert Path.absname("/./foo") |> strip_drive_letter_if_windows == "/foo"
-    assert Path.absname("/foo/bar") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.absname("/foo/bar/") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.absname("/foo/bar/../bar") |> strip_drive_letter_if_windows == "/foo/bar/../bar"
+    assert Path.absname("/") |> strip_drive_letter_if_windows() == "/"
+    assert Path.absname("/foo") |> strip_drive_letter_if_windows() == "/foo"
+    assert Path.absname("/./foo") |> strip_drive_letter_if_windows() == "/foo"
+    assert Path.absname("/foo/bar") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.absname("/foo/bar/") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.absname("/foo/bar/../bar") |> strip_drive_letter_if_windows() == "/foo/bar/../bar"
 
     assert Path.absname("bar", "/foo") == "/foo/bar"
     assert Path.absname("bar/", "/foo") == "/foo/bar"
@@ -273,33 +273,33 @@ defmodule PathTest do
   end
 
   test "expand/1,2" do
-    assert Path.expand("/") |> strip_drive_letter_if_windows == "/"
-    assert Path.expand("/foo/../..") |> strip_drive_letter_if_windows == "/"
-    assert Path.expand("/foo") |> strip_drive_letter_if_windows == "/foo"
-    assert Path.expand("/./foo") |> strip_drive_letter_if_windows == "/foo"
-    assert Path.expand("/../foo") |> strip_drive_letter_if_windows == "/foo"
-    assert Path.expand("/foo/bar") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.expand("/foo/bar/") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.expand("/foo/bar/.") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.expand("/foo/bar/../bar") |> strip_drive_letter_if_windows == "/foo/bar"
+    assert Path.expand("/") |> strip_drive_letter_if_windows() == "/"
+    assert Path.expand("/foo/../..") |> strip_drive_letter_if_windows() == "/"
+    assert Path.expand("/foo") |> strip_drive_letter_if_windows() == "/foo"
+    assert Path.expand("/./foo") |> strip_drive_letter_if_windows() == "/foo"
+    assert Path.expand("/../foo") |> strip_drive_letter_if_windows() == "/foo"
+    assert Path.expand("/foo/bar") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.expand("/foo/bar/") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.expand("/foo/bar/.") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.expand("/foo/bar/../bar") |> strip_drive_letter_if_windows() == "/foo/bar"
 
-    assert Path.expand("bar", "/foo") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.expand("bar/", "/foo") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.expand("bar/.", "/foo") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.expand("bar/../bar", "/foo") |> strip_drive_letter_if_windows == "/foo/bar"
+    assert Path.expand("bar", "/foo") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.expand("bar/", "/foo") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.expand("bar/.", "/foo") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.expand("bar/../bar", "/foo") |> strip_drive_letter_if_windows() == "/foo/bar"
 
     drive_letter =
-      Path.expand("../bar/../bar", "/foo/../foo/../foo") |> strip_drive_letter_if_windows
+      Path.expand("../bar/../bar", "/foo/../foo/../foo") |> strip_drive_letter_if_windows()
 
     assert drive_letter == "/bar"
 
     drive_letter =
       Path.expand([~c"..", ?/, "bar/../bar"], ~c"/foo/../foo/../foo")
-      |> strip_drive_letter_if_windows
+      |> strip_drive_letter_if_windows()
 
     assert "/bar" == drive_letter
 
-    assert Path.expand("/..") |> strip_drive_letter_if_windows == "/"
+    assert Path.expand("/..") |> strip_drive_letter_if_windows() == "/"
 
     assert Path.expand("bar/../bar", "foo") == Path.expand("foo/bar")
   end

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -379,78 +379,80 @@ defmodule URITest do
     end
 
     assert URI.merge("http://google.com/foo", "http://example.com/baz")
-           |> to_string == "http://example.com/baz"
+           |> to_string() == "http://example.com/baz"
 
     assert URI.merge("http://google.com/foo", "http://example.com/.././bar/../../baz")
-           |> to_string == "http://example.com/baz"
+           |> to_string() == "http://example.com/baz"
 
     assert URI.merge("http://google.com/foo", "//example.com/baz")
-           |> to_string == "http://example.com/baz"
+           |> to_string() == "http://example.com/baz"
 
     assert URI.merge("http://google.com/foo", URI.new!("//example.com/baz"))
-           |> to_string == "http://example.com/baz"
+           |> to_string() == "http://example.com/baz"
 
     assert URI.merge("http://google.com/foo", "//example.com/.././bar/../../../baz")
-           |> to_string == "http://example.com/baz"
+           |> to_string() == "http://example.com/baz"
 
     assert URI.merge("http://example.com", URI.new!("/foo"))
-           |> to_string == "http://example.com/foo"
+           |> to_string() == "http://example.com/foo"
 
     assert URI.merge("http://example.com", URI.new!("/.././bar/../../../baz"))
-           |> to_string == "http://example.com/baz"
+           |> to_string() == "http://example.com/baz"
 
     base = URI.new!("http://example.com/foo/bar")
-    assert URI.merge(base, "") |> to_string == "http://example.com/foo/bar"
-    assert URI.merge(base, "#fragment") |> to_string == "http://example.com/foo/bar#fragment"
-    assert URI.merge(base, "?query") |> to_string == "http://example.com/foo/bar?query"
-    assert URI.merge(base, %URI{}) |> to_string == "http://example.com/foo/bar"
+    assert URI.merge(base, "") |> to_string() == "http://example.com/foo/bar"
+    assert URI.merge(base, "#fragment") |> to_string() == "http://example.com/foo/bar#fragment"
+    assert URI.merge(base, "?query") |> to_string() == "http://example.com/foo/bar?query"
+    assert URI.merge(base, %URI{}) |> to_string() == "http://example.com/foo/bar"
 
     assert URI.merge(base, %URI{fragment: "fragment"})
-           |> to_string == "http://example.com/foo/bar#fragment"
+           |> to_string() == "http://example.com/foo/bar#fragment"
 
     base = URI.new!("http://example.com")
-    assert URI.merge(base, "/foo") |> to_string == "http://example.com/foo"
-    assert URI.merge(base, "foo") |> to_string == "http://example.com/foo"
+    assert URI.merge(base, "/foo") |> to_string() == "http://example.com/foo"
+    assert URI.merge(base, "foo") |> to_string() == "http://example.com/foo"
 
     base = URI.new!("http://example.com/foo/bar")
-    assert URI.merge(base, "/baz") |> to_string == "http://example.com/baz"
-    assert URI.merge(base, "baz") |> to_string == "http://example.com/foo/baz"
-    assert URI.merge(base, "../baz") |> to_string == "http://example.com/baz"
-    assert URI.merge(base, ".././baz") |> to_string == "http://example.com/baz"
-    assert URI.merge(base, "./baz") |> to_string == "http://example.com/foo/baz"
-    assert URI.merge(base, "bar/./baz") |> to_string == "http://example.com/foo/bar/baz"
+    assert URI.merge(base, "/baz") |> to_string() == "http://example.com/baz"
+    assert URI.merge(base, "baz") |> to_string() == "http://example.com/foo/baz"
+    assert URI.merge(base, "../baz") |> to_string() == "http://example.com/baz"
+    assert URI.merge(base, ".././baz") |> to_string() == "http://example.com/baz"
+    assert URI.merge(base, "./baz") |> to_string() == "http://example.com/foo/baz"
+    assert URI.merge(base, "bar/./baz") |> to_string() == "http://example.com/foo/bar/baz"
 
     base = URI.new!("http://example.com/foo/bar/")
-    assert URI.merge(base, "/baz") |> to_string == "http://example.com/baz"
-    assert URI.merge(base, "baz") |> to_string == "http://example.com/foo/bar/baz"
-    assert URI.merge(base, "../baz") |> to_string == "http://example.com/foo/baz"
-    assert URI.merge(base, ".././baz") |> to_string == "http://example.com/foo/baz"
-    assert URI.merge(base, "./baz") |> to_string == "http://example.com/foo/bar/baz"
-    assert URI.merge(base, "bar/./baz") |> to_string == "http://example.com/foo/bar/bar/baz"
+    assert URI.merge(base, "/baz") |> to_string() == "http://example.com/baz"
+    assert URI.merge(base, "baz") |> to_string() == "http://example.com/foo/bar/baz"
+    assert URI.merge(base, "../baz") |> to_string() == "http://example.com/foo/baz"
+    assert URI.merge(base, ".././baz") |> to_string() == "http://example.com/foo/baz"
+    assert URI.merge(base, "./baz") |> to_string() == "http://example.com/foo/bar/baz"
+    assert URI.merge(base, "bar/./baz") |> to_string() == "http://example.com/foo/bar/bar/baz"
 
     base = URI.new!("http://example.com/foo/bar/baz")
-    assert URI.merge(base, "../../foobar") |> to_string == "http://example.com/foobar"
-    assert URI.merge(base, "../../../foobar") |> to_string == "http://example.com/foobar"
-    assert URI.merge(base, "../../../../../../foobar") |> to_string == "http://example.com/foobar"
+    assert URI.merge(base, "../../foobar") |> to_string() == "http://example.com/foobar"
+    assert URI.merge(base, "../../../foobar") |> to_string() == "http://example.com/foobar"
+
+    assert URI.merge(base, "../../../../../../foobar") |> to_string() ==
+             "http://example.com/foobar"
 
     base = URI.new!("http://example.com/foo/../bar")
-    assert URI.merge(base, "baz") |> to_string == "http://example.com/baz"
+    assert URI.merge(base, "baz") |> to_string() == "http://example.com/baz"
 
     base = URI.new!("http://example.com/foo/./bar")
-    assert URI.merge(base, "baz") |> to_string == "http://example.com/foo/baz"
+    assert URI.merge(base, "baz") |> to_string() == "http://example.com/foo/baz"
 
     base = URI.new!("http://example.com/foo?query1")
-    assert URI.merge(base, "?query2") |> to_string == "http://example.com/foo?query2"
-    assert URI.merge(base, "") |> to_string == "http://example.com/foo?query1"
+    assert URI.merge(base, "?query2") |> to_string() == "http://example.com/foo?query2"
+    assert URI.merge(base, "") |> to_string() == "http://example.com/foo?query1"
 
     base = URI.new!("http://example.com/foo#fragment1")
-    assert URI.merge(base, "#fragment2") |> to_string == "http://example.com/foo#fragment2"
-    assert URI.merge(base, "") |> to_string == "http://example.com/foo"
+    assert URI.merge(base, "#fragment2") |> to_string() == "http://example.com/foo#fragment2"
+    assert URI.merge(base, "") |> to_string() == "http://example.com/foo"
 
     page_url = "https://example.com/guide/"
     image_url = "https://images.example.com/t/1600x/https://images.example.com/foo.jpg"
 
-    assert URI.merge(URI.new!(page_url), URI.new!(image_url)) |> to_string ==
+    assert URI.merge(URI.new!(page_url), URI.new!(image_url)) |> to_string() ==
              "https://images.example.com/t/1600x/https://images.example.com/foo.jpg"
   end
 
@@ -856,8 +858,8 @@ defmodule URITest do
 
     test "merges empty path" do
       base = URI.parse("http://example.com")
-      assert URI.merge(base, "/foo") |> to_string == "http://example.com/foo"
-      assert URI.merge(base, "foo") |> to_string == "http://example.com/foo"
+      assert URI.merge(base, "/foo") |> to_string() == "http://example.com/foo"
+      assert URI.merge(base, "foo") |> to_string() == "http://example.com/foo"
     end
   end
 end

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -590,13 +590,13 @@ defmodule IEx.Helpers do
   def runtime_info(topic) when is_atom(topic) and topic in @runtime_info_topics do
     topic
     |> List.wrap()
-    |> runtime_info
+    |> runtime_info()
   end
 
   def runtime_info(topics) when is_list(topics) do
     topics
     |> Enum.uniq()
-    |> print_runtime_info
+    |> print_runtime_info()
   end
 
   defp print_runtime_info(topics) do

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -184,7 +184,7 @@ defmodule Mix.Tasks.Compile do
   end
 
   defp first_line(doc) do
-    String.split(doc, "\n", parts: 2) |> hd |> String.trim() |> String.trim_trailing(".")
+    String.split(doc, "\n", parts: 2) |> hd() |> String.trim() |> String.trim_trailing(".")
   end
 
   defp merge_diagnostics({status1, diagnostics1}, {status2, diagnostics2}) do

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -309,7 +309,7 @@ defmodule Mix.Utils do
   end
 
   defp depth(_pretty?, []), do: ""
-  defp depth(pretty?, depth), do: Enum.reverse(depth) |> tl |> Enum.map(&entry(pretty?, &1))
+  defp depth(pretty?, depth), do: Enum.reverse(depth) |> tl() |> Enum.map(&entry(pretty?, &1))
 
   defp entry(false, true), do: "|   "
   defp entry(false, false), do: "    "


### PR DESCRIPTION
First step of https://github.com/elixir-lang/elixir/issues/12122.

~The next step is to add a warning indicating to run mix format.~ => we decided not to add any warning here, since there's no ambiguity

The second commit is just auto-generated.