### PR TITLE
Add override_for to dep options

### DIFF
--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -392,7 +392,7 @@ defmodule Mix.Dep do
     if dep.opts[:from_umbrella] || other.opts[:from_umbrella] do
       "Please remove the conflicting options from your definition"
     else
-      "Ensure they match or specify one of the above in your deps and set \"override: true\""
+      "Ensure they match or specify one of the above in your deps and set \"override: true\" or \"override_for:\""
     end
   end
 

--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -299,7 +299,7 @@ defmodule Mix.Dep.Converger do
         end
 
         cond do
-          in_upper? && other_opts[:override] ->
+          in_upper? && (other_opts[:override] || override_for?(other_opts, app)) ->
             {:match, list}
 
           not converge?(other, dep) ->
@@ -329,6 +329,10 @@ defmodule Mix.Dep.Converger do
             {:match, pre ++ [other | pos]}
         end
     end
+  end
+
+  defp override_for?(opts, app) do
+    !!opts[:override_for] && app in opts[:override_for]
   end
 
   defp with_matching_only_and_targets(other, dep, in_upper?) do

--- a/lib/mix/lib/mix/dep/fetcher.ex
+++ b/lib/mix/lib/mix/dep/fetcher.ex
@@ -110,6 +110,8 @@ defmodule Mix.Dep.Fetcher do
     Mix.Dep.Lock.write(lock, opts)
     mark_as_fetched(parent_deps)
 
+    evaluate_overrides(Enum.filter(deps, & &1.opts[:override_for]), deps)
+
     # See if any of the deps diverged and abort.
     show_diverged!(Enum.filter(all_deps, &Mix.Dep.diverged?/1))
 
@@ -154,6 +156,43 @@ defmodule Mix.Dep.Fetcher do
     Enum.map(given, fn app ->
       if is_binary(app), do: String.to_atom(app), else: app
     end)
+  end
+
+  defp evaluate_overrides([], _deps), do: :ok
+
+  defp evaluate_overrides(override_deps, deps) do
+    for override_dep <- override_deps,
+        dep <- deps,
+        dep_dependency <- dep.deps,
+        override_dep.app == dep_dependency.app do
+      overridden? = dep.app in override_dep.opts[:override_for]
+
+      {:ok, satisfied?} =
+        Mix.Dep.Loader.vsn_match(dep_dependency.requirement, override_dep.requirement, dep.app)
+
+      cond do
+        overridden? && satisfied? ->
+          show_expired_override(override_dep, dep.app)
+
+        not overridden? && not satisfied? ->
+          show_missing_override(override_dep, dep.app)
+
+        true ->
+          :ok
+      end
+    end
+
+    :ok
+  end
+
+  defp show_expired_override(dep, app) do
+    Mix.shell().info(
+      "Dependency #{Mix.Dep.format_dep(dep)} no longer requires override_for on #{app}"
+    )
+  end
+
+  defp show_missing_override(dep, app) do
+    Mix.shell().info("Dependency #{Mix.Dep.format_dep(dep)} requires override_for on #{app}")
   end
 
   defp show_diverged!([]), do: :ok

--- a/lib/mix/test/fixtures/deps_status/custom/override_for_repo/mix.exs
+++ b/lib/mix/test/fixtures/deps_status/custom/override_for_repo/mix.exs
@@ -1,0 +1,11 @@
+defmodule OverrideForRepo do
+  use Mix.Project
+
+  def project do
+    [
+      app: :override_for_repo,
+      version: "0.1.0",
+      deps: [{:git_repo, "0.3.0", [git: MixTest.Case.fixture_path("git_repo")]}]
+    ]
+  end
+end


### PR DESCRIPTION
override_for gives more information about when deps should explicitly be overridden or not.

If a dep no longer needs an override, a message will be written indicating so. Alternatively, if a dep needs an override when a dep is already using override_for, it will alert the dev.

With override: true set, if a user were to add a new dep that depends on the overridden app, there would be no indication of a potential issue.