### PR TITLE
Restore behaviour implicitly supporting `async: nil` in ExUnit

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -562,7 +562,7 @@ defmodule ExUnit.Case do
       |> Map.new()
 
     opts = Module.get_attribute(module, :ex_unit_module, [])
-    async? = Keyword.get(opts, :async, false)
+    async? = Keyword.get(opts, :async) || false
     group = Keyword.get(opts, :group, nil)
     parameterize = Keyword.get(opts, :parameterize, nil)
 


### PR DESCRIPTION
Intentionally or otherwise, https://github.com/elixir-lang/elixir/pull/13618/commits/c4556ef9d5c05874a5e216ff27939d89bca86a5b introduced a subtle change in `ExUnit.Case`. Previously `async: nil` was supported implicitly and interpreted as `async: false`. After this commit however, `async: nil` introduces unexpected behaviour.

Honestly, I'm not sure that it's actually a good idea to allow `async: nil`, but I'll highlight an illustrative example of how our test suite was broken by the change and how others might be affected.

* we have fairly typical `Hello.DataCase`
* we then have an additional `Hello.ExtendedDataCase` that builds on this
```elixir
defmodule Hello.ExtendedDataCase do
  use ExUnit.CaseTemplate

  using opts do
    use Hello.DataCase, async: unquote(opts[:async])
    # ...
  end
end
```

```elixir
# test/hello/some_test.exs
defmodule Hello.SomeTest do
  use Hello.ExtendedDataCase

  test "..." do
  end
end
```

When we run the above test, we get an error like this
```
== Compilation error in file test/hello/some_test.exs ==
** (RuntimeError) cannot add module named Hello.SomeTest to test suite after the suite starts running
    (ex_unit 1.18.1) lib/ex_unit/server.ex:31: ExUnit.Server.add_module/2
    (stdlib 6.2) lists.erl:2146: :lists.foldl/3
    (elixir 1.18.1) lib/kernel/parallel_compiler.ex:547: Kernel.ParallelCompiler.require_file/2
    (elixir 1.18.1) lib/kernel/parallel_compiler.ex:430: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/8
```


It's a fairly simple fix on our side, but I thought I would open a PR here in case the change would be considered a regression.
```diff
defmodule Hello.ExtendedDataCase do
  use ExUnit.CaseTemplate

  using opts do
-    use Hello.DataCase, async: unquote(opts[:async])
+    use Hello.DataCase, async: unquote(opts[:async] || false)
    # ...
  end
end
```
