### PR TITLE
[IEx][Autocomplete] Fix crashing on autocompleting structs

### DIFF
--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -362,7 +362,7 @@ defmodule IEx.Autocomplete do
       end)
 
     entries =
-      for {key, _value} <- pairs,
+      for key when key != :__struct__ <- Map.keys(pairs),
           name = Atom.to_string(key),
           if(hint == "",
             do: not String.starts_with?(name, "_"),

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -440,6 +440,21 @@ defmodule IEx.AutocompleteTest do
     assert {:yes, ~c"ry: ", []} = expand(~c"%URI{var | path: \"foo\", que")
     assert {:no, [], []} = expand(~c"%URI{var | path: \"foo\", unkno")
     assert {:no, [], []} = expand(~c"%Unknown{var | path: \"foo\", unkno")
+
+    eval "var = %URI{}"
+
+    assert {:yes, ~c"", entries} = expand(~c"%{var | ")
+    assert ~c"path:" in entries
+    assert ~c"query:" in entries
+
+    assert {:yes, ~c"", entries} = expand(~c"%{var | path: \"foo\",")
+    assert ~c"path:" not in entries
+    assert ~c"query:" in entries
+
+    assert {:yes, ~c"ry: ", []} = expand(~c"%{var | path: \"foo\", que")
+    assert {:no, [], []} = expand(~c"%URI{var | path: \"foo\", unkno")
+
+
   end
 
   test "completion for map keys in update syntax" do

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -453,8 +453,6 @@ defmodule IEx.AutocompleteTest do
 
     assert {:yes, ~c"ry: ", []} = expand(~c"%{var | path: \"foo\", que")
     assert {:no, [], []} = expand(~c"%URI{var | path: \"foo\", unkno")
-
-
   end
 
   test "completion for map keys in update syntax" do

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -441,7 +441,7 @@ defmodule IEx.AutocompleteTest do
     assert {:no, [], []} = expand(~c"%URI{var | path: \"foo\", unkno")
     assert {:no, [], []} = expand(~c"%Unknown{var | path: \"foo\", unkno")
 
-    eval "var = %URI{}"
+    eval("var = %URI{}")
 
     assert {:yes, ~c"", entries} = expand(~c"%{var | ")
     assert ~c"path:" in entries


### PR DESCRIPTION
Fixes the behaviour of autocompleting map update with structures described in issue #14149 

```elixir
iex> u = %URI{}
iex> %{u | 
```

Autocompleting the last line now works properly