### PR TITLE
Deprecate complex module expressions in &mod.fun/arity captures

### DIFF
--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -84,6 +84,18 @@ capture_require({{'.', DotMeta, [Left, Right]}, RequireMeta, Args}, S, E, ArgsTy
     {EscLeft, []} ->
       {ELeft, SE, EE} = elixir_expand:expand(EscLeft, S, E),
 
+      case ELeft of
+        _ when ArgsType /= arity ->
+          ok;
+        Atom when is_atom(Atom) ->
+          ok;
+        {Var, _, Ctx} when is_atom(Var), is_atom(Ctx) ->
+          ok;
+        _ ->
+          elixir_errors:file_warn(RequireMeta, E, ?MODULE,
+            {complex_module_capture, Left, Right, length(Args)})
+      end,
+
       Res = ArgsType /= non_sequential andalso case ELeft of
         {Name, _, Context} when is_atom(Name), is_atom(Context) ->
           {remote, ELeft, Right, length(Args)};
@@ -112,6 +124,7 @@ capture_expr(Meta, Expr, S, E, Escaped, ArgsType) ->
   case escape(Expr, E, Escaped) of
     {_, []} when ArgsType == non_sequential ->
       invalid_capture(Meta, Expr, E);
+    % TODO remove this clause once we raise on complex module captures like &get_mod().fun/0
     {{{'.', _, [_, _]} = Dot, _, Args}, []} ->
       Meta2 = lists:keydelete(no_parens, 1, Meta),
       Fn = {fn, Meta2, [{'->', Meta2, [[], {Dot, Meta2, Args}]}]},
@@ -186,6 +199,13 @@ format_error({parens_remote_capture, Mod, Fun}) ->
   io_lib:format("extra parentheses on a remote function capture &~ts.~ts()/0 have been "
                  "deprecated. Please remove the parentheses: &~ts.~ts/0",
                  ['Elixir.Macro':to_string(Mod), Fun, 'Elixir.Macro':to_string(Mod), Fun]);
+format_error({complex_module_capture, Mod, Fun, Arity}) ->
+  io_lib:format("using complex expressions for modules in &module.function/arity capture syntax has been deprecated:\n"
+                "  &~ts.~ts/~B\n\n"
+                "You can either:\n"
+                "  * use the fn syntax\n"
+                "  * assign the module to a variable if it can be evaluated outside of the capture",
+                 ['Elixir.Macro':to_string(Mod), Fun, Arity]);
 format_error(clauses_with_different_arities) ->
   "cannot mix clauses with different arities in anonymous functions";
 format_error(defaults_in_args) ->

--- a/lib/elixir/test/elixir/kernel/fn_test.exs
+++ b/lib/elixir/test/elixir/kernel/fn_test.exs
@@ -95,12 +95,6 @@ defmodule Kernel.FnTest do
     assert (&mod.flatten/1) == (&List.flatten/1)
   end
 
-  test "capture with module from local call" do
-    assert (&math_mod().pi/0).() == :math.pi()
-  end
-
-  defp math_mod, do: :math
-
   test "local partial application" do
     assert (&atb(&1, :utf8)).(:a) == "a"
     assert (&atb(List.to_atom(&1), :utf8)).(~c"a") == "a"

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -2199,12 +2199,8 @@ defmodule Kernel.WarningTest do
       [
         "nofile:2:",
         """
-        using complex expressions for modules in &module.function/arity capture syntax has been deprecated:
-          &hd(modules).module_info/0
-
-        You can either:
-          * use the fn syntax
-          * assign the module to a variable if it can be evaluated outside of the capture
+        expected the module in &module.fun/arity to expand to a variable or an atom, got: hd(modules)
+        You can either compute the module name outside of & or convert it to a regular anonymous function.
         """
       ],
       """

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -2194,6 +2194,29 @@ defmodule Kernel.WarningTest do
     )
   end
 
+  test "deprecate &module.fun/arity captures with complex expressions as modules" do
+    assert_warn_eval(
+      [
+        "nofile:2:",
+        """
+        using complex expressions for modules in &module.function/arity capture syntax has been deprecated:
+          &hd(modules).module_info/0
+
+        You can either:
+          * use the fn syntax
+          * assign the module to a variable if it can be evaluated outside of the capture
+        """
+      ],
+      """
+      defmodule Sample do
+        def foo(modules), do: &hd(modules).module_info/0
+      end
+      """
+    )
+  after
+    purge(Sample)
+  end
+
   defp assert_compile_error(messages, string) do
     captured =
       capture_err(fn ->


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/14091

Separated the first commit for easier review: 5f5ef9c919213e1fdae6a2d1efee1e48f31851fb
We needed to make the decision **after** expansion, so we need to distinguish if we come from the arity notation and propagate this info.

Using the example from https://github.com/elixir-lang/elixir/issues/14089:

<img width="768" alt="Screenshot 2024-12-21 at 10 06 42" src="https://github.com/user-attachments/assets/bac998fd-29c7-435c-b9d2-72c46fd31eb9" />

Feedback welcome on the wording, this isn't my strong suit :)