### PR TITLE
Use the correct incorrect typespec definition in exception.ex

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1381,7 +1381,7 @@ defmodule Kernel.TypespecError do
 
   will raise:
 
-      ** (Kernel.TypespecError) type strng/0 undefined
+      ** (Kernel.TypespecError) type intger/0 undefined
 
   """
 


### PR DESCRIPTION
Noticed a small typo in the example of a typespec typo 😄 