### PR TITLE
Improving docs: Add note section to Process.exit/2 to make it clear

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -219,6 +219,16 @@ defmodule Process do
 
   Inlined by the compiler.
 
+  > #### Note {: .info }
+  >
+  > The functions `Kernel.exit/1` and `Process.exit/2` are
+  > named similarly but provide very different functionalities. The
+  > `Kernel:exit/1` function should be used when the intent is to stop the current
+  > process while `Process:exit/2` should be used when the intent is to send an
+  > exit signal to another process. Note also that `Kernel:exit/1` raises an
+  > exception that can be caught while `Process:exit/2` does not cause any
+  > exception to be raised.
+
   ## Examples
 
       Process.exit(pid, :kill)

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -219,7 +219,7 @@ defmodule Process do
 
   Inlined by the compiler.
 
-  > #### Note {: .info }
+  > #### Differences to `Kernel.exit/1` {: .info }
   >
   > The functions `Kernel.exit/1` and `Process.exit/2` are
   > named similarly but provide very different functionalities. The

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -224,10 +224,10 @@ defmodule Process do
   > The functions `Kernel.exit/1` and `Process.exit/2` are
   > named similarly but provide very different functionalities. The
   > `Kernel:exit/1` function should be used when the intent is to stop the current
-  > process while `Process:exit/2` should be used when the intent is to send an
-  > exit signal to another process. Note also that `Kernel:exit/1` raises an
-  > exception that can be caught while `Process:exit/2` does not cause any
-  > exception to be raised.
+  > process while `Process.exit/2` should be used when the intent is to send an
+  > exit signal to another process. Note also that `Kernel.exit/1` can be caught
+  > with `try/1` while `Process.exit/2` can only be handled by trapping exits and
+  > when the signal is different than `:kill`.
 
   ## Examples
 


### PR DESCRIPTION
I'm adding a note section to have the same note that explicts the difference between exit/1 and exit/2 from erlang documentation directly in elixir doc. I could also add a link to erlang docs if it's better. 
