### PR TITLE
Feat:  Add examples to exception.ex for clearer error handling

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -346,7 +346,7 @@ defmodule Exception do
   defp rewrite_arg(arg) do
     Macro.prewalk(arg, fn
       {:%{}, meta, [__struct__: Range, first: first, last: last, step: step]} ->
-        {:"..//", meta, [first, last, step]}
+        {:..//, meta, [first, last, step]}
 
       other ->
         other

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1041,7 +1041,7 @@ defmodule ArgumentError do
 
   You can raise this exception when you want to signal that an argument to
   a function is invalid. For example, this exception is raised when calling
-  `Integer.to_string/1` without an invalid argument:
+  `Integer.to_string/1` with an invalid argument:
 
       iex> Integer.to_string(1.0)
       ** (ArgumentError) errors were found at the given arguments:

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1210,17 +1210,6 @@ defmodule SyntaxError do
     * `:column` - the column where the error occurred
     * `:description` - a description of the syntax error
 
-    if true else
-  IO.puts("This will break")
-  end
-
-  ** (SyntaxError) invalid syntax found on Desktop/important/notebook/error_handling.livemd#cell:sslzfkto2taubx37:3:1:
-    error: unexpected reserved word: end
-    │
-  3 │ end
-    │
-
-
   """
 
   defexception [:file, :line, :column, :snippet, description: "syntax error"]


### PR DESCRIPTION
1. Adds example to the module with only an explanation but no example, to see how the error is caused.
2. Some module in exception do not have description for example: UnicodeConversionError module
4. These changes was added to enrich the documentation to assist developers understand how the exception are raised.