### PR TITLE
Show hints when run mix test --no-color

### DIFF
--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -332,6 +332,9 @@ defmodule ExUnit.FormatterTest do
                 hint:  you are comparing strings that have the same visual representation but are made of different Unicode codepoints
            """
 
+    assert format_test_failure(test(), failure, 1, 80, &diff_formatter/2) ==
+             format_test_failure(test(), failure, 1, 80, &formatter/2)
+
     assert format_assertion_diff(assertion_error, 0, :infinity, &diff_formatter/2)
            |> kw_to_string() ==
              [


### PR DESCRIPTION
The hint for `:equivalent_but_different_strings` is not shown when you run `mix test --no-color`. 

This PR fixes it by running `find_diff` regardless of whether the `diff_formatter` is enabled. The returned hints are always kept and the formatted result is set to nil if the `diff_formatter` is not enabled.