### PR TITLE
Add zero padding recursively in calendar

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1678,21 +1678,25 @@ defmodule Calendar.ISO do
   defp sign(total) when total < 0, do: ?-
   defp sign(_), do: ?+
 
-  defp zero_pad(val, count) when val >= 0 and count <= 6 do
-    num = Integer.to_string(val)
-
-    case max(count - byte_size(num), 0) do
-      0 -> num
-      1 -> ["0" | num]
-      2 -> ["00" | num]
-      3 -> ["000" | num]
-      4 -> ["0000" | num]
-      5 -> ["00000" | num]
-    end
+  defp zero_pad(val, count) when val >= 0 do
+    do_zero_pad(val, count, [])
   end
 
   defp zero_pad(val, count) do
     [?- | zero_pad(-val, count)]
+  end
+
+  defp do_zero_pad(val, count, acc) when val > 0 do
+    digit = rem(val, 10)
+    do_zero_pad(div(val, 10), count - 1, [digit + ?0 | acc])
+  end
+
+  defp do_zero_pad(0, count, acc) when count > 0 do
+    do_zero_pad(0, count - 1, [?0 | acc])
+  end
+
+  defp do_zero_pad(0, _count, acc) do
+    acc
   end
 
   @doc """


### PR DESCRIPTION
This padding can be done recursively, it looks cleaner.
```
Name                                        ips        average  deviation         median         99th %
Calendar.IOISO.datetime_to_string        3.80 M      263.24 ns  ±6555.12%         220 ns         340 ns
Calendar.ISO.datetime_to_string          3.50 M      285.55 ns  ±5974.86%         241 ns         371 ns

Comparison: 
Calendar.IOISO.datetime_to_string        3.80 M
Calendar.ISO.datetime_to_string          3.50 M - 1.08x slower +22.31 ns

Memory usage statistics:

Name                                 Memory usage
Calendar.IOISO.datetime_to_string           544 B
Calendar.ISO.datetime_to_string             456 B - 0.84x memory usage -88 B
```