### PR TITLE
mention alternatives to DateTime.compare/2 for comparison

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -13,8 +13,8 @@ defmodule DateTime do
 
   Remember, comparisons in Elixir using `==/2`, `>/2`, `</2` and friends
   are structural and based on the DateTime struct fields. For proper
-  comparison between datetimes, use the `compare/2` function. The
-  existence of the `compare/2` function in this module also allows
+  comparison between datetimes, use the `compare/2`, `after?/2` and `before?/2` functions.
+  The existence of the `compare/2` function in this module also allows
   using `Enum.min/2` and `Enum.max/2` functions to get the minimum and
   maximum datetime of an `Enum`. For example:
 


### PR DESCRIPTION
During our upgrade to Elixir 1.18 we got some compile warnings about the usage of `==` on `DateTime` structs. <https://hexdocs.pm/elixir/1.18.1/DateTime.html> suggested using `compare/2` which led to replacing

```elixir
  if user.password_reset_token_sent_at > oldest_allowed_token_datetime do
```

with

```elixir
  if DateTime.compare(user.password_reset_token_sent_at, oldest_allowed_token_datetime) == :gt do
```

However, a far better solution is:

```elixir
  if DateTime.after?(user.password_reset_token_sent_at, oldest_allowed_token_datetime) do
```

To make it easier for developers to think of these functions (`after?` and `before?`), I suggest mentioning them alongside `compare/2`.