### PR TITLE
Do not set docs source_ref to -latest tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,9 @@ clean_elixir:
 
 #==> Documentation tasks
 
-SOURCE_REF = $(shell tag="$(call GIT_TAG)" revision="$(call GIT_REVISION)"; echo "$${tag:-$$revision}")
+SOURCE_REF = $(shell tag="$(call GIT_TAG)"; revision="$(call GIT_REVISION)"; \
+               if echo "$$tag" | grep -Eq -- '-latest$$'; then tag=""; fi; \
+               echo "$${tag:-$$revision}")
 DOCS_COMPILE = CANONICAL=$(CANONICAL) bin/elixir ../ex_doc/bin/ex_doc "$(1)" "$(VERSION)" "lib/$(2)/ebin" --main "$(3)" --source-url "https://github.com/elixir-lang/elixir" --source-ref "$(call SOURCE_REF)" --logo lib/elixir/pages/images/logo.png --output doc/$(2) --canonical "https://hexdocs.pm/$(2)/$(CANONICAL)" --homepage-url "https://elixir-lang.org/docs.html" $(4)
 DOCS_CONFIG = bin/elixir lib/elixir/scripts/docs_config.exs "$(1)"
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ INSTALL_DIR = $(INSTALL) -m755 -d
 INSTALL_DATA = $(INSTALL) -m644
 INSTALL_PROGRAM = $(INSTALL) -m755
 GIT_REVISION = $(strip $(shell git rev-parse HEAD 2> /dev/null ))
-GIT_TAG = $(strip $(shell head="$(call GIT_REVISION)"; git tag --points-at $$head 2> /dev/null | tail -1) )
+GIT_TAG = $(strip $(shell head="$(call GIT_REVISION)"; git tag --points-at $$head 2> /dev/null | grep -v latest | tail -1))
 SOURCE_DATE_EPOCH_PATH = lib/elixir/tmp/ebin_reproducible
 SOURCE_DATE_EPOCH_FILE = $(SOURCE_DATE_EPOCH_PATH)/SOURCE_DATE_EPOCH
 
@@ -176,9 +176,7 @@ clean_elixir:
 
 #==> Documentation tasks
 
-SOURCE_REF = $(shell tag="$(call GIT_TAG)"; revision="$(call GIT_REVISION)"; \
-               if echo "$$tag" | grep -Eq -- '-latest$$'; then tag=""; fi; \
-               echo "$${tag:-$$revision}")
+SOURCE_REF = $(shell tag="$(call GIT_TAG)" revision="$(call GIT_REVISION)"; echo "$${tag:-$$revision}")
 DOCS_COMPILE = CANONICAL=$(CANONICAL) bin/elixir ../ex_doc/bin/ex_doc "$(1)" "$(VERSION)" "lib/$(2)/ebin" --main "$(3)" --source-url "https://github.com/elixir-lang/elixir" --source-ref "$(call SOURCE_REF)" --logo lib/elixir/pages/images/logo.png --output doc/$(2) --canonical "https://hexdocs.pm/$(2)/$(CANONICAL)" --homepage-url "https://elixir-lang.org/docs.html" $(4)
 DOCS_CONFIG = bin/elixir lib/elixir/scripts/docs_config.exs "$(1)"
 


### PR DESCRIPTION
Prior to this we had a regression, the source link was using the tag as seen as the bottom of the screen:

<img width="1018" alt="image" src="https://github.com/user-attachments/assets/cf6c12a2-b795-4a57-b9fe-f477f7d38fc5" />
