### PR TITLE
Document VC++ required for Windows releases

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Release do
   Once a release is assembled, it can be packaged and deployed to a
   target, as long as the target runs on the same operating system (OS)
   distribution and version as the machine running the `mix release`
-  command.
+  command. Windows releases also require Microsoft Visual C++ Runtime.
 
   A release can be configured in your `mix.exs` file under the `:releases`
   key inside `def project`:


### PR DESCRIPTION
Without the VC++ Runtime you get an error when trying to run the release:
```
Unable to load emulator DLL
([...erts folder]\bin\beam.smp.dll)
```

Someone [ran into this before on the elixir forum](https://elixirforum.com/t/mix-release-or-rather-erl-exe-package-require-additional-files-to-work-standalone/29090) but the help was not updated.

Note: I have [asked in the Erlang forum](https://erlangforums.com/t/minimum-visual-c-runtime-version/4369) what the minimum version of the runtime is.