### PR TITLE
Turn type inference up to 1000

### DIFF
--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -285,7 +285,7 @@ defmodule Module.Types do
               Pattern.of_head(args, guards, expected, {:infer, expected}, meta, stack, context)
 
             {return_type, context} =
-              Expr.of_expr(body, Descr.term(), :ok, stack, context)
+              Expr.of_expr(body, Descr.term(), body, stack, context)
 
             args_types =
               if stack.mode == :traversal do

--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -285,7 +285,7 @@ defmodule Module.Types do
               Pattern.of_head(args, guards, expected, {:infer, expected}, meta, stack, context)
 
             {return_type, context} =
-              Expr.of_expr(body, stack, context)
+              Expr.of_expr(body, {Descr.term(), :ok}, stack, context)
 
             {type_index, inferred} =
               add_inferred(inferred, args_types, return_type, total - 1, [])

--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -285,7 +285,7 @@ defmodule Module.Types do
               Pattern.of_head(args, guards, expected, {:infer, expected}, meta, stack, context)
 
             {return_type, context} =
-              Expr.of_expr(body, {Descr.term(), :ok}, stack, context)
+              Expr.of_expr(body, Descr.term(), :ok, stack, context)
 
             args_types =
               if stack.mode == :traversal do

--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -308,7 +308,18 @@ defmodule Module.Types do
           end
       end)
 
-    inferred = {:infer, Enum.reverse(clauses_types)}
+    domain =
+      case clauses_types do
+        [_] ->
+          nil
+
+        _ ->
+          clauses_types
+          |> Enum.map(fn {args, _} -> args end)
+          |> Enum.zip_with(fn types -> Enum.reduce(types, &Descr.union/2) end)
+      end
+
+    inferred = {:infer, domain, Enum.reverse(clauses_types)}
     {inferred, mapping, restore_context(clauses_context, context)}
   end
 

--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -145,6 +145,7 @@ defmodule Module.Types.Apply do
         {:erlang, :>, [{[term(), term()], boolean()}]},
         {:erlang, :>=, [{[term(), term()], boolean()}]},
         {:erlang, :abs, [{[integer()], integer()}, {[float()], float()}]},
+        # TODO: Decide if it returns dynamic() or term()
         {:erlang, :apply, [{[fun(), list(term())], dynamic()}]},
         {:erlang, :apply, [{[atom(), atom(), list(term())], dynamic()}]},
         {:erlang, :and, and_signature},

--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -72,16 +72,16 @@ defmodule Module.Types.Apply do
     domain = atom(Keyword.keys(clauses))
     clauses = Enum.map(clauses, fn {key, return} -> {[atom([key])], return} end)
 
-    defp signature(unquote(name), 1) do
+    def signature(unquote(name), 1) do
       {:strong, [unquote(Macro.escape(domain))], unquote(Macro.escape(clauses))}
     end
   end
 
-  defp signature(:module_info, 0) do
+  def signature(:module_info, 0) do
     {:strong, nil, [{[], unquote(Macro.escape(kw.(module_info)))}]}
   end
 
-  defp signature(_, _), do: :none
+  def signature(_, _), do: :none
 
   # Remote for compiler functions
 
@@ -254,11 +254,11 @@ defmodule Module.Types.Apply do
           {:strong, domain, clauses}
       end
 
-    defp signature(unquote(mod), unquote(fun), unquote(arity)),
+    def signature(unquote(mod), unquote(fun), unquote(arity)),
       do: unquote(Macro.escape(domain_clauses))
   end
 
-  defp signature(_mod, _fun, _arity), do: :none
+  def signature(_mod, _fun, _arity), do: :none
 
   @doc """
   Returns the domain of an unknown module.

--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -265,6 +265,7 @@ defmodule Module.Types.Apply do
 
   Used only by info functions.
   """
+  # PENDING: expected
   def remote_domain(_fun, args, _expected, %{mode: :traversal}) do
     {:none, Enum.map(args, fn _ -> term() end)}
   end
@@ -628,7 +629,8 @@ defmodule Module.Types.Apply do
 
   ## Local
 
-  def local_domain(fun, args, meta, stack, context) do
+  # PENDING: expected
+  def local_domain(fun, args, _expected, meta, stack, context) do
     arity = length(args)
 
     case stack.local_handler.(meta, {fun, arity}, stack, context) do

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -1885,6 +1885,7 @@ defmodule Module.Types.Descr do
         end
 
       :open ->
+        fields = Map.to_list(fields)
         {:%{}, [], [{:..., [], nil} | map_fields_to_quoted(tag, Enum.sort(fields), opts)]}
     end
   end

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -637,15 +637,6 @@ defmodule Module.Types.Descr do
   def number_type?(%{bitmap: bitmap}) when (bitmap &&& @bit_number) != 0, do: true
   def number_type?(_), do: false
 
-  @doc """
-  Optimized version of `not empty?(intersection(atom(), type))`.
-  """
-  def atom_type?(:term), do: true
-  def atom_type?(%{dynamic: :term}), do: true
-  def atom_type?(%{dynamic: %{atom: _}}), do: true
-  def atom_type?(%{atom: _}), do: true
-  def atom_type?(_), do: false
-
   ## Bitmaps
 
   defp bitmap_to_quoted(val) do
@@ -746,20 +737,6 @@ defmodule Module.Types.Descr do
 
       _ ->
         :always_true
-    end
-  end
-
-  @doc """
-  Optimized version of `not empty?(intersection(atom([atom]), type))`.
-  """
-  def atom_type?(:term, _atom), do: true
-
-  def atom_type?(%{} = descr, atom) do
-    case Map.get(descr, :dynamic, descr) do
-      :term -> true
-      %{atom: {:union, set}} -> :sets.is_element(atom, set)
-      %{atom: {:negation, set}} -> not :sets.is_element(atom, set)
-      %{} -> false
     end
   end
 

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -572,14 +572,14 @@ defmodule Module.Types.Descr do
     cond do
       empty?(left_static) ->
         dynamic = intersection_static(unfold(left_dynamic), unfold(right_dynamic))
-        if empty?(dynamic), do: :error, else: {:ok, dynamic(dynamic)}
+        if empty?(dynamic), do: {:error, left}, else: {:ok, dynamic(dynamic)}
 
       subtype_static?(left_static, right_dynamic) ->
         dynamic = intersection_static(unfold(left_dynamic), unfold(right_dynamic))
         {:ok, union(dynamic(dynamic), left_static)}
 
       true ->
-        :error
+        {:error, left}
     end
   end
 

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -360,7 +360,7 @@ defmodule Module.Types.Expr do
         {timeout_type, context} = of_expr(timeout, {@timeout_type, after_expr}, stack, context)
         {body_type, context} = of_expr(body, expected_expr, stack, context)
 
-        if integer_type?(timeout_type) or atom_type?(timeout_type, :infinity) do
+        if compatible?(timeout_type, @timeout_type) do
           {union(body_type, acc), reset_vars(context, original)}
         else
           error = {:badtimeout, timeout_type, timeout, context}
@@ -592,10 +592,9 @@ defmodule Module.Types.Expr do
 
   defp for_clause({:<<>>, _, [{:<-, meta, [left, right]}]} = expr, stack, context) do
     {right_type, context} = of_expr(right, {binary(), expr}, stack, context)
-
     context = Pattern.of_match(left, binary(), expr, :for, stack, context)
 
-    if binary_type?(right_type) do
+    if compatible?(right_type, binary()) do
       context
     else
       error = {:badbinary, right_type, right, context}

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -360,7 +360,7 @@ defmodule Module.Types.Expr do
         {timeout_type, context} = of_expr(timeout, {@timeout_type, after_expr}, stack, context)
         {body_type, context} = of_expr(body, expected_expr, stack, context)
 
-        if compatible?(timeout_type, @timeout_type) do
+        if integer_type?(timeout_type) or atom_type?(timeout_type, :infinity) do
           {union(body_type, acc), reset_vars(context, original)}
         else
           error = {:badtimeout, timeout_type, timeout, context}
@@ -620,6 +620,8 @@ defmodule Module.Types.Expr do
   defp for_into(into, meta, stack, context) do
     {type, context} = of_expr(into, @expected_expr, stack, context)
 
+    # We use subtype? instead of compatible because we want to handle
+    # only binary/list, even if a dynamic with something else is given.
     if subtype?(type, @into_compile) do
       case {binary_type?(type), empty_list_type?(type)} do
         {false, true} -> {[:list], gradual?(type), context}

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -535,7 +535,7 @@ defmodule Module.Types.Expr do
     if stack.mode == :traversal do
       {dynamic(), context}
     else
-      Of.refine_existing_var(var, expected, expr, stack, context)
+      Of.refine_body_var(var, expected, expr, stack, context)
     end
   end
 
@@ -567,7 +567,10 @@ defmodule Module.Types.Expr do
         _ ->
           expected = if structs == [], do: @exception, else: Enum.reduce(structs, &union/2)
           formatter = fn expr -> {"rescue #{expr_to_string(expr)} ->", hints} end
-          {_ok?, _type, context} = Of.refine_var(var, expected, expr, formatter, stack, context)
+
+          {_ok?, _type, context} =
+            Of.refine_head_var(var, expected, expr, formatter, stack, context)
+
           context
       end
 

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -49,39 +49,39 @@ defmodule Module.Types.Expr do
                 )
               )
 
-  @expected_expr {term(), :ok}
-  @term_expected {term(), :ok}
+  @term term()
+  @pending term()
 
   # :atom
-  def of_expr(atom, _expected_expr, _stack, context) when is_atom(atom),
+  def of_expr(atom, _expected, _expr, _stack, context) when is_atom(atom),
     do: {atom([atom]), context}
 
   # 12
-  def of_expr(literal, _expected_expr, _stack, context) when is_integer(literal),
+  def of_expr(literal, _expected, _expr, _stack, context) when is_integer(literal),
     do: {integer(), context}
 
   # 1.2
-  def of_expr(literal, _expected_expr, _stack, context) when is_float(literal),
+  def of_expr(literal, _expected, _expr, _stack, context) when is_float(literal),
     do: {float(), context}
 
   # "..."
-  def of_expr(literal, _expected_expr, _stack, context) when is_binary(literal),
+  def of_expr(literal, _expected, _expr, _stack, context) when is_binary(literal),
     do: {binary(), context}
 
   # #PID<...>
-  def of_expr(literal, _expected_expr, _stack, context) when is_pid(literal),
+  def of_expr(literal, _expected, _expr, _stack, context) when is_pid(literal),
     do: {pid(), context}
 
   # []
-  def of_expr([], _expected_expr, _stack, context),
+  def of_expr([], _expected, _expr, _stack, context),
     do: {empty_list(), context}
 
   # [expr, ...]
   # TODO: here
-  def of_expr(list, _expected_expr, stack, context) when is_list(list) do
+  def of_expr(list, _expected, expr, stack, context) when is_list(list) do
     {prefix, suffix} = unpack_list(list, [])
-    {prefix, context} = Enum.map_reduce(prefix, context, &of_expr(&1, @expected_expr, stack, &2))
-    {suffix, context} = of_expr(suffix, @expected_expr, stack, context)
+    {prefix, context} = Enum.map_reduce(prefix, context, &of_expr(&1, @pending, expr, stack, &2))
+    {suffix, context} = of_expr(suffix, @pending, expr, stack, context)
 
     if stack.mode == :traversal do
       {dynamic(), context}
@@ -92,9 +92,9 @@ defmodule Module.Types.Expr do
 
   # {left, right}
   # TODO: here
-  def of_expr({left, right}, _expected_expr, stack, context) do
-    {left, context} = of_expr(left, @expected_expr, stack, context)
-    {right, context} = of_expr(right, @expected_expr, stack, context)
+  def of_expr({left, right}, _expected, expr, stack, context) do
+    {left, context} = of_expr(left, @pending, expr, stack, context)
+    {right, context} = of_expr(right, @pending, expr, stack, context)
 
     if stack.mode == :traversal do
       {dynamic(), context}
@@ -105,8 +105,8 @@ defmodule Module.Types.Expr do
 
   # {...}
   # TODO: here
-  def of_expr({:{}, _meta, exprs}, _expected_expr, stack, context) do
-    {types, context} = Enum.map_reduce(exprs, context, &of_expr(&1, @expected_expr, stack, &2))
+  def of_expr({:{}, _meta, exprs}, _expected, expr, stack, context) do
+    {types, context} = Enum.map_reduce(exprs, context, &of_expr(&1, @pending, expr, stack, &2))
 
     if stack.mode == :traversal do
       {dynamic(), context}
@@ -117,26 +117,26 @@ defmodule Module.Types.Expr do
 
   # <<...>>>
   # TODO: here (including tests)
-  def of_expr({:<<>>, _meta, args}, _expected_expr, stack, context) do
+  def of_expr({:<<>>, _meta, args}, _expected, _expr, stack, context) do
     context = Of.binary(args, :expr, stack, context)
     {binary(), context}
   end
 
-  def of_expr({:__CALLER__, _meta, var_context}, _expected_expr, _stack, context)
+  def of_expr({:__CALLER__, _meta, var_context}, _expected, _expr, _stack, context)
       when is_atom(var_context) do
     {@caller, context}
   end
 
-  def of_expr({:__STACKTRACE__, _meta, var_context}, _expected_expr, _stack, context)
+  def of_expr({:__STACKTRACE__, _meta, var_context}, _expected, _expr, _stack, context)
       when is_atom(var_context) do
     {@stacktrace, context}
   end
 
   # left = right
   # TODO: here
-  def of_expr({:=, _, [left_expr, right_expr]} = expr, _expected_expr, stack, context) do
+  def of_expr({:=, _, [left_expr, right_expr]} = expr, _expected, _expr, stack, context) do
     {left_expr, right_expr} = repack_match(left_expr, right_expr)
-    {right_type, context} = of_expr(right_expr, @expected_expr, stack, context)
+    {right_type, context} = of_expr(right_expr, @pending, expr, stack, context)
 
     # We do not raise on underscore in case someone writes _ = raise "omg"
     context =
@@ -151,10 +151,10 @@ defmodule Module.Types.Expr do
   # %{map | ...}
   # TODO: Once we support typed structs, we need to type check them here.
   # TODO: here
-  def of_expr({:%{}, meta, [{:|, _, [map, args]}]} = expr, _expected_expr, stack, context) do
-    {map_type, context} = of_expr(map, @expected_expr, stack, context)
+  def of_expr({:%{}, meta, [{:|, _, [map, args]}]} = expr, _expected, _expr, stack, context) do
+    {map_type, context} = of_expr(map, @pending, expr, stack, context)
 
-    Of.permutate_map(args, stack, context, &of_expr(&1, @expected_expr, &2, &3), fn
+    Of.permutate_map(args, stack, context, &of_expr(&1, @pending, expr, &2, &3), fn
       fallback, keys, pairs ->
         # If there is no fallback (i.e. it is closed), we can update the existing map,
         # otherwise we only assert the existing keys.
@@ -195,13 +195,14 @@ defmodule Module.Types.Expr do
   # TODO: here
   def of_expr(
         {:%, struct_meta, [module, {:%{}, _, [{:|, update_meta, [map, args]}]}]} = expr,
-        _expected_expr,
+        _expected,
+        _expr,
         stack,
         context
       ) do
     {info, context} = Of.struct_info(module, struct_meta, stack, context)
     struct_type = Of.struct_type(module, info)
-    {map_type, context} = of_expr(map, @expected_expr, stack, context)
+    {map_type, context} = of_expr(map, @pending, expr, stack, context)
 
     if disjoint?(struct_type, map_type) do
       warning = {:badstruct, expr, struct_type, map_type, context}
@@ -211,7 +212,7 @@ defmodule Module.Types.Expr do
 
       Enum.reduce(args, {map_type, context}, fn
         {key, value}, {map_type, context} when is_atom(key) ->
-          {value_type, context} = of_expr(value, @expected_expr, stack, context)
+          {value_type, context} = of_expr(value, @pending, expr, stack, context)
           {map_put!(map_type, key, value_type), context}
       end)
     end
@@ -219,39 +220,39 @@ defmodule Module.Types.Expr do
 
   # %{...}
   # TODO: here
-  def of_expr({:%{}, _meta, args}, _expected_expr, stack, context) do
-    Of.closed_map(args, stack, context, &of_expr(&1, @expected_expr, &2, &3))
+  def of_expr({:%{}, _meta, args}, _expected, expr, stack, context) do
+    Of.closed_map(args, stack, context, &of_expr(&1, @pending, expr, &2, &3))
   end
 
   # %Struct{}
   # TODO: here
-  def of_expr({:%, meta, [module, {:%{}, _, args}]}, _expected_expr, stack, context) do
-    Of.struct_instance(module, args, meta, stack, context, &of_expr(&1, @expected_expr, &2, &3))
+  def of_expr({:%, meta, [module, {:%{}, _, args}]}, _expected, expr, stack, context) do
+    Of.struct_instance(module, args, meta, stack, context, &of_expr(&1, @pending, expr, &2, &3))
   end
 
   # ()
-  def of_expr({:__block__, _meta, []}, _expected_expr, _stack, context) do
+  def of_expr({:__block__, _meta, []}, _expected, _expr, _stack, context) do
     {atom([nil]), context}
   end
 
   # (expr; expr)
-  def of_expr({:__block__, _meta, exprs}, expected_expr, stack, context) do
+  def of_expr({:__block__, _meta, exprs}, expected, expr, stack, context) do
     {pre, [post]} = Enum.split(exprs, -1)
 
     context =
       Enum.reduce(pre, context, fn expr, context ->
-        {_, context} = of_expr(expr, @term_expected, stack, context)
+        {_, context} = of_expr(expr, @term, :ok, stack, context)
         context
       end)
 
-    of_expr(post, expected_expr, stack, context)
+    of_expr(post, expected, expr, stack, context)
   end
 
-  def of_expr({:cond, _meta, [[{:do, clauses}]]}, expected_expr, stack, original) do
+  def of_expr({:cond, _meta, [[{:do, clauses}]]}, expected, expr, stack, original) do
     clauses
     |> reduce_non_empty({none(), original}, fn
       {:->, meta, [[head], body]}, {acc, context}, last? ->
-        {head_type, context} = of_expr(head, @term_expected, stack, context)
+        {head_type, context} = of_expr(head, @pending, :ok, stack, context)
 
         context =
           if stack.mode in [:infer, :traversal] do
@@ -271,15 +272,15 @@ defmodule Module.Types.Expr do
             end
           end
 
-        {body_type, context} = of_expr(body, expected_expr, stack, context)
+        {body_type, context} = of_expr(body, expected, expr, stack, context)
         {union(body_type, acc), reset_vars(context, original)}
     end)
     |> dynamic_unless_static(stack)
   end
 
   # TODO: here
-  def of_expr({:case, meta, [case_expr, [{:do, clauses}]]}, _expected_expr, stack, context) do
-    {case_type, context} = of_expr(case_expr, @term_expected, stack, context)
+  def of_expr({:case, meta, [case_expr, [{:do, clauses}]]}, expected, expr, stack, context) do
+    {case_type, context} = of_expr(case_expr, @pending, :ok, stack, context)
 
     # If we are only type checking the expression and the expression is a literal,
     # let's mark it as generated, as it is most likely a macro code. However, if
@@ -289,31 +290,47 @@ defmodule Module.Types.Expr do
     else
       clauses
     end
-    |> of_clauses([case_type], {:case, meta, case_type, case_expr}, stack, {none(), context})
+    |> of_clauses(
+      [case_type],
+      expected,
+      expr,
+      {:case, meta, case_type, case_expr},
+      stack,
+      {none(), context}
+    )
     |> dynamic_unless_static(stack)
   end
 
   # TODO: fn pat -> expr end
   # TODO: here
-  def of_expr({:fn, _meta, clauses}, _expected_expr, stack, context) do
+  def of_expr({:fn, _meta, clauses}, _expected, _expr, stack, context) do
     [{:->, _, [head, _]} | _] = clauses
     {patterns, _guards} = extract_head(head)
-    expected = Enum.map(patterns, fn _ -> dynamic() end)
-    {_acc, context} = of_clauses(clauses, expected, :fn, stack, {none(), context})
+    domain = Enum.map(patterns, fn _ -> dynamic() end)
+    {_acc, context} = of_clauses(clauses, domain, @pending, :ok, :fn, stack, {none(), context})
     {fun(), context}
   end
 
   # TODO: here
-  def of_expr({:try, _meta, [[do: body] ++ blocks]}, _expected_expr, stack, original) do
-    {type, context} = of_expr(body, @expected_expr, stack, original)
+  def of_expr({:try, _meta, [[do: body] ++ blocks]}, expected, expr, stack, original) do
     {after_block, blocks} = Keyword.pop(blocks, :after)
     {else_block, blocks} = Keyword.pop(blocks, :else)
 
     {type, context} =
       if else_block do
-        of_clauses(else_block, [type], {:try_else, type}, stack, {none(), context})
+        {type, context} = of_expr(body, @pending, :ok, stack, original)
+
+        of_clauses(
+          else_block,
+          [type],
+          expected,
+          expr,
+          {:try_else, type},
+          stack,
+          {none(), context}
+        )
       else
-        {type, context}
+        of_expr(body, expected, expr, stack, original)
       end
 
     {type, context} =
@@ -332,12 +349,20 @@ defmodule Module.Types.Expr do
           end)
 
         {:catch, clauses}, {acc, context} ->
-          of_clauses(clauses, [@try_catch, dynamic()], :try_catch, stack, {acc, context})
+          of_clauses(
+            clauses,
+            [@try_catch, dynamic()],
+            expected,
+            expr,
+            :try_catch,
+            stack,
+            {acc, context}
+          )
       end)
       |> dynamic_unless_static(stack)
 
     if after_block do
-      {_type, context} = of_expr(after_block, @expected_expr, stack, context)
+      {_type, context} = of_expr(after_block, @term, :ok, stack, context)
       {type, context}
     else
       {type, context}
@@ -347,18 +372,18 @@ defmodule Module.Types.Expr do
   @timeout_type union(integer(), atom([:infinity]))
 
   # TODO: here
-  def of_expr({:receive, _meta, [blocks]}, expected_expr, stack, original) do
+  def of_expr({:receive, _meta, [blocks]}, expected, expr, stack, original) do
     blocks
     |> Enum.reduce({none(), original}, fn
       {:do, {:__block__, _, []}}, acc_context ->
         acc_context
 
       {:do, clauses}, acc_context ->
-        of_clauses(clauses, [dynamic()], :receive, stack, acc_context)
+        of_clauses(clauses, [dynamic()], expected, expr, :receive, stack, acc_context)
 
       {:after, [{:->, meta, [[timeout], body]}] = after_expr}, {acc, context} ->
-        {timeout_type, context} = of_expr(timeout, {@timeout_type, after_expr}, stack, context)
-        {body_type, context} = of_expr(body, expected_expr, stack, context)
+        {timeout_type, context} = of_expr(timeout, @timeout_type, after_expr, stack, context)
+        {body_type, context} = of_expr(body, expected, expr, stack, context)
 
         if compatible?(timeout_type, @timeout_type) do
           {union(body_type, acc), reset_vars(context, original)}
@@ -372,7 +397,7 @@ defmodule Module.Types.Expr do
 
   # TODO: for pat <- expr do expr end
   # TODO: here
-  def of_expr({:for, meta, [_ | _] = args}, _expected_expr, stack, context) do
+  def of_expr({:for, meta, [_ | _] = args}, expected, expr, stack, context) do
     {clauses, [[{:do, block} | opts]]} = Enum.split(args, -1)
     context = Enum.reduce(clauses, context, &for_clause(&1, stack, &2))
 
@@ -380,14 +405,14 @@ defmodule Module.Types.Expr do
     # We handle reduce and into accordingly instead.
     if Keyword.has_key?(opts, :reduce) do
       reduce = Keyword.fetch!(opts, :reduce)
-      {reduce_type, context} = of_expr(reduce, @expected_expr, stack, context)
+      {reduce_type, context} = of_expr(reduce, expected, expr, stack, context)
       # TODO: We need to type check against dynamic() instead of using reduce_type
       # because this is recursive. We need to infer the block type first.
-      of_clauses(block, [dynamic()], :for_reduce, stack, {reduce_type, context})
+      of_clauses(block, [dynamic()], expected, expr, :for_reduce, stack, {reduce_type, context})
     else
       into = Keyword.get(opts, :into, [])
       {into_wrapper, gradual?, context} = for_into(into, meta, stack, context)
-      {block_type, context} = of_expr(block, @expected_expr, stack, context)
+      {block_type, context} = of_expr(block, @pending, :ok, stack, context)
 
       for_type =
         for type <- into_wrapper do
@@ -405,7 +430,7 @@ defmodule Module.Types.Expr do
 
   # TODO: with pat <- expr do expr end
   # TODO: here
-  def of_expr({:with, _meta, [_ | _] = clauses}, _expected_expr, stack, original) do
+  def of_expr({:with, _meta, [_ | _] = clauses}, _expected, _expr, stack, original) do
     {clauses, [options]} = Enum.split(clauses, -1)
     context = Enum.reduce(clauses, original, &with_clause(&1, stack, &2))
     context = Enum.reduce(options, context, &with_option(&1, stack, &2, original))
@@ -413,11 +438,12 @@ defmodule Module.Types.Expr do
   end
 
   # TODO: fun.(args)
-  def of_expr({{:., meta, [fun]}, _meta, args} = call, _expected_expr, stack, context) do
-    {fun_type, context} = of_expr(fun, {fun(), call}, stack, context)
+  # TODO: here
+  def of_expr({{:., meta, [fun]}, _meta, args} = call, _expected, _expr, stack, context) do
+    {fun_type, context} = of_expr(fun, fun(), call, stack, context)
 
     {_args_types, context} =
-      Enum.map_reduce(args, context, &of_expr(&1, @expected_expr, stack, &2))
+      Enum.map_reduce(args, context, &of_expr(&1, @pending, :ok, stack, &2))
 
     case fun_fetch(fun_type, length(args)) do
       :ok ->
@@ -430,28 +456,29 @@ defmodule Module.Types.Expr do
   end
 
   # TODO: here
-  def of_expr({{:., _, [callee, key_or_fun]}, meta, []} = expr, _expected_expr, stack, context)
+  def of_expr({{:., _, [callee, key_or_fun]}, meta, []} = call, expected, expr, stack, context)
       when not is_atom(callee) and is_atom(key_or_fun) do
     if Keyword.get(meta, :no_parens, false) do
-      {type, context} = of_expr(callee, {open_map([{key_or_fun, term()}]), expr}, stack, context)
-      Of.map_fetch(expr, type, key_or_fun, stack, context)
+      {type, context} = of_expr(callee, open_map([{key_or_fun, expected}]), expr, stack, context)
+      Of.map_fetch(call, type, key_or_fun, stack, context)
     else
-      {type, context} = of_expr(callee, {atom(), expr}, stack, context)
-      {mods, context} = Of.modules(type, key_or_fun, 0, [:dot], expr, meta, stack, context)
-      apply_many(mods, key_or_fun, [], [], expr, stack, context)
+      {type, context} = of_expr(callee, atom(), call, stack, context)
+      {mods, context} = Of.modules(type, key_or_fun, 0, [:dot], call, meta, stack, context)
+      apply_many(mods, key_or_fun, [], [], call, stack, context)
     end
   end
 
   # TODO: here
   def of_expr(
-        {{:., _, [remote, :apply]}, _meta, [mod, fun, args]} = expr,
-        _expected_expr,
+        {{:., _, [remote, :apply]}, _meta, [mod, fun, args]} = call,
+        _expected,
+        _expr,
         stack,
         context
       )
       when remote in [Kernel, :erlang] and is_list(args) do
-    {mod_type, context} = of_expr(mod, {atom(), expr}, stack, context)
-    {fun_type, context} = of_expr(fun, {atom(), expr}, stack, context)
+    {mod_type, context} = of_expr(mod, atom(), call, stack, context)
+    {fun_type, context} = of_expr(fun, atom(), call, stack, context)
     improper_list? = Enum.any?(args, &match?({:|, _, [_, _]}, &1))
 
     case atom_fetch(fun_type) do
@@ -463,75 +490,76 @@ defmodule Module.Types.Expr do
           end
 
         {args_types, context} =
-          Enum.map_reduce(args, context, &of_expr(&1, @expected_expr, stack, &2))
+          Enum.map_reduce(args, context, &of_expr(&1, @pending, :ok, stack, &2))
 
         {types, context} =
           Enum.map_reduce(funs, context, fn fun, context ->
-            apply_many(mods, fun, args, args_types, expr, stack, context)
+            apply_many(mods, fun, args, args_types, call, stack, context)
           end)
 
         {Enum.reduce(types, &union/2), context}
 
       _ ->
-        {args_type, context} = of_expr(args, {list(term()), expr}, stack, context)
+        {args_type, context} = of_expr(args, list(term()), call, stack, context)
         args_types = [mod_type, fun_type, args_type]
-        Apply.remote(:erlang, :apply, [mod, fun, args], args_types, expr, stack, context)
+        Apply.remote(:erlang, :apply, [mod, fun, args], args_types, call, stack, context)
     end
   end
 
   # TODO: here
-  def of_expr({{:., _, [remote, name]}, meta, args} = expr, _expected_expr, stack, context) do
-    {remote_type, context} = of_expr(remote, {atom(), expr}, stack, context)
+  def of_expr({{:., _, [remote, name]}, meta, args} = call, _expected, _expr, stack, context) do
+    {remote_type, context} = of_expr(remote, atom(), call, stack, context)
 
     {args_types, context} =
-      Enum.map_reduce(args, context, &of_expr(&1, @expected_expr, stack, &2))
+      Enum.map_reduce(args, context, &of_expr(&1, @pending, :ok, stack, &2))
 
-    {mods, context} = Of.modules(remote_type, name, length(args), expr, meta, stack, context)
-    apply_many(mods, name, args, args_types, expr, stack, context)
+    {mods, context} = Of.modules(remote_type, name, length(args), call, meta, stack, context)
+    apply_many(mods, name, args, args_types, call, stack, context)
   end
 
   # TODO: &Foo.bar/1
   def of_expr(
-        {:&, _, [{:/, _, [{{:., _, [remote, name]}, meta, []}, arity]}]} = expr,
-        _expected_expr,
+        {:&, _, [{:/, _, [{{:., _, [remote, name]}, meta, []}, arity]}]} = call,
+        _expected,
+        _expr,
         stack,
         context
       )
       when is_atom(name) and is_integer(arity) do
-    {remote_type, context} = of_expr(remote, {atom(), expr}, stack, context)
-    {mods, context} = Of.modules(remote_type, name, arity, expr, meta, stack, context)
+    {remote_type, context} = of_expr(remote, atom(), call, stack, context)
+    {mods, context} = Of.modules(remote_type, name, arity, call, meta, stack, context)
     Apply.remote_capture(mods, name, arity, meta, stack, context)
   end
 
   # TODO: &foo/1
-  def of_expr({:&, _meta, [{:/, _, [{fun, meta, _}, arity]}]}, _expected_expr, stack, context) do
+  def of_expr({:&, _meta, [{:/, _, [{fun, meta, _}, arity]}]}, _expected, _expr, stack, context) do
     Apply.local_capture(fun, arity, meta, stack, context)
   end
 
   # Super
   # TODO: here
-  def of_expr({:super, meta, args} = expr, _expected_expr, stack, context) when is_list(args) do
+  def of_expr({:super, meta, args} = expr, _expected, _expr, stack, context) when is_list(args) do
     {_kind, fun} = Keyword.fetch!(meta, :super)
 
     {args_types, context} =
-      Enum.map_reduce(args, context, &of_expr(&1, @expected_expr, stack, &2))
+      Enum.map_reduce(args, context, &of_expr(&1, @pending, :ok, stack, &2))
 
     Apply.local(fun, args_types, expr, stack, context)
   end
 
   # Local calls
   # TODO: here
-  def of_expr({fun, _meta, args} = expr, _expected_expr, stack, context)
+  def of_expr({fun, _meta, args} = expr, _expected, _expr, stack, context)
       when is_atom(fun) and is_list(args) do
     {args_types, context} =
-      Enum.map_reduce(args, context, &of_expr(&1, @expected_expr, stack, &2))
+      Enum.map_reduce(args, context, &of_expr(&1, @pending, :ok, stack, &2))
 
     Apply.local(fun, args_types, expr, stack, context)
   end
 
   # var
   # TODO: here
-  def of_expr(var, {expected, expr}, stack, context) when is_var(var) do
+  def of_expr(var, expected, expr, stack, context) when is_var(var) do
     if stack.mode == :traversal do
       {dynamic(), context}
     else
@@ -574,7 +602,7 @@ defmodule Module.Types.Expr do
           context
       end
 
-    {type, context} = of_expr(body, @expected_expr, stack, context)
+    {type, context} = of_expr(body, @pending, :ok, stack, context)
     {type, reset_vars(context, original)}
   end
 
@@ -583,7 +611,7 @@ defmodule Module.Types.Expr do
   defp for_clause({:<-, meta, [left, right]}, stack, context) do
     expr = {:<-, [type_check: :generator] ++ meta, [left, right]}
     {pattern, guards} = extract_head([left])
-    {type, context} = of_expr(right, @expected_expr, stack, context)
+    {type, context} = of_expr(right, @pending, :ok, stack, context)
 
     context = Pattern.of_match(pattern, guards, dynamic(), expr, :for, stack, context)
 
@@ -594,7 +622,7 @@ defmodule Module.Types.Expr do
   end
 
   defp for_clause({:<<>>, _, [{:<-, meta, [left, right]}]} = expr, stack, context) do
-    {right_type, context} = of_expr(right, {binary(), expr}, stack, context)
+    {right_type, context} = of_expr(right, binary(), expr, stack, context)
     context = Pattern.of_match(left, binary(), expr, :for, stack, context)
 
     if compatible?(right_type, binary()) do
@@ -606,7 +634,7 @@ defmodule Module.Types.Expr do
   end
 
   defp for_clause(expr, stack, context) do
-    {_type, context} = of_expr(expr, @term_expected, stack, context)
+    {_type, context} = of_expr(expr, @term, expr, stack, context)
     context
   end
 
@@ -620,7 +648,7 @@ defmodule Module.Types.Expr do
 
   # TODO: Use the collectable protocol for the output
   defp for_into(into, meta, stack, context) do
-    {type, context} = of_expr(into, @expected_expr, stack, context)
+    {type, context} = of_expr(into, @pending, :ok, stack, context)
 
     # We use subtype? instead of compatible because we want to handle
     # only binary/list, even if a dynamic with something else is given.
@@ -648,22 +676,24 @@ defmodule Module.Types.Expr do
   defp with_clause({:<-, _meta, [left, right]} = expr, stack, context) do
     {pattern, guards} = extract_head([left])
     context = Pattern.of_match(pattern, guards, dynamic(), expr, :with, stack, context)
-    {_, context} = of_expr(right, @expected_expr, stack, context)
+    {_, context} = of_expr(right, @pending, :ok, stack, context)
     context
   end
 
   defp with_clause(expr, stack, context) do
-    {_type, context} = of_expr(expr, @expected_expr, stack, context)
+    {_type, context} = of_expr(expr, @pending, :ok, stack, context)
     context
   end
 
   defp with_option({:do, body}, stack, context, original) do
-    {_type, context} = of_expr(body, @expected_expr, stack, context)
+    {_type, context} = of_expr(body, @pending, :ok, stack, context)
     reset_vars(context, original)
   end
 
   defp with_option({:else, clauses}, stack, context, _original) do
-    {_, context} = of_clauses(clauses, [dynamic()], :with_else, stack, {none(), context})
+    {_, context} =
+      of_clauses(clauses, [dynamic()], @pending, :ok, :with_else, stack, {none(), context})
+
     context
   end
 
@@ -695,16 +725,15 @@ defmodule Module.Types.Expr do
   defp dynamic_unless_static({_, _} = output, %{mode: :static}), do: output
   defp dynamic_unless_static({type, context}, %{mode: _}), do: {dynamic(type), context}
 
-  defp of_clauses(clauses, expected, info, %{mode: mode} = stack, {acc, original}) do
+  defp of_clauses(clauses, domain, expected, expr, info, %{mode: mode} = stack, {acc, original}) do
     %{failed: failed?} = original
 
     Enum.reduce(clauses, {acc, original}, fn {:->, meta, [head, body]}, {acc, context} ->
       {failed?, context} = reset_failed(context, failed?)
       {patterns, guards} = extract_head(head)
+      {_trees, context} = Pattern.of_head(patterns, guards, domain, info, meta, stack, context)
 
-      {_trees, context} = Pattern.of_head(patterns, guards, expected, info, meta, stack, context)
-
-      {body, context} = of_expr(body, @expected_expr, stack, context)
+      {body, context} = of_expr(body, expected, expr, stack, context)
       context = context |> set_failed(failed?) |> reset_vars(original)
 
       if mode == :traversal do

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -148,7 +148,7 @@ defmodule Module.Types.Expr do
         type_fun = fn pattern_type, context ->
           # See if we can use the expected type to further refine the pattern type,
           # if we cannot, use the pattern type as that will fail later on.
-          {_ok_or_error, type} = compatible_intersection(pattern_type, expected)
+          {_ok_or_error, type} = compatible_intersection(dynamic(pattern_type), expected)
           of_expr(right_expr, type, expr, stack, context)
         end
 

--- a/lib/elixir/lib/module/types/helpers.ex
+++ b/lib/elixir/lib/module/types/helpers.ex
@@ -333,4 +333,19 @@ defmodule Module.Types.Helpers do
   The type to return when there is an error.
   """
   def error_type, do: Module.Types.Descr.dynamic()
+
+  ## Enum helpers
+
+  def zip_map_reduce(args1, args2, acc, fun) do
+    zip_map_reduce(args1, args2, [], acc, fun)
+  end
+
+  defp zip_map_reduce([arg1 | args1], [arg2 | args2], list, acc, fun) do
+    {item, acc} = fun.(arg1, arg2, acc)
+    zip_map_reduce(args1, args2, [item | list], acc, fun)
+  end
+
+  defp zip_map_reduce([], [], list, acc, _fun) do
+    {Enum.reverse(list), acc}
+  end
 end

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -366,7 +366,7 @@ defmodule Module.Types.Of do
 
         :expr ->
           left = annotate_interpolation(left, right)
-          {actual, context} = Module.Types.Expr.of_expr(left, {type, expr}, stack, context)
+          {actual, context} = Module.Types.Expr.of_expr(left, type, expr, stack, context)
           compatible(actual, type, expr, stack, context)
       end
 
@@ -406,7 +406,7 @@ defmodule Module.Types.Of do
 
   defp specifier_size(:expr, {:size, _, [arg]} = expr, stack, context)
        when not is_integer(arg) do
-    {actual, context} = Module.Types.Expr.of_expr(arg, {integer(), expr}, stack, context)
+    {actual, context} = Module.Types.Expr.of_expr(arg, integer(), expr, stack, context)
     {_, context} = compatible(actual, integer(), expr, stack, context)
     context
   end

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -59,7 +59,7 @@ defmodule Module.Types.Of do
             data = %{
               data
               | type: new_type,
-                off_traces: new_trace(expr, new_type, :default, stack, off_traces)
+                off_traces: new_trace(expr, new_type, stack, off_traces)
             }
 
             %{context | vars: %{vars | version => data}}
@@ -81,7 +81,7 @@ defmodule Module.Types.Of do
   because we want to refine types. Otherwise we should
   use compatibility.
   """
-  def refine_head_var(var, type, expr, formatter \\ :default, stack, context) do
+  def refine_head_var(var, type, expr, stack, context) do
     {var_name, meta, var_context} = var
     version = Keyword.fetch!(meta, :version)
 
@@ -92,7 +92,7 @@ defmodule Module.Types.Of do
         data = %{
           data
           | type: new_type,
-            off_traces: new_trace(expr, type, formatter, stack, off_traces)
+            off_traces: new_trace(expr, type, stack, off_traces)
         }
 
         context = %{context | vars: %{vars | version => data}}
@@ -110,7 +110,7 @@ defmodule Module.Types.Of do
           type: type,
           name: var_name,
           context: var_context,
-          off_traces: new_trace(expr, type, formatter, stack, [])
+          off_traces: new_trace(expr, type, stack, [])
         }
 
         context = %{context | vars: Map.put(vars, version, data)}
@@ -118,11 +118,11 @@ defmodule Module.Types.Of do
     end
   end
 
-  defp new_trace(nil, _type, _formatter, _stack, traces),
+  defp new_trace(nil, _type, _stack, traces),
     do: traces
 
-  defp new_trace(expr, type, formatter, stack, traces),
-    do: [{expr, stack.file, type, formatter} | traces]
+  defp new_trace(expr, type, stack, traces),
+    do: [{expr, stack.file, type} | traces]
 
   ## Implementations
 

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -52,26 +52,23 @@ defmodule Module.Types.Of do
     version = Keyword.fetch!(meta, :version)
     %{vars: %{^version => %{type: old_type, off_traces: off_traces} = data} = vars} = context
 
-    context =
-      if gradual?(old_type) and type not in [term(), dynamic()] do
-        case compatible_intersection(old_type, type) do
-          {:ok, new_type} when new_type != old_type ->
-            data = %{
-              data
-              | type: new_type,
-                off_traces: new_trace(expr, new_type, stack, off_traces)
-            }
+    if gradual?(old_type) and type not in [term(), dynamic()] do
+      case compatible_intersection(old_type, type) do
+        {:ok, new_type} when new_type != old_type ->
+          data = %{
+            data
+            | type: new_type,
+              off_traces: new_trace(expr, new_type, stack, off_traces)
+          }
 
-            %{context | vars: %{vars | version => data}}
+          {new_type, %{context | vars: %{vars | version => data}}}
 
-          _ ->
-            context
-        end
-      else
-        context
+        _ ->
+          {old_type, context}
       end
-
-    {old_type, context}
+    else
+      {old_type, context}
+    end
   end
 
   @doc """
@@ -173,34 +170,70 @@ defmodule Module.Types.Of do
   @doc """
   Builds a closed map.
   """
-  def closed_map(pairs, stack, context, of_fun) do
-    permutate_map(pairs, stack, context, of_fun, fn fallback, _keys, pairs ->
-      # TODO: Use the fallback type to actually indicate if open or closed.
-      if fallback == none(), do: closed_map(pairs), else: open_map(pairs)
-    end)
+  def closed_map(pairs, expected, stack, context, of_fun) do
+    {pairs_types, context} = pairs(pairs, expected, stack, context, of_fun)
+
+    map =
+      permutate_map(pairs_types, stack, fn fallback, _keys, pairs ->
+        # TODO: Use the fallback type to actually indicate if open or closed.
+        if fallback == none(), do: closed_map(pairs), else: open_map(pairs)
+      end)
+
+    {map, context}
   end
 
   @doc """
-  Builds permutation of maps according to the given keys.
+  Computes the types of key-value pairs.
   """
-  def permutate_map(pairs, %{mode: :traversal} = stack, context, of_fun, _of_map) do
-    context =
-      Enum.reduce(pairs, context, fn {key, value}, context ->
-        {_, context} = of_fun.(key, stack, context)
-        {_, context} = of_fun.(value, stack, context)
-        context
-      end)
-
-    {dynamic(), context}
+  def pairs(pairs, _expected, %{mode: :traversal} = stack, context, of_fun) do
+    Enum.map_reduce(pairs, context, fn {key, value}, context ->
+      {_key_type, context} = of_fun.(key, term(), stack, context)
+      {value_type, context} = of_fun.(value, term(), stack, context)
+      {{true, :none, value_type}, context}
+    end)
   end
 
-  def permutate_map(pairs, stack, context, of_fun, of_map) do
-    {dynamic?, fallback, single, multiple, assert, context} =
-      Enum.reduce(pairs, {false, none(), [], [], [], context}, fn
-        {key, value}, {dynamic?, fallback, single, multiple, assert, context} ->
-          {dynamic_key?, keys, context} = finite_key_type(key, stack, context, of_fun)
-          {value_type, context} = of_fun.(value, stack, context)
-          dynamic? = dynamic? or dynamic_key? or gradual?(value_type)
+  def pairs(pairs, expected, stack, context, of_fun) do
+    Enum.map_reduce(pairs, context, fn {key, value}, context ->
+      {dynamic_key?, keys, context} = finite_key_type(key, stack, context, of_fun)
+
+      expected_value_type =
+        with [key] <- keys, {_, expected_value_type} <- map_fetch(expected, key) do
+          expected_value_type
+        else
+          _ -> term()
+        end
+
+      {value_type, context} = of_fun.(value, expected_value_type, stack, context)
+      {{dynamic_key? or gradual?(value_type), keys, value_type}, context}
+    end)
+  end
+
+  defp finite_key_type(key, _stack, context, _of_fun) when is_atom(key) do
+    {false, [key], context}
+  end
+
+  defp finite_key_type(key, stack, context, of_fun) do
+    {key_type, context} = of_fun.(key, term(), stack, context)
+
+    case atom_fetch(key_type) do
+      {:finite, list} -> {gradual?(key_type), list, context}
+      _ -> {gradual?(key_type), :none, context}
+    end
+  end
+
+  @doc """
+  Builds permutation of maps according to the given pairs types.
+  """
+  def permutate_map(_pairs_types, %{mode: :traversal}, _of_map) do
+    dynamic()
+  end
+
+  def permutate_map(pairs_types, _stack, of_map) do
+    {dynamic?, fallback, single, multiple, assert} =
+      Enum.reduce(pairs_types, {false, none(), [], [], []}, fn
+        {dynamic_pair?, keys, value_type}, {dynamic?, fallback, single, multiple, assert} ->
+          dynamic? = dynamic? or dynamic_pair?
 
           case keys do
             :none ->
@@ -216,13 +249,15 @@ defmodule Module.Types.Of do
                   {union(fallback, type), keys ++ assert}
                 end)
 
-              {dynamic?, fallback, [], [], assert, context}
+              {dynamic?, fallback, [], [], assert}
 
+            # Because a multiple key may override single keys, we can only
+            # collect single keys while there are no multiples.
             [key] when multiple == [] ->
-              {dynamic?, fallback, [{key, value_type} | single], multiple, assert, context}
+              {dynamic?, fallback, [{key, value_type} | single], multiple, assert}
 
             keys ->
-              {dynamic?, fallback, single, [{keys, value_type} | multiple], assert, context}
+              {dynamic?, fallback, single, [{keys, value_type} | multiple], assert}
           end
       end)
 
@@ -238,20 +273,7 @@ defmodule Module.Types.Of do
           |> Enum.reduce(&union/2)
       end
 
-    if dynamic?, do: {dynamic(map), context}, else: {map, context}
-  end
-
-  defp finite_key_type(key, _stack, context, _of_fun) when is_atom(key) do
-    {false, [key], context}
-  end
-
-  defp finite_key_type(key, stack, context, of_fun) do
-    {key_type, context} = of_fun.(key, stack, context)
-
-    case atom_fetch(key_type) do
-      {:finite, list} -> {gradual?(key_type), list, context}
-      _ -> {gradual?(key_type), :none, context}
-    end
+    if dynamic?, do: dynamic(map), else: map
   end
 
   defp cartesian_map(lists) do
@@ -267,17 +289,27 @@ defmodule Module.Types.Of do
   @doc """
   Handles instantiation of a new struct.
   """
-  def struct_instance(struct, args, meta, stack, context, of_fun)
+  # TODO: Type check the fields match the struct
+  def struct_instance(struct, args, expected, meta, %{mode: mode} = stack, context, of_fun)
       when is_atom(struct) do
+    {_info, context} = struct_info(struct, meta, stack, context)
+
     # The compiler has already checked the keys are atoms and which ones are required.
     {args_types, context} =
       Enum.map_reduce(args, context, fn {key, value}, context when is_atom(key) ->
-        {type, context} = of_fun.(value, stack, context)
+        value_type =
+          with true <- mode != :traversal,
+               {_, expected_value_type} <- map_fetch(expected, key) do
+            expected_value_type
+          else
+            _ -> term()
+          end
+
+        {type, context} = of_fun.(value, value_type, stack, context)
         {{key, type}, context}
       end)
 
-    {info, context} = struct_info(struct, meta, stack, context)
-    {struct_type(struct, info, args_types), context}
+    {closed_map([{:__struct__, atom([struct])} | args_types]), context}
   end
 
   @doc """
@@ -306,8 +338,10 @@ defmodule Module.Types.Of do
   @doc """
   Builds a type from the struct info.
   """
+  # TODO: This function shuold not receive args_types once
+  # we introduce typed structs. They are only used by exceptions.
   def struct_type(struct, info, args_types \\ []) do
-    term = term()
+    term = dynamic()
     pairs = for %{field: field} <- info, do: {field, term}
     pairs = [{:__struct__, atom([struct])} | pairs]
     pairs = if args_types == [], do: pairs, else: pairs ++ args_types

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -124,9 +124,10 @@ defmodule Module.Types.Pattern do
     {tree, context} = of_pattern(pattern, [{:arg, 0, expr}], stack, context)
     {pattern_info, context} = pop_pattern_info(context)
     {expected, context} = expected_fun.(of_pattern_tree(tree, context), context)
+    tag = {:match, expected}
 
     {[type], context} =
-      of_single_pattern_recur(expected, {:match, expected}, tree, pattern_info, expr, stack, context)
+      of_single_pattern_recur(expected, tag, tree, pattern_info, expr, stack, context)
 
     {type, context}
   end
@@ -144,7 +145,10 @@ defmodule Module.Types.Pattern do
     context = init_pattern_info(context)
     {tree, context} = of_pattern(pattern, [{:arg, 0, expr}], stack, context)
     {pattern_info, context} = pop_pattern_info(context)
-    {_, context} = of_single_pattern_recur(expected, tag, tree, pattern_info, expr, stack, context)
+
+    {_, context} =
+      of_single_pattern_recur(expected, tag, tree, pattern_info, expr, stack, context)
+
     {_, context} = Enum.map_reduce(guards, context, &of_guard(&1, @guard, &1, stack, &2))
     context
   end

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -324,7 +324,8 @@ defmodule Module.Types.Pattern do
   and binary patterns.
   """
   def of_match_var({:^, _, [var]}, expected, expr, stack, context) do
-    Of.intersect(Of.var(var, context), expected, expr, stack, context)
+    {type, context} = Of.refine_existing_var(var, expected, expr, stack, context)
+    Of.intersect(type, expected, expr, stack, context)
   end
 
   def of_match_var({:_, _, _}, expected, _expr, _stack, context) do
@@ -687,7 +688,8 @@ defmodule Module.Types.Pattern do
   # ^var
   def of_guard({:^, _meta, [var]}, expected, expr, stack, context) do
     # This is by definition a variable defined outside of this pattern, so we don't track it.
-    Of.intersect(Of.var(var, context), expected, expr, stack, context)
+    {type, context} = Of.refine_existing_var(var, expected, expr, stack, context)
+    Of.intersect(type, expected, expr, stack, context)
   end
 
   # {...}

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -618,48 +618,28 @@ defmodule Module.Types.Pattern do
   # This function is public as it is invoked from Of.binary/4.
 
   # :atom
-  def of_guard(atom, expected, expr, stack, context) when is_atom(atom) do
-    if atom_type?(expected, atom) do
-      {atom([atom]), context}
-    else
-      {error_type(), Of.incompatible_error(expr, expected, atom([atom]), stack, context)}
-    end
+  def of_guard(atom, _expected, _expr, _stack, context) when is_atom(atom) do
+    {atom([atom]), context}
   end
 
   # 12
-  def of_guard(literal, expected, expr, stack, context) when is_integer(literal) do
-    if integer_type?(expected) do
-      {integer(), context}
-    else
-      {error_type(), Of.incompatible_error(expr, expected, integer(), stack, context)}
-    end
+  def of_guard(literal, _expected, _expr, _stack, context) when is_integer(literal) do
+    {integer(), context}
   end
 
   # 1.2
-  def of_guard(literal, expected, expr, stack, context) when is_float(literal) do
-    if float_type?(expected) do
-      {float(), context}
-    else
-      {error_type(), Of.incompatible_error(expr, expected, float(), stack, context)}
-    end
+  def of_guard(literal, _expected, _expr, _stack, context) when is_float(literal) do
+    {float(), context}
   end
 
   # "..."
-  def of_guard(literal, expected, expr, stack, context) when is_binary(literal) do
-    if binary_type?(expected) do
-      {binary(), context}
-    else
-      {error_type(), Of.incompatible_error(expr, expected, binary(), stack, context)}
-    end
+  def of_guard(literal, _expected, _expr, _stack, context) when is_binary(literal) do
+    {binary(), context}
   end
 
   # []
-  def of_guard([], expected, expr, stack, context) do
-    if empty_list_type?(expected) do
-      {empty_list(), context}
-    else
-      {error_type(), Of.incompatible_error(expr, expected, empty_list(), stack, context)}
-    end
+  def of_guard([], _expected, _expr, _stack, context) do
+    {empty_list(), context}
   end
 
   # [expr, ...]
@@ -691,13 +671,9 @@ defmodule Module.Types.Pattern do
   end
 
   # <<>>
-  def of_guard({:<<>>, _meta, args}, expected, expr, stack, context) do
-    if binary_type?(expected) do
-      context = Of.binary(args, :guard, stack, context)
-      {binary(), context}
-    else
-      {error_type(), Of.incompatible_error(expr, expected, binary(), stack, context)}
-    end
+  def of_guard({:<<>>, _meta, args}, _expected, _expr, stack, context) do
+    context = Of.binary(args, :guard, stack, context)
+    {binary(), context}
   end
 
   # ^var

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -177,7 +177,7 @@ defmodule Module.Types.Pattern do
 
               case of_pattern_var(path, actual, true, info, context) do
                 {type, reachable_var?} ->
-                  # If current type is already a subtype, there is nothing to refine.
+                  # Optimization: if current type is already a subtype, there is nothing to refine.
                   with %{^version => %{type: current_type}} <- context.vars,
                        true <- subtype?(current_type, type) do
                     {var_changed?, context}

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -674,9 +674,9 @@ defmodule Module.Types.Pattern do
     {prefix, suffix} = unpack_list(list, [])
 
     {prefix, context} =
-      Enum.map_reduce(prefix, context, &of_guard(&1, dynamic(), expr, stack, &2))
+      Enum.map_reduce(prefix, context, &of_guard(&1, term(), expr, stack, &2))
 
-    {suffix, context} = of_guard(suffix, dynamic(), expr, stack, context)
+    {suffix, context} = of_guard(suffix, term(), expr, stack, context)
     {non_empty_list(Enum.reduce(prefix, &union/2), suffix), context}
   end
 
@@ -712,14 +712,14 @@ defmodule Module.Types.Pattern do
 
   # {...}
   def of_guard({:{}, _meta, args}, _expected, expr, stack, context) do
-    {types, context} = Enum.map_reduce(args, context, &of_guard(&1, dynamic(), expr, stack, &2))
+    {types, context} = Enum.map_reduce(args, context, &of_guard(&1, term(), expr, stack, &2))
     {tuple(types), context}
   end
 
   # var.field
   def of_guard({{:., _, [callee, key]}, _, []} = map_fetch, _expected, expr, stack, context)
       when not is_atom(callee) do
-    {type, context} = of_guard(callee, dynamic(), expr, stack, context)
+    {type, context} = of_guard(callee, term(), expr, stack, context)
     Of.map_fetch(map_fetch, type, key, stack, context)
   end
 
@@ -727,7 +727,7 @@ defmodule Module.Types.Pattern do
   def of_guard({{:., _, [:erlang, function]}, _, args}, _expected, expr, stack, context)
       when function in [:==, :"/=", :"=:=", :"=/="] do
     {_args_type, context} =
-      Enum.map_reduce(args, context, &of_guard(&1, dynamic(), expr, stack, &2))
+      Enum.map_reduce(args, context, &of_guard(&1, term(), expr, stack, &2))
 
     {boolean(), context}
   end

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -686,15 +686,15 @@ defmodule Module.Types.Pattern do
   end
 
   # %Struct{...}
-  def of_guard({:%, meta, [module, {:%{}, _, args}]} = struct, _expected, _expr, stack, context)
+  def of_guard({:%, meta, [module, {:%{}, _, args}]} = struct, expected, _expr, stack, context)
       when is_atom(module) do
-    fun = &of_guard(&1, dynamic(), struct, &2, &3)
-    Of.struct_instance(module, args, meta, stack, context, fun)
+    fun = &of_guard(&1, &2, struct, &3, &4)
+    Of.struct_instance(module, args, expected, meta, stack, context, fun)
   end
 
   # %{...}
-  def of_guard({:%{}, _meta, args}, _expected, expr, stack, context) do
-    Of.closed_map(args, stack, context, &of_guard(&1, dynamic(), expr, &2, &3))
+  def of_guard({:%{}, _meta, args}, expected, expr, stack, context) do
+    Of.closed_map(args, expected, stack, context, &of_guard(&1, &2, expr, &3, &4))
   end
 
   # <<>>

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1825,6 +1825,10 @@ defmodule String do
   from a validation perspective (they will always produce the same output), but
   `:fast_ascii` can yield significant performance benefits in specific scenarios.
 
+  If anything else but a string is given as argument, it raises.
+
+  ## Fast ASCII
+
   If all of the following conditions are true, you may want to experiment with
   the `:fast_ascii` algorithm to see if it yields performance benefits in your
   specific scenario:
@@ -1857,9 +1861,6 @@ defmodule String do
 
       iex> String.valid?("a", :fast_ascii)
       true
-
-      iex> String.valid?(4)
-      ** (FunctionClauseError) no function clause matching in String.valid?/2
 
   """
   @spec valid?(t, :default | :fast_ascii) :: boolean

--- a/lib/elixir/pages/references/gradual-set-theoretic-types.md
+++ b/lib/elixir/pages/references/gradual-set-theoretic-types.md
@@ -96,7 +96,7 @@ On the other hand, type inference offers the benefit of enabling type checking f
 
   * Type inference of patterns (and guards in future releases) - the argument types of a function are automatically inferred based on patterns and guards, which capture and narrow types based on common Elixir constructs.
 
-  * Module-local inference of return types - the gradual return types of functions are computed considering all of the functions within the module itself. Any call to a function in another module is conservatively assumed to return `dynamic()`.
+  * Module-local inference of return types - the gradual return types of functions are computed considering all of the functions within the module itself. Any call to a function in another module is conservatively assumed to return `dynamic()` during inference.
 
 The last two items offer gradual reconstruction of type signatures. Our goal is to provide an efficient type reconstruction algorithm that can detect definite bugs in dynamic codebases, even in the absence of explicit type annotations. The gradual system focuses on proving cases where all combinations of a type *will* fail, rather than issuing warnings for cases where some combinations *might* error.
 

--- a/lib/elixir/pages/references/gradual-set-theoretic-types.md
+++ b/lib/elixir/pages/references/gradual-set-theoretic-types.md
@@ -90,17 +90,9 @@ Inferring type signatures comes with a series of trade-offs:
 
   * Cascading errors - when a user accidentally makes type errors or the code has conflicting assumptions, type inference may lead to less clear error messages as the type system tries to reconcile diverging type assumptions across code paths.
 
-On the other hand, type inference offers the benefit of enabling type checking for functions and codebases without requiring the user to add type annotations. To balance these trade-offs, Elixir’s type system provides the following type reconstruction capabilities:
+On the other hand, type inference offers the benefit of enabling type checking for functions and codebases without requiring the user to add type annotations. To balance these trade-offs, Elixir performs module-local inference: the arguments, returns types, and all variables in a function are computed considering all of the function calls to the same module and to Elixir's standard library. Any call to a function in another module is conservatively assumed to return `dynamic()` during inference. Our goal is to provide an efficient type reconstruction algorithm that can detect definite bugs in dynamic codebases, even in the absence of explicit type annotations.
 
-  * Local type inference - the type system automatically infer the types of variables, at the place those variables are defined.
-
-  * Type inference of patterns (and guards in future releases) - the argument types of a function are automatically inferred based on patterns and guards, which capture and narrow types based on common Elixir constructs.
-
-  * Module-local inference of return types - the gradual return types of functions are computed considering all of the functions within the module itself. Any call to a function in another module is conservatively assumed to return `dynamic()` during inference.
-
-The last two items offer gradual reconstruction of type signatures. Our goal is to provide an efficient type reconstruction algorithm that can detect definite bugs in dynamic codebases, even in the absence of explicit type annotations. The gradual system focuses on proving cases where all combinations of a type *will* fail, rather than issuing warnings for cases where some combinations *might* error.
-
-Once Elixir introduces typed function signatures (see "Roadmap"), any function with an explicit type signature will be checked against the user-provided type, as in other statically typed languages, without performing type inference of the function signature.
+The gradual system focuses on proving cases where all combinations of a type *will* fail, rather than issuing warnings for cases where some combinations *might* error. Once Elixir introduces typed function signatures (see "Roadmap"), any function with an explicit type signature will be checked against the user-provided type, as in other statically typed languages, without performing type inference.
 
 ## Roadmap
 

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -53,11 +53,11 @@ defmodule Calendar.ISOTest do
   describe "naive_datetime_to_iso_days/7" do
     test "raises with invalid dates" do
       assert_raise ArgumentError, "invalid date: 2018-02-30", fn ->
-        Calendar.ISO.naive_datetime_to_iso_days(2018, 2, 30, 0, 0, 0, 0)
+        Calendar.ISO.naive_datetime_to_iso_days(2018, 2, 30, 0, 0, 0, {0, 0})
       end
 
       assert_raise ArgumentError, "invalid date: 2017-11--03", fn ->
-        Calendar.ISO.naive_datetime_to_iso_days(2017, 11, -3, 0, 0, 0, 0)
+        Calendar.ISO.naive_datetime_to_iso_days(2017, 11, -3, 0, 0, 0, {0, 0})
       end
     end
   end

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -595,10 +595,9 @@ defmodule Inspect.MapTest do
 
     {my_argument_error, stacktrace} =
       try do
-        atom_to_string(failing.name)
+        atom_to_string(Process.get(:unused, failing.name))
       rescue
-        e ->
-          {e, __STACKTRACE__}
+        e -> {e, __STACKTRACE__}
       end
 
     inspected =

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -51,11 +51,6 @@ defmodule IntegerTest do
     assert_raise ArithmeticError, fn -> Integer.mod(-50, 0) end
   end
 
-  test "mod/2 raises ArithmeticError when non-integers used as arguments" do
-    assert_raise ArithmeticError, fn -> Integer.mod(3.0, 2) end
-    assert_raise ArithmeticError, fn -> Integer.mod(20, 1.2) end
-  end
-
   test "floor_div/2" do
     assert Integer.floor_div(3, 2) == 1
     assert Integer.floor_div(0, 10) == 0

--- a/lib/elixir/test/elixir/kernel/comprehension_test.exs
+++ b/lib/elixir/test/elixir/kernel/comprehension_test.exs
@@ -147,7 +147,7 @@ defmodule Kernel.ComprehensionTest do
 
   test "for comprehensions with errors on filters" do
     assert_raise ArgumentError, fn ->
-      for x <- 1..3, hd(x), do: x * 2
+      for x <- 1..3, hd(x), do: :ok
     end
   end
 
@@ -338,7 +338,7 @@ defmodule Kernel.ComprehensionTest do
 
   test "list for comprehensions with errors on filters" do
     assert_raise ArgumentError, fn ->
-      for x <- [1, 2, 3], hd(x), do: x * 2
+      for x <- [1, 2, 3], hd(Process.get(:unused, x)), do: x * 2
     end
   end
 

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -941,7 +941,7 @@ defmodule Kernel.ErrorsTest do
 
   test "failed remote call stacktrace includes file/line info" do
     try do
-      bad_remote_call(1)
+      bad_remote_call(Process.get(:unused, 1))
     rescue
       ArgumentError ->
         assert [

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -2387,6 +2387,15 @@ defmodule Kernel.ExpansionTest do
                |> clean_bit_modifiers()
     end
 
+    test "invalid match" do
+      assert_compile_error(
+        "a bitstring only accepts binaries, numbers, and variables inside a match",
+        fn ->
+          expand(quote(do: <<%{}>> = foo()))
+        end
+      )
+    end
+
     test "nested match" do
       assert expand(quote(do: <<foo = bar>>)) |> clean_meta([:alignment]) ==
                quote(do: <<foo = bar()::integer>>) |> clean_bit_modifiers()
@@ -2395,16 +2404,6 @@ defmodule Kernel.ExpansionTest do
              |> clean_meta([:alignment]) ==
                quote(do: <<45::integer, <<_::integer, _::binary>> = rest()::binary>>)
                |> clean_bit_modifiers()
-
-      message = ~r"cannot pattern match inside a bitstring that is already in match"
-
-      assert_compile_error(message, fn ->
-        expand(quote(do: <<bar = baz>> = foo()))
-      end)
-
-      assert_compile_error(message, fn ->
-        expand(quote(do: <<?-, <<_, _::binary>> = rest::binary>> = foo()))
-      end)
     end
 
     test "inlines binaries inside interpolation" do

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -1198,6 +1198,10 @@ defmodule Module.Types.DescrTest do
 
     test "dynamic" do
       assert dynamic() |> to_quoted_string() == "dynamic()"
+
+      assert dynamic(union(atom(), integer())) |> union(integer()) |> to_quoted_string() ==
+               "dynamic(atom()) or integer()"
+
       assert intersection(binary(), dynamic()) |> to_quoted_string() == "binary()"
 
       assert intersection(union(binary(), pid()), dynamic()) |> to_quoted_string() ==

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -579,20 +579,6 @@ defmodule Module.Types.DescrTest do
     end
   end
 
-  describe "queries" do
-    test "atom_type?" do
-      assert atom_type?(term(), :foo)
-      assert atom_type?(dynamic(), :foo)
-
-      assert atom_type?(atom([:foo, :bar]), :foo)
-      refute atom_type?(atom([:foo, :bar]), :baz)
-      assert atom_type?(negation(atom([:foo, :bar])), :baz)
-
-      refute atom_type?(union(atom([:foo, :bar]), integer()), :baz)
-      refute atom_type?(dynamic(union(atom([:foo, :bar]), integer())), :baz)
-    end
-  end
-
   describe "projections" do
     test "fun_fetch" do
       assert fun_fetch(term(), 1) == :error

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -1231,6 +1231,16 @@ defmodule Module.Types.ExprTest do
              ) == dynamic(atom([:ok, :error, :timeout]))
     end
 
+    test "infers type for timeout" do
+      assert typecheck!(
+               [x],
+               receive do
+               after
+                 x -> x
+               end
+             ) == dynamic(union(integer(), atom([:infinity])))
+    end
+
     test "resets branches" do
       assert typecheck!(
                [x, timeout = :infinity],

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -179,11 +179,11 @@ defmodule Module.Types.ExprTest do
       assert typecheck!(
                [x],
                (
-                 x.foo_bar
-                 x.baz_bat
+                 :foo = x.foo_bar
+                 123 = x.baz_bat
                  x
                )
-             ) == dynamic(open_map(foo_bar: term(), baz_bat: term()))
+             ) == dynamic(open_map(foo_bar: atom([:foo]), baz_bat: integer()))
     end
 
     test "undefined function warnings" do

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -495,6 +495,16 @@ defmodule Module.Types.ExprTest do
       assert typecheck!([x], {:ok, x}) == dynamic(tuple([atom([:ok]), term()]))
     end
 
+    test "inference" do
+      assert typecheck!(
+               [x, y],
+               (
+                 {:ok, :error} = {x, y}
+                 {x, y}
+               )
+             ) == dynamic(tuple([atom([:ok]), atom([:error])]))
+    end
+
     test "elem/2" do
       assert typecheck!(elem({:ok, 123}, 0)) == atom([:ok])
       assert typecheck!(elem({:ok, 123}, 1)) == integer()
@@ -618,7 +628,7 @@ defmodule Module.Types.ExprTest do
                """
     end
 
-    test "duplicate/2" do
+    test "Tuple.duplicate/2" do
       assert typecheck!(Tuple.duplicate(123, 0)) == tuple([])
       assert typecheck!(Tuple.duplicate(123, 1)) == tuple([integer()])
       assert typecheck!(Tuple.duplicate(123, 2)) == tuple([integer(), integer()])

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -196,6 +196,16 @@ defmodule Module.Types.ExprTest do
              ) == dynamic(open_map(foo_bar: atom([:foo]), baz_bat: integer()))
     end
 
+    test "infers args" do
+      assert typecheck!(
+               [x, y],
+               (
+                 z = Integer.to_string(x + y)
+                 {x, y, z}
+               )
+             ) == dynamic(tuple([integer(), integer(), binary()]))
+    end
+
     test "undefined function warnings" do
       assert typewarn!(URI.unknown("foo")) ==
                {dynamic(), "URI.unknown/1 is undefined or private"}

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -922,93 +922,90 @@ defmodule Module.Types.ExprTest do
     end
 
     test "warns when comparison is constant" do
-      assert typewarn!([x = :foo, y = 321], min(x, y)) ==
-               {dynamic(union(integer(), atom([:foo]))),
-                ~l"""
-                comparison between distinct types found:
+      assert typeerror!([x = :foo, y = 321], min(x, y)) ==
+               ~l"""
+               comparison between distinct types found:
 
-                    min(x, y)
+                   min(x, y)
 
-                given types:
+               given types:
 
-                    min(dynamic(:foo), integer())
+                   min(dynamic(:foo), integer())
 
-                where "x" was given the type:
+               where "x" was given the type:
 
-                    # type: dynamic(:foo)
-                    # from: types_test.ex:LINE-2
-                    x = :foo
+                   # type: dynamic(:foo)
+                   # from: types_test.ex:LINE-1
+                   x = :foo
 
-                where "y" was given the type:
+               where "y" was given the type:
 
-                    # type: integer()
-                    # from: types_test.ex:LINE-2
-                    y = 321
+                   # type: integer()
+                   # from: types_test.ex:LINE-1
+                   y = 321
 
-                While Elixir can compare across all types, you are comparing across types \
-                which are always disjoint, and the result is either always true or always false
-                """}
+               While Elixir can compare across all types, you are comparing across types \
+               which are always disjoint, and the result is either always true or always false
+               """
 
-      assert typewarn!([x = 123, y = 456.0], x === y) ==
-               {boolean(),
-                ~l"""
-                comparison between distinct types found:
+      assert typeerror!([x = 123, y = 456.0], x === y) ==
+               ~l"""
+               comparison between distinct types found:
 
-                    x === y
+                   x === y
 
-                given types:
+               given types:
 
-                    integer() === float()
+                   integer() === float()
 
-                where "x" was given the type:
+               where "x" was given the type:
 
-                    # type: integer()
-                    # from: types_test.ex:LINE-2
-                    x = 123
+                   # type: integer()
+                   # from: types_test.ex:LINE-1
+                   x = 123
 
-                where "y" was given the type:
+               where "y" was given the type:
 
-                    # type: float()
-                    # from: types_test.ex:LINE-2
-                    y = 456.0
+                   # type: float()
+                   # from: types_test.ex:LINE-1
+                   y = 456.0
 
-                While Elixir can compare across all types, you are comparing across types \
-                which are always disjoint, and the result is either always true or always false
-                """}
+               While Elixir can compare across all types, you are comparing across types \
+               which are always disjoint, and the result is either always true or always false
+               """
     end
 
     test "warns on comparison with struct across dynamic call" do
-      assert typewarn!([x = :foo, y = %Point{}, mod = Kernel], mod.<=(x, y)) ==
-               {boolean(),
-                ~l"""
-                comparison with structs found:
+      assert typeerror!([x = :foo, y = %Point{}, mod = Kernel], mod.<=(x, y)) ==
+               ~l"""
+               comparison with structs found:
 
-                    mod.<=(x, y)
+                   mod.<=(x, y)
 
-                given types:
+               given types:
 
-                    dynamic(:foo) <= dynamic(%Point{})
+                   dynamic(:foo) <= dynamic(%Point{})
 
-                where "mod" was given the type:
+               where "mod" was given the type:
 
-                    # type: dynamic(Kernel)
-                    # from: types_test.ex:LINE-2
-                    mod = Kernel
+                   # type: dynamic(Kernel)
+                   # from: types_test.ex:LINE-1
+                   mod = Kernel
 
-                where "x" was given the type:
+               where "x" was given the type:
 
-                    # type: dynamic(:foo)
-                    # from: types_test.ex:LINE-2
-                    x = :foo
+                   # type: dynamic(:foo)
+                   # from: types_test.ex:LINE-1
+                   x = :foo
 
-                where "y" was given the type:
+               where "y" was given the type:
 
-                    # type: dynamic(%Point{})
-                    # from: types_test.ex:LINE-2
-                    y = %Point{}
+                   # type: dynamic(%Point{})
+                   # from: types_test.ex:LINE-1
+                   y = %Point{}
 
-                Comparison operators (>, <, >=, <=, min, and max) perform structural and not semantic comparison. Comparing with a struct won't give meaningful results. Structs that can be compared typically define a compare/2 function within their modules that can be used for semantic comparison.
-                """}
+               Comparison operators (>, <, >=, <=, min, and max) perform structural and not semantic comparison. Comparing with a struct won't give meaningful results. Structs that can be compared typically define a compare/2 function within their modules that can be used for semantic comparison.
+               """
     end
   end
 

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -1279,6 +1279,17 @@ defmodule Module.Types.ExprTest do
                  # from: types_test.ex:LINE-5
                  x = :timeout
              """
+
+      # Check for compatibility, not subtyping
+      assert typeerror!(
+               [<<x::integer, y::float>>],
+               receive do
+               after
+                 if(:rand.uniform(), do: x, else: y) -> :ok
+               end
+             ) =~ "expected "
+    after
+      " timeout given to receive to be an integer"
     end
   end
 
@@ -1551,6 +1562,13 @@ defmodule Module.Types.ExprTest do
 
                #{hints(:inferred_bitstring_spec)}
                """
+
+      # Check for compatibility, not subtyping
+      assert typeerror!(
+               [<<x::integer, y::binary>>],
+               for(<<i <- if(:rand.uniform() > 0.5, do: x, else: y)>>, do: i)
+             ) =~
+               "expected the right side of <- in a binary generator to be a binary"
     end
 
     test "infers binary generators" do

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -340,6 +340,16 @@ defmodule Module.Types.ExprTest do
   end
 
   describe "binaries" do
+    test "inference" do
+      assert typecheck!(
+               [x, y],
+               (
+                 <<x::float-size(y)>>
+                 {x, y}
+               )
+             ) == dynamic(tuple([union(float(), integer()), integer()]))
+    end
+
     test "warnings" do
       assert typeerror!([<<x::binary-size(2)>>], <<x::float>>) ==
                ~l"""
@@ -1606,7 +1616,7 @@ defmodule Module.Types.ExprTest do
              ) == dynamic(union(binary(), list(float())))
     end
 
-    test ":reduce" do
+    test ":reduce checks" do
       assert typecheck!(
                [list],
                for _ <- list, reduce: :ok do
@@ -1614,6 +1624,20 @@ defmodule Module.Types.ExprTest do
                  _ -> 2.0
                end
              ) == union(atom([:ok]), union(integer(), float()))
+    end
+
+    test ":reduce inference" do
+      assert typecheck!(
+               [list, x],
+               (
+                 123 =
+                   for _ <- list, reduce: x do
+                     x -> x
+                   end
+
+                 x
+               )
+             ) == dynamic(integer())
     end
   end
 

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -41,6 +41,16 @@ defmodule Module.Types.ExprTest do
       assert typecheck!([x], [:ok | x]) == dynamic(non_empty_list(term(), term()))
     end
 
+    test "inference" do
+      assert typecheck!(
+               [x, y, z],
+               (
+                 List.to_integer([x, y | z])
+                 {x, y, z}
+               )
+             ) == dynamic(tuple([integer(), integer(), list(integer())]))
+    end
+
     test "hd" do
       assert typecheck!([x = [123, :foo]], hd(x)) == dynamic(union(atom([:foo]), integer()))
       assert typecheck!([x = [123 | :foo]], hd(x)) == dynamic(integer())

--- a/lib/elixir/test/elixir/module/types/infer_test.exs
+++ b/lib/elixir/test/elixir/module/types/infer_test.exs
@@ -48,6 +48,22 @@ defmodule Module.Types.InferTest do
     assert types[{:fun4, 4}] == {:infer, [{args, atom([:ok])}]}
   end
 
+  test "infer types from expressions", config do
+    types =
+      infer config do
+        def fun(x) do
+          x.foo + x.bar
+        end
+      end
+
+    assert types[{:fun, 1}] ==
+             {:infer,
+              [
+                {[dynamic(open_map(foo: term(), bar: term()))],
+                 dynamic(union(integer(), float()))}
+              ]}
+  end
+
   test "infer with Elixir built-in", config do
     types =
       infer config do

--- a/lib/elixir/test/elixir/module/types/integration_test.exs
+++ b/lib/elixir/test/elixir/module/types/integration_test.exs
@@ -68,7 +68,7 @@ defmodule Module.Types.IntegrationTest do
 
       assert [
                {{:c, 0}, %{}},
-               {{:e, 0}, %{deprecated: "oops", sig: {:infer, _}}}
+               {{:e, 0}, %{deprecated: "oops", sig: {:infer, _, _}}}
              ] = read_chunk(modules[A]).exports
 
       assert read_chunk(modules[B]).exports == [
@@ -119,7 +119,7 @@ defmodule Module.Types.IntegrationTest do
       refute stderr =~ "this_wont_warn"
 
       itself_arg = fn mod ->
-        {_, %{sig: {:infer, [{[value], value}]}}} =
+        {_, %{sig: {:infer, nil, [{[value], value}]}}} =
           List.keyfind(read_chunk(modules[mod]).exports, {:itself, 1}, 0)
 
         value

--- a/lib/elixir/test/elixir/module/types/integration_test.exs
+++ b/lib/elixir/test/elixir/module/types/integration_test.exs
@@ -396,8 +396,10 @@ defmodule Module.Types.IntegrationTest do
 
             but expected a type that implements the String.Chars protocol, it must be one of:
 
-                %Date{} or %DateTime{} or %NaiveDateTime{} or %Time{} or %URI{} or %Version{} or
-                  %Version.Requirement{} or atom() or binary() or float() or integer() or list(term())
+                dynamic(
+                  %Date{} or %DateTime{} or %NaiveDateTime{} or %Time{} or %URI{} or %Version{} or
+                    %Version.Requirement{}
+                ) or atom() or binary() or float() or integer() or list(term())
 
             where "data" was given the type:
 
@@ -418,8 +420,10 @@ defmodule Module.Types.IntegrationTest do
 
             but expected a type that implements the String.Chars protocol, it must be one of:
 
-                %Date{} or %DateTime{} or %NaiveDateTime{} or %Time{} or %URI{} or %Version{} or
-                  %Version.Requirement{} or atom() or binary() or float() or integer() or list(term())
+                dynamic(
+                  %Date{} or %DateTime{} or %NaiveDateTime{} or %Time{} or %URI{} or %Version{} or
+                    %Version.Requirement{}
+                ) or atom() or binary() or float() or integer() or list(term())
 
             where "data" was given the type:
 
@@ -455,8 +459,10 @@ defmodule Module.Types.IntegrationTest do
 
             but expected a type that implements the Enumerable protocol, it must be one of:
 
-                %Date.Range{} or %File.Stream{} or %GenEvent.Stream{} or %HashDict{} or %HashSet{} or
-                  %IO.Stream{} or %MapSet{} or %Range{} or %Stream{} or fun() or list(term()) or non_struct_map()
+                dynamic(
+                  %Date.Range{} or %File.Stream{} or %GenEvent.Stream{} or %HashDict{} or %HashSet{} or
+                    %IO.Stream{} or %MapSet{} or %Range{} or %Stream{}
+                ) or fun() or list(term()) or non_struct_map()
 
             where "date" was given the type:
 
@@ -484,7 +490,7 @@ defmodule Module.Types.IntegrationTest do
 
             but expected a type that implements the Collectable protocol, it must be one of:
 
-                %File.Stream{} or %HashDict{} or %HashSet{} or %IO.Stream{} or %MapSet{} or binary() or
+                dynamic(%File.Stream{} or %HashDict{} or %HashSet{} or %IO.Stream{} or %MapSet{}) or binary() or
                   list(term()) or non_struct_map()
 
             hint: the :into option in for-comprehensions use the Collectable protocol to build its result. Either pass a valid data type or implement the protocol accordingly

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -42,9 +42,9 @@ defmodule Module.Types.PatternTest do
 
                where "name" was given the type:
 
-                   # type: dynamic()
-                   # from: types_test.ex
-                   {name, arity}
+                   # type: dynamic(atom())
+                   # from: types_test.ex:LINE-1
+                   Atom.to_charlist(name)
                """
     end
 

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -103,6 +103,16 @@ defmodule Module.Types.PatternTest do
              ) == uri_type
     end
 
+    test "refines types" do
+      assert typecheck!(
+               [x, foo = :foo, bar = 123],
+               (
+                 {^foo, ^bar} = x
+                 x
+               )
+             ) == dynamic(tuple([atom([:foo]), integer()]))
+    end
+
     test "reports incompatible types" do
       assert typeerror!([x = {:ok, _}], [_ | _] = x) == ~l"""
              the following pattern will never match:

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -287,6 +287,16 @@ defmodule Module.Types.PatternTest do
              """
     end
 
+    test "pin inference" do
+      assert typecheck!(
+               [x, y],
+               (
+                 <<^x>> = y
+                 x
+               )
+             ) == dynamic(integer())
+    end
+
     test "size ok" do
       assert typecheck!([<<x, y, _::size(x - y)>>], :ok) == atom([:ok])
     end
@@ -312,6 +322,16 @@ defmodule Module.Types.PatternTest do
                    # from: types_test.ex:LINE-1
                    <<x::float, ...>>
                """
+    end
+
+    test "size pin inference" do
+      assert typecheck!(
+               [x, y],
+               (
+                 <<_::size(^x)>> = y
+                 x
+               )
+             ) == dynamic(integer())
     end
   end
 end

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -42,9 +42,9 @@ defmodule Module.Types.PatternTest do
 
                where "name" was given the type:
 
-                   # type: dynamic(atom())
-                   # from: types_test.ex:LINE-1
-                   Atom.to_charlist(name)
+                   # type: dynamic()
+                   # from: types_test.ex
+                   {name, arity}
                """
     end
 

--- a/lib/elixir/test/elixir/module/types/type_helper.exs
+++ b/lib/elixir/test/elixir/module/types/type_helper.exs
@@ -116,12 +116,12 @@ defmodule TypeHelper do
 
   def __typecheck__(mode, patterns, guards, body) do
     stack = new_stack(mode)
-    expected = Enum.map(patterns, fn _ -> Module.Types.Descr.dynamic() end)
+    expected = Enum.map(patterns, fn _ -> Descr.dynamic() end)
 
     {_types, context} =
       Pattern.of_head(patterns, guards, expected, :default, [], stack, new_context())
 
-    Expr.of_expr(body, stack, context)
+    Expr.of_expr(body, {Descr.term(), :ok}, stack, context)
   end
 
   defp expand_and_unpack(patterns, guards, body, env) do

--- a/lib/elixir/test/elixir/module/types/type_helper.exs
+++ b/lib/elixir/test/elixir/module/types/type_helper.exs
@@ -118,7 +118,7 @@ defmodule TypeHelper do
     stack = new_stack(mode)
     expected = Enum.map(patterns, fn _ -> Descr.dynamic() end)
 
-    {_types, context} =
+    {_trees, context} =
       Pattern.of_head(patterns, guards, expected, :default, [], stack, new_context())
 
     Expr.of_expr(body, {Descr.term(), :ok}, stack, context)

--- a/lib/elixir/test/elixir/module/types/type_helper.exs
+++ b/lib/elixir/test/elixir/module/types/type_helper.exs
@@ -121,7 +121,7 @@ defmodule TypeHelper do
     {_trees, context} =
       Pattern.of_head(patterns, guards, expected, :default, [], stack, new_context())
 
-    Expr.of_expr(body, {Descr.term(), :ok}, stack, context)
+    Expr.of_expr(body, Descr.term(), :ok, stack, context)
   end
 
   defp expand_and_unpack(patterns, guards, body, env) do

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Compilers.Elixir do
   @moduledoc false
 
-  @manifest_vsn 27
+  @manifest_vsn 28
   @checkpoint_vsn 2
 
   import Record

--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -37,6 +37,7 @@ defmodule Mix.Tasks.Local.Hex do
   used for fetching Hex, set the `HEX_BUILDS_URL` environment variable.
   """
   @switches [if_missing: :boolean, force: :boolean]
+  @compile {:no_warn_undefined, {Hex, :version, 0}}
 
   @impl true
   def run(argv) do
@@ -46,8 +47,7 @@ defmodule Mix.Tasks.Local.Hex do
     should_install? =
       if Keyword.get(opts, :if_missing, false) do
         if version do
-          not Code.ensure_loaded?(Hex) or
-            Version.compare(apply(Hex, :version, []), version) == :gt
+          not Code.ensure_loaded?(Hex) or Version.compare(Hex.version(), version) == :gt
         else
           not Code.ensure_loaded?(Hex)
         end


### PR DESCRIPTION
Prior to this PR, we performed type inference only in patterns. This pull requests adds type inference to most expressions in Elixir, including function calls, paving the way for us to add inference of guards.

The best way to show this is with an example. The following code:

    def add_foo_bar(x) do
      x.foo + x.bar
    end

Will automatically infer that x is a map, which has at least the `.foo` and `.bar` keys, where their values must be integers or floats. The return type is either an integer or a float.

There are about 10 TODOs I must tackle before merging this.