### PR TITLE
Fix type warning in pop_in/1

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3308,7 +3308,7 @@ defmodule Kernel do
   end
 
   defp nest_pop_in(:map, h, [{:access, key}]) do
-    quote do
+    quote generated: true do
       case unquote(h) do
         nil -> {nil, nil}
         h -> Access.pop(h, unquote(key))

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3329,7 +3329,7 @@ defmodule Kernel do
   end
 
   defp nest_pop_in(_, h, [{:access, key}]) do
-    quote do
+    quote generated: true do
       case unquote(h) do
         nil -> :pop
         h -> Access.pop(h, unquote(key))

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1136,6 +1136,8 @@ defmodule KernelTest do
     test "pop_in/1" do
       users = %{"john" => %{age: 27}, "meg" => %{age: 23}}
 
+      assert pop_in(users["john"]) == {%{age: 27}, %{"meg" => %{age: 23}}}
+
       assert pop_in(users["john"][:age]) == {27, %{"john" => %{}, "meg" => %{age: 23}}}
       assert pop_in(users["john"][:name]) == {nil, %{"john" => %{age: 27}, "meg" => %{age: 23}}}
       assert pop_in(users["bob"][:age]) == {nil, %{"john" => %{age: 27}, "meg" => %{age: 23}}}


### PR DESCRIPTION
Otherwise the type system complains about the fact that the `nil` clause is never used (in v1.18 rc.0):

<img width="624" alt="Screenshot 2024-12-12 at 14 59 42" src="https://github.com/user-attachments/assets/6e8445b7-2b95-45c3-a5c0-5a15fcc77c25" />

To be backported once/if merged.