### PR TITLE
Fix Stream.resource/3 docs to mention unfold/2 instead of transform/3

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1508,7 +1508,7 @@ defmodule Stream do
   @doc """
   Emits a sequence of values for the given resource.
 
-  Similar to `transform/3` but the initial accumulated value is
+  Similar to `unfold/2` but the initial accumulated value is
   computed lazily via `start_fun` and executes an `after_fun` at
   the end of enumeration (both in cases of success and failure).
 


### PR DESCRIPTION
I think the docs here are wrong and instead of `transform/3` the intention was to mention the `unfold/2` function.
