### PR TITLE
Improve doc navigability for child spec options

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -203,14 +203,16 @@ defmodule GenServer do
   The generated `child_spec/1` can be customized with the following options:
 
     * `:id` - the child specification identifier, defaults to the current module
-    * `:restart` - when the child should be restarted, defaults to `:permanent`
-    * `:shutdown` - how to shut down the child, either immediately or by giving it time to shut down
+    * [`:restart`](`m:Supervisor#module-restart-values-restart`) - when the
+      child should be restarted, defaults to `:permanent`
+    * [`:shutdown`](`m:Supervisor#module-shutdown-values-shutdown`) - how to
+      shut down the child, either immediately or by giving it time to shut down
 
   For example:
 
       use GenServer, restart: :transient, shutdown: 10_000
 
-  See the "Child specification" section in the `Supervisor` module for more
+  See the ["Child specification"](`m:Supervisor#module-child_spec-1-function`) section in the `Supervisor` module for more
   detailed information. The `@doc` annotation immediately preceding
   `use GenServer` will be attached to the generated `child_spec/1` function.
 

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -130,11 +130,11 @@ defmodule Supervisor do
       to start the child process. This key is required.
 
     * `:restart` - an atom that defines when a terminated child process
-       should be restarted (see the "Restart values" section below).
+       should be restarted (see the ["Restart values"](#module-restart-values-restart) section below).
        This key is optional and defaults to `:permanent`.
 
     * `:shutdown` - an integer or atom that defines how a child process should
-      be terminated (see the "Shutdown values" section below). This key
+      be terminated (see the ["Shutdown values"](#module-shutdown-values-shutdown) section below). This key
       is optional and defaults to `5_000` if the type is `:worker` or
       `:infinity` if the type is `:supervisor`.
 


### PR DESCRIPTION
Make it easier to navigate docs and jump to relevant sections about [`:restart`](https://hexdocs.pm/elixir/1.18.0/Supervisor.html#module-restart-values-restart) and [`:shutdown`](https://hexdocs.pm/elixir/1.18.0/Supervisor.html#module-shutdown-values-shutdown) from [`GenServer`](https://hexdocs.pm/elixir/1.18.0/GenServer.html#module-how-to-supervise), and from/to [this](https://hexdocs.pm/elixir/1.18.0/Supervisor.html#module-child-specification).

After (GenServer)

<img width="905" alt="Screenshot 2024-12-21 at 19 05 42" src="https://github.com/user-attachments/assets/e2ba6ce0-9aa4-4752-8cbb-f4c570f633ff" />

After (Supervisor)

<img width="877" alt="Screenshot 2024-12-21 at 19 05 33" src="https://github.com/user-attachments/assets/852f53a9-5010-41b8-bbda-2be70ba5522e" />