### PR TITLE
Fix ExUnit crash when diffing bitstring specifiers

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -878,7 +878,8 @@ defmodule ExUnit.Diff do
   end
 
   defp rebuild_split_strings(%{contents: contents, delimiter: delimiter}, right) do
-    %{contents: contents ++ [{false, right}], delimiter: delimiter}
+    {new_right, diff} = extract_diff_meta(right)
+    %{contents: contents ++ [{diff, new_right}], delimiter: delimiter}
   end
 
   defp rebuild_concat_string(literal, nil, []) do

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -1133,6 +1133,12 @@ defmodule ExUnit.DiffTest do
       "-<<trap::binary-size(3)>> <> \"baz\"-",
       "+\"foobar\"+"
     )
+
+    refute_diff(
+      "hello " <> <<_::binary-size(6)>> = "hello world",
+      "\"hello \" <> -<<_::binary-size(6)>>-",
+      "\"hello +world+\""
+    )
   end
 
   test "underscore" do


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/14157

<img width="642" alt="Screenshot 2025-01-09 at 9 05 36" src="https://github.com/user-attachments/assets/d6b45a38-2b27-462e-a7f1-af3b7615b04c" />
