### PR TITLE
Support Sensitive Data Scrubbing with Inspect.Opts.custom_options

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -315,7 +315,7 @@ defimpl Inspect, for: List do
     %Inspect.Opts{
       charlists: lists,
       char_lists: lists_deprecated,
-      printable_limit: printable_limit,
+      printable_limit: printable_limit
     } = opts
 
     lists =
@@ -365,7 +365,7 @@ defimpl Inspect, for: List do
     filter_values = Keyword.get(opts.custom_options, :filter, [])
     filter_message = Keyword.get(opts.custom_options, :filter_message, "[FILTERED]")
 
-    value = if value in filter_values, do: filter_message, else: value
+    value = if key in filter_values, do: filter_message, else: value
 
     key = color_doc(Macro.inspect_atom(:key, key), :atom, opts)
     concat(key, concat(" ", to_doc(value, opts)))
@@ -403,17 +403,18 @@ defimpl Inspect, for: Map do
       end
 
     list =
-        case Keyword.get(opts.custom_options, :filter, []) do
-          [] ->
-            list
+      case Keyword.get(opts.custom_options, :filter, []) do
+        [] ->
+          list
 
-          filter_values ->
-            filter_message = Keyword.get(opts.custom_options, :filter_message, "[FILTERED]")
-            Enum.map(list, fn {key, value} -> 
-              value = if key in filter_values, do: filter_message, else: value
-              {key, value}
-            end)
-        end
+        filter_values ->
+          filter_message = Keyword.get(opts.custom_options, :filter_message, "[FILTERED]")
+
+          Enum.map(list, fn {key, value} ->
+            value = if key in filter_values, do: filter_message, else: value
+            {key, value}
+          end)
+      end
 
     fun =
       if Inspect.List.keyword?(list) do

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -296,13 +296,15 @@ defmodule Inspect.ListTest do
 
   test "keyword - with filtering" do
     assert inspect([password: "hideme"], custom_options: [filter: [:password]]) ==
-             "[password: [FILTERED]]"
+             "[password: \"[FILTERED]\"]"
 
     # Adding custom messages supported
     redact = "[REDACTED]"
 
-    assert inspect([password: "hideme"], filter: [:password], filter_message: redact) ==
-             "[password: [REDACTED]]"
+    assert inspect([password: "hideme"],
+             custom_options: [filter: [:password], filter_message: redact]
+           ) ==
+             "[password: \"[REDACTED]\"]"
   end
 
   test "keyword operators" do
@@ -441,7 +443,7 @@ defmodule Inspect.MapTest do
 
     redact = "[REDACTED]"
 
-    assert inspect(%{password: "hideme"}, 
+    assert inspect(%{password: "hideme"},
              custom_options: [filter: [:password], filter_message: redact]
            ) ==
              "%{password: \"#{redact}\"}"

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -294,6 +294,17 @@ defmodule Inspect.ListTest do
              "[\n  foo: [1, 2, 3],\n  baz: [4, 5, 6]\n]"
   end
 
+  test "keyword - with filtering" do
+    assert inspect([password: "hideme"], filter: [:password]) ==
+             "[password: [FILTERED]]"
+
+    # Adding custom messages supported
+    redact = "[REDACTED]"
+
+    assert inspect([password: "hideme"], filter: [:password], filter_message: redact) ==
+             "[password: [REDACTED]]"
+  end
+
   test "keyword operators" do
     assert inspect("::": 1, +: 2) == ~s(["::": 1, +: 2])
   end
@@ -405,7 +416,10 @@ defmodule Inspect.MapTest do
   end
 
   test "basic - with filtering" do
-    redact = "[FILTERED]"
+    assert inspect(%{"password" => "hideme"}, filter: ["password"]) ==
+             "%{\"password\" => [FILTERED]}"
+
+    redact = "[REDACTED]"
 
     assert inspect(%{"password" => "hideme"}, filter: ["password"], filter_message: redact) ==
              "%{\"password\" => #{redact}}"
@@ -420,7 +434,10 @@ defmodule Inspect.MapTest do
   end
 
   test "keyword - with filtering" do
-    redact = "[FILTERED]"
+    assert inspect(%{"password" => "hideme"}, filter: ["password"]) ==
+             "%{\"password\" => [FILTERED]}"
+
+    redact = "[REDACTED]"
 
     assert inspect(%{password: "hideme"}, filter: [:password], filter_message: redact) ==
              "%{password: #{redact}}"

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -295,7 +295,7 @@ defmodule Inspect.ListTest do
   end
 
   test "keyword - with filtering" do
-    assert inspect([password: "hideme"], filter: [:password]) ==
+    assert inspect([password: "hideme"], custom_options: [filter: [:password]]) ==
              "[password: [FILTERED]]"
 
     # Adding custom messages supported
@@ -436,13 +436,15 @@ defmodule Inspect.MapTest do
   end
 
   test "keyword - with filtering" do
-    assert inspect(%{password: "hideme"}, custom_options: [filter: ["password"]]) ==
-             "%{password: [FILTERED]}"
+    assert inspect(%{password: "hideme"}, custom_options: [filter: [:password]]) ==
+             "%{password: \"[FILTERED]\"}"
 
     redact = "[REDACTED]"
 
-    assert inspect(%{password: "hideme"}, filter: [:password], filter_message: redact) ==
-             "%{password: #{redact}}"
+    assert inspect(%{password: "hideme"}, 
+             custom_options: [filter: [:password], filter_message: redact]
+           ) ==
+             "%{password: \"#{redact}\"}"
   end
 
   test "with limit" do

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -416,13 +416,15 @@ defmodule Inspect.MapTest do
   end
 
   test "basic - with filtering" do
-    assert inspect(%{"password" => "hideme"}, filter: ["password"]) ==
-             "%{\"password\" => [FILTERED]}"
+    assert inspect(%{"password" => "hideme"}, custom_options: [filter: ["password"]]) ==
+             "%{\"password\" => \"[FILTERED]\"}"
 
     redact = "[REDACTED]"
 
-    assert inspect(%{"password" => "hideme"}, filter: ["password"], filter_message: redact) ==
-             "%{\"password\" => #{redact}}"
+    assert inspect(%{"password" => "hideme"},
+             custom_options: [filter: ["password"], filter_message: redact]
+           ) ==
+             "%{\"password\" => \"#{redact}\"}"
   end
 
   test "keyword" do
@@ -434,8 +436,8 @@ defmodule Inspect.MapTest do
   end
 
   test "keyword - with filtering" do
-    assert inspect(%{"password" => "hideme"}, filter: ["password"]) ==
-             "%{\"password\" => [FILTERED]}"
+    assert inspect(%{password: "hideme"}, custom_options: [filter: ["password"]]) ==
+             "%{password: [FILTERED]}"
 
     redact = "[REDACTED]"
 

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -404,12 +404,26 @@ defmodule Inspect.MapTest do
              "%{\n  1 => \"b\",\n  2 => \"c\"\n}"
   end
 
+  test "basic - with filtering" do
+    redact = "[FILTERED]"
+
+    assert inspect(%{"password" => "hideme"}, filter: ["password"], filter_message: redact) ==
+             "%{\"password\" => #{redact}}"
+  end
+
   test "keyword" do
     assert inspect(%{a: 1}) == "%{a: 1}"
     assert inspect(%{a: 1, b: 2}, custom_options: [sort_maps: true]) == "%{a: 1, b: 2}"
 
     assert inspect(%{a: 1, b: 2, c: 3}, custom_options: [sort_maps: true]) ==
              "%{a: 1, b: 2, c: 3}"
+  end
+
+  test "keyword - with filtering" do
+    redact = "[FILTERED]"
+
+    assert inspect(%{password: "hideme"}, filter: [:password], filter_message: redact) ==
+             "%{password: #{redact}}"
   end
 
   test "with limit" do


### PR DESCRIPTION
This PR is an alternate implementation of overriding the `IO.Inspect.default_inspect_fn/2` where instead of overriding the function call itself, the opts would be overridden for the case of filtering. This is the [default example](https://github.com/elixir-lang/elixir/blob/main/lib/elixir/lib/inspect/algebra.ex#L134), but I think there may be benefit in having this as an option and maintained on the language side in that:
- filtering performance can be more tightly governed by the language
- filtering can be predictably extended overtime as needed

This behavior covers both maps and structs, and keyword lists. Built this recently as a default_inspect_fn so I thought I'd share. Thanks!