### PR TITLE
Remove duplicate call to mkdir in concurrency lock

### DIFF
--- a/lib/mix/lib/mix/sync/lock.ex
+++ b/lib/mix/lib/mix/sync/lock.ex
@@ -120,10 +120,9 @@ defmodule Mix.Sync.Lock do
   end
 
   defp base_path do
+    # We include user in the dir to avoid permission conflicts across users
     user = System.get_env("USER", "default")
-    path = Path.join([System.tmp_dir!(), "mix_lock_#{Base.url_encode64(user, padding: false)}"])
-    File.mkdir_p!(path)
-    path
+    Path.join(System.tmp_dir!(), "mix_lock_#{Base.url_encode64(user, padding: false)}")
   end
 
   defp lock_disabled?(), do: System.get_env("MIX_OS_CONCURRENCY_LOCK") in ~w(0 false)

--- a/lib/mix/lib/mix/sync/pubsub.ex
+++ b/lib/mix/lib/mix/sync/pubsub.ex
@@ -272,16 +272,15 @@ defmodule Mix.Sync.PubSub do
 
   defp hash(key), do: :erlang.md5(key)
 
-  defp base_path do
-    user = System.get_env("USER", "default")
-    path = Path.join([System.tmp_dir!(), "mix_pubsub_#{Base.url_encode64(user, padding: false)}"])
-    File.mkdir_p!(path)
-    path
-  end
-
   defp path(hash) do
     hash = Base.url_encode64(hash, padding: false)
     Path.join(base_path(), hash)
+  end
+
+  defp base_path do
+    # We include user in the dir to avoid permission conflicts across users
+    user = System.get_env("USER", "default")
+    Path.join(System.tmp_dir!(), "mix_pubsub_#{Base.url_encode64(user, padding: false)}")
   end
 
   defp recv(socket, size, timeout \\ :infinity) do


### PR DESCRIPTION
We call `File.mkdir_p!` when necessary down the line already, so there's no need for doing that twice.