### PR TITLE
refactor dbg for if 

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1495,7 +1495,7 @@ defmodule Macro do
     :error
   end
 
-  defp op_call({:"..//", _, [left, middle, right]} = ast, fun) do
+  defp op_call({:..//, _, [left, middle, right]} = ast, fun) do
     left = op_to_string(left, fun, :.., :left)
     middle = op_to_string(middle, fun, :.., :right)
     right = op_to_string(right, fun, :"//", :right)
@@ -1946,7 +1946,7 @@ defmodule Macro do
   @spec operator?(name :: atom(), arity()) :: boolean()
   def operator?(name, arity)
 
-  def operator?(:"..//", 3),
+  def operator?(:..//, 3),
     do: true
 
   # Code.Identifier treats :// as a binary operator for precedence
@@ -2482,7 +2482,7 @@ defmodule Macro do
   #
   defp inner_classify(atom) when is_atom(atom) do
     cond do
-      atom in [:%, :%{}, :{}, :<<>>, :..., :.., :., :"..//", :->] ->
+      atom in [:%, :%{}, :{}, :<<>>, :..., :.., :., :..//, :->] ->
         :not_callable
 
       # <|>, ^^^, and ~~~ are deprecated

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2692,23 +2692,17 @@ defmodule Macro do
 
         quote do
           Macro.write_underline("If condition:", unquote(options))
+          Macro.write_ast(unquote(escape(condition_ast)), unquote(options))
+
           unquote(condition_result_var) = unquote(condition_ast)
 
-          Macro.write_ast_value(
-            unquote(escape(condition_ast)),
-            unquote(condition_result_var),
-            unquote(options)
-          )
-
+          Macro.write_result(unquote(condition_result_var), unquote(options))
           Macro.write_underline("If expression:", unquote(options))
+          Macro.write_ast(unquote(escape(ast)), unquote(options))
+
           unquote(result_var) = unquote({:if, meta, [condition_result_var, clauses]})
 
-          Macro.write_ast_value(
-            unquote(escape(ast)),
-            unquote(result_var),
-            unquote(options)
-          )
-
+          Macro.write_result(unquote(result_var), unquote(options))
           Macro.write("\n", [])
 
           {:if, unquote(result_var)}
@@ -3002,9 +2996,20 @@ defmodule Macro do
     |> __MODULE__.write(options)
   end
 
-  def write_ast_value(ast, value, options) do
-    dbg_format_ast_with_value(ast, value, options)
-    |> __MODULE__.write(options)
+  def write_result(value, options) do
+    formatted = [" ", inspect(value, options), ?\n, ?\n]
+    ansi_enabled? = options[:syntax_colors] != []
+    :ok = IO.write(IO.ANSI.format(formatted, ansi_enabled?))
+  end
+
+  def write_ast(ast, options) do
+    formatted =
+      ast
+      |> to_string_with_colors(options)
+      |> dbg_format_ast()
+
+    ansi_enabled? = options[:syntax_colors] != []
+    :ok = IO.write(IO.ANSI.format(formatted, ansi_enabled?))
   end
 
   def write(formatted, options) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -803,7 +803,8 @@ defmodule MacroTest do
               true
             else
               :error -> false
-            end
+            end,
+            print_location: false
           )
         end
 


### PR DESCRIPTION
@josevalim This is what I came up. 
It requires calling the macro module where we have defined the functions that print the data.
It looks a bit confusing calling `Macro.write` so I think it makes sense to move all the logic to `macro/dbg.ex` then the implementation would call `Dbg.write` or similar. In case it will show up in traces it will look less confusing.

![image](https://github.com/user-attachments/assets/f56089fa-121c-4d36-9a10-d221cb784a5e)
