### PR TITLE
Improve clarity of Path.safe_relative/2 argument names

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -884,7 +884,7 @@ defmodule Path do
     * A `..` component would make it so that the path would traverse up above
       the root of `relative_to`.
 
-    * A symbolic link in the path points to something above the root of `cwd`.
+    * A symbolic link in the path points to something above the root of `relative_to`.
 
   ## Examples
 
@@ -906,10 +906,10 @@ defmodule Path do
   """
   @doc since: "1.14.0"
   @spec safe_relative(t, t) :: {:ok, binary} | :error
-  def safe_relative(path, cwd \\ File.cwd!()) do
+  def safe_relative(path, relative_to \\ File.cwd!()) do
     path = IO.chardata_to_string(path)
 
-    case :filelib.safe_relative_path(path, cwd) do
+    case :filelib.safe_relative_path(path, relative_to) do
       :unsafe -> :error
       relative_path -> {:ok, IO.chardata_to_string(relative_path)}
     end


### PR DESCRIPTION
Not a big issue, but while reading the docs for the function, I had a moment of confusion as they were referencing a `relative_to` argument which wasn't there in the function signature.

The PR switches from `cwd` to `relative_to`, which is more generic and more consistent with possible use cases of the function.