### PR TITLE
Fix typo in alias-require-and-import.md

### DIFF
--- a/lib/elixir/pages/getting-started/alias-require-and-import.md
+++ b/lib/elixir/pages/getting-started/alias-require-and-import.md
@@ -112,7 +112,7 @@ end
 
 In the example above, the imported `List.duplicate/2` is only visible within that specific function. `duplicate/2` won't be available in any other function in that module (or any other module for that matter).
 
-While `import`s can be a useful for frameworks and libraries to build abstractions, developers should generally prefer `alias` to `import` on their own codebases, as aliases make the origin of the function being invoked clearer.
+While `import`s can be useful for frameworks and libraries to build abstractions, developers should generally prefer `alias` to `import` on their own codebases, as aliases make the origin of the function being invoked clearer.
 
 ## use
 


### PR DESCRIPTION
Reading the docs at the moment and loving them. 🎉

## What
Fixes a typo in `alias-require-and-import.md`.