### PR TITLE
Fix JSON.decode/3 spec

### DIFF
--- a/lib/elixir/lib/json.ex
+++ b/lib/elixir/lib/json.ex
@@ -265,7 +265,8 @@ defmodule JSON do
 
   For streaming decoding, see Erlang's `:json` module.
   """
-  @spec decode(binary(), term(), keyword()) :: {term(), term(), binary()} | decode_error_reason()
+  @spec decode(binary(), term(), keyword()) ::
+          {term(), term(), binary()} | {:error, decode_error_reason()}
   def decode(binary, acc, decoders) when is_binary(binary) and is_list(decoders) do
     decoders = Keyword.put_new(decoders, :null, nil)
 


### PR DESCRIPTION
The error clause was missing the :error tuple wrapping

(I think this change should be back-ported to the v1.18 branch)