### PR TITLE
dk_use_iodata_for_datetime_formatting

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1233,7 +1233,7 @@ defmodule Calendar.ISO do
   @doc """
   Converts the given time into a iodata.
 
-  Loog at time_to_string/5 for more information
+  Look at time_to_string/5 for more information
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1233,7 +1233,7 @@ defmodule Calendar.ISO do
   @doc """
   Converts the given time into a iodata.
 
-  Look at time_to_string/5 for more information
+  See time_to_string/5 for more information
 
   ## Examples
 
@@ -1329,7 +1329,7 @@ defmodule Calendar.ISO do
 
   @doc """
   Converts the given date into a iodata.
-  Look at date_to_string/4 for more information
+  See date_to_string/4 for more information
 
   ## Examples
 
@@ -1408,7 +1408,7 @@ defmodule Calendar.ISO do
 
   @doc """
   Converts the given naive_datetime into a iodata.
-  Look at naive_datetime_to_iodata/8 for more information
+  See naive_datetime_to_iodata/8 for more information
 
   ## Examples
 
@@ -1532,7 +1532,7 @@ defmodule Calendar.ISO do
 
   @doc """
   Converts the given datetime into a iodata.
-  Look at datetime_to_iodata/12 for more information
+  See datetime_to_iodata/12 for more information
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1237,11 +1237,19 @@ defmodule Calendar.ISO do
 
   ## Examples
 
-      iex> Calendar.ISO.time_to_iodata(2, 2, 2, {2, 6})
-      [[["0", "2"], 58, ["0", "2"], 58, ["0", "2"]], 46, ["00000", "2"]]
+      iex> data = Calendar.ISO.time_to_iodata(2, 2, 2, {2, 6})
+      iex> IO.iodata_to_binary(data)
+      "02:02:02.000002"
 
   """
   @doc since: "1.19.0"
+  @spec time_to_iodata(
+          Calendar.hour(),
+          Calendar.minute(),
+          Calendar.second(),
+          Calendar.microsecond(),
+          :basic | :extended
+        ) :: iodata
   def time_to_iodata(
         hour,
         minute,
@@ -1261,15 +1269,16 @@ defmodule Calendar.ISO do
   defp time_to_iodata_guarded(hour, minute, second, {microsecond, precision}, format) do
     [
       time_to_iodata_format(hour, minute, second, format),
-      ?.,
-      microseconds_to_iodata(microsecond, precision)
+      ?.
+      | microseconds_to_iodata(microsecond, precision)
     ]
   end
 
-  defp microseconds_to_iodata(_microsecond, 0), do: []
-  defp microseconds_to_iodata(microsecond, 6), do: zero_pad(microsecond, 6)
+  @doc false
+  def microseconds_to_iodata(_microsecond, 0), do: []
+  def microseconds_to_iodata(microsecond, 6), do: zero_pad(microsecond, 6)
 
-  defp microseconds_to_iodata(microsecond, precision) do
+  def microseconds_to_iodata(microsecond, precision) do
     num = div(microsecond, div_factor(precision))
     zero_pad(num, precision)
   end
@@ -1281,11 +1290,11 @@ defmodule Calendar.ISO do
   defp div_factor(5), do: 10
 
   defp time_to_iodata_format(hour, minute, second, :extended) do
-    [zero_pad(hour, 2), ?:, zero_pad(minute, 2), ?:, zero_pad(second, 2)]
+    [zero_pad(hour, 2), ?:, zero_pad(minute, 2), ?: | zero_pad(second, 2)]
   end
 
   defp time_to_iodata_format(hour, minute, second, :basic) do
-    [zero_pad(hour, 2), zero_pad(minute, 2), zero_pad(second, 2)]
+    [zero_pad(hour, 2), zero_pad(minute, 2) | zero_pad(second, 2)]
   end
 
   @doc """
@@ -1324,8 +1333,9 @@ defmodule Calendar.ISO do
 
   ## Examples
 
-      iex> Calendar.ISO.date_to_iodata(2015, 2, 28)
-      ["2015", 45, ["0", "2"], 45, "28"]
+      iex> data = Calendar.ISO.date_to_iodata(2015, 2, 28)
+      iex> IO.iodata_to_binary(data)
+      "2015-02-28"
   """
   @doc since: "1.19.0"
   @spec date_to_iodata(year, month, day, :basic | :extended) :: iodata
@@ -1336,11 +1346,11 @@ defmodule Calendar.ISO do
   end
 
   defp date_to_iodata_guarded(year, month, day, :extended) do
-    [zero_pad(year, 4), ?-, zero_pad(month, 2), ?-, zero_pad(day, 2)]
+    [zero_pad(year, 4), ?-, zero_pad(month, 2), ?- | zero_pad(day, 2)]
   end
 
   defp date_to_iodata_guarded(year, month, day, :basic) do
-    [zero_pad(year, 4), zero_pad(month, 2), zero_pad(day, 2)]
+    [zero_pad(year, 4), zero_pad(month, 2) | zero_pad(day, 2)]
   end
 
   @doc """
@@ -1402,11 +1412,26 @@ defmodule Calendar.ISO do
 
   ## Examples
 
-      iex> Calendar.ISO.naive_datetime_to_iodata(2015, 2, 28, 1, 2, 3, {4, 6}, :basic)
-      [["2015", ["0", "2"], "28"], 32, [[["0", "1"], ["0", "2"], ["0", "3"]], 46, ["00000", "4"]]]
+      iex> data = Calendar.ISO.naive_datetime_to_iodata(2015, 2, 28, 1, 2, 3, {4, 6}, :basic)
+      iex> IO.iodata_to_binary(data)
+      "20150228 010203.000004"
+
+      iex> data = Calendar.ISO.naive_datetime_to_iodata(2015, 2, 28, 1, 2, 3, {4, 6}, :extended)
+      iex> IO.iodata_to_binary(data)
+      "2015-02-28 01:02:03.000004"
 
   """
   @doc since: "1.19.0"
+  @spec naive_datetime_to_string(
+          year,
+          month,
+          day,
+          Calendar.hour(),
+          Calendar.minute(),
+          Calendar.second(),
+          Calendar.microsecond(),
+          :basic | :extended
+        ) :: iodata
   def naive_datetime_to_iodata(
         year,
         month,
@@ -1419,8 +1444,8 @@ defmodule Calendar.ISO do
       ) do
     [
       date_to_iodata(year, month, day, format),
-      ?\s,
-      time_to_iodata(hour, minute, second, microsecond, format)
+      ?\s
+      | time_to_iodata(hour, minute, second, microsecond, format)
     ]
   end
 
@@ -1512,11 +1537,26 @@ defmodule Calendar.ISO do
   ## Examples
 
       iex> time_zone = "Etc/UTC"
-      iex> Calendar.ISO.datetime_to_iodata(2017, 8, 1, 1, 2, 3, {4, 5}, time_zone, "UTC", 0, 0)
-      [["2017", 45, ["0", "8"], 45, ["0", "1"]], 32, [[["0", "1"], 58, ["0", "2"], 58, ["0", "3"]], 46, ["0000", "0"]], 90, []]
+      iex> data = Calendar.ISO.datetime_to_iodata(2017, 8, 1, 1, 2, 3, {4, 5}, time_zone, "UTC", 0, 0)
+      iex> IO.iodata_to_binary(data)
+      "2017-08-01 01:02:03.00000Z"
 
   """
   @doc since: "1.19.0"
+  @spec datetime_to_iodata(
+          year,
+          month,
+          day,
+          Calendar.hour(),
+          Calendar.minute(),
+          Calendar.second(),
+          Calendar.microsecond(),
+          Calendar.time_zone(),
+          Calendar.zone_abbr(),
+          Calendar.utc_offset(),
+          Calendar.std_offset(),
+          :basic | :extended
+        ) :: iodata
   def datetime_to_iodata(
         year,
         month,
@@ -1562,15 +1602,15 @@ defmodule Calendar.ISO do
   end
 
   defp format_offset(total, hour, minute, :extended) do
-    [sign(total), zero_pad(hour, 2), ?:, zero_pad(minute, 2)]
+    [sign(total), zero_pad(hour, 2), ?: | zero_pad(minute, 2)]
   end
 
   defp format_offset(total, hour, minute, :basic) do
-    [sign(total), zero_pad(hour, 2), zero_pad(minute, 2)]
+    [sign(total), zero_pad(hour, 2) | zero_pad(minute, 2)]
   end
 
   defp zone_to_iodata(_, _, _, "Etc/UTC"), do: []
-  defp zone_to_iodata(_, _, abbr, zone), do: [?\s, abbr, ?\s, zone]
+  defp zone_to_iodata(_, _, abbr, zone), do: [?\s, abbr, ?\s | zone]
 
   @doc """
   Determines if the date given is valid according to the proleptic Gregorian calendar.
@@ -1639,16 +1679,16 @@ defmodule Calendar.ISO do
 
     case max(count - byte_size(num), 0) do
       0 -> num
-      1 -> ["0", num]
-      2 -> ["00", num]
-      3 -> ["000", num]
-      4 -> ["0000", num]
-      5 -> ["00000", num]
+      1 -> ["0" | num]
+      2 -> ["00" | num]
+      3 -> ["000" | num]
+      4 -> ["0000" | num]
+      5 -> ["00000" | num]
     end
   end
 
   defp zero_pad(val, count) do
-    [?-, zero_pad(-val, count)]
+    [?- | zero_pad(-val, count)]
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1443,6 +1443,37 @@ defmodule Calendar.ISO do
         utc_offset,
         std_offset,
         format \\ :extended
+      ) do
+    datetime_to_iodata(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      microsecond,
+      time_zone,
+      zone_abbr,
+      utc_offset,
+      std_offset,
+      format
+    )
+    |> IO.iodata_to_binary()
+  end
+
+  def datetime_to_iodata(
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        microsecond,
+        time_zone,
+        zone_abbr,
+        utc_offset,
+        std_offset,
+        format \\ :extended
       )
       when is_time_zone(time_zone) and is_zone_abbr(zone_abbr) and is_utc_offset(utc_offset) and
              is_std_offset(std_offset) do
@@ -1453,7 +1484,6 @@ defmodule Calendar.ISO do
       offset_to_iodata(utc_offset, std_offset, time_zone, format),
       zone_to_iodata(utc_offset, std_offset, zone_abbr, time_zone)
     ]
-    |> IO.iodata_to_binary()
   end
 
   @doc false

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1250,9 +1250,23 @@ defmodule Calendar.ISO do
     [
       time_to_iodata_format(hour, minute, second, format),
       ".",
-      microsecond |> zero_pad(6) |> IO.iodata_to_binary() |> binary_part(0, precision)
+      microseconds_to_iodata(microsecond, precision)
     ]
   end
+
+  defp microseconds_to_iodata(_microsecond, 0), do: []
+  defp microseconds_to_iodata(microsecond, 6), do: zero_pad(microsecond, 6)
+
+  defp microseconds_to_iodata(microsecond, precision) do
+    num = div(microsecond, div_factor(precision))
+    zero_pad(num, precision)
+  end
+
+  defp div_factor(1), do: 100_000
+  defp div_factor(2), do: 10_000
+  defp div_factor(3), do: 1_000
+  defp div_factor(4), do: 100
+  defp div_factor(5), do: 10
 
   defp time_to_iodata_format(hour, minute, second, :extended) do
     [zero_pad(hour, 2), ":", zero_pad(minute, 2), ":", zero_pad(second, 2)]
@@ -1577,7 +1591,7 @@ defmodule Calendar.ISO do
   defp sign(total) when total < 0, do: "-"
   defp sign(_), do: "+"
 
-  defp zero_pad(val, count) when val >= 0 do
+  defp zero_pad(val, count) when val >= 0 and count <= 6 do
     num = Integer.to_string(val)
 
     case max(count - byte_size(num), 0) do
@@ -1587,7 +1601,6 @@ defmodule Calendar.ISO do
       3 -> ["000", num]
       4 -> ["0000", num]
       5 -> ["00000", num]
-      6 -> ["000000", num]
     end
   end
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1233,7 +1233,7 @@ defmodule Calendar.ISO do
   @doc """
   Converts the given time into a iodata.
 
-  See time_to_string/5 for more information
+  See `time_to_string/5` for more information.
 
   ## Examples
 
@@ -1330,7 +1330,7 @@ defmodule Calendar.ISO do
   @doc """
   Converts the given date into a iodata.
 
-  See date_to_string/4 for more information
+  See `date_to_string/4` for more information.
 
   ## Examples
 
@@ -1410,7 +1410,7 @@ defmodule Calendar.ISO do
   @doc """
   Converts the given naive_datetime into a iodata.
 
-  See naive_datetime_to_iodata/8 for more information
+  See `naive_datetime_to_iodata/8` for more information.
 
   ## Examples
 
@@ -1535,7 +1535,7 @@ defmodule Calendar.ISO do
   @doc """
   Converts the given datetime into a iodata.
 
-  See datetime_to_iodata/12 for more information
+  See `datetime_to_iodata/12` for more information.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1230,6 +1230,18 @@ defmodule Calendar.ISO do
     |> IO.iodata_to_binary()
   end
 
+  @doc """
+  Converts the given time into a iodata.
+
+  Loog at time_to_string/5 for more information
+
+  ## Examples
+
+      iex> Calendar.ISO.time_to_iodata(2, 2, 2, {2, 6})
+      [[["0", "2"], 58, ["0", "2"], 58, ["0", "2"]], 46, ["00000", "2"]]
+
+  """
+  @doc since: "1.19.0"
   def time_to_iodata(
         hour,
         minute,
@@ -1306,6 +1318,17 @@ defmodule Calendar.ISO do
     |> IO.iodata_to_binary()
   end
 
+  @doc """
+  Converts the given date into a iodata.
+  Look at date_to_string/4 for more information
+
+  ## Examples
+
+      iex> Calendar.ISO.date_to_iodata(2015, 2, 28)
+      ["2015", 45, ["0", "2"], 45, "28"]
+  """
+  @doc since: "1.19.0"
+  @spec date_to_iodata(year, month, day, :basic | :extended) :: iodata
   def date_to_iodata(year, month, day, format \\ :extended)
       when is_integer(year) and is_integer(month) and is_integer(day) and
              format in [:basic, :extended] do
@@ -1373,6 +1396,17 @@ defmodule Calendar.ISO do
     |> IO.iodata_to_binary()
   end
 
+  @doc """
+  Converts the given naive_datetime into a iodata.
+  Look at naive_datetime_to_iodata/8 for more information
+
+  ## Examples
+
+      iex> Calendar.ISO.naive_datetime_to_iodata(2015, 2, 28, 1, 2, 3, {4, 6}, :basic)
+      [["2015", ["0", "2"], "28"], 32, [[["0", "1"], ["0", "2"], ["0", "3"]], 46, ["00000", "4"]]]
+
+  """
+  @doc since: "1.19.0"
   def naive_datetime_to_iodata(
         year,
         month,
@@ -1471,6 +1505,18 @@ defmodule Calendar.ISO do
     |> IO.iodata_to_binary()
   end
 
+  @doc """
+  Converts the given datetime into a iodata.
+  Look at datetime_to_iodata/12 for more information
+
+  ## Examples
+
+      iex> time_zone = "Etc/UTC"
+      iex> Calendar.ISO.datetime_to_iodata(2017, 8, 1, 1, 2, 3, {4, 5}, time_zone, "UTC", 0, 0)
+      [["2017", 45, ["0", "8"], 45, ["0", "1"]], 32, [[["0", "1"], 58, ["0", "2"], 58, ["0", "3"]], 46, ["0000", "0"]], 90, []]
+
+  """
+  @doc since: "1.19.0"
   def datetime_to_iodata(
         year,
         month,
@@ -1504,6 +1550,7 @@ defmodule Calendar.ISO do
     |> IO.iodata_to_binary()
   end
 
+  @doc false
   def offset_to_iodata(0, 0, "Etc/UTC", _format), do: ?Z
 
   def offset_to_iodata(utc, std, _zone, format) do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1249,7 +1249,7 @@ defmodule Calendar.ISO do
   defp time_to_iodata_guarded(hour, minute, second, {microsecond, precision}, format) do
     [
       time_to_iodata_format(hour, minute, second, format),
-      ".",
+      ?.,
       microseconds_to_iodata(microsecond, precision)
     ]
   end
@@ -1269,7 +1269,7 @@ defmodule Calendar.ISO do
   defp div_factor(5), do: 10
 
   defp time_to_iodata_format(hour, minute, second, :extended) do
-    [zero_pad(hour, 2), ":", zero_pad(minute, 2), ":", zero_pad(second, 2)]
+    [zero_pad(hour, 2), ?:, zero_pad(minute, 2), ?:, zero_pad(second, 2)]
   end
 
   defp time_to_iodata_format(hour, minute, second, :basic) do
@@ -1313,15 +1313,11 @@ defmodule Calendar.ISO do
   end
 
   defp date_to_iodata_guarded(year, month, day, :extended) do
-    [zero_pad(year, 4), "-", zero_pad(month, 2), "-", zero_pad(day, 2)]
+    [zero_pad(year, 4), ?-, zero_pad(month, 2), ?-, zero_pad(day, 2)]
   end
 
   defp date_to_iodata_guarded(year, month, day, :basic) do
-    [
-      zero_pad(year, 4),
-      zero_pad(month, 2),
-      zero_pad(day, 2)
-    ]
+    [zero_pad(year, 4), zero_pad(month, 2), zero_pad(day, 2)]
   end
 
   @doc """
@@ -1389,7 +1385,7 @@ defmodule Calendar.ISO do
       ) do
     [
       date_to_iodata(year, month, day, format),
-      " ",
+      ?\s,
       time_to_iodata(hour, minute, second, microsecond, format)
     ]
   end
@@ -1493,7 +1489,7 @@ defmodule Calendar.ISO do
              is_std_offset(std_offset) do
     [
       date_to_iodata(year, month, day, format),
-      " ",
+      ?\s,
       time_to_iodata(hour, minute, second, microsecond, format),
       offset_to_iodata(utc_offset, std_offset, time_zone, format),
       zone_to_iodata(utc_offset, std_offset, zone_abbr, time_zone)
@@ -1508,7 +1504,7 @@ defmodule Calendar.ISO do
     |> IO.iodata_to_binary()
   end
 
-  def offset_to_iodata(0, 0, "Etc/UTC", _format), do: "Z"
+  def offset_to_iodata(0, 0, "Etc/UTC", _format), do: ?Z
 
   def offset_to_iodata(utc, std, _zone, format) do
     total = utc + std
@@ -1519,15 +1515,15 @@ defmodule Calendar.ISO do
   end
 
   defp format_offset(total, hour, minute, :extended) do
-    [sign(total), zero_pad(hour, 2), ":", zero_pad(minute, 2)]
+    [sign(total), zero_pad(hour, 2), ?:, zero_pad(minute, 2)]
   end
 
   defp format_offset(total, hour, minute, :basic) do
     [sign(total), zero_pad(hour, 2), zero_pad(minute, 2)]
   end
 
-  defp zone_to_iodata(_, _, _, "Etc/UTC"), do: ""
-  defp zone_to_iodata(_, _, abbr, zone), do: [" ", abbr, " ", zone]
+  defp zone_to_iodata(_, _, _, "Etc/UTC"), do: []
+  defp zone_to_iodata(_, _, abbr, zone), do: [?\s, abbr, ?\s, zone]
 
   @doc """
   Determines if the date given is valid according to the proleptic Gregorian calendar.
@@ -1588,8 +1584,8 @@ defmodule Calendar.ISO do
     {0, 1}
   end
 
-  defp sign(total) when total < 0, do: "-"
-  defp sign(_), do: "+"
+  defp sign(total) when total < 0, do: ?-
+  defp sign(_), do: ?+
 
   defp zero_pad(val, count) when val >= 0 and count <= 6 do
     num = Integer.to_string(val)
@@ -1605,7 +1601,7 @@ defmodule Calendar.ISO do
   end
 
   defp zero_pad(val, count) do
-    ["-", zero_pad(-val, count)]
+    [?-, zero_pad(-val, count)]
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1329,6 +1329,7 @@ defmodule Calendar.ISO do
 
   @doc """
   Converts the given date into a iodata.
+
   See date_to_string/4 for more information
 
   ## Examples
@@ -1408,6 +1409,7 @@ defmodule Calendar.ISO do
 
   @doc """
   Converts the given naive_datetime into a iodata.
+
   See naive_datetime_to_iodata/8 for more information
 
   ## Examples
@@ -1532,6 +1534,7 @@ defmodule Calendar.ISO do
 
   @doc """
   Converts the given datetime into a iodata.
+
   See datetime_to_iodata/12 for more information
 
   ## Examples


### PR DESCRIPTION
The benchmark with go made me think if we can get any speed gains in synthetic tests :D
This pr changes datetime formatting functions:
around 55% of memory usage and 3x speedup when serializing with optional 4x when using iodata ;)

It also adds new functions `*_to_iodata` that can be used by libraries that operate on iodata like ecto or json
```elixir
defmodule CalendarStringBench do
  def run do
    datetime = ~U[2024-12-30 12:21:45.000123Z]

    Benchee.run(
      %{
        "Elixir.DateTime.to_string" => fn -> DateTime.to_string(datetime) end,
        "Calendar.ISO.datetime_to_string" => fn ->
          Calendar.ISO.naive_datetime_to_string(
            datetime.year,
            datetime.month,
            datetime.day,
            datetime.hour,
            datetime.minute,
            datetime.second,
            datetime.microsecond
          )
        end,
        "Calendar.IOISO.datetime_to_string" => fn ->
          Calendar.IOISO.naive_datetime_to_string(
            datetime.year,
            datetime.month,
            datetime.day,
            datetime.hour,
            datetime.minute,
            datetime.second,
            datetime.microsecond
          )
        end,
        "Calendar.IOISO.datetime_to_iodata" => fn ->
          Calendar.IOISO.naive_datetime_to_iodata(
            datetime.year,
            datetime.month,
            datetime.day,
            datetime.hour,
            datetime.minute,
            datetime.second,
            datetime.microsecond
          )
        end
      },
      time: 10,
      memory_time: 2,
      formatters: [
        #  {Benchee.Formatters.HTML, file: "bench/output/calendar_string.html"},
        Benchee.Formatters.Console
      ]
    )
  end
end

# Run the benchmark
CalendarStringBench.run()
```
result
```
Benchmarking Calendar.IOISO.datetime_to_iodata ...                                                                                            
Benchmarking Calendar.IOISO.datetime_to_string ...                                                                                            
Benchmarking Calendar.ISO.datetime_to_string ...                                                                                              
Benchmarking Elixir.DateTime.to_string ...                                                                                                    
Calculating statistics...                                                                                                                     
Formatting results...                                                                                                                         
                                                                                                                                              
Name                                        ips        average  deviation         median         99th %                                       
Calendar.IOISO.datetime_to_iodata        3.80 M      263.30 ns ±12989.04%         201 ns         350 ns                                       
Calendar.IOISO.datetime_to_string        2.86 M      350.05 ns  ±6363.30%         290 ns         471 ns                                       
Calendar.ISO.datetime_to_string          1.10 M      905.92 ns  ±3587.70%         651 ns        1352 ns                                       
Elixir.DateTime.to_string                1.04 M      958.94 ns  ±2794.13%         701 ns        1673 ns                                       
                                                                                                                                              
Comparison:                                                                                                                                   
Calendar.IOISO.datetime_to_iodata        3.80 M                                                                                               
Calendar.IOISO.datetime_to_string        2.86 M - 1.33x slower +86.75 ns
Calendar.ISO.datetime_to_string          1.10 M - 3.44x slower +642.62 ns
Elixir.DateTime.to_string                1.04 M - 3.64x slower +695.65 ns

Memory usage statistics:

Name                                 Memory usage                      
Calendar.IOISO.datetime_to_iodata           480 B                      
Calendar.IOISO.datetime_to_string           528 B - 1.10x memory usage +48 B
Calendar.ISO.datetime_to_string             896 B - 1.87x memory usage +416 B
Elixir.DateTime.to_string                   896 B - 1.87x memory usage +416 B
```