### PR TITLE
[ex_unit] Omit excluded tests from test count in CLI summary

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -352,7 +352,7 @@ defmodule ExUnit.CLIFormatter do
       )
       |> if_true(
         config.excluded_counter > 0,
-        &(&1 <> ", #{config.excluded_counter} excluded")
+        &(&1 <> " (#{config.excluded_counter} excluded)")
       )
 
     cond do

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -384,14 +384,20 @@ defmodule ExUnit.CLIFormatter do
     IO.puts(formatted)
   end
 
-  defp format_test_type_counts(%{test_counter: test_counter} = _config) do
-    test_counter
+  defp format_test_type_counts(config) do
+    config.test_counter
     |> Enum.sort()
     |> Enum.map(fn {test_type, count} ->
-      type_pluralized = pluralize(count, test_type, ExUnit.plural_rule(test_type |> to_string()))
-      "#{count} #{type_pluralized}, "
+      executed_count = calculate_executed_test_count(test_type, count, config.excluded_counter)
+      plural_rule = ExUnit.plural_rule(test_type |> to_string())
+      type_pluralized = pluralize(executed_count, test_type, plural_rule)
+
+      "#{executed_count} #{type_pluralized}, "
     end)
   end
+
+  defp calculate_executed_test_count(:test, count, excluded_counter), do: count - excluded_counter
+  defp calculate_executed_test_count(_test_type, count, _excluded_counter), do: count
 
   defp collect_test_type_counts(%{test_counter: test_counter} = _config) do
     Enum.reduce(test_counter, 0, fn {_, count}, acc ->

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -343,16 +343,16 @@ defmodule ExUnit.CLIFormatter do
     message =
       "#{formatted_test_type_counts}#{config.failure_counter} #{failure_pl}"
       |> if_true(
-        config.excluded_counter > 0,
-        &(&1 <> ", #{config.excluded_counter} excluded")
-      )
-      |> if_true(
         config.invalid_counter > 0,
         &(&1 <> ", #{config.invalid_counter} invalid")
       )
       |> if_true(
         config.skipped_counter > 0,
         &(&1 <> ", " <> skipped("#{config.skipped_counter} skipped", config))
+      )
+      |> if_true(
+        config.excluded_counter > 0,
+        &(&1 <> ", #{config.excluded_counter} excluded")
       )
 
     cond do

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -508,6 +508,7 @@ defmodule ExUnitTest do
 
     # Empty because it is already loaded
     {result, output} = run_with_filter([exclude: :module], [])
+
     assert result == %{failures: 0, skipped: 0, excluded: 2, total: 2}
     assert output =~ "\n0 tests, 0 failures, 2 excluded\n"
 

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -29,7 +29,7 @@ defmodule ExUnitTest do
     assert capture_io(fn ->
              assert ExUnit.async_run() |> ExUnit.await_run() ==
                       %{failures: 0, skipped: 0, total: 0, excluded: 0}
-           end) =~ "\n0 failures\n"
+           end) =~ "\n0 tests, 0 failures\n"
   end
 
   test "supports rerunning given modules" do
@@ -137,7 +137,7 @@ defmodule ExUnitTest do
     assert result =~ """
            Showing results so far...
 
-           0 failures
+           0 tests, 0 failures
            """
   end
 

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -331,19 +331,19 @@ defmodule ExUnitTest do
 
     {result, output} = run_with_filter([exclude: [even: true]], [ParityTest])
     assert result == %{failures: 0, skipped: 0, excluded: 1, total: 4}
-    assert output =~ "\n4 tests, 0 failures, 1 excluded\n"
+    assert output =~ "\n3 tests, 0 failures, 1 excluded\n"
 
     {result, output} = run_with_filter([exclude: :even], [ParityTest])
     assert result == %{failures: 0, skipped: 0, excluded: 3, total: 4}
-    assert output =~ "\n4 tests, 0 failures, 3 excluded\n"
+    assert output =~ "\n1 test, 0 failures, 3 excluded\n"
 
     {result, output} = run_with_filter([exclude: :even, include: [even: true]], [ParityTest])
     assert result == %{failures: 1, skipped: 0, excluded: 2, total: 4}
-    assert output =~ "\n4 tests, 1 failure, 2 excluded\n"
+    assert output =~ "\n2 tests, 1 failure, 2 excluded\n"
 
     {result, output} = run_with_filter([exclude: :test, include: [even: true]], [ParityTest])
     assert result == %{failures: 1, skipped: 0, excluded: 3, total: 4}
-    assert output =~ "\n4 tests, 1 failure, 3 excluded\n"
+    assert output =~ "\n1 test, 1 failure, 3 excluded\n"
   end
 
   test "log capturing" do
@@ -509,7 +509,7 @@ defmodule ExUnitTest do
     # Empty because it is already loaded
     {result, output} = run_with_filter([exclude: :module], [])
     assert result == %{failures: 0, skipped: 0, excluded: 2, total: 2}
-    assert output =~ "\n2 tests, 0 failures, 2 excluded\n"
+    assert output =~ "\n0 tests, 0 failures, 2 excluded\n"
 
     {result, output} =
       [exclude: :test, include: [module: "ExUnitTest.SecondTestModule"]]
@@ -517,7 +517,7 @@ defmodule ExUnitTest do
 
     assert result == %{failures: 1, skipped: 0, excluded: 1, total: 2}
     assert output =~ "\n  1) test false (ExUnitTest.SecondTestModule)\n"
-    assert output =~ "\n2 tests, 1 failure, 1 excluded\n"
+    assert output =~ "\n1 test, 1 failure, 1 excluded\n"
   end
 
   test "raises on reserved tag :file in module" do
@@ -680,7 +680,7 @@ defmodule ExUnitTest do
       end)
 
     refute output =~ max_failures_reached_msg()
-    assert output =~ "\n6 tests, 0 failures, 1 excluded, 4 invalid, 1 skipped\n"
+    assert output =~ "\n5 tests, 0 failures, 1 excluded, 4 invalid, 1 skipped\n"
   end
 
   test "parameterized tests" do
@@ -787,7 +787,7 @@ defmodule ExUnitTest do
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert output =~ "\n6 tests, 2 failures, 1 excluded, 1 skipped\n"
+      assert output =~ "\n5 tests, 2 failures, 1 excluded, 1 skipped\n"
     end
 
     test ":max_failures is not reached" do
@@ -818,7 +818,7 @@ defmodule ExUnitTest do
         end)
 
       refute output =~ max_failures_reached_msg()
-      assert output =~ "\n8 tests, 2 failures, 2 excluded, 1 skipped\n"
+      assert output =~ "\n6 tests, 2 failures, 2 excluded, 1 skipped\n"
     end
 
     test ":max_failures has been reached" do
@@ -852,7 +852,7 @@ defmodule ExUnitTest do
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert output =~ "\n7 tests, 2 failures, 2 excluded, 2 skipped\n"
+      assert output =~ "\n5 tests, 2 failures, 2 excluded, 2 skipped\n"
     end
 
     # Excluded and skipped tests are detected before setup_all
@@ -886,7 +886,7 @@ defmodule ExUnitTest do
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert output =~ "\n4 tests, 0 failures, 1 excluded, 2 invalid, 1 skipped\n"
+      assert output =~ "\n3 tests, 0 failures, 1 excluded, 2 invalid, 1 skipped\n"
     end
 
     test ":max_failures flushes all async/sync cases" do
@@ -1059,7 +1059,7 @@ defmodule ExUnitTest do
       end)
 
     assert output =~ "All tests have been excluded.\n"
-    assert output =~ "2 tests, 0 failures, 2 excluded\n"
+    assert output =~ "0 tests, 0 failures, 2 excluded\n"
   end
 
   test "tests are run in compile order (FIFO)" do

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -331,19 +331,19 @@ defmodule ExUnitTest do
 
     {result, output} = run_with_filter([exclude: [even: true]], [ParityTest])
     assert result == %{failures: 0, skipped: 0, excluded: 1, total: 4}
-    assert output =~ "\n3 tests, 0 failures, 1 excluded\n"
+    assert output =~ "\n3 tests, 0 failures (1 excluded)\n"
 
     {result, output} = run_with_filter([exclude: :even], [ParityTest])
     assert result == %{failures: 0, skipped: 0, excluded: 3, total: 4}
-    assert output =~ "\n1 test, 0 failures, 3 excluded\n"
+    assert output =~ "\n1 test, 0 failures (3 excluded)\n"
 
     {result, output} = run_with_filter([exclude: :even, include: [even: true]], [ParityTest])
     assert result == %{failures: 1, skipped: 0, excluded: 2, total: 4}
-    assert output =~ "\n2 tests, 1 failure, 2 excluded\n"
+    assert output =~ "\n2 tests, 1 failure (2 excluded)\n"
 
     {result, output} = run_with_filter([exclude: :test, include: [even: true]], [ParityTest])
     assert result == %{failures: 1, skipped: 0, excluded: 3, total: 4}
-    assert output =~ "\n1 test, 1 failure, 3 excluded\n"
+    assert output =~ "\n1 test, 1 failure (3 excluded)\n"
   end
 
   test "log capturing" do
@@ -510,7 +510,7 @@ defmodule ExUnitTest do
     {result, output} = run_with_filter([exclude: :module], [])
 
     assert result == %{failures: 0, skipped: 0, excluded: 2, total: 2}
-    assert output =~ "\n0 tests, 0 failures, 2 excluded\n"
+    assert output =~ "\n0 tests, 0 failures (2 excluded)\n"
 
     {result, output} =
       [exclude: :test, include: [module: "ExUnitTest.SecondTestModule"]]
@@ -518,7 +518,7 @@ defmodule ExUnitTest do
 
     assert result == %{failures: 1, skipped: 0, excluded: 1, total: 2}
     assert output =~ "\n  1) test false (ExUnitTest.SecondTestModule)\n"
-    assert output =~ "\n1 test, 1 failure, 1 excluded\n"
+    assert output =~ "\n1 test, 1 failure (1 excluded)\n"
   end
 
   test "raises on reserved tag :file in module" do
@@ -681,7 +681,7 @@ defmodule ExUnitTest do
       end)
 
     refute output =~ max_failures_reached_msg()
-    assert output =~ "\n5 tests, 0 failures, 4 invalid, 1 skipped, 1 excluded\n"
+    assert output =~ "\n5 tests, 0 failures, 4 invalid, 1 skipped (1 excluded)\n"
   end
 
   test "parameterized tests" do
@@ -788,7 +788,7 @@ defmodule ExUnitTest do
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert output =~ "\n5 tests, 2 failures, 1 skipped, 1 excluded\n"
+      assert output =~ "\n5 tests, 2 failures, 1 skipped (1 excluded)\n"
     end
 
     test ":max_failures is not reached" do
@@ -819,7 +819,7 @@ defmodule ExUnitTest do
         end)
 
       refute output =~ max_failures_reached_msg()
-      assert output =~ "\n6 tests, 2 failures, 1 skipped, 2 excluded\n"
+      assert output =~ "\n6 tests, 2 failures, 1 skipped (2 excluded)\n"
     end
 
     test ":max_failures has been reached" do
@@ -853,7 +853,7 @@ defmodule ExUnitTest do
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert output =~ "\n5 tests, 2 failures, 2 skipped, 2 excluded\n"
+      assert output =~ "\n5 tests, 2 failures, 2 skipped (2 excluded)\n"
     end
 
     # Excluded and skipped tests are detected before setup_all
@@ -887,7 +887,7 @@ defmodule ExUnitTest do
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert output =~ "\n3 tests, 0 failures, 2 invalid, 1 skipped, 1 excluded\n"
+      assert output =~ "\n3 tests, 0 failures, 2 invalid, 1 skipped (1 excluded)\n"
     end
 
     test ":max_failures flushes all async/sync cases" do
@@ -1060,7 +1060,7 @@ defmodule ExUnitTest do
       end)
 
     assert output =~ "All tests have been excluded.\n"
-    assert output =~ "0 tests, 0 failures, 2 excluded\n"
+    assert output =~ "0 tests, 0 failures (2 excluded)\n"
   end
 
   test "tests are run in compile order (FIFO)" do

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -681,7 +681,7 @@ defmodule ExUnitTest do
       end)
 
     refute output =~ max_failures_reached_msg()
-    assert output =~ "\n5 tests, 0 failures, 1 excluded, 4 invalid, 1 skipped\n"
+    assert output =~ "\n5 tests, 0 failures, 4 invalid, 1 skipped, 1 excluded\n"
   end
 
   test "parameterized tests" do
@@ -788,7 +788,7 @@ defmodule ExUnitTest do
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert output =~ "\n5 tests, 2 failures, 1 excluded, 1 skipped\n"
+      assert output =~ "\n5 tests, 2 failures, 1 skipped, 1 excluded\n"
     end
 
     test ":max_failures is not reached" do
@@ -819,7 +819,7 @@ defmodule ExUnitTest do
         end)
 
       refute output =~ max_failures_reached_msg()
-      assert output =~ "\n6 tests, 2 failures, 2 excluded, 1 skipped\n"
+      assert output =~ "\n6 tests, 2 failures, 1 skipped, 2 excluded\n"
     end
 
     test ":max_failures has been reached" do
@@ -853,7 +853,7 @@ defmodule ExUnitTest do
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert output =~ "\n5 tests, 2 failures, 2 excluded, 2 skipped\n"
+      assert output =~ "\n5 tests, 2 failures, 2 skipped, 2 excluded\n"
     end
 
     # Excluded and skipped tests are detected before setup_all
@@ -887,7 +887,7 @@ defmodule ExUnitTest do
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert output =~ "\n3 tests, 0 failures, 1 excluded, 2 invalid, 1 skipped\n"
+      assert output =~ "\n3 tests, 0 failures, 2 invalid, 1 skipped, 1 excluded\n"
     end
 
     test ":max_failures flushes all async/sync cases" do

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -238,7 +238,7 @@ defmodule Mix.Tasks.TestTest do
         # Of the passing tests, 1 is tagged with `@tag :foo`.
         # But only the failing test with that tag should run.
         output = mix(["test", "--failed", "--only", "foo"])
-        assert output =~ "2 tests, 1 failure, 1 excluded"
+        assert output =~ "1 test, 1 failure (1 excluded)"
 
         # Run again to give it a chance to record as passed
         System.put_env("PASS_FAILING_TESTS", "true")
@@ -548,7 +548,7 @@ defmodule Mix.Tasks.TestTest do
                Including tags: [location: {"test/bar_tests.exs", 5}]
                """
 
-        assert output =~ "4 tests, 0 failures, 3 excluded\n"
+        assert output =~ "1 test, 0 failures (3 excluded)\n"
       end)
     end
   end


### PR DESCRIPTION
Discussed here: https://groups.google.com/g/elixir-lang-core/c/xh-hMsDi7c4

This PR omits the count of excluded tests from the overall test count in the CLI summary report

### Example

**Before:** `27 tests, 3 failures, 14 excluded`
**After:** `13 tests, 3 failures, 14 excluded`