### PR TITLE
Fix a typo in "mix xref" docs

### DIFF
--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -332,7 +332,7 @@ defmodule Mix.Tasks.Xref do
 
   ### Understanding the printed cycle
 
-  If you run `mix xref graph --format cycle`, Elixir will print cycles
+  If you run `mix xref graph --format cycles`, Elixir will print cycles
   of shape:
 
       Cycle of length 3:


### PR DESCRIPTION
Because copy-pasting the current example results in an error:

```console
$ mix xref graph --format cycle
** (Mix) Unknown --format cycle in mix xref graph
```

But the "fix" works

```console
$ mix xref graph --format cycles | head
119 cycles found. Showing them in decreasing size:

Cycle of length 45:

    extra/lib/plausible/stats/sampling.ex
    lib/plausible/stats/query.ex
    lib/plausible/stats/legacy/legacy_query_builder.ex
    lib/plausible/stats/metrics.ex
    extra/lib/plausible/stats/goal/revenue.ex
    lib/plausible/goal/schema.ex
Failed to write log message to stdout, trying stderr

00:04:58.920 [error] Writer crashed (:epipe)
** (ErlangError) Erlang error: :terminated
    (stdlib 6.0) io.erl:198: :io.put_chars(:standard_io, [[[], "    lib/plausible/auth/auth.ex"], 10])
    (mix 1.17.1) lib/mix/tasks/xref.ex:1073: anonymous fn/3 in Mix.Tasks.Xref.print_cycles/2
    (elixir 1.17.1) lib/enum.ex:2531: Enum."-reduce/3-lists^foldl/2-0-"/3
    (mix 1.17.1) lib/mix/tasks/xref.ex:1072: anonymous fn/3 in Mix.Tasks.Xref.print_cycles/2
    (elixir 1.17.1) lib/enum.ex:2531: Enum."-reduce/3-lists^foldl/2-0-"/3
    (mix 1.17.1) lib/mix/tasks/xref.ex:1069: anonymous fn/2 in Mix.Tasks.Xref.print_cycles/2
    (mix 1.17.1) lib/mix/tasks/xref.ex:1032: Mix.Tasks.Xref.with_digraph/2
    (mix 1.17.1) lib/mix/tasks/xref.ex:909: Mix.Tasks.Xref.write_graph/3
```

Hm. Maybe closing pipes should be handled more gracefully, but that's a separate issue :)