### PR TITLE
Prevent crash on zero arity def in protocol

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -666,7 +666,7 @@ defmodule Protocol do
       end
 
     new_signatures =
-      for {{fun, arity}, :def, _, _} <- definitions do
+      for {{fun, arity}, :def, _, _} when arity > 0 <- definitions do
         rest = List.duplicate(Descr.term(), arity - 1)
         {{fun, arity}, {:strong, nil, [{[domain | rest], Descr.dynamic()}]}}
       end

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -684,7 +684,7 @@ defmodule Protocol do
     Enum.find_value(clauses, fn
       {_meta, [:functions], [], clauses} -> clauses
       _ -> nil
-    end)
+    end) || raise "could not find protocol functions"
   end
 
   defp change_protocol({_name, _kind, meta, clauses}, types) do

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -614,10 +614,12 @@ defmodule Protocol do
         {impl_for!, definitions} = List.keytake(definitions, {:impl_for!, 1}, 0)
         {struct_impl_for, definitions} = List.keytake(definitions, {:struct_impl_for, 1}, 0)
 
+        protocol_funs = get_protocol_functions(protocol_def)
+
         protocol_def = change_protocol(protocol_def, types)
         impl_for = change_impl_for(impl_for, protocol, types)
         struct_impl_for = change_struct_impl_for(struct_impl_for, protocol, types, structs)
-        new_signatures = new_signatures(definitions, protocol, types)
+        new_signatures = new_signatures(definitions, protocol_funs, protocol, types)
 
         definitions = [protocol_def, impl_for, impl_for!, struct_impl_for] ++ definitions
         signatures = Enum.into(new_signatures, signatures)
@@ -628,7 +630,7 @@ defmodule Protocol do
     end
   end
 
-  defp new_signatures(definitions, protocol, types) do
+  defp new_signatures(definitions, protocol_funs, protocol, types) do
     alias Module.Types.Descr
 
     clauses =
@@ -665,11 +667,9 @@ defmodule Protocol do
           end
       end
 
-    fun_arities = :sets.from_list(protocol.__protocol__(:functions), version: 2)
-
     new_signatures =
       for {{_fun, arity} = fun_arity, :def, _, _} <- definitions,
-          :sets.is_element(fun_arity, fun_arities) do
+          fun_arity in protocol_funs do
         rest = List.duplicate(Descr.term(), arity - 1)
         {fun_arity, {:strong, nil, [{[domain | rest], Descr.dynamic()}]}}
       end
@@ -678,6 +678,13 @@ defmodule Protocol do
       {{:impl_for, 1}, {:strong, [Descr.term()], impl_for}},
       {{:impl_for!, 1}, {:strong, [domain], impl_for!}}
     ] ++ new_signatures
+  end
+
+  defp get_protocol_functions({_name, _kind, _meta, clauses}) do
+    Enum.find_value(clauses, fn
+      {_meta, [:functions], [], clauses} -> clauses
+      _ -> nil
+    end)
   end
 
   defp change_protocol({_name, _kind, meta, clauses}, types) do

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -665,10 +665,13 @@ defmodule Protocol do
           end
       end
 
+    fun_arities = :sets.from_list(protocol.__protocol__(:functions), version: 2)
+
     new_signatures =
-      for {{fun, arity}, :def, _, _} when arity > 0 <- definitions do
+      for {{_fun, arity} = fun_arity, :def, _, _} <- definitions,
+          :sets.is_element(fun_arity, fun_arities) do
         rest = List.duplicate(Descr.term(), arity - 1)
-        {{fun, arity}, {:strong, nil, [{[domain | rest], Descr.dynamic()}]}}
+        {fun_arity, {:strong, nil, [{[domain | rest], Descr.dynamic()}]}}
       end
 
     [

--- a/lib/elixir/test/elixir/fixtures/consolidation/extra_def.ex
+++ b/lib/elixir/test/elixir/fixtures/consolidation/extra_def.ex
@@ -1,0 +1,5 @@
+defprotocol Protocol.ConsolidationTest.ExtraDef do
+  def protocol_fun(term)
+
+  Kernel.def(regular_fun(term), do: term + 1)
+end

--- a/lib/elixir/test/elixir/fixtures/consolidation/extra_def.ex
+++ b/lib/elixir/test/elixir/fixtures/consolidation/extra_def.ex
@@ -1,5 +1,0 @@
-defprotocol Protocol.ConsolidationTest.ExtraDef do
-  def protocol_fun(term)
-
-  Kernel.def(regular_fun(term), do: term + 1)
-end

--- a/lib/elixir/test/elixir/fixtures/consolidation/sample.ex
+++ b/lib/elixir/test/elixir/fixtures/consolidation/sample.ex
@@ -5,6 +5,8 @@ defprotocol Protocol.ConsolidationTest.Sample do
   @spec ok(t) :: boolean
   def ok(term)
 
-  # Not a protocol function
+  # Not a protocol function. While this is not "officially" supported,
+  # it does happen in practice, so we need to make sure we preserve
+  # its signature.
   Kernel.def(regular_fun(term), do: term + 1)
 end

--- a/lib/elixir/test/elixir/fixtures/consolidation/sample.ex
+++ b/lib/elixir/test/elixir/fixtures/consolidation/sample.ex
@@ -4,4 +4,7 @@ defprotocol Protocol.ConsolidationTest.Sample do
   @deprecated "Reason"
   @spec ok(t) :: boolean
   def ok(term)
+
+  # Not a protocol function
+  Kernel.def(regular_fun(term), do: term + 1)
 end

--- a/lib/elixir/test/elixir/protocol/consolidation_test.exs
+++ b/lib/elixir/test/elixir/protocol/consolidation_test.exs
@@ -8,7 +8,7 @@ Kernel.ParallelCompiler.compile_to_path(files, path, return_diagnostics: true)
 
 defmodule Protocol.ConsolidationTest do
   use ExUnit.Case, async: true
-  alias Protocol.ConsolidationTest.{Sample, WithAny, NoImpl}
+  alias Protocol.ConsolidationTest.{Sample, WithAny, NoImpl, ExtraDef}
 
   defimpl WithAny, for: Map do
     def ok(map, _opts) do
@@ -64,6 +64,14 @@ defmodule Protocol.ConsolidationTest do
   :code.load_binary(NoImpl, ~c"protocol_test.exs", binary)
 
   defp no_impl_binary, do: unquote(binary)
+
+  # No Any
+  :code.purge(ExtraDef)
+  :code.delete(ExtraDef)
+  {:ok, binary} = Protocol.consolidate(ExtraDef, [])
+  :code.load_binary(ExtraDef, ~c"protocol_test.exs", binary)
+
+  defp extra_def_binary, do: unquote(binary)
 
   test "consolidated?/1" do
     assert Protocol.consolidated?(WithAny)
@@ -232,6 +240,15 @@ defmodule Protocol.ConsolidationTest do
       assert clauses == [{[none()], none()}]
 
       assert %{{:ok, 1} => %{sig: {:strong, nil, clauses}}} = exports
+      assert clauses == [{[none()], dynamic()}]
+    end
+
+    test "handles regular function definitions" do
+      exports = exports(extra_def_binary())
+
+      assert %{{:regular_fun, 1} => %{sig: :none}} = exports
+
+      assert %{{:protocol_fun, 1} => %{sig: {:strong, nil, clauses}}} = exports
       assert clauses == [{[none()], dynamic()}]
     end
   end

--- a/lib/elixir/test/elixir/protocol/consolidation_test.exs
+++ b/lib/elixir/test/elixir/protocol/consolidation_test.exs
@@ -8,7 +8,7 @@ Kernel.ParallelCompiler.compile_to_path(files, path, return_diagnostics: true)
 
 defmodule Protocol.ConsolidationTest do
   use ExUnit.Case, async: true
-  alias Protocol.ConsolidationTest.{Sample, WithAny, NoImpl, ExtraDef}
+  alias Protocol.ConsolidationTest.{Sample, WithAny, NoImpl}
 
   defimpl WithAny, for: Map do
     def ok(map, _opts) do
@@ -64,14 +64,6 @@ defmodule Protocol.ConsolidationTest do
   :code.load_binary(NoImpl, ~c"protocol_test.exs", binary)
 
   defp no_impl_binary, do: unquote(binary)
-
-  # No Any
-  :code.purge(ExtraDef)
-  :code.delete(ExtraDef)
-  {:ok, binary} = Protocol.consolidate(ExtraDef, [])
-  :code.load_binary(ExtraDef, ~c"protocol_test.exs", binary)
-
-  defp extra_def_binary, do: unquote(binary)
 
   test "consolidated?/1" do
     assert Protocol.consolidated?(WithAny)
@@ -244,12 +236,9 @@ defmodule Protocol.ConsolidationTest do
     end
 
     test "handles regular function definitions" do
-      exports = exports(extra_def_binary())
+      exports = exports(sample_binary())
 
       assert %{{:regular_fun, 1} => %{sig: :none}} = exports
-
-      assert %{{:protocol_fun, 1} => %{sig: {:strong, nil, clauses}}} = exports
-      assert clauses == [{[none()], dynamic()}]
     end
   end
 


### PR DESCRIPTION
We can feel the excitement in the commits 😄 https://github.com/elixir-lang/elixir/pull/14145/commits/1763865312f8ad4c51c3a69450ad9e8d86921960.

I tried `main` on a project and got a compiler crash due to this [dependency](https://github.com/lexmag/msgpax/blob/e2f31aacdbd476fec4be6abbc88d51e0dfae8c9a/lib/msgpax/packer.ex#L110) which defines regular functions inside a protocol, basically:

```elixir
defprotocol Msgpax.Packer do
  def pack(term)

  Kernel.def(pack_nan(), do: <<0xCB, -1::64>>)
end
```

The lib should probably be fixed and we should probably not allow this in the first place (same spirit as https://github.com/elixir-lang/elixir/issues/14158), but right now this crashes the compiler on consolidation: (`fun: :pack_nan, arity: 0`)

```elixir
08:40:08.671 [error] Task #PID<0.7509.0> started from #PID<0.94.0> terminating
** (FunctionClauseError) no function clause matching in :lists.duplicate/2
    (stdlib 6.2) lists.erl:510: :lists.duplicate(-1, :term)
    (elixir 1.19.0-dev) lib/protocol.ex:670: anonymous fn/3 in Protocol.new_signatures/3
    (elixir 1.19.0-dev) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
    (elixir 1.19.0-dev) lib/protocol.ex:669: Protocol.new_signatures/3
    (elixir 1.19.0-dev) lib/protocol.ex:620: Protocol.consolidate/5
    (elixir 1.19.0-dev) lib/protocol.ex:565: Protocol.consolidate/2
    (mix 1.19.0-dev) lib/mix/compilers/protocol.ex:153: Mix.Compilers.Protocol.consolidate_each/4
    (elixir 1.19.0-dev) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
Function: #Function<8.117671614/0 in Mix.Compilers.Protocol.consolidate/4>
    Args: []
```

I tried to add a test but consolidation tests are a bit high ceremony and I wasn't sure it was worth defining a fixture etc. especially if this is going to be forbidden.