### PR TITLE
Add an environment variable to optionally disable compilation locking

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -352,9 +352,10 @@ defmodule Mix do
     * `MIX_INSTALL_DIR` *(since v1.12.0)* - specifies directory where `Mix.install/2` keeps
        install cache
 
-    * `MIX_DISABLE_LOCK` - disables mix compilation locking. While not recommended, this may be
-      necessary in cases where hard links or TCP sockets are not available. When opting for this
-      behaviour, make sure to not start concurrent compilations of the same project.
+    * `MIX_OS_CONCURRENCY_LOCK` - when set to `0` or `false`, disables mix compilation locking.
+      While not recommended, this may be necessary in cases where hard links or TCP sockets are
+      not available. When opting for this behaviour, make sure to not start concurrent compilations
+      of the same project.
 
     * `MIX_PATH` - appends extra code paths
 

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -352,6 +352,10 @@ defmodule Mix do
     * `MIX_INSTALL_DIR` *(since v1.12.0)* - specifies directory where `Mix.install/2` keeps
        install cache
 
+    * `MIX_DISABLE_LOCK` - disables mix compilation locking. While not recommended, this may be
+      necessary in cases where hard links or TCP sockets are not available. When opting for this
+      behaviour, make sure to not start concurrent compilations of the same project.
+
     * `MIX_PATH` - appends extra code paths
 
     * `MIX_PROFILE` - a list of comma-separated Mix tasks to profile the time spent on

--- a/lib/mix/lib/mix/sync/lock.ex
+++ b/lib/mix/lib/mix/sync/lock.ex
@@ -79,8 +79,9 @@ defmodule Mix.Sync.Lock do
   This function can also be called if this process already has the
   lock. In such case the function is executed immediately.
 
-  When the `MIX_DISABLE_LOCK` environment variable is set, the lock is
-  ignored and the function is executed immediately.
+  When the `MIX_OS_CONCURRENCY_LOCK` environment variable is set to
+  a falsy value, the lock is ignored and the function is executed
+  immediately.
 
   ## Options
 
@@ -118,7 +119,7 @@ defmodule Mix.Sync.Lock do
     end
   end
 
-  defp lock_disabled?(), do: System.get_env("MIX_DISABLE_LOCK") in ~w(1 true)
+  defp lock_disabled?(), do: System.get_env("MIX_OS_CONCURRENCY_LOCK") in ~w(0 false)
 
   defp lock(path, on_taken) do
     File.mkdir_p!(path)
@@ -207,7 +208,7 @@ defmodule Mix.Sync.Lock do
         could not create hard link from #{port_path} to "#{lock_path}: #{:file.format_error(reason)}.
 
         Hard link support is required for Mix compilation locking. If your system \
-        does not support hard links, set MIX_DISABLE_LOCK=1\
+        does not support hard links, set MIX_OS_CONCURRENCY_LOCK=1\
         """)
     end
   end

--- a/lib/mix/lib/mix/sync/lock.ex
+++ b/lib/mix/lib/mix/sync/lock.ex
@@ -208,7 +208,7 @@ defmodule Mix.Sync.Lock do
         could not create hard link from #{port_path} to "#{lock_path}: #{:file.format_error(reason)}.
 
         Hard link support is required for Mix compilation locking. If your system \
-        does not support hard links, set MIX_OS_CONCURRENCY_LOCK=1\
+        does not support hard links, set MIX_OS_CONCURRENCY_LOCK=0\
         """)
     end
   end


### PR DESCRIPTION
Apparently Android does not allow hard links, see https://groups.google.com/g/elixir-lang-core/c/YRpdDlH-aGA/m/PXLcuC3uBAAJ?utm_medium=email&utm_source=footer.

I believe that with an extra step we could adjust the implementation to work with symlinks (in our case, the useful property of hard links is that creating the link fails if the source file no longer exists). If you think it's worth it, I can revisit it in a separate PR, though for edge cases like this a flag may be enough.