### PR TITLE
Fix `--no-color` not working

### DIFF
--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -301,7 +301,7 @@ defmodule Kernel.CLI do
   end
 
   defp parse_argv([~c"--no-color" | t], config) do
-    Application.put_env(:elixir, :ansi_enabled, true)
+    Application.put_env(:elixir, :ansi_enabled, false)
     parse_argv(t, config)
   end
 


### PR DESCRIPTION
I wanted to try out the new `--color`/`--no-color` options in Elixir 1.18.2 and disabling color doesn't work.

If I create the following file `test.exs`
```elixir
IO.puts(IO.ANSI.format([:bright, "test message", :reset]))
```
and run it from my color enabled terminal it correctly displays in bright text.

If I run it with `elixir --no-color test.exs` it still prints it with bright text.

After applying the patch in this PR it prints correctly without any ANSI color escape sequences.

![image](https://github.com/user-attachments/assets/272b21e0-038e-460e-8df9-7ab6ac2f0163)

This seems to be an error when the changes introduced in 786f3ce79721779efdd4985989c72264b98b2e7c where refectored: https://github.com/elixir-lang/elixir/commit/2c1a836db32898d2b7a17b0dd28e07425bf46213#diff-78a6fd95d2c5f4d0c0a5414b1393fc082ac242d2f70a665abe06f5e571da557d