### PR TITLE
Improve warning for charlist deprecation

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -826,9 +826,10 @@ handle_strings(T, Line, Column, H, Scope, Tokens) ->
       NewScope =
         case H of
           $' ->
-            Message = "single-quoted strings represent charlists. "
+            Message = "using single-quoted strings to represent charlists is deprecated.\n"
               "Use ~c\"\" if you indeed want a charlist or use \"\" instead.\n"
-              "You may run \"mix format --migrate\" to fix this warning automatically.",
+              "You may run \"mix format --migrate\" to change all single-quoted\n"
+              "strings to use the ~c sigil and fix this warning.",
             prepend_warning(Line, Column-1, Message, InterScope);
 
           _ ->


### PR DESCRIPTION
I was confused when I saw the current charlist warning and this PR slightly tweaks the language to make the reason for the warning clearer. Specifically I wanted to highlight that this is not a stylistic disagreement, but is about a deprecation, which the current language omits.

P.s. this is my first PR on elixir and would welcome feedback. A huge fan of the language and all of the work y'all do!