### PR TITLE
Improve warning in Range.new/2 with negative step

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -192,7 +192,7 @@ defmodule Range do
         IO.warn_once(
           {__MODULE__, :new},
           fn ->
-            "Range.new/2 has a default step of -1, please call Range.new/3 explicitly passing the step of -1 instead"
+            "Range.new/2 has a default step of -1 when last < first, please call Range.new/3 explicitly passing the step of -1 instead"
           end,
           3
         )


### PR DESCRIPTION
Was confused by the current warning, a bug can be introduced if somebody blindly adds `-1` as step.