### PR TITLE
Clarify that `mix do` early-exits on error

### DIFF
--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -4,8 +4,9 @@ defmodule Mix.Tasks.Do do
   @shortdoc "Executes the tasks separated by plus"
 
   @moduledoc """
-  Executes the tasks separated by `+`, aborting if any task exits
-  with an error:
+  Executes the tasks separated by `+`, aborting if any task errors.
+  
+  Here is an example:
 
       $ mix do compile --list + deps
 

--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -4,7 +4,8 @@ defmodule Mix.Tasks.Do do
   @shortdoc "Executes the tasks separated by plus"
 
   @moduledoc """
-  Executes the tasks separated by `+`:
+  Executes the tasks separated by `+`, aborting if any task exits
+  with an error:
 
       $ mix do compile --list + deps
 
@@ -40,6 +41,16 @@ defmodule Mix.Tasks.Do do
 
   Since then, the `+` operator has been introduced as a
   separator for better support on Windows terminals.
+
+  ## Error handling
+
+  If any task in the list of tasks exits with an error,
+  no subsequent tasks will be run. For instance:
+
+      $ mix do compile + test
+
+  If the compilation step fails, the tests will not be
+  attempted.
 
   ## Command line options
 


### PR DESCRIPTION
A coworker and I had to test this ourselves to figure out what would happen in `mix do compile + test` if the compilation step failed, so I figured it'd be worth calling out this behavior in the docs.