### PR TITLE
mention alternatives to compare/2 for comparison in other dates and times

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -31,9 +31,10 @@ defmodule Date do
 
   Comparisons in Elixir using `==/2`, `>/2`, `</2` and similar are structural
   and based on the `Date` struct fields. For proper comparison between
-  dates, use the `compare/2` function. The existence of the `compare/2`
-  function in this module also allows using `Enum.min/2` and `Enum.max/2`
-  functions to get the minimum and maximum date of an `Enum`. For example:
+  dates, use the `compare/2`, `after?/2` and `before?/2` functions.
+  The existence of the `compare/2` function in this module also allows
+  using `Enum.min/2` and `Enum.max/2` functions to get the minimum and
+  maximum date of an `Enum`. For example:
 
       iex>  Enum.min([~D[2017-03-31], ~D[2017-04-01]], Date)
       ~D[2017-03-31]

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -36,10 +36,10 @@ defmodule NaiveDateTime do
 
   Comparisons in Elixir using `==/2`, `>/2`, `</2` and similar are structural
   and based on the `NaiveDateTime` struct fields. For proper comparison
-  between naive datetimes, use the `compare/2` function. The existence of the
-  `compare/2` function in this module also allows using `Enum.min/2` and
-  `Enum.max/2` functions to get the minimum and maximum naive datetime of an
-  `Enum`. For example:
+  between naive datetimes, use the `compare/2`, `after?/2` and `before?/2` functions.
+  The existence of the `compare/2` function in this module also allows
+  using `Enum.min/2` and `Enum.max/2` functions to get the minimum and
+  maximum naive datetime of an `Enum`. For example:
 
       iex> Enum.min([~N[2020-01-01 23:00:07], ~N[2000-01-01 23:00:07]], NaiveDateTime)
       ~N[2000-01-01 23:00:07]

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -31,9 +31,10 @@ defmodule Time do
 
   Comparisons in Elixir using `==/2`, `>/2`, `</2` and similar are structural
   and based on the `Time` struct fields. For proper comparison between
-  times, use the `compare/2` function. The existence of the `compare/2`
-  function in this module also allows using `Enum.min/2` and `Enum.max/2`
-  functions to get the minimum and maximum time of an `Enum`. For example:
+  times, use the `compare/2`, `after?/2` and `before?/2` functions.
+  The existence of the `compare/2` function in this module also allows
+  using `Enum.min/2` and `Enum.max/2` functions to get the minimum and
+  maximum time of an `Enum`. For example:
 
       iex> Enum.min([~T[23:00:07.001], ~T[10:00:07.001]], Time)
       ~T[10:00:07.001]


### PR DESCRIPTION
Similar to https://github.com/elixir-lang/elixir/pull/14147

During our upgrade to Elixir 1.18 we got some compile warnings about the usage of `==` on `DateTime` structs. <https://hexdocs.pm/elixir/1.18.1/DateTime.html> suggested using `compare/2` which led to replacing

```elixir
  if user.password_reset_token_sent_at > oldest_allowed_token_datetime do
```

with

```elixir
  if DateTime.compare(user.password_reset_token_sent_at, oldest_allowed_token_datetime) == :gt do
```

However, a far better solution is:

```elixir```
  if DateTime.after?(user.password_reset_token_sent_at, oldest_allowed_token_datetime) do
```

To make it easier for developers to think of these functions (`after?/2` and `before?/2`), I suggest mentioning them alongside `compare/2`.