### PR TITLE
Setup OSS Review Toolkit SBoM generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,3 +122,27 @@ jobs:
           shellcheck -e SC2039,2086 bin/elixir && echo "bin/elixir is POSIX compliant"
           shellcheck bin/elixirc && echo "bin/elixirc is POSIX compliant"
           shellcheck bin/iex && echo "bin/iex is POSIX compliant"
+  
+  license_compliance:
+    name: Check Licence Compliance
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Use HTTPS instead of SSH for Git cloning
+        id: git-config
+        shell: bash
+        run: git config --global url.https://github.com/.insteadOf ssh://git@github.com/
+  
+      - name: Checkout project
+        id: checkout
+        uses: actions/checkout@v4
+  
+      - name: "Run OSS Review Toolkit"
+        id: ort
+        uses: ./.github/workflows/ort
+        with:
+          upload-reports: true
+          fail-on-violation: true
+          report-formats: "WebApp"
+          version: "${{ github.sha }}"

--- a/.github/workflows/ort/action.yml
+++ b/.github/workflows/ort/action.yml
@@ -1,0 +1,96 @@
+name: "Run OSS Review Toolkit"
+description: "Runs OSS Review Toolkit & generates SBoMs"
+inputs:
+  build-artifacts:
+    description: |
+      Build Artifact paths to include into SBoM.
+      May contain a glob pattern or list of paths separated by a newline.
+    required: false
+    default: ""
+  report-formats:
+    description: "ORT Report Formats"
+    required: true
+  fail-on-violation:
+    description: "Whether to fail on violation."
+    required: false
+    default: false
+  upload-reports:
+    description: "Whether to upload all reports"
+    required: false
+    default: false
+  version:
+    desctiption: "Elixir Version (Tag / SHA)"
+    required: true
+
+outputs:
+  results-path:
+    description: "See oss-review-toolkit/ort-ci-github-action action"
+    value: "${{ steps.ort.outputs.results-path }}"
+  results-sbom-cyclonedx-xml-path:
+    description: "See oss-review-toolkit/ort-ci-github-action action"
+    value: "${{ steps.ort.outputs.results-sbom-cyclonedx-xml-path }}"
+  results-sbom-cyclonedx-json-path:
+    description: "See oss-review-toolkit/ort-ci-github-action action"
+    value: "${{ steps.ort.outputs.results-sbom-cyclonedx-json-path }}"
+  results-sbom-spdx-yml-path:
+    description: "See oss-review-toolkit/ort-ci-github-action action"
+    value: "${{ steps.ort.outputs.results-sbom-spdx-yml-path }}"
+  results-sbom-spdx-json-path:
+    description: "See oss-review-toolkit/ort-ci-github-action action"
+    value: "${{ steps.ort.outputs.results-sbom-spdx-json-path }}"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Fetch Default ORT Config
+      id: fetch-default-ort-config
+      uses: actions/checkout@v4
+      with:
+        repository: oss-review-toolkit/ort-config
+        ref: "main"
+        path: ".ort-config"
+
+    - name: Setup ORT Config
+      id: setup-ort-config
+      shell: bash
+      run: |
+        mkdir -p "/$HOME/.ort/"
+
+        # Move Fetched Default Config into Place
+        mv .ort-config "/$HOME/.ort/config"
+        
+        # Append Global ORT Config
+        cat .ort/config/config.yml >> "$HOME/.ort/config/config.yml"
+        
+        # Override Default Evaluator Rules
+        cp .ort/config/evaluator.rules.kts "$HOME/.ort/config/evaluator.rules.kts"
+
+    - name: "Cache ScanCode"
+      uses: actions/cache@v4
+      with:
+        path: "~/.cache/scancode-tk"
+        key: ${{ runner.os }}-scancode
+
+    - name: Run OSS Review Toolkit
+      id: ort
+      # TODO: Use released version once the following issue has been released:
+      # * https://github.com/oss-review-toolkit/ort-ci-github-action/issues/37
+      # * https://github.com/oss-review-toolkit/ort-ci-github-action/pull/41
+      # * https://github.com/oss-review-toolkit/ort-ci-github-action/pull/43
+      uses: maennchen/ort-ci-github-action@action-output
+      with:
+        image: ghcr.io/oss-review-toolkit/ort-minimal:latest
+        run: >
+          labels,
+          cache-dependencies,
+          cache-scan-results,
+          analyzer,
+          scanner,
+          advisor,
+          evaluator,
+          reporter,
+          ${{ inputs.upload-reports == 'true' && 'upload-results' || '' }}
+        fail-on: "${{ inputs.fail-on-violation == 'true' && 'violations,issues' || '' }}"
+        report-formats: "${{ inputs.report-formats }}"
+        ort-cli-report-args: '-O CycloneDX=output.file.formats=json,xml -O SpdxDocument=outputFileFormats=JSON,YAML'
+        sw-version: "${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,8 @@ jobs:
           git push origin $ref_name --force
 
   build:
+    name: "Build Elixir"
+
     strategy:
       fail-fast: true
       matrix:
@@ -64,7 +66,9 @@ jobs:
           - otp: 27
             otp_version: "27.0"
             build_docs: build_docs
+
     runs-on: ubuntu-22.04
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,19 +80,6 @@ jobs:
           otp_version: ${{ matrix.otp_version }}
           otp: ${{ matrix.otp }}
           build_docs: ${{ matrix.build_docs }}
-
-      - name: "Attest docs provenance"
-        uses: actions/attest-build-provenance@v2
-        id: attest-docs-provenance
-        if: matrix.build_docs
-        with:
-          subject-path: "Docs.zip"
-
-      - name: "Copy docs provenance"
-        if: matrix.build_docs
-        run: cp "$ATTESTATION" Docs.zip.sigstore
-        env:
-          ATTESTATION: "${{ steps.attest-docs-provenance.outputs.bundle-path }}"
 
       - name: Create Docs Hashes
         if: matrix.build_docs
@@ -150,18 +141,6 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
-      - name: "Attest release provenance"
-        id: attest-provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: ${{ env.RELEASE_FILE }}
-
-      - name: "Copy release .zip provenance"
-        shell: bash
-        run: cp "$ATTESTATION" "${RELEASE_FILE}.sigstore"
-        env:
-          ATTESTATION: "${{ steps.attest-provenance.outputs.bundle-path }}"
-
       - name: Create Release Hashes
         if: matrix.flavor == 'windows'
         shell: pwsh
@@ -185,14 +164,92 @@ jobs:
           name: sign-${{ matrix.flavor }}-elixir-otp-${{ matrix.otp }}
           path: ${{ env.RELEASE_FILE }}*
 
+  sbom:
+    name: Generate SBoM
+
+    needs: [build, sign]
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Use HTTPS instead of SSH for Git cloning
+        id: git-config
+        shell: bash
+        run: git config --global url.https://github.com/.insteadOf ssh://git@github.com/
+  
+      - name: Checkout project
+        id: checkout
+        uses: actions/checkout@v4
+  
+      - name: "Download Build Artifacts"
+        id: download-build-artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "{sign-*-elixir-otp-*,Docs}"
+          merge-multiple: true
+          path: /tmp/build-artifacts/
+        
+      - name: "Run OSS Review Toolkit"
+        id: ort
+        uses: ./.github/workflows/ort
+        with:
+          build-artifacts: "/tmp/build-artifacts/*"
+          report-formats: "CycloneDx,SpdxDocument"
+          version: "${{ github.ref_type	== 'tag' && github.ref_name || github.sha }}"
+
+      - name: Attest Distribution Assets with SBoM
+        id: attest-sbom
+        uses: actions/attest-sbom@v2
+        with:
+          subject-path: |
+            /tmp/build-artifacts/{elixir-otp-*.*,Docs.zip}
+            ${{ steps.ort.outputs.results-sbom-cyclonedx-xml-path }}
+            ${{ steps.ort.outputs.results-sbom-cyclonedx-json-path }}
+            ${{ steps.ort.outputs.results-sbom-spdx-yml-path }}
+            ${{ steps.ort.outputs.results-sbom-spdx-json-path }}
+          sbom-path: "${{ steps.ort.outputs.results-sbom-spdx-json-path }}"
+
+      - name: "Copy SBoM provenance"
+        id: sbom-provenance
+        shell: bash
+        run: |
+          mkdir attestations
+
+          for FILE in /tmp/build-artifacts/{elixir-otp-*.*,Docs.zip}; do
+            cp "$ATTESTATION" "attestations/$(basename "$FILE").sigstore"
+          done
+
+          cp "$ATTESTATION" "attestations/$(basename "${{ steps.ort.outputs.results-sbom-cyclonedx-xml-path }}").sigstore"
+          cp "$ATTESTATION" "attestations/$(basename "${{ steps.ort.outputs.results-sbom-cyclonedx-json-path }}").sigstore"
+          cp "$ATTESTATION" "attestations/$(basename "${{ steps.ort.outputs.results-sbom-spdx-yml-path }}").sigstore"
+          cp "$ATTESTATION" "attestations/$(basename "${{ steps.ort.outputs.results-sbom-spdx-json-path }}").sigstore"
+        env:
+          ATTESTATION: "${{ steps.attest-sbom.outputs.bundle-path }}"
+
+      - name: "Assemble Release SBoM Artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: "SBoM"
+          path: |
+            ${{ steps.ort.outputs.results-sbom-cyclonedx-xml-path }}
+            ${{ steps.ort.outputs.results-sbom-cyclonedx-json-path }}
+            ${{ steps.ort.outputs.results-sbom-spdx-yml-path }}
+            ${{ steps.ort.outputs.results-sbom-spdx-json-path }}
+
+      - name: "Assemble Distribution Attestations"
+        uses: actions/upload-artifact@v4
+        with:
+          name: "Attestations"
+          path: "attestations/*.sigstore"
+
   upload-release:
-    needs: [create_draft_release, build, sign]
+    needs: [create_draft_release, build, sign, sbom]
     runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/download-artifact@v4
         with:
-          pattern: "{sign-*-elixir-otp-*,Docs}"
+          pattern: "{sign-*-elixir-otp-*,Docs,SBoM,Attestations}"
           merge-multiple: true
 
       - name: Upload Pre-built
@@ -218,7 +275,8 @@ jobs:
             elixir-otp-*.exe.sigstore \
             Docs.zip \
             Docs.zip.sha{1,256}sum \
-            Docs.zip.sigstore
+            Docs.zip.sigstore \
+            bom.*
 
   upload-builds-hex-pm:
     needs: [build, sign]

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,0 +1,20 @@
+curations:
+  license_findings:
+    - path: "lib/elixir/pages/images/logo.png"
+      reason: "INCORRECT"
+      comment: "Apply Trademark Policy to Elixir Logo"
+      detected_license: "NONE"
+      concluded_license: "LicenseRef-elixir-trademark-policy"
+
+    - path: "lib/elixir/pages/references/library-guidelines.md"
+      reason: "INCORRECT"
+      comment: |
+        The guide mentions multiple licenses for users to choose from.
+        It however is not licensed itself by the mentioned licenses.
+      concluded_license: "Apache-2.0"
+
+    - path: "**/*"
+      reason: "INCORRECT"
+      comment: "Apply default license to all unknown files"
+      detected_license: "NONE"
+      concluded_license: "Apache-2.0"

--- a/.ort/config/config.yml
+++ b/.ort/config/config.yml
@@ -1,0 +1,9 @@
+ort:
+  scanner:
+    skipConcluded: false
+    includeFilesWithoutFindings: true
+
+  analyzer:
+    allowDynamicVersions: true
+    enabledPackageManagers: [Unmanaged]
+    skipExcluded: true

--- a/.ort/config/evaluator.rules.kts
+++ b/.ort/config/evaluator.rules.kts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2019 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
+ * Copyright (c) 2021 The Elixir Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ // Docs: https://oss-review-toolkit.org/ort/docs/configuration/evaluator-rules
+
+val whitelistedLicenses = listOf(
+  // License for Elixir & Imported Erlang Projects
+  "Apache-2.0",
+  // License for the Elixir Logo
+  "LicenseRef-elixir-trademark-policy",
+  // License for included Unicode Files
+  "LicenseRef-scancode-unicode"
+).map { SpdxSingleLicenseExpression.parse(it) }.toSet()
+
+fun PackageRule.howToFixDefault() = """
+      * Check if this license violation is intended
+      * Adjust evaluation rules in `.ort/config/evaluator.rules.kts`
+    """.trimIndent()
+
+fun PackageRule.LicenseRule.isHandled() =
+  object : RuleMatcher {
+    override val description = "isHandled($license)"
+
+    override fun matches() = license in whitelistedLicenses
+  }
+
+fun RuleSet.unhandledLicenseRule() = packageRule("UNHANDLED_LICENSE") {
+  // Do not trigger this rule on packages that have been excluded in the .ort.yml.
+  require {
+    -isExcluded()
+  }
+
+  // Define a rule that is executed for each license of the package.
+  licenseRule("UNHANDLED_LICENSE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+    require {
+      -isExcluded()
+      -isHandled()
+    }
+
+    // Throw an error message including guidance how to fix the issue.
+    error(
+      "The license $license is currently not covered by policy rules. " +
+        "The license was ${licenseSource.name.lowercase()} in package " +
+        "${pkg.metadata.id.toCoordinates()}.",
+      howToFixDefault()
+    )
+  }
+}
+
+fun RuleSet.unmappedDeclaredLicenseRule() = packageRule("UNMAPPED_DECLARED_LICENSE") {
+  require {
+    -isExcluded()
+  }
+
+  resolvedLicenseInfo.licenseInfo.declaredLicenseInfo.processed.unmapped.forEach { unmappedLicense ->
+    warning(
+      "The declared license '$unmappedLicense' could not be mapped to a valid license or parsed as an SPDX " +
+        "expression. The license was found in package ${pkg.metadata.id.toCoordinates()}.",
+      howToFixDefault()
+    )
+  }
+}
+
+val ruleSet = ruleSet(ortResult, licenseInfoResolver, resolutionProvider) {
+  unhandledLicenseRule()
+  unmappedDeclaredLicenseRule()
+}
+
+ruleViolations += ruleSet.violations

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/LicenseRef-elixir-trademark-policy.txt
+++ b/LICENSES/LicenseRef-elixir-trademark-policy.txt
@@ -1,0 +1,98 @@
+ELIXIR TEAM TRADEMARKS POLICY
+
+This document outlines the policy for allowed usage of the “Elixir” word and the
+Elixir logo by other parties.
+
+“Elixir” and the Elixir logo are registered trademarks of the Elixir Team. The
+Elixir Team believes in a decentralized approach to growing the community and
+the ecosystem, independent of the Elixir project and the Elixir Team.
+
+Anyone can use the Elixir trademarks if that use of the trademark is nominative.
+The trademarks must not be used to disparage the project and its community, nor
+be used in any way to imply ownership, endorsement, or association with the
+Elixir project and the Elixir Team.
+
+You must not visually combine the Elixir logo with any other images, or change
+the logo in any way other than ways required by printing restrictions. If you
+want to create your own visual identity in relation to Elixir, you might use the
+shape of an unrelated “water drop” as part of your design, as seen in many
+community projects and initiatives. You must not combine or modify the Elixir
+logo.
+
+The Elixir logo is available in our repository in both vertical and horizontal
+versions.
+
+Nominative use
+The “nominative use” (or “nominative fair use”) is a legal doctrine that
+authorizes everyone (even commercial companies) to use or refer to the trademark
+of another if:
+
+The product or service in question must be one not readily identifiable without
+use of the trademark.
+
+Only so much of the mark or marks may be used as is reasonably necessary to
+identify the product or service.
+
+The organization using the mark must do nothing that would, in conjunction with
+the mark, suggest sponsorship or endorsement by the trademark holder.
+
+Our trademarks must be used to refer to the Elixir programming language.
+
+Examples of permitted use
+All examples listed next must strictly adhere to the terms outlined in the
+previous sections:
+
+Usage of the Elixir logo to say a technology is “powered by Elixir” under
+nominative use. Linking back to the Elixir website, if possible, is appreciated.
+
+Usage of the Elixir logo to display it as a supported technology in a service or
+platform. For instance, you may say “we support Elixir” and use the Elixir logo,
+but you may not refer to yourself as “the Elixir platform” nor imply any form of
+endorsement or association with Elixir.
+
+Usage of the Elixir logo in non-commercial community meetups, in presentations,
+and in courses when referring to the language and its ecosystem under nominative
+use.
+
+Usage of the Elixir logo in non-commercial swag (stickers, t-shirts, mugs, etc)
+to promote the Elixir programming language. The Elixir marks must be the only
+marks featured in the product. You need permission to make swag that include
+Elixir and other third party marks in them.
+
+Inclusion of the Elixir logo in non-commercial icon sets. Use of the Elixir
+icons must still adhere to Elixir’s trademark policies.
+
+Usage of the “Elixir” word in book titles, meetups, conferences, and podcasts.
+You must not use the word to imply uniqueness or endorsement from the Elixir
+team. “The Elixir book” and “The Elixir podcast” are not permitted.
+“Elixir in Action”, “Thinking Elixir”, and “Kraków Elixir User Group” are valid
+examples already in use today.
+
+Usage of the “Elixir” word in the names of freely distributed software and
+hardware products is allowed when referring to use with or suitability for the
+Elixir programming language, such as wxElixir, Elixirsense, etc. If the product
+includes the Elixir programming language itself, then you must also respect its
+license.
+
+Examples of not permitted use
+Here is a non-exhaustive list of non permitted uses of the marks:
+
+Usage of the Elixir logo in book covers, conferences, and podcasts.
+
+Usage of the Elixir logo as the mark of third party projects, even in combination
+with other marks.
+
+Naming any company or product after Elixir, such as “The Elixir Hosting”,
+“The Elixir Consultants”, etc.
+
+Examples that require permission
+Here are some examples that may be granted permission upon request:
+
+Selling merchandise (stickers, t-shirts, mugs, etc).
+You can request permission by emailing trademarks@elixir-lang.org.
+
+Important note
+Nothing in this page shall be interpreted to allow any third party to claim any
+association with the Elixir project and the Elixir Team, or to imply any
+approval or support by the Elixir project and the Elixir Team for any third
+party products, services, or events.

--- a/LICENSES/LicenseRef-scancode-unicode.txt
+++ b/LICENSES/LicenseRef-scancode-unicode.txt
@@ -1,0 +1,58 @@
+UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+
+Unicode Data Files include all data files under the directories
+http://www.unicode.org/Public/, http://www.unicode.org/reports/, and
+http://www.unicode.org/cldr/data/ . Unicode Software includes any source
+code published in the Unicode Standard or under the directories
+http://www.unicode.org/Public/, http://www.unicode.org/reports/, and
+http://www.unicode.org/cldr/data/.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S DATA
+FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"), YOU UNEQUIVOCALLY
+ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE TERMS AND CONDITIONS OF THIS
+AGREEMENT. IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE
+OR USE THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright ©  Unicode, Inc. All rights reserved. Distributed under
+the Terms of Use in http://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of the Unicode data files and any associated documentation (the
+"Data Files") or Unicode software and any associated documentation (the
+"Software") to deal in the Data Files or Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, and/or sell copies of the Data Files or Software,
+and to permit persons to whom the Data Files or Software are furnished
+to do so, provided that
+
+(a) the above copyright notice(s) and this permission notice appear with
+all copies of the Data Files or Software,
+
+(b) both the above copyright notice(s) and this permission notice appear
+in associated documentation, and
+
+(c) there is clear notice in each modified Data File or in the Software
+as well as in the documentation associated with the Data File(s) or
+Software that the data or software has been modified.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR
+ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or
+other dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+
+Unicode and the Unicode logo are trademarks of Unicode, Inc., and may be
+registered in some jurisdictions. All other trademarks and registered
+trademarks mentioned herein are the property of their respective owners.


### PR DESCRIPTION
Implement Source SBoM Generation

## Scope

This PR implements source SBoM generation using [OSS Review Toolkit](https://oss-review-toolkit.org/ort/)
in the following formats:
* CycloneDX (v1.6) JSON / XML
* SPDX (v2.2) JSON / YML

The PR implements a very simple Open Source Policy with a list of allowed licenses. Namely:
* `Apache-2.0` (Elixir itself / copied OTP code)
* `LicenseRef-elixir-trademark-policy` (Elixir Logo)
* `LicenseRef-scancode-unicode` (Unicode Files)

The idea is that if we add other code / dependencies with other licenses, the inclusion has to be
agreed by the Elixir team and the list extended.

## OpenChain

This PR implements the technical parts of [OpenChain](https://openchainproject.org/) ISO/IEC 18974:2023.

Specifically:

> **§ 4.1.5 Standard practice implementation**
>
> The program shall demonstrate sound and robust handling procedures of known vulnerabilities and secure
> software development by defining and implementing following procedures:
> 
> [...]
>
> * Method for detecting existence of known vulnerabilities in supplied software;
> [...]
> * Method to export information about identified risks to third parties as appropriate.

> **§ 4.3.1 Software bill of materials**
>
> A process shall exist for creating and maintaining a bill of materials that includes each open source software 
> component from which the supplied software is comprised.
>
> **Verification material(s):**
> * 4.3.1.1: A documented procedure ensuring all open source software used in the supplied software is 
>   continuously recorded across the life-cycle of the supplied software. This includes an archive of all open 
>   source software used in the supplied software;
> * 4.3.1.2:  open  source  software  component  records  for  the  supplied  software  that  demonstrates  the 
>   documented procedure was properly followed.

## Future

There's a few things I would like to address in the future:
* Full OpenChain compliance - Since Elixir does not have many dependencies, it should
  be relatively trivial to achieve OpenChain compliance after this PR. I'd like to
  propose the required documentation and certify compliance. (btw. Ericsson including
  OTP is OpenChain compliant and on the way to be certified as well.)
* OSS Review Toolkit currently does not recognize mix / rebar applications as packages.
* While we attest the distribution assets with the SBoMs, the SBoM itself does not list
  the distribution assets. This is not feasible until ORT recognizes mix applications.
* Erlang is not listed as a build dependency in the SBoMs. As soon as OTP publishes
  SBoMs themselves, I'd like to incorporate that.
* Source Licenses currently are largely defined with an override in `.ort.yml`. It would be
  better to include a header in each file to state the license explicitly. This also
  works when code is copied from this repository.
* Copyright is currently only detected because of the copyright text in the `LICENSE` in the
  root. It would be better to include a header in each file to state the copyright explicitly.
  This also works when code is copied from this repository.

## Results

* Example `ci.yml` run: https://github.com/maennchen/elixir/actions/runs/13029706072
* Example `release.yml` run: https://github.com/maennchen/elixir/actions/runs/13029706053
* Example GitHub Release: https://github.com/maennchen/elixir/releases/tag/jm%2Foss-review-toolkit-latest
