### PR TITLE
Inline Licence Info & Copyright for non-test files

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 [
   inputs: [
     "lib/*/{lib,scripts,unicode,test}/**/*.{ex,exs}",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 lib/elixir/test/elixir/fixtures/*.txt text eol=lf
 *.ex diff=elixir
 *.exs diff=elixir

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 ---
 blank_issues_enabled: true
 

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 ---
 name: Report an issue
 description:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/workflows/ci-markdown.yml
+++ b/.github/workflows/ci-markdown.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 name: CI for Markdown content
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 name: CI
 
 on:

--- a/.github/workflows/notify.exs
+++ b/.github/workflows/notify.exs
@@ -1,4 +1,8 @@
 # #!/usr/bin/env elixir
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 [tag] = System.argv()
 
 Mix.install([

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 name: Notify
 
 on:

--- a/.github/workflows/ort/action.yml
+++ b/.github/workflows/ort/action.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 name: "Run OSS Review Toolkit"
 description: "Runs OSS Review Toolkit & generates SBoMs"
 inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 name: Release
 
 on:

--- a/.github/workflows/release_pre_built/action.yml
+++ b/.github/workflows/release_pre_built/action.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 name: "Release pre built"
 description: "Builds elixir release, ExDoc and generates docs"
 inputs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 /doc/
 /lib/*/ebin/
 /lib/*/_build/

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2021 The Elixir Team
+
 {
   // Consecutive header levels (h1 -> h2 -> h3). We don't care about this.
   "MD001": false,

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 curations:
   license_findings:
     - path: "lib/elixir/pages/images/logo.png"

--- a/.ort/config/config.yml
+++ b/.ort/config/config.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 ort:
   scanner:
     skipConcluded: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 # Changelog for Elixir v1.19
 
 ## Type system improvements

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 # Code of Conduct
 
 Contact: elixir-lang-conduct@googlegroups.com

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 PREFIX ?= /usr/local
 TEST_FILES ?= "*_test.exs"
 SHARE_PREFIX ?= $(PREFIX)/share

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 <h1>
  <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/elixir-lang/elixir-lang.github.com/raw/main/images/logo/logo-dark.png">

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 # Release process
 
 ## Shipping a new version

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 # Security Policy
 
 ## Supported versions

--- a/bin/elixir
+++ b/bin/elixir
@@ -1,4 +1,9 @@
 #!/bin/sh
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 set -e
 
 ELIXIR_VERSION=1.19.0-dev

--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -1,5 +1,9 @@
 @echo off
 
+:: SPDX-License-Identifier: Apache-2.0
+:: SPDX-FileCopyrightText: 2021 The Elixir Team
+:: SPDX-FileCopyrightText: 2012 Plataformatec
+
 set ELIXIR_VERSION=1.19.0-dev
 
 if    ""%1""==""""                if ""%2""=="""" goto documentation

--- a/bin/elixirc
+++ b/bin/elixirc
@@ -1,4 +1,9 @@
 #!/bin/sh
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 set -e
 
 if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then

--- a/bin/elixirc.bat
+++ b/bin/elixirc.bat
@@ -1,4 +1,9 @@
 @echo off
+
+:: SPDX-License-Identifier: Apache-2.0
+:: SPDX-FileCopyrightText: 2021 The Elixir Team
+:: SPDX-FileCopyrightText: 2012 Plataformatec
+
 setlocal
 set argc=0
 for %%A in (%*) do (

--- a/bin/iex
+++ b/bin/iex
@@ -1,4 +1,9 @@
 #!/bin/sh
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 set -e
 
 if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then

--- a/bin/iex.bat
+++ b/bin/iex.bat
@@ -1,4 +1,9 @@
 @echo off
+
+:: SPDX-License-Identifier: Apache-2.0
+:: SPDX-FileCopyrightText: 2021 The Elixir Team
+:: SPDX-FileCopyrightText: 2012 Plataformatec
+
 setlocal
 if /I ""%1""==""--help"" goto documentation
 if /I ""%1""==""-h""     goto documentation

--- a/bin/mix
+++ b/bin/mix
@@ -1,2 +1,7 @@
 #!/usr/bin/env elixir
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Mix.CLI.main()

--- a/bin/mix.bat
+++ b/bin/mix.bat
@@ -1,2 +1,7 @@
 @echo off
+
+:: SPDX-License-Identifier: Apache-2.0
+:: SPDX-FileCopyrightText: 2021 The Elixir Team
+:: SPDX-FileCopyrightText: 2012 Plataformatec
+
 call "%~dp0\elixir.bat" "%~dp0\mix" %*

--- a/bin/mix.ps1
+++ b/bin/mix.ps1
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # Store path to mix.bat as a FileInfo object
 $mixBatPath = (Get-ChildItem (((Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName) + '\mix.bat'))
 $newArgs = @()

--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule EEx.SyntaxError do
   defexception [:file, :line, :column, :snippet, message: "syntax error"]
 

--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule EEx.Compiler do
   @moduledoc false
 

--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule EEx.Engine do
   @moduledoc ~S"""
   Basic EEx engine that ships with Elixir.

--- a/lib/eex/lib/eex/smart_engine.ex
+++ b/lib/eex/lib/eex/smart_engine.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule EEx.SmartEngine do
   @moduledoc """
   The default engine used by EEx.

--- a/lib/eex/mix.exs
+++ b/lib/eex/mix.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule EEx.MixProject do
   use Mix.Project
 

--- a/lib/elixir/Emakefile
+++ b/lib/elixir/Emakefile
@@ -1,3 +1,7 @@
+%% SPDX-License-Identifier: Apache-2.0
+%% SPDX-FileCopyrightText: 2021 The Elixir Team
+%% SPDX-FileCopyrightText: 2012 Plataformatec
+
 {'src/*', [
   warn_unused_vars,
   warn_export_all,

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Access do
   @moduledoc """
   Key-based access to data structures.

--- a/lib/elixir/lib/agent.ex
+++ b/lib/elixir/lib/agent.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Agent do
   @moduledoc """
   Agents are a simple abstraction around state.

--- a/lib/elixir/lib/agent/server.ex
+++ b/lib/elixir/lib/agent/server.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Agent.Server do
   @moduledoc false
 

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Application do
   @moduledoc """
   A module for working with applications and defining application callbacks.

--- a/lib/elixir/lib/atom.ex
+++ b/lib/elixir/lib/atom.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Atom do
   @moduledoc """
   Atoms are constants whose values are their own name.

--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Base do
   import Bitwise
 

--- a/lib/elixir/lib/behaviour.ex
+++ b/lib/elixir/lib/behaviour.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Behaviour do
   @moduledoc """
   Mechanism for handling behaviours.

--- a/lib/elixir/lib/bitwise.ex
+++ b/lib/elixir/lib/bitwise.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Bitwise do
   @moduledoc """
   A set of functions that perform calculations on bits.

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Calendar do
   @moduledoc """
   This module defines the responsibilities for working with

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Date do
   @moduledoc """
   A Date struct and functions.

--- a/lib/elixir/lib/calendar/date_range.ex
+++ b/lib/elixir/lib/calendar/date_range.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Date.Range do
   @moduledoc """
   Returns an inclusive range between dates.

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule DateTime do
   @moduledoc """
   A datetime implementation with a time zone.

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Duration do
   @moduledoc """
   Struct and functions for handling durations.

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Calendar.ISO do
   @moduledoc """
   The default calendar implementation, a Gregorian calendar following ISO 8601.

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule NaiveDateTime do
   @moduledoc """
   A NaiveDateTime struct (without a time zone) and functions.

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Time do
   @moduledoc """
   A Time struct and functions.

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Calendar.TimeZoneDatabase do
   @moduledoc """
   This module defines a behaviour for providing time zone data.

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Code do
   @moduledoc ~S"""
   Utilities for managing code compilation, code evaluation, and code loading.

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Code.Formatter do
   @moduledoc false
   import Inspect.Algebra, except: [format: 2, surround: 3, surround: 4]

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Code.Fragment do
   @moduledoc """
   This module provides conveniences for analyzing fragments of

--- a/lib/elixir/lib/code/identifier.ex
+++ b/lib/elixir/lib/code/identifier.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Code.Identifier do
   @moduledoc false
 

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Code.Normalizer do
   @moduledoc false
 

--- a/lib/elixir/lib/code/typespec.ex
+++ b/lib/elixir/lib/code/typespec.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Code.Typespec do
   @moduledoc false
 

--- a/lib/elixir/lib/collectable.ex
+++ b/lib/elixir/lib/collectable.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defprotocol Collectable do
   @moduledoc """
   A protocol to traverse data structures.

--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Config do
   @moduledoc ~S"""
   A simple keyword-based configuration API.

--- a/lib/elixir/lib/config/provider.ex
+++ b/lib/elixir/lib/config/provider.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Config.Provider do
   @moduledoc """
   Specifies a provider API that loads configuration during boot.

--- a/lib/elixir/lib/config/reader.ex
+++ b/lib/elixir/lib/config/reader.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Config.Reader do
   @moduledoc """
   API for reading config files defined with `Config`.

--- a/lib/elixir/lib/dict.ex
+++ b/lib/elixir/lib/dict.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Dict do
   @moduledoc ~S"""
   Generic API for dictionaries.

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule DynamicSupervisor do
   @moduledoc ~S"""
   A supervisor optimized to only start children dynamically.

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defprotocol Enumerable do
   @moduledoc """
   Enumerable protocol used by `Enum` and `Stream` modules.

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Exception do
   @moduledoc """
   Functions for dealing with throw/catch/exit and exceptions.

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule File do
   @moduledoc ~S"""
   This module contains functions to manipulate files.

--- a/lib/elixir/lib/file/stat.ex
+++ b/lib/elixir/lib/file/stat.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 require Record
 
 defmodule File.Stat do

--- a/lib/elixir/lib/file/stream.ex
+++ b/lib/elixir/lib/file/stream.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule File.Stream do
   @moduledoc """
   Defines a `File.Stream` struct returned by `File.stream!/3`.

--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 import Kernel, except: [round: 1]
 
 defmodule Float do

--- a/lib/elixir/lib/function.ex
+++ b/lib/elixir/lib/function.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Function do
   @moduledoc """
   A set of functions for working with functions.

--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule GenEvent do
   # Functions from this module are deprecated in elixir_dispatch.
 

--- a/lib/elixir/lib/gen_event/stream.ex
+++ b/lib/elixir/lib/gen_event/stream.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule GenEvent.Stream do
   @moduledoc false
   defstruct manager: nil, timeout: :infinity

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule GenServer do
   @moduledoc """
   A behaviour module for implementing the server of a client-server relation.

--- a/lib/elixir/lib/hash_dict.ex
+++ b/lib/elixir/lib/hash_dict.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule HashDict do
   @moduledoc """
   Tuple-based HashDict implementation.

--- a/lib/elixir/lib/hash_set.ex
+++ b/lib/elixir/lib/hash_set.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule HashSet do
   @moduledoc """
   Tuple-based HashSet implementation.

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 import Kernel, except: [inspect: 1]
 import Inspect.Algebra
 

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Inspect.Opts do
   @moduledoc """
   Defines the options used by the `Inspect` protocol.

--- a/lib/elixir/lib/inspect/error.ex
+++ b/lib/elixir/lib/inspect/error.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Inspect.Error do
   @moduledoc """
   Raised when a struct cannot be inspected.

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Integer do
   @moduledoc """
   Functions for working with integers.

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IO do
   @moduledoc ~S"""
   Functions handling input/output (IO).

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IO.ANSI.Sequence do
   @moduledoc false
 

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IO.ANSI.Docs do
   @moduledoc false
 

--- a/lib/elixir/lib/io/stream.ex
+++ b/lib/elixir/lib/io/stream.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IO.StreamError do
   defexception [:reason]
 

--- a/lib/elixir/lib/json.ex
+++ b/lib/elixir/lib/json.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defprotocol JSON.Encoder do
   @moduledoc """
   A protocol for custom JSON encoding of data structures.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # Use elixir_bootstrap module to be able to bootstrap Kernel.
 # The bootstrap module provides simpler implementations of the
 # functions removed, simple enough to bootstrap.

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Kernel.CLI do
   @moduledoc false
 

--- a/lib/elixir/lib/kernel/error_handler.ex
+++ b/lib/elixir/lib/kernel/error_handler.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # Implement error_handler pattern for Erlang
 # which is integrated with Kernel.ParallelCompiler
 defmodule Kernel.ErrorHandler do

--- a/lib/elixir/lib/kernel/lexical_tracker.ex
+++ b/lib/elixir/lib/kernel/lexical_tracker.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # This is an Elixir module responsible for tracking references
 # to modules, remote dispatches, and the usage of
 # aliases/imports/requires in the Elixir scope.

--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Kernel.ParallelCompiler do
   @moduledoc """
   A module responsible for compiling and requiring files in parallel.

--- a/lib/elixir/lib/kernel/parallel_require.ex
+++ b/lib/elixir/lib/kernel/parallel_require.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Kernel.ParallelRequire do
   @moduledoc false
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Kernel.SpecialForms do
   @moduledoc """
   Special forms are the basic building blocks of Elixir, and therefore

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Kernel.Typespec do
   @moduledoc false
 

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 import Kernel, except: [destructure: 2, defdelegate: 2, defstruct: 2]
 
 defmodule Kernel.Utils do

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Keyword do
   @moduledoc """
   A keyword list is a list that consists exclusively of two-element tuples.

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule List do
   @moduledoc """
   Linked lists hold zero, one, or more elements in the chosen order.

--- a/lib/elixir/lib/list/chars.ex
+++ b/lib/elixir/lib/list/chars.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defprotocol List.Chars do
   @moduledoc ~S"""
   The `List.Chars` protocol is responsible for

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 import Kernel, except: [to_string: 1]
 
 defmodule Macro do

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Macro.Env do
   @moduledoc """
   A struct that holds compile time environment information.

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Map do
   @moduledoc """
   Maps are the "go to" key-value data structure in Elixir.

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule MapSet do
   @moduledoc """
   Functions that work on sets.

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Module do
   @moduledoc ~S'''
   Provides functions to deal with modules during compilation time.

--- a/lib/elixir/lib/module/behaviour.ex
+++ b/lib/elixir/lib/module/behaviour.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Module.Behaviour do
   # Checking functionality for @behaviours and @impl
   @moduledoc false

--- a/lib/elixir/lib/module/parallel_checker.ex
+++ b/lib/elixir/lib/module/parallel_checker.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Module.ParallelChecker do
   @moduledoc false
 

--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Module.Types do
   @moduledoc false
   alias Module.Types.{Descr, Expr, Pattern, Helpers}

--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Module.Types.Apply do
   # Typing functionality shared between Expr and Pattern.
   # Generic AST and Enum helpers go to Module.Types.Helpers.

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Module.Types.Descr do
   @moduledoc false
 

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Module.Types.Expr do
   @moduledoc false
 

--- a/lib/elixir/lib/module/types/helpers.ex
+++ b/lib/elixir/lib/module/types/helpers.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Module.Types.Helpers do
   # AST and enumeration helpers.
   @moduledoc false

--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Module.Types.Of do
   # Typing functionality shared between Expr and Pattern.
   # Generic AST and Enum helpers go to Module.Types.Helpers.

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Module.Types.Pattern do
   @moduledoc false
 

--- a/lib/elixir/lib/node.ex
+++ b/lib/elixir/lib/node.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Node do
   @moduledoc """
   Functions related to VM nodes.

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule OptionParser do
   @moduledoc """
   Functions for parsing command line arguments.

--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule PartitionSupervisor do
   @moduledoc """
   A supervisor that starts multiple partitions of the same child.

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Path do
   @moduledoc """
   This module provides conveniences for manipulating or

--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Port do
   @moduledoc ~S"""
   Functions for interacting with the external world through ports.

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Process do
   @moduledoc """
   Conveniences for working with processes and the process dictionary.

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Protocol do
   @moduledoc ~S"""
   Reference and functions for working with protocols.

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Range do
   @moduledoc """
   Ranges represent a sequence of zero, one or many, ascending

--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Record do
   @moduledoc """
   Module to work with, define, and import records.

--- a/lib/elixir/lib/record/extractor.ex
+++ b/lib/elixir/lib/record/extractor.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Record.Extractor do
   @moduledoc false
 

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Regex do
   @moduledoc ~S"""
   Provides regular expressions for Elixir.

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Registry do
   @moduledoc ~S"""
   A local, decentralized and scalable key-value process storage.

--- a/lib/elixir/lib/set.ex
+++ b/lib/elixir/lib/set.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Set do
   @moduledoc ~S"""
   Generic API for sets.

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Stream do
   @moduledoc """
   Functions for creating and composing streams.

--- a/lib/elixir/lib/stream/reducers.ex
+++ b/lib/elixir/lib/stream/reducers.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Stream.Reducers do
   # Collection of reducers and utilities shared by Enum and Stream.
   @moduledoc false

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 import Kernel, except: [length: 1]
 
 defmodule String do

--- a/lib/elixir/lib/string/chars.ex
+++ b/lib/elixir/lib/string/chars.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 import Kernel, except: [to_string: 1]
 
 defprotocol String.Chars do

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule StringIO do
   @moduledoc """
   Controls an IO device process that wraps a string.

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Supervisor do
   @moduledoc ~S"""
   A behaviour module for implementing supervisors.

--- a/lib/elixir/lib/supervisor/default.ex
+++ b/lib/elixir/lib/supervisor/default.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Supervisor.Default do
   @moduledoc false
 

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Supervisor.Spec do
   @moduledoc """
   Outdated functions for building child specifications.

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule System do
   @moduledoc """
   The `System` module provides functions that interact directly

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Task do
   @moduledoc """
   Conveniences for spawning and awaiting tasks.

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Task.Supervised do
   @moduledoc false
   @ref_timeout 5000

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Task.Supervisor do
   @moduledoc """
   A task supervisor.

--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Tuple do
   @moduledoc """
   Functions for working with tuples.

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule URI do
   @moduledoc """
   Utilities for working with URIs.

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Version do
   @moduledoc ~S"""
   Functions for parsing and matching versions against requirements.

--- a/lib/elixir/mix.exs
+++ b/lib/elixir/mix.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Elixir.MixProject do
   use Mix.Project
 

--- a/lib/elixir/pages/anti-patterns/code-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/code-anti-patterns.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Code-related anti-patterns
 
 This document outlines potential anti-patterns related to your code and particular Elixir idioms and features.

--- a/lib/elixir/pages/anti-patterns/design-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/design-anti-patterns.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Design-related anti-patterns
 
 This document outlines potential anti-patterns related to your modules, functions, and the role they play within a codebase.

--- a/lib/elixir/pages/anti-patterns/macro-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/macro-anti-patterns.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Meta-programming anti-patterns
 
 This document outlines potential anti-patterns related to meta-programming.

--- a/lib/elixir/pages/anti-patterns/process-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/process-anti-patterns.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Process-related anti-patterns
 
 This document outlines potential anti-patterns related to processes and process-based abstractions.

--- a/lib/elixir/pages/anti-patterns/what-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/what-anti-patterns.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # What are anti-patterns?
 
 Anti-patterns describe common mistakes or indicators of problems in code.

--- a/lib/elixir/pages/cheatsheets/enum-cheat.cheatmd
+++ b/lib/elixir/pages/cheatsheets/enum-cheat.cheatmd
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Enum cheatsheet
 
 A quick reference into the `Enum` module, a module for working with collections (known as enumerables). Most of the examples below use the following data structure:

--- a/lib/elixir/pages/getting-started/alias-require-and-import.md
+++ b/lib/elixir/pages/getting-started/alias-require-and-import.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # alias, require, import, and use
 
 In order to facilitate software reuse, Elixir provides three directives (`alias`, `require`, and `import`) plus a macro called `use` summarized below:

--- a/lib/elixir/pages/getting-started/anonymous-functions.md
+++ b/lib/elixir/pages/getting-started/anonymous-functions.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Anonymous functions
 
 Anonymous functions allow us to store and pass executable code around as if it was an integer or a string. Let's learn more.

--- a/lib/elixir/pages/getting-started/basic-types.md
+++ b/lib/elixir/pages/getting-started/basic-types.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Basic types
 
 In this chapter we will learn more about Elixir basic types: integers, floats, booleans, atoms, and strings. Other data types, such as lists and tuples, will be explored in the next chapter.

--- a/lib/elixir/pages/getting-started/binaries-strings-and-charlists.md
+++ b/lib/elixir/pages/getting-started/binaries-strings-and-charlists.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Binaries, strings, and charlists
 
 In ["Basic types"](basic-types.md), we learned a bit about strings and we used the `is_binary/1` function for checks:

--- a/lib/elixir/pages/getting-started/case-cond-and-if.md
+++ b/lib/elixir/pages/getting-started/case-cond-and-if.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # case, cond, and if
 
 In this chapter, we will learn about the [`case`](`case/2`), [`cond`](`cond/1`), and [`if`](`if/2`) control flow structures.

--- a/lib/elixir/pages/getting-started/comprehensions.md
+++ b/lib/elixir/pages/getting-started/comprehensions.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Comprehensions
 
 In Elixir, it is common to loop over an `Enumerable`, often filtering out some results and mapping values into another list. Comprehensions are syntactic sugar for such constructs: they group those common tasks into the `for` special form.

--- a/lib/elixir/pages/getting-started/debugging.md
+++ b/lib/elixir/pages/getting-started/debugging.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Debugging
 
 There are a number of ways to debug code in Elixir. In this chapter we will cover some of the more common ways of doing so.

--- a/lib/elixir/pages/getting-started/enumerable-and-streams.md
+++ b/lib/elixir/pages/getting-started/enumerable-and-streams.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Enumerables and Streams
 
 While Elixir allows us to write recursive code, most operations we perform on collections is done with the help of the `Enum` and `Stream` modules. Let's learn how.

--- a/lib/elixir/pages/getting-started/erlang-libraries.md
+++ b/lib/elixir/pages/getting-started/erlang-libraries.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Erlang libraries
 
 Elixir provides excellent interoperability with Erlang libraries. In fact, Elixir discourages simply wrapping Erlang libraries in favor of directly interfacing with Erlang code. In this section, we will present some of the most common and useful Erlang functionality that is not found in Elixir.

--- a/lib/elixir/pages/getting-started/introduction.md
+++ b/lib/elixir/pages/getting-started/introduction.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Introduction
 
 Welcome!

--- a/lib/elixir/pages/getting-started/io-and-the-file-system.md
+++ b/lib/elixir/pages/getting-started/io-and-the-file-system.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # IO and the file system
 
 This chapter introduces the input/output mechanisms, file-system-related tasks, and related modules such as `IO`, `File`, and `Path`. The IO system provides a great opportunity to shed some light on some philosophies and curiosities of Elixir and the Erlang VM.

--- a/lib/elixir/pages/getting-started/keywords-and-maps.md
+++ b/lib/elixir/pages/getting-started/keywords-and-maps.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Keyword lists and maps
 
 Now let's talk about associative data structures. Associative data structures are able to associate a key to a certain value. Different languages call these different names like dictionaries, hashes, associative arrays, etc.

--- a/lib/elixir/pages/getting-started/lists-and-tuples.md
+++ b/lib/elixir/pages/getting-started/lists-and-tuples.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Lists and tuples
 
 In this chapter we will learn two of the most used collection data-types in Elixir: lists and tuples.

--- a/lib/elixir/pages/getting-started/module-attributes.md
+++ b/lib/elixir/pages/getting-started/module-attributes.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Module attributes
 
 Module attributes in Elixir serve three purposes:

--- a/lib/elixir/pages/getting-started/modules-and-functions.md
+++ b/lib/elixir/pages/getting-started/modules-and-functions.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Modules and functions
 
 In Elixir we group several functions into modules. We've already used many different modules in the previous chapters, such as the `String` module:

--- a/lib/elixir/pages/getting-started/optional-syntax.md
+++ b/lib/elixir/pages/getting-started/optional-syntax.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Optional syntax sheet
 
 In the previous chapters, we learned that the Elixir syntax allows developers to omit delimiters in a few occasions to make code more readable. For example, we learned that parentheses are optional:

--- a/lib/elixir/pages/getting-started/pattern-matching.md
+++ b/lib/elixir/pages/getting-started/pattern-matching.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Pattern matching
 
 In this chapter, we will learn why the [`=`](`=/2`) operator in Elixir is called the match operator and how to use it to pattern match inside data structures. We will learn about the pin operator [`^`](`^/1`) used to access previously bound values.

--- a/lib/elixir/pages/getting-started/processes.md
+++ b/lib/elixir/pages/getting-started/processes.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Processes
 
 In Elixir, all code runs inside processes. Processes are isolated from each other, run concurrent to one another and communicate via message passing. Processes are not only the basis for concurrency in Elixir, but they also provide the means for building distributed and fault-tolerant programs.

--- a/lib/elixir/pages/getting-started/protocols.md
+++ b/lib/elixir/pages/getting-started/protocols.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Protocols
 
 Protocols are a mechanism to achieve polymorphism in Elixir where you want the behavior to vary depending on the data type. We are already familiar with one way of solving this type of problem: via pattern matching and guard clauses. Consider a simple utility module that would tell us the type of input variable:

--- a/lib/elixir/pages/getting-started/recursion.md
+++ b/lib/elixir/pages/getting-started/recursion.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Recursion
 
 Elixir does not provide loop constructs. Instead we leverage recursion and high-level functions for working with collections. This chapter will explore the former.

--- a/lib/elixir/pages/getting-started/sigils.md
+++ b/lib/elixir/pages/getting-started/sigils.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Sigils
 
 Elixir provides double-quoted strings as well as a concept called charlists, which are defined using the `~c"hello world"` sigil syntax. In this chapter, we will learn more about sigils and how to define our own.

--- a/lib/elixir/pages/getting-started/structs.md
+++ b/lib/elixir/pages/getting-started/structs.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Structs
 
 We learned about maps [in earlier chapters](keywords-and-maps.md):

--- a/lib/elixir/pages/getting-started/try-catch-and-rescue.md
+++ b/lib/elixir/pages/getting-started/try-catch-and-rescue.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # try, catch, and rescue
 
 Elixir has three error mechanisms: errors, throws, and exits. In this chapter, we will explore each of them and include remarks about when each should be used.

--- a/lib/elixir/pages/getting-started/writing-documentation.md
+++ b/lib/elixir/pages/getting-started/writing-documentation.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 # Writing documentation
 
 Elixir treats documentation as a first-class citizen. Documentation must be easy to write and easy to read. In this guide you will learn how to write documentation in Elixir, covering constructs like module attributes, style practices, and doctests.

--- a/lib/elixir/pages/meta-programming/domain-specific-languages.md
+++ b/lib/elixir/pages/meta-programming/domain-specific-languages.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Domain-Specific Languages (DSLs)
 
 [Domain-specific Languages (DSLs)](https://en.wikipedia.org/wiki/Domain-specific_language) are languages tailored to a specific application domain. You don't need macros in order to have a DSL: every data structure and every function you define in your module is part of your domain-specific language.

--- a/lib/elixir/pages/meta-programming/macros.md
+++ b/lib/elixir/pages/meta-programming/macros.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Macros
 
 Even though Elixir attempts its best to provide a safe environment for macros, most of the responsibility of writing clean code with macros falls on developers. Macros are harder to write than ordinary Elixir functions, and it's considered to be bad style to use them when they're not necessary. Write macros responsibly.

--- a/lib/elixir/pages/meta-programming/quote-and-unquote.md
+++ b/lib/elixir/pages/meta-programming/quote-and-unquote.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Quote and unquote
 
 This guide aims to introduce the meta-programming techniques available in Elixir. The ability to represent an Elixir program by its own data structures is at the heart of meta-programming. This chapter starts by exploring those structures and the associated `quote/2` and `unquote/1` constructs, so we can take a look at macros in the next guide, and finally build our own domain specific language.

--- a/lib/elixir/pages/mix-and-otp/agents.md
+++ b/lib/elixir/pages/mix-and-otp/agents.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Simple state management with agents
 
 In this chapter, we will learn how to keep and share state between multiple entities. If you have previous programming experience, you may think of globally shared variables, but the model we will learn here is quite different. The next chapters will generalize the concepts introduced here.

--- a/lib/elixir/pages/mix-and-otp/config-and-releases.md
+++ b/lib/elixir/pages/mix-and-otp/config-and-releases.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Configuration and releases
 
 In this last guide, we will make the routing table for our distributed key-value store configurable, and then finally package the software for production.

--- a/lib/elixir/pages/mix-and-otp/dependencies-and-umbrella-projects.md
+++ b/lib/elixir/pages/mix-and-otp/dependencies-and-umbrella-projects.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Dependencies and umbrella projects
 
 In this chapter, we will discuss how to manage dependencies in Mix.

--- a/lib/elixir/pages/mix-and-otp/distributed-tasks.md
+++ b/lib/elixir/pages/mix-and-otp/distributed-tasks.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Distributed tasks and tags
 
 In this chapter, we will go back to the `:kv` application and add a routing layer that will allow us to distribute requests between nodes based on the bucket name.

--- a/lib/elixir/pages/mix-and-otp/docs-tests-and-with.md
+++ b/lib/elixir/pages/mix-and-otp/docs-tests-and-with.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Doctests, patterns, and with
 
 In this chapter, we will implement the code that parses the commands we described in the first chapter:

--- a/lib/elixir/pages/mix-and-otp/dynamic-supervisor.md
+++ b/lib/elixir/pages/mix-and-otp/dynamic-supervisor.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Supervising dynamic children
 
 We have now successfully defined our supervisor which is automatically started (and stopped) as part of our application life cycle.

--- a/lib/elixir/pages/mix-and-otp/erlang-term-storage.md
+++ b/lib/elixir/pages/mix-and-otp/erlang-term-storage.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Speeding up with ETS
 
 Every time we need to look up a bucket, we need to send a message to the registry. In case our registry is being accessed concurrently by multiple processes, the registry may become a bottleneck!

--- a/lib/elixir/pages/mix-and-otp/genservers.md
+++ b/lib/elixir/pages/mix-and-otp/genservers.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Client-server communication with GenServer
 
 In the [previous chapter](agents.md), we used agents to represent our buckets. In the [introduction to mix](introduction-to-mix.md), we specified we would like to name each bucket so we can do the following:

--- a/lib/elixir/pages/mix-and-otp/introduction-to-mix.md
+++ b/lib/elixir/pages/mix-and-otp/introduction-to-mix.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Introduction to Mix
 
 In this guide, we will build a complete Elixir application, with its own supervision tree, configuration, tests, and more.

--- a/lib/elixir/pages/mix-and-otp/supervisor-and-application.md
+++ b/lib/elixir/pages/mix-and-otp/supervisor-and-application.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Supervision trees and applications
 
 In the previous chapter about `GenServer`, we implemented `KV.Registry` to manage buckets. At some point, we started monitoring buckets so we were able to take action whenever a `KV.Bucket` crashed. Although the change was relatively small, it introduced a question which is frequently asked by Elixir developers: what happens when something fails?

--- a/lib/elixir/pages/mix-and-otp/task-and-gen-tcp.md
+++ b/lib/elixir/pages/mix-and-otp/task-and-gen-tcp.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Task and gen_tcp
 
 In this chapter, we are going to learn how to use Erlang's [`:gen_tcp` module](`:gen_tcp`) to serve requests. This provides a great opportunity to explore Elixir's `Task` module. In future chapters, we will expand our server so that it can actually serve the commands.

--- a/lib/elixir/pages/references/compatibility-and-deprecations.md
+++ b/lib/elixir/pages/references/compatibility-and-deprecations.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 # Compatibility and deprecations
 
 Elixir is versioned according to a vMAJOR.MINOR.PATCH schema.

--- a/lib/elixir/pages/references/gradual-set-theoretic-types.md
+++ b/lib/elixir/pages/references/gradual-set-theoretic-types.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Gradual set-theoretic types
 
 Elixir is in the process of incorporating set-theoretic types into the compiler. This document outlines the current stage of our implementation for this Elixir version. Elixir's type system is:

--- a/lib/elixir/pages/references/library-guidelines.md
+++ b/lib/elixir/pages/references/library-guidelines.md
@@ -1,3 +1,8 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+-->
+
 # Library guidelines
 
 This document outlines general guidelines for those writing and publishing

--- a/lib/elixir/pages/references/naming-conventions.md
+++ b/lib/elixir/pages/references/naming-conventions.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 # Naming conventions
 
 This document is a reference of the naming conventions in Elixir, from casing to punctuation characters.

--- a/lib/elixir/pages/references/operators.md
+++ b/lib/elixir/pages/references/operators.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 # Operators reference
 
 This document is a complete reference of operators in Elixir, how they are parsed, how they can be defined, and how they can be overridden.

--- a/lib/elixir/pages/references/patterns-and-guards.md
+++ b/lib/elixir/pages/references/patterns-and-guards.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 # Patterns and guards
 
 Elixir provides pattern matching, which allows us to assert on the shape or extract values from data structures. Patterns are often augmented with guards, which give developers the ability to perform more complex checks, albeit limited.

--- a/lib/elixir/pages/references/syntax-reference.md
+++ b/lib/elixir/pages/references/syntax-reference.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 # Syntax reference
 
 Elixir syntax was designed to have a straightforward conversion to an abstract syntax tree (AST). This means the Elixir syntax is mostly uniform with a handful of "syntax sugar" constructs to reduce the noise in common Elixir idioms.

--- a/lib/elixir/pages/references/typespecs.md
+++ b/lib/elixir/pages/references/typespecs.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 # Typespecs reference
 
 > #### Typespecs are not set-theoretic types {: .warning}

--- a/lib/elixir/pages/references/unicode-syntax.md
+++ b/lib/elixir/pages/references/unicode-syntax.md
@@ -1,3 +1,9 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  SPDX-FileCopyrightText: 2021 The Elixir Team
+  SPDX-FileCopyrightText: 2012 Plataformatec
+-->
+
 # Unicode syntax
 
 Elixir supports Unicode throughout the language. This document is a complete reference of how

--- a/lib/elixir/scripts/diff.exs
+++ b/lib/elixir/scripts/diff.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Diff do
   @moduledoc """
   Utilities for comparing build artifacts.

--- a/lib/elixir/scripts/docs_config.exs
+++ b/lib/elixir/scripts/docs_config.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 # Generate docs_config.js for version chooser in ExDoc
 [app] = System.argv()
 

--- a/lib/elixir/scripts/elixir_docs.exs
+++ b/lib/elixir/scripts/elixir_docs.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # Returns config for Elixir docs (exclusively)
 canonical = System.fetch_env!("CANONICAL")
 

--- a/lib/elixir/scripts/generate_app.escript
+++ b/lib/elixir/scripts/generate_app.escript
@@ -1,4 +1,9 @@
 #!/usr/bin/env escript
+
+%% SPDX-License-Identifier: Apache-2.0
+%% SPDX-FileCopyrightText: 2021 The Elixir Team
+%% SPDX-FileCopyrightText: 2012 Plataformatec
+
 %% -*- erlang -*-
 
 main([Version]) ->

--- a/lib/elixir/scripts/mix_docs.exs
+++ b/lib/elixir/scripts/mix_docs.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 # Returns config for other apps except Elixir
 canonical = System.fetch_env!("CANONICAL")
 

--- a/lib/elixir/scripts/windows_installer/.gitignore
+++ b/lib/elixir/scripts/windows_installer/.gitignore
@@ -1,1 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 tmp/

--- a/lib/elixir/scripts/windows_installer/build.sh
+++ b/lib/elixir/scripts/windows_installer/build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 # Usage:
 #
 # With Elixir archive:

--- a/lib/elixir/scripts/windows_installer/installer.nsi
+++ b/lib/elixir/scripts/windows_installer/installer.nsi
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 !include "MUI2.nsh"
 !include "StrFunc.nsh"
 ${Using:StrFunc} UnStrStr

--- a/lib/elixir/unicode/security.ex
+++ b/lib/elixir/unicode/security.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule String.Tokenizer.Security do
   @moduledoc false
 

--- a/lib/elixir/unicode/tokenizer.ex
+++ b/lib/elixir/unicode/tokenizer.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule String.Tokenizer do
   @moduledoc false
 

--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # How to update the Unicode files
 #
 # Unicode files can be found in https://www.unicode.org/Public/VERSION_NUMBER/ where

--- a/lib/ex_unit/examples/difference.exs
+++ b/lib/ex_unit/examples/difference.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # Run it from root as: make compile && bin/elixir lib/ex_unit/examples/difference.exs
 ExUnit.start(seed: 0)
 

--- a/lib/ex_unit/examples/one_of_each.exs
+++ b/lib/ex_unit/examples/one_of_each.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # Run it from root as: make compile && bin/elixir lib/ex_unit/examples/one_of_each.exs
 ExUnit.start(seed: 0)
 

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit do
   @moduledoc """
   Unit testing framework for Elixir.

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.AssertionError do
   @moduledoc """
   Raised to signal an assertion error.

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.Callbacks do
   @moduledoc ~S"""
   Defines ExUnit callbacks.

--- a/lib/ex_unit/lib/ex_unit/capture_io.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_io.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.CaptureIO do
   @moduledoc ~S"""
   Functionality to capture IO for testing.

--- a/lib/ex_unit/lib/ex_unit/capture_log.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_log.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.CaptureLog do
   @moduledoc ~S"""
   Functionality to capture logs for testing.

--- a/lib/ex_unit/lib/ex_unit/capture_server.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_server.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.CaptureServer do
   @moduledoc false
   @compile {:no_warn_undefined, Logger}

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.Case do
   @moduledoc """
   Helpers for defining test cases.

--- a/lib/ex_unit/lib/ex_unit/case_template.ex
+++ b/lib/ex_unit/lib/ex_unit/case_template.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.CaseTemplate do
   @moduledoc """
   Defines a module template to be used throughout your test suite.

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.CLIFormatter do
   @moduledoc false
   use GenServer

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.Diff do
   @moduledoc false
 

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.DocTest do
   @moduledoc ~S"""
   Extract test cases from the documentation.

--- a/lib/ex_unit/lib/ex_unit/event_manager.ex
+++ b/lib/ex_unit/lib/ex_unit/event_manager.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.EventManager do
   @moduledoc false
   @timeout :infinity

--- a/lib/ex_unit/lib/ex_unit/failures_manifest.ex
+++ b/lib/ex_unit/lib/ex_unit/failures_manifest.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.FailuresManifest do
   @moduledoc false
 

--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.Filters do
   @moduledoc """
   Conveniences for parsing and evaluating filters.

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.Formatter do
   @moduledoc """
   Helper functions for formatting and the formatting protocols.

--- a/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
+++ b/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.OnExitHandler do
   @moduledoc false
 

--- a/lib/ex_unit/lib/ex_unit/on_exit_handler/supervisor.ex
+++ b/lib/ex_unit/lib/ex_unit/on_exit_handler/supervisor.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule ExUnit.OnExitHandler.Supervisor do
   @moduledoc false
   use Supervisor

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.Runner do
   @moduledoc false
 

--- a/lib/ex_unit/lib/ex_unit/runner_stats.ex
+++ b/lib/ex_unit/lib/ex_unit/runner_stats.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.RunnerStats do
   @moduledoc false
 

--- a/lib/ex_unit/lib/ex_unit/server.ex
+++ b/lib/ex_unit/lib/ex_unit/server.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.Server do
   @moduledoc false
   @name __MODULE__

--- a/lib/ex_unit/mix.exs
+++ b/lib/ex_unit/mix.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule ExUnit.MixProject do
   use Mix.Project
 

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IEx do
   @moduledoc ~S"""
   Elixir's interactive shell.

--- a/lib/iex/lib/iex/app.ex
+++ b/lib/iex/lib/iex/app.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IEx.App do
   @moduledoc false
 

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IEx.Autocomplete do
   @moduledoc false
 

--- a/lib/iex/lib/iex/broker.ex
+++ b/lib/iex/lib/iex/broker.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IEx.Broker do
   @moduledoc false
   @name __MODULE__

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IEx.Config do
   @moduledoc false
   use Agent

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IEx.Evaluator do
   @moduledoc false
 

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IEx.Helpers do
   @moduledoc """
   Welcome to Interactive Elixir. You are currently

--- a/lib/iex/lib/iex/history.ex
+++ b/lib/iex/lib/iex/history.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IEx.History do
   @moduledoc false
 

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defprotocol IEx.Info do
   @fallback_to_any true
 

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # Convenience helpers for showing docs, specs, types
 # and opening modules. Invoked directly from IEx.Helpers.
 defmodule IEx.Introspection do

--- a/lib/iex/lib/iex/mix_listener.ex
+++ b/lib/iex/lib/iex/mix_listener.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule IEx.MixListener do
   @moduledoc false
 

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IEx.Pry do
   @moduledoc """
   The low-level API for prying sessions and setting up breakpoints.

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IEx.Server do
   @moduledoc """
   The IEx.Server.

--- a/lib/iex/mix.exs
+++ b/lib/iex/mix.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule IEx.MixProject do
   use Mix.Project
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -163,7 +163,7 @@ defmodule IEx.HelpersTest do
     end
 
     test "opens Elixir module" do
-      assert capture_iex("open(IEx.Helpers)") |> maybe_trim_quotes() =~ ~r/#{@iex_helpers}:1$/
+      assert capture_iex("open(IEx.Helpers)") |> maybe_trim_quotes() =~ ~r/#{@iex_helpers}:5$/
     end
 
     test "opens function" do

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger do
   @moduledoc ~S"""
   A logger for Elixir applications.

--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.App do
   @moduledoc false
 

--- a/lib/logger/lib/logger/backends/config.ex
+++ b/lib/logger/lib/logger/backends/config.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.Backends.Config do
   @moduledoc false
 

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.Backends.Console do
   @moduledoc ~S"""
   A logger backend that logs messages by printing them to the console.

--- a/lib/logger/lib/logger/backends/handler.ex
+++ b/lib/logger/lib/logger/backends/handler.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.Backends.Handler do
   @moduledoc false
   @internal_keys [:counter]

--- a/lib/logger/lib/logger/backends/internal.ex
+++ b/lib/logger/lib/logger/backends/internal.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Logger.Backends.Internal do
   @moduledoc false
 

--- a/lib/logger/lib/logger/backends/supervisor.ex
+++ b/lib/logger/lib/logger/backends/supervisor.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.Backends.Supervisor do
   @moduledoc false
   use Supervisor

--- a/lib/logger/lib/logger/backends/watcher.ex
+++ b/lib/logger/lib/logger/backends/watcher.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.Backends.Watcher do
   @moduledoc false
   require Logger

--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 import Kernel, except: [inspect: 2]
 
 defmodule Logger.Formatter do

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.Translator do
   @moduledoc """
   Default translation for Erlang log messages.

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.Utils do
   @moduledoc false
 

--- a/lib/logger/mix.exs
+++ b/lib/logger/mix.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.MixProject do
   use Mix.Project
 

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix do
   @moduledoc ~S"""
   Mix is a build tool that provides tasks for creating, compiling,

--- a/lib/mix/lib/mix/app_loader.ex
+++ b/lib/mix/lib/mix/app_loader.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Mix.AppLoader do
   @moduledoc false
 

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.CLI do
   @moduledoc false
 

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Compilers.Elixir do
   @moduledoc false
 

--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Compilers.Erlang do
   @moduledoc false
 

--- a/lib/mix/lib/mix/compilers/protocol.ex
+++ b/lib/mix/lib/mix/compilers/protocol.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Compilers.Protocol do
   @moduledoc false
   @manifest "compile.protocols"

--- a/lib/mix/lib/mix/compilers/test.ex
+++ b/lib/mix/lib/mix/compilers/test.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Compilers.Test do
   @moduledoc false
 

--- a/lib/mix/lib/mix/config.ex
+++ b/lib/mix/lib/mix/config.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Config do
   @moduledoc false
 

--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Dep do
   @moduledoc false
 

--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # This module is the one responsible for converging
 # dependencies in a recursive fashion. This
 # module and its functions are private to Mix.

--- a/lib/mix/lib/mix/dep/elixir_scm.ex
+++ b/lib/mix/lib/mix/dep/elixir_scm.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # Manifest file where we treat Elixir and SCMs as a dependency.
 defmodule Mix.Dep.ElixirSCM do
   @moduledoc false

--- a/lib/mix/lib/mix/dep/fetcher.ex
+++ b/lib/mix/lib/mix/dep/fetcher.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # Module responsible for fetching (getting/updating)
 # dependencies from their sources.
 #

--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # This module is responsible for loading dependencies
 # of the current project. This module and its functions
 # are private to Mix.

--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # This module keeps a lock file and the manifest for the lock file.
 # The lockfile keeps the latest dependency information while the
 # manifest is used whenever a dependency is affected via any of the

--- a/lib/mix/lib/mix/dep/umbrella.ex
+++ b/lib/mix/lib/mix/dep/umbrella.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Dep.Umbrella do
   @moduledoc false
 

--- a/lib/mix/lib/mix/exceptions.ex
+++ b/lib/mix/lib/mix/exceptions.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.NoTaskError do
   defexception [:task, :message, mix: true]
 

--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Generator do
   @moduledoc """
   Conveniences for working with paths and generating content.

--- a/lib/mix/lib/mix/hex.ex
+++ b/lib/mix/lib/mix/hex.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Hex do
   @moduledoc false
   @compile {:no_warn_undefined, Hex}

--- a/lib/mix/lib/mix/local.ex
+++ b/lib/mix/lib/mix/local.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Local do
   @moduledoc false
 

--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Local.Installer do
   @moduledoc false
 

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Project do
   @moduledoc """
   Defines and manipulates Mix projects.

--- a/lib/mix/lib/mix/project_stack.ex
+++ b/lib/mix/lib/mix/project_stack.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.ProjectStack do
   @moduledoc false
 

--- a/lib/mix/lib/mix/pubsub.ex
+++ b/lib/mix/lib/mix/pubsub.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Mix.PubSub do
   @moduledoc false
 

--- a/lib/mix/lib/mix/pubsub/subscriber.ex
+++ b/lib/mix/lib/mix/pubsub/subscriber.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Mix.PubSub.Subscriber do
   @moduledoc false
 

--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Rebar do
   @moduledoc false
 

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Release do
   @moduledoc """
   Defines the release structure and convenience for assembling releases.

--- a/lib/mix/lib/mix/remote_converger.ex
+++ b/lib/mix/lib/mix/remote_converger.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.RemoteConverger do
   @moduledoc false
 

--- a/lib/mix/lib/mix/scm.ex
+++ b/lib/mix/lib/mix/scm.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.SCM do
   @moduledoc """
   This module provides helper functions and defines the

--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.SCM.Git do
   @behaviour Mix.SCM
   @moduledoc false

--- a/lib/mix/lib/mix/scm/path.ex
+++ b/lib/mix/lib/mix/scm/path.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.SCM.Path do
   @behaviour Mix.SCM
   @moduledoc false

--- a/lib/mix/lib/mix/shell.ex
+++ b/lib/mix/lib/mix/shell.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Shell do
   @moduledoc """
   Defines `Mix.Shell` contract.

--- a/lib/mix/lib/mix/shell/io.ex
+++ b/lib/mix/lib/mix/shell/io.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Shell.IO do
   @moduledoc """
   This is Mix's default shell.

--- a/lib/mix/lib/mix/shell/process.ex
+++ b/lib/mix/lib/mix/shell/process.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Shell.Process do
   @moduledoc """
   Mix shell that uses the current process mailbox for communication.

--- a/lib/mix/lib/mix/shell/quiet.ex
+++ b/lib/mix/lib/mix/shell/quiet.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Shell.Quiet do
   @moduledoc """
   This is Mix's default shell when the `MIX_QUIET` environment

--- a/lib/mix/lib/mix/state.ex
+++ b/lib/mix/lib/mix/state.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.State do
   @moduledoc false
   @name __MODULE__

--- a/lib/mix/lib/mix/sync/lock.ex
+++ b/lib/mix/lib/mix/sync/lock.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Mix.Sync.Lock do
   @moduledoc false
 

--- a/lib/mix/lib/mix/sync/pubsub.ex
+++ b/lib/mix/lib/mix/sync/pubsub.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Mix.Sync.PubSub do
   @moduledoc false
 

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Task.Compiler do
   @moduledoc """
   This module defines the behaviour for a Mix task that does compilation.

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Task do
   @moduledoc """
   Provides conveniences for creating, loading, and manipulating Mix tasks.

--- a/lib/mix/lib/mix/tasks/app.config.ex
+++ b/lib/mix/lib/mix/tasks/app.config.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Mix.Tasks.App.Config do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/app.start.ex
+++ b/lib/mix/lib/mix/tasks/app.start.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.App.Start do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/app.tree.ex
+++ b/lib/mix/lib/mix/tasks/app.tree.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.App.Tree do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/archive.build.ex
+++ b/lib/mix/lib/mix/tasks/archive.build.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Archive.Build do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/archive.check.ex
+++ b/lib/mix/lib/mix/tasks/archive.check.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Archive.Check do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/archive.ex
+++ b/lib/mix/lib/mix/tasks/archive.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Archive do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Archive.Install do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/archive.uninstall.ex
+++ b/lib/mix/lib/mix/tasks/archive.uninstall.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Archive.Uninstall do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/clean.ex
+++ b/lib/mix/lib/mix/tasks/clean.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Clean do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/cmd.ex
+++ b/lib/mix/lib/mix/tasks/cmd.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Cmd do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/compile.all.ex
+++ b/lib/mix/lib/mix/tasks/compile.all.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Compile.All do
   use Mix.Task.Compiler
 

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Compile.App do
   use Mix.Task.Compiler
 

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Compile.Elixir do
   use Mix.Task.Compiler
 

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Compile.Erlang do
   use Mix.Task.Compiler
   alias Mix.Compilers.Erlang

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Compile do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Compile.Leex do
   use Mix.Task.Compiler
   alias Mix.Compilers.Erlang

--- a/lib/mix/lib/mix/tasks/compile.protocols.ex
+++ b/lib/mix/lib/mix/tasks/compile.protocols.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Compile.Protocols do
   @moduledoc false
   use Mix.Task

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Compile.Yecc do
   use Mix.Task.Compiler
   alias Mix.Compilers.Erlang

--- a/lib/mix/lib/mix/tasks/deps.clean.ex
+++ b/lib/mix/lib/mix/tasks/deps.clean.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Deps.Clean do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Deps.Compile do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Deps do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/deps.get.ex
+++ b/lib/mix/lib/mix/tasks/deps.get.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Deps.Get do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/deps.loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/deps.loadpaths.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Deps.Loadpaths do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/deps.precompile.ex
+++ b/lib/mix/lib/mix/tasks/deps.precompile.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Deps.Precompile do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Deps.Tree do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Deps.Unlock do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/deps.update.ex
+++ b/lib/mix/lib/mix/tasks/deps.update.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Deps.Update do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Do do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Escript.Build do
   use Mix.Task
   import Bitwise, only: [|||: 2]

--- a/lib/mix/lib/mix/tasks/escript.ex
+++ b/lib/mix/lib/mix/tasks/escript.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Escript do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/escript.install.ex
+++ b/lib/mix/lib/mix/tasks/escript.install.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Escript.Install do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/escript.uninstall.ex
+++ b/lib/mix/lib/mix/tasks/escript.uninstall.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Escript.Uninstall do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/eval.ex
+++ b/lib/mix/lib/mix/tasks/eval.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Mix.Tasks.Eval do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Format do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/help.ex
+++ b/lib/mix/lib/mix/tasks/help.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Help do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/iex.ex
+++ b/lib/mix/lib/mix/tasks/iex.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Iex do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/loadconfig.ex
+++ b/lib/mix/lib/mix/tasks/loadconfig.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Loadconfig do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/loadpaths.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Loadpaths do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/local.ex
+++ b/lib/mix/lib/mix/tasks/local.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Local do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Local.Hex do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/local.public_keys.ex
+++ b/lib/mix/lib/mix/tasks/local.public_keys.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Local.PublicKeys do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Local.Rebar do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.New do
   use Mix.Task
   import Mix.Generator

--- a/lib/mix/lib/mix/tasks/profile.cprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.cprof.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Profile.Cprof do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/profile.eprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.eprof.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Profile.Eprof do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Profile.Fprof do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/profile.tprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.tprof.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Mix.Tasks.Profile.Tprof do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Release do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Release.Init do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Run do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/test.coverage.ex
+++ b/lib/mix/lib/mix/tasks/test.coverage.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Mix.Tasks.Test.Coverage do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Test do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks/will_recompile.ex
+++ b/lib/mix/lib/mix/tasks/will_recompile.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.WillRecompile do
   use Mix.Task
   @moduledoc false

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Tasks.Xref do
   use Mix.Task
 

--- a/lib/mix/lib/mix/tasks_server.ex
+++ b/lib/mix/lib/mix/tasks_server.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.TasksServer do
   @moduledoc false
   @name __MODULE__

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.Utils do
   @moduledoc false
 

--- a/lib/mix/mix.exs
+++ b/lib/mix/mix.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Mix.MixProject do
   use Mix.Project
 

--- a/man/common
+++ b/man/common
@@ -1,3 +1,6 @@
+.\" SPDX-License-Identifier: Apache-2.0
+.\" SPDX-FileCopyrightText: 2021 The Elixir Team
+.\" SPDX-FileCopyrightText: 2012 Plataformatec
 .It Fl h , -help
 Displays the help message to the standard error (stderr) and exits.
 .It Fl v , -version

--- a/man/elixir.1.in
+++ b/man/elixir.1.in
@@ -1,3 +1,6 @@
+.\" SPDX-License-Identifier: Apache-2.0
+.\" SPDX-FileCopyrightText: 2021 The Elixir Team
+.\" SPDX-FileCopyrightText: 2012 Plataformatec
 .Dd February 3, 2019
 .Dt ELIXIR 1
 .Os

--- a/man/elixirc.1
+++ b/man/elixirc.1
@@ -1,3 +1,6 @@
+.\" SPDX-License-Identifier: Apache-2.0
+.\" SPDX-FileCopyrightText: 2021 The Elixir Team
+.\" SPDX-FileCopyrightText: 2012 Plataformatec
 .Dd April 10, 2015
 .Dt ELIXIRC 1
 .Os

--- a/man/iex.1.in
+++ b/man/iex.1.in
@@ -1,3 +1,6 @@
+.\" SPDX-License-Identifier: Apache-2.0
+.\" SPDX-FileCopyrightText: 2021 The Elixir Team
+.\" SPDX-FileCopyrightText: 2012 Plataformatec
 .Dd February 3, 2019
 .Dt IEX 1
 .Os

--- a/man/mix.1
+++ b/man/mix.1
@@ -1,3 +1,6 @@
+.\" SPDX-License-Identifier: Apache-2.0
+.\" SPDX-FileCopyrightText: 2021 The Elixir Team
+.\" SPDX-FileCopyrightText: 2012 Plataformatec
 .Dd May 27, 2015
 .Dt MIX 1
 .Os


### PR DESCRIPTION
Follow up of #14241

* Inlines Licence Info & Copyright for all non-test files.
* Fixes one test in `lib/iex/test/iex/helpers_test.exs` referencing a line number

Test files (especially fixtures) will be done in a separate PR since they require lots of small changes in the tests themselves.

This PR includes man files. I'm however not sure how to test the `man/common` file. (I don't exactly know how they work...) Calling `man man/common` yields garbage before the change already.