### PR TITLE
Inline Licence Info & Copyright for test files

### DIFF
--- a/lib/eex/test/eex/smart_engine_test.exs
+++ b/lib/eex/test/eex/smart_engine_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule EEx.SmartEngineTest do

--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule EEx.TokenizerTest do

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 require EEx
@@ -860,13 +864,13 @@ defmodule EExTest do
       file = to_charlist(Path.relative_to_cwd(__ENV__.file))
 
       assert EExTest.Compiled.before_compile() ==
-               {7, {EExTest.Compiled, :before_compile, 0, [file: file, line: 7]}}
+               {11, {EExTest.Compiled, :before_compile, 0, [file: file, line: 11]}}
 
       assert EExTest.Compiled.after_compile() ==
-               {21, {EExTest.Compiled, :after_compile, 0, [file: file, line: 21]}}
+               {25, {EExTest.Compiled, :after_compile, 0, [file: file, line: 25]}}
 
       assert EExTest.Compiled.unknown() ==
-               {26, {EExTest.Compiled, :unknown, 0, [file: ~c"unknown", line: 26]}}
+               {30, {EExTest.Compiled, :unknown, 0, [file: ~c"unknown", line: 30]}}
     end
   end
 

--- a/lib/eex/test/test_helper.exs
+++ b/lib/eex/test/test_helper.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 {line_exclude, line_include} =
   if line = System.get_env("LINE"), do: {[:test], [line: line]}, else: {[], []}
 

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule AccessTest do

--- a/lib/elixir/test/elixir/agent_test.exs
+++ b/lib/elixir/test/elixir/agent_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule AgentTest do

--- a/lib/elixir/test/elixir/application_test.exs
+++ b/lib/elixir/test/elixir/application_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule ApplicationTest do

--- a/lib/elixir/test/elixir/atom_test.exs
+++ b/lib/elixir/test/elixir/atom_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule AtomTest do

--- a/lib/elixir/test/elixir/base_test.exs
+++ b/lib/elixir/test/elixir/base_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule BaseTest do

--- a/lib/elixir/test/elixir/bitwise_test.exs
+++ b/lib/elixir/test/elixir/bitwise_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule BitwiseTest do

--- a/lib/elixir/test/elixir/calendar/date_range_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_range_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 Code.require_file("holocene.exs", __DIR__)
 

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 Code.require_file("holocene.exs", __DIR__)
 Code.require_file("fakes.exs", __DIR__)

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 Code.require_file("holocene.exs", __DIR__)
 Code.require_file("fakes.exs", __DIR__)

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule DurationTest do

--- a/lib/elixir/test/elixir/calendar/fakes.exs
+++ b/lib/elixir/test/elixir/calendar/fakes.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule FakeCalendar do
   def time_to_string(hour, minute, second, _), do: "#{hour}::#{minute}::#{second}"
   def date_to_string(year, month, day), do: "#{day}/#{month}/#{year}"

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Calendar.Holocene do
   # This calendar is used to test conversions between calendars.
   # It implements the Holocene calendar, which is based on the

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Calendar.ISOTest do

--- a/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 Code.require_file("holocene.exs", __DIR__)
 Code.require_file("fakes.exs", __DIR__)

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 Code.require_file("holocene.exs", __DIR__)
 Code.require_file("fakes.exs", __DIR__)

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule CalendarTest do

--- a/lib/elixir/test/elixir/changelog_test.exs
+++ b/lib/elixir/test/elixir/changelog_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 ExUnit.start()
 
 defmodule ChangelogTest do

--- a/lib/elixir/test/elixir/code_formatter/calls_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/calls_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Code.Formatter.CallsTest do

--- a/lib/elixir/test/elixir/code_formatter/comments_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/comments_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Code.Formatter.CommentsTest do

--- a/lib/elixir/test/elixir/code_formatter/containers_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/containers_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Code.Formatter.ContainersTest do

--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Code.Formatter.GeneralTest do

--- a/lib/elixir/test/elixir/code_formatter/integration_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/integration_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Code.Formatter.IntegrationTest do

--- a/lib/elixir/test/elixir/code_formatter/literals_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/literals_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Code.Formatter.LiteralsTest do

--- a/lib/elixir/test/elixir/code_formatter/migration_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/migration_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Code.Formatter.MigrationTest do

--- a/lib/elixir/test/elixir/code_formatter/operators_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/operators_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Code.Formatter.OperatorsTest do

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule CodeFragmentTest do

--- a/lib/elixir/test/elixir/code_identifier_test.exs
+++ b/lib/elixir/test/elixir/code_identifier_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule Code.IdentifierTest do

--- a/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Code.Normalizer.FormatterASTTest do

--- a/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Code.Normalizer.QuotedASTTest do

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule CodeTest do

--- a/lib/elixir/test/elixir/collectable_test.exs
+++ b/lib/elixir/test/elixir/collectable_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule CollectableTest do

--- a/lib/elixir/test/elixir/config/provider_test.exs
+++ b/lib/elixir/test/elixir/config/provider_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Config.ProviderTest do

--- a/lib/elixir/test/elixir/config/reader_test.exs
+++ b/lib/elixir/test/elixir/config/reader_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Config.ReaderTest do

--- a/lib/elixir/test/elixir/config_test.exs
+++ b/lib/elixir/test/elixir/config_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule ConfigTest do

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule DynamicSupervisorTest do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule EnumTest do

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule ExceptionTest do

--- a/lib/elixir/test/elixir/file/stream_test.exs
+++ b/lib/elixir/test/elixir/file/stream_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule File.StreamTest do

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule FileTest do

--- a/lib/elixir/test/elixir/float_test.exs
+++ b/lib/elixir/test/elixir/float_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule FloatTest do

--- a/lib/elixir/test/elixir/function_test.exs
+++ b/lib/elixir/test/elixir/function_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule DummyFunction do

--- a/lib/elixir/test/elixir/gen_server_test.exs
+++ b/lib/elixir/test/elixir/gen_server_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule GenServerTest do

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Inspect.OptsTest do

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule Inspect.AtomTest do

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule IntegerTest do

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule IO.ANSI.DocsTest do

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule IO.ANSITest do

--- a/lib/elixir/test/elixir/io_test.exs
+++ b/lib/elixir/test/elixir/io_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule IOTest do

--- a/lib/elixir/test/elixir/json_test.exs
+++ b/lib/elixir/test/elixir/json_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule JSONTest do

--- a/lib/elixir/test/elixir/kernel/alias_test.exs
+++ b/lib/elixir/test/elixir/kernel/alias_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 alias Kernel.AliasTest.Nested, as: Nested

--- a/lib/elixir/test/elixir/kernel/binary_test.exs
+++ b/lib/elixir/test/elixir/kernel/binary_test.exs
@@ -1,17 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.BinaryTest do
   use ExUnit.Case, async: true
 
   test "heredoc" do
-    assert 7 == __ENV__.line
+    assert 11 == __ENV__.line
 
     assert "foo\nbar\n" == """
            foo
            bar
            """
 
-    assert 14 == __ENV__.line
+    assert 18 == __ENV__.line
 
     assert "foo\nbar \"\"\"\n" == """
            foo
@@ -27,11 +31,11 @@ defmodule Kernel.BinaryTest do
   end
 
   test "heredoc with interpolation" do
-    assert "31\n" == """
+    assert "35\n" == """
            #{__ENV__.line}
            """
 
-    assert "\n36\n" == """
+    assert "\n40\n" == """
 
            #{__ENV__.line}
            """

--- a/lib/elixir/test/elixir/kernel/charlist_test.exs
+++ b/lib/elixir/test/elixir/kernel/charlist_test.exs
@@ -1,17 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule CharlistTest do
   use ExUnit.Case, async: true
 
   test "heredoc" do
-    assert __ENV__.line == 7
+    assert __ENV__.line == 11
 
     assert ~c"foo\nbar\n" == ~c"""
            foo
            bar
            """
 
-    assert __ENV__.line == 14
+    assert __ENV__.line == 18
 
     assert ~c"foo\nbar '''\n" == ~c"""
            foo

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 import PathHelpers

--- a/lib/elixir/test/elixir/kernel/comprehension_test.exs
+++ b/lib/elixir/test/elixir/kernel/comprehension_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.ComprehensionTest do

--- a/lib/elixir/test/elixir/kernel/defaults_test.exs
+++ b/lib/elixir/test/elixir/kernel/defaults_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.DefaultsTest do

--- a/lib/elixir/test/elixir/kernel/deprecated_test.exs
+++ b/lib/elixir/test/elixir/kernel/deprecated_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.DeprecatedTest do

--- a/lib/elixir/test/elixir/kernel/diagnostics_test.exs
+++ b/lib/elixir/test/elixir/kernel/diagnostics_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.DiagnosticsTest do

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.DialyzerTest do

--- a/lib/elixir/test/elixir/kernel/docs_test.exs
+++ b/lib/elixir/test/elixir/kernel/docs_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.DocsTest do

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.ErrorsTest do

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.ExpansionTarget do

--- a/lib/elixir/test/elixir/kernel/fn_test.exs
+++ b/lib/elixir/test/elixir/kernel/fn_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.FnTest do

--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.GuardTest do

--- a/lib/elixir/test/elixir/kernel/impl_test.exs
+++ b/lib/elixir/test/elixir/kernel/impl_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.ImplTest do

--- a/lib/elixir/test/elixir/kernel/import_test.exs
+++ b/lib/elixir/test/elixir/kernel/import_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.ImportTest do

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.LexicalTrackerTest do

--- a/lib/elixir/test/elixir/kernel/macros_test.exs
+++ b/lib/elixir/test/elixir/kernel/macros_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.MacrosTest.Nested do

--- a/lib/elixir/test/elixir/kernel/overridable_test.exs
+++ b/lib/elixir/test/elixir/kernel/overridable_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.Overridable do

--- a/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
+++ b/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 import PathHelpers

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.ParserTest do

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.QuoteTest do

--- a/lib/elixir/test/elixir/kernel/raise_test.exs
+++ b/lib/elixir/test/elixir/kernel/raise_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.RaiseTest do
@@ -22,7 +26,7 @@ defmodule Kernel.RaiseTest do
 
     file = __ENV__.file |> Path.relative_to_cwd() |> String.to_charlist()
 
-    assert {__MODULE__, :"test raise preserves the stacktrace", _, [file: ^file, line: 18] ++ _} =
+    assert {__MODULE__, :"test raise preserves the stacktrace", _, [file: ^file, line: 22] ++ _} =
              stacktrace
   end
 

--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.SigilsTest do

--- a/lib/elixir/test/elixir/kernel/special_forms_test.exs
+++ b/lib/elixir/test/elixir/kernel/special_forms_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.SpecialFormsTest do

--- a/lib/elixir/test/elixir/kernel/string_tokenizer_test.exs
+++ b/lib/elixir/test/elixir/kernel/string_tokenizer_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.StringTokenizerTest do

--- a/lib/elixir/test/elixir/kernel/tracers_test.exs
+++ b/lib/elixir/test/elixir/kernel/tracers_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.TracersTest do

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.WarningTest do
@@ -63,7 +67,7 @@ defmodule Kernel.WarningTest do
 
   test "warnings from macro" do
     assert_warn_eval(
-      ["demo:60\n", "key :dup will be overridden in map\n"],
+      ["demo:64\n", "key :dup will be overridden in map\n"],
       """
       import Kernel.WarningTest
       will_warn()

--- a/lib/elixir/test/elixir/kernel/with_test.exs
+++ b/lib/elixir/test/elixir/kernel/with_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Kernel.WithTest do

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule KernelTest do

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule KeywordTest do

--- a/lib/elixir/test/elixir/list/chars_test.exs
+++ b/lib/elixir/test/elixir/list/chars_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule List.Chars.AtomTest do

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule ListTest do

--- a/lib/elixir/test/elixir/macro/env_test.exs
+++ b/lib/elixir/test/elixir/macro/env_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule MacroEnvMacros do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule Macro.ExternalTest do

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule MapSetTest do

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule MapTest do

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("type_helper.exs", __DIR__)
 
 defmodule Decimal do

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("type_helper.exs", __DIR__)
 
 defmodule Module.Types.ExprTest do
@@ -964,7 +968,7 @@ defmodule Module.Types.ExprTest do
              where "p" was given the type:
 
                  # type: %Point{x: integer(), y: nil, z: integer()}
-                 # from: types_test.ex:947
+                 # from: types_test.ex:951
                  p = %Point{..., x: 123}
              """
     end

--- a/lib/elixir/test/elixir/module/types/helpers_test.exs
+++ b/lib/elixir/test/elixir/module/types/helpers_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("type_helper.exs", __DIR__)
 
 defmodule Module.Types.HelpersTest do

--- a/lib/elixir/test/elixir/module/types/infer_test.exs
+++ b/lib/elixir/test/elixir/module/types/infer_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("type_helper.exs", __DIR__)
 
 defmodule Module.Types.InferTest do

--- a/lib/elixir/test/elixir/module/types/integration_test.exs
+++ b/lib/elixir/test/elixir/module/types/integration_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("type_helper.exs", __DIR__)
 
 defmodule Module.Types.IntegrationTest do

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("type_helper.exs", __DIR__)
 
 defmodule Module.Types.PatternTest do

--- a/lib/elixir/test/elixir/module/types/type_helper.exs
+++ b/lib/elixir/test/elixir/module/types/type_helper.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Point do

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule ModuleTest.ToBeUsed do
@@ -35,7 +39,7 @@ end
 
 defmodule ModuleTest.ToUse do
   # Moving the next line around can make tests fail
-  38 = __ENV__.line
+  42 = __ENV__.line
   var = 1
   # Not available in callbacks
   _ = var
@@ -122,7 +126,7 @@ defmodule ModuleTest do
   ## Callbacks
 
   test "retrieves line from use callsite" do
-    assert ModuleTest.ToUse.line() == 43
+    assert ModuleTest.ToUse.line() == 47
   end
 
   test "executes custom before_compile callback" do

--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule OptionParserTest do

--- a/lib/elixir/test/elixir/partition_supervisor_test.exs
+++ b/lib/elixir/test/elixir/partition_supervisor_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule PartitionSupervisorTest do

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule PathTest do

--- a/lib/elixir/test/elixir/port_test.exs
+++ b/lib/elixir/test/elixir/port_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule PortTest do

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule ProcessTest do

--- a/lib/elixir/test/elixir/protocol/consolidation_test.exs
+++ b/lib/elixir/test/elixir/protocol/consolidation_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 path = Path.expand("../../ebin", __DIR__)

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule ProtocolTest do
@@ -184,15 +188,15 @@ defmodule ProtocolTest do
   end
 
   test "protocol defines callbacks" do
-    assert [{:type, {13, 13}, :fun, args}] = get_callbacks(@sample_binary, :ok, 1)
+    assert [{:type, {17, 13}, :fun, args}] = get_callbacks(@sample_binary, :ok, 1)
 
     assert args == [
-             {:type, {13, 13}, :product, [{:user_type, {13, 16}, :t, []}]},
-             {:type, {13, 22}, :boolean, []}
+             {:type, {17, 13}, :product, [{:user_type, {17, 16}, :t, []}]},
+             {:type, {17, 22}, :boolean, []}
            ]
 
-    assert [{:type, 23, :fun, args}] = get_callbacks(@with_any_binary, :ok, 1)
-    assert args == [{:type, 23, :product, [{:user_type, 23, :t, []}]}, {:type, 23, :term, []}]
+    assert [{:type, 27, :fun, args}] = get_callbacks(@with_any_binary, :ok, 1)
+    assert args == [{:type, 27, :product, [{:user_type, 27, :t, []}]}, {:type, 27, :term, []}]
   end
 
   test "protocol defines t/0 type with documentation" do

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule RangeTest do

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule RecordTest do
@@ -350,7 +354,7 @@ defmodule RecordTest do
       end
     )
 
-    {:docs_v1, 348, :elixir, "text/markdown", _, %{}, docs} = Code.fetch_docs(RecordTest.Metadata)
+    {:docs_v1, 352, :elixir, "text/markdown", _, %{}, docs} = Code.fetch_docs(RecordTest.Metadata)
     {{:macro, :user, 1}, _meta, _sig, _docs, metadata} = List.keyfind(docs, {:macro, :user, 1}, 0)
     assert %{record: {:user, [foo: 0, bar: "baz"]}} = metadata
   end

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule RegexTest do

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule Registry.CommonTest do

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule StreamTest do

--- a/lib/elixir/test/elixir/string/chars_test.exs
+++ b/lib/elixir/test/elixir/string/chars_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule String.Chars.AtomTest do

--- a/lib/elixir/test/elixir/string_io_test.exs
+++ b/lib/elixir/test/elixir/string_io_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule StringIOTest do

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule StringTest do

--- a/lib/elixir/test/elixir/supervisor_test.exs
+++ b/lib/elixir/test/elixir/supervisor_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule SupervisorTest do

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule SystemTest do

--- a/lib/elixir/test/elixir/task/supervisor_test.exs
+++ b/lib/elixir/test/elixir/task/supervisor_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Task.SupervisorTest do

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule TaskTest do

--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # Beam files compiled on demand
 path = Path.expand("../../tmp/beams", __DIR__)
 File.rm_rf!(path)

--- a/lib/elixir/test/elixir/tuple_test.exs
+++ b/lib/elixir/test/elixir/tuple_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule TupleTest do

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 # Holds tests for both Kernel.Typespec and Code.Typespec
@@ -128,7 +132,7 @@ defmodule TypespecTest do
 
     test "redefined type" do
       assert_raise Kernel.TypespecError,
-                   ~r"type foo/0 is already defined in .*test/elixir/typespec_test.exs:134",
+                   ~r"type foo/0 is already defined in .*test/elixir/typespec_test.exs:138",
                    fn ->
                      test_module do
                        @type foo :: atom
@@ -137,7 +141,7 @@ defmodule TypespecTest do
                    end
 
       assert_raise Kernel.TypespecError,
-                   ~r"type foo/2 is already defined in .*test/elixir/typespec_test.exs:144",
+                   ~r"type foo/2 is already defined in .*test/elixir/typespec_test.exs:148",
                    fn ->
                      test_module do
                        @type foo :: atom
@@ -147,7 +151,7 @@ defmodule TypespecTest do
                    end
 
       assert_raise Kernel.TypespecError,
-                   ~r"type foo/0 is already defined in .*test/elixir/typespec_test.exs:153",
+                   ~r"type foo/0 is already defined in .*test/elixir/typespec_test.exs:157",
                    fn ->
                      test_module do
                        @type foo :: atom

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule URITest do

--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule VersionTest do

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.AssertionsTest.Value do

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.CallbacksTest do

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.CaptureIOTest do

--- a/lib/ex_unit/test/ex_unit/capture_log_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_log_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.CaptureLogTest do

--- a/lib/ex_unit/test/ex_unit/case_template_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_template_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.SampleCase do

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.CaseTest do

--- a/lib/ex_unit/test/ex_unit/describe_test.exs
+++ b/lib/ex_unit/test/ex_unit/describe_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.DescribeTest do

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.DiffTest do

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.BeamHelpers do
@@ -875,7 +879,7 @@ defmodule ExUnit.DocTestTest do
                 Doctest did not compile, got: (TokenMissingError) token missing on #{location}:#{line}:20:
                      error: missing terminator: }
                      │
-                 228 │ {:ok, #Inspect<[]>}
+                 #{line} │ {:ok, #Inspect<[]>}
                      │ │                  └ missing closing delimiter (expected "}")
                      │ └ unclosed delimiter
                      │
@@ -1109,22 +1113,22 @@ defmodule ExUnit.DocTestTest do
     assert %{
              test_type: :doctest,
              doctest: NoImport,
-             doctest_line: 133,
-             doctest_data: %{end_line: 134}
+             doctest_line: 137,
+             doctest_data: %{end_line: 138}
            } = test1.tags
 
     assert %{
              test_type: :doctest,
              doctest: NoImport,
-             doctest_line: 136,
-             doctest_data: %{end_line: 137}
+             doctest_line: 140,
+             doctest_data: %{end_line: 141}
            } = test2.tags
 
     assert %{
              test_type: :doctest,
              doctest: NoTrailing,
-             doctest_line: 145,
-             doctest_data: %{end_line: 145}
+             doctest_line: 149,
+             doctest_data: %{end_line: 149}
            } = test3.tags
   end
 

--- a/lib/ex_unit/test/ex_unit/failures_manifest_test.exs
+++ b/lib/ex_unit/test/ex_unit/failures_manifest_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.FailuresManifestTest do

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.FiltersTest do

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.FormatterTest do
@@ -219,7 +223,7 @@ defmodule ExUnit.FormatterTest do
   end
 
   test "formats test errors with code snippets" do
-    stack = {Hello, :world, 1, [file: __ENV__.file, line: 3]}
+    stack = {Hello, :world, 1, [file: __ENV__.file, line: 7]}
     failure = [{:error, catch_error(raise "oops"), [stack]}]
 
     assert format_test_failure(test(), failure, 1, 80, &formatter/2) =~ """

--- a/lib/ex_unit/test/ex_unit/register_test.exs
+++ b/lib/ex_unit/test/ex_unit/register_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.RegisterTest do

--- a/lib/ex_unit/test/ex_unit/runner_stats_test.exs
+++ b/lib/ex_unit/test/ex_unit/runner_stats_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.RunnerStatsTest do

--- a/lib/ex_unit/test/ex_unit/supervised_test.exs
+++ b/lib/ex_unit/test/ex_unit/supervised_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.SupervisedTest do

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule ExUnitTest do

--- a/lib/ex_unit/test/test_helper.exs
+++ b/lib/ex_unit/test/test_helper.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Logger.configure_backend(:console, colors: [enabled: false])
 
 {line_exclude, line_include} =

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule IEx.AutocompleteTest do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule IEx.HelpersTest do
@@ -13,9 +17,9 @@ defmodule IEx.HelpersTest do
     end
 
     test "shows current location for custom envs" do
-      whereami = capture_iex("whereami()", [], env: %{__ENV__ | line: 3})
-      assert whereami =~ "test/iex/helpers_test.exs:3"
-      assert whereami =~ "3: defmodule IEx.HelpersTest do"
+      whereami = capture_iex("whereami()", [], env: %{__ENV__ | line: 7})
+      assert whereami =~ "test/iex/helpers_test.exs:7"
+      assert whereami =~ "7: defmodule IEx.HelpersTest do"
     end
 
     test "prints message when location is not available" do

--- a/lib/iex/test/iex/info_test.exs
+++ b/lib/iex/test/iex/info_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule IEx.InfoTest do

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule IEx.InteractionTest do

--- a/lib/iex/test/iex/pry_test.exs
+++ b/lib/iex/test/iex/pry_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule IEx.PryTest do
@@ -11,24 +15,22 @@ defmodule IEx.PryTest do
     test "shows lines with radius" do
       Application.put_env(:elixir, :ansi_enabled, true)
 
-      {:ok, contents} = IEx.Pry.whereami(__ENV__.file, 3, 2)
+      {:ok, contents} = IEx.Pry.whereami(__ENV__.file, 7, 2)
 
       assert IO.iodata_to_binary(contents) == """
-                 1: Code.require_file("../test_helper.exs", __DIR__)
-                 2:\s
-             \e[1m    3: defmodule IEx.PryTest do
-             \e[22m    4:   use ExUnit.Case
-                 5:\s
+                 5: Code.require_file("../test_helper.exs", __DIR__)
+                 6:\s
+             \e[1m    7: defmodule IEx.PryTest do
+             \e[22m    8:   use ExUnit.Case
+                 9:\s
              """
 
-      {:ok, contents} = IEx.Pry.whereami(__ENV__.file, 1, 4)
+      {:ok, contents} = IEx.Pry.whereami(__ENV__.file, 7, 1)
 
       assert IO.iodata_to_binary(contents) == """
-             \e[1m    1: Code.require_file("../test_helper.exs", __DIR__)
-             \e[22m    2:\s
-                 3: defmodule IEx.PryTest do
-                 4:   use ExUnit.Case
-                 5:\s
+                 6:\s
+             \e[1m    7: defmodule IEx.PryTest do
+             \e[22m    8:   use ExUnit.Case
              """
     after
       Application.delete_env(:elixir, :ansi_enabled)

--- a/lib/iex/test/iex/server_test.exs
+++ b/lib/iex/test/iex/server_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule IEx.ServerTest do

--- a/lib/iex/test/test_helper.exs
+++ b/lib/iex/test/test_helper.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 assert_timeout = String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT") || "500")
 System.put_env("ELIXIR_EDITOR", "echo")
 

--- a/lib/logger/test/logger/backends/console_test.exs
+++ b/lib/logger/test/logger/backends/console_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.Backends.ConsoleTest do
   use Logger.Case
 

--- a/lib/logger/test/logger/backends/handler_test.exs
+++ b/lib/logger/test/logger/backends/handler_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.Backends.HandlerTest do
   use Logger.Case
   @moduletag :logger

--- a/lib/logger/test/logger/backends_test.exs
+++ b/lib/logger/test/logger/backends_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Logger.BackendsTest do
   use Logger.Case
   require Logger

--- a/lib/logger/test/logger/formatter_test.exs
+++ b/lib/logger/test/logger/formatter_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.FormatterTest do
   use Logger.Case, async: true
 

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.TranslatorTest do
   use Logger.Case
 

--- a/lib/logger/test/logger/utils_test.exs
+++ b/lib/logger/test/logger/utils_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule Logger.UtilsTest do
   use Logger.Case, async: true
 

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 defmodule LoggerTest do
   use Logger.Case
   require Logger

--- a/lib/logger/test/test_helper.exs
+++ b/lib/logger/test/test_helper.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 {line_exclude, line_include} =
   if line = System.get_env("LINE"), do: {[:test], [line: line]}, else: {[], []}
 

--- a/lib/mix/test/fixtures/.gitignore
+++ b/lib/mix/test/fixtures/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 # Remember to update Makefile "clean_residual_files" target for any modifications
 # made in this file.
 /deps_on_git_repo/

--- a/lib/mix/test/mix/aliases_test.exs
+++ b/lib/mix/test/mix/aliases_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.AliasesTest do

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.CLITest do

--- a/lib/mix/test/mix/dep/converger_test.exs
+++ b/lib/mix/test/mix/dep/converger_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Dep.ConvergerTest do

--- a/lib/mix/test/mix/dep/lock_test.exs
+++ b/lib/mix/test/mix/dep/lock_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Dep.LockTest do

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.DepTest do

--- a/lib/mix/test/mix/generator_test.exs
+++ b/lib/mix/test/mix/generator_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.GeneratorTest do

--- a/lib/mix/test/mix/local/installer_test.exs
+++ b/lib/mix/test/mix/local/installer_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Local.InstallerTest do

--- a/lib/mix/test/mix/local_test.exs
+++ b/lib/mix/test/mix/local_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.LocalTest do

--- a/lib/mix/test/mix/project_test.exs
+++ b/lib/mix/test/mix/project_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.ProjectTest do

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.RebarTest do

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.ReleaseTest do

--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.SCM.GitTest do

--- a/lib/mix/test/mix/scm_test.exs
+++ b/lib/mix/test/mix/scm_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.SCMTest do

--- a/lib/mix/test/mix/shell/io_test.exs
+++ b/lib/mix/test/mix/shell/io_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Shell.IOTest do

--- a/lib/mix/test/mix/shell/quiet_test.exs
+++ b/lib/mix/test/mix/shell/quiet_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Shell.QuietTest do

--- a/lib/mix/test/mix/shell_test.exs
+++ b/lib/mix/test/mix/shell_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.ShellTest do

--- a/lib/mix/test/mix/sync/lock_test.exs
+++ b/lib/mix/test/mix/sync/lock_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Sync.LockTest do

--- a/lib/mix/test/mix/sync/pubsub_test.exs
+++ b/lib/mix/test/mix/sync/pubsub_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Sync.PubSubTest do

--- a/lib/mix/test/mix/task_test.exs
+++ b/lib/mix/test/mix/task_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.TaskTest do

--- a/lib/mix/test/mix/tasks/app.config_test.exs
+++ b/lib/mix/test/mix/tasks/app.config_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.App.ConfigTest do

--- a/lib/mix/test/mix/tasks/app.start_test.exs
+++ b/lib/mix/test/mix/tasks/app.start_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.App.StartTest do

--- a/lib/mix/test/mix/tasks/app.tree_test.exs
+++ b/lib/mix/test/mix/tasks/app.tree_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.App.TreeTest do

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.ArchiveTest do

--- a/lib/mix/test/mix/tasks/clean_test.exs
+++ b/lib/mix/test/mix/tasks/clean_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.CleanTest do

--- a/lib/mix/test/mix/tasks/cmd_test.exs
+++ b/lib/mix/test/mix/tasks/cmd_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.CmdTest do

--- a/lib/mix/test/mix/tasks/compile.app_test.exs
+++ b/lib/mix/test/mix/tasks/compile.app_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Compile.AppTest do

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Compile.ElixirTest do

--- a/lib/mix/test/mix/tasks/compile.erlang_test.exs
+++ b/lib/mix/test/mix/tasks/compile.erlang_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Compile.ErlangTest do

--- a/lib/mix/test/mix/tasks/compile.leex_test.exs
+++ b/lib/mix/test/mix/tasks/compile.leex_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Compile.LeexTest do

--- a/lib/mix/test/mix/tasks/compile.yecc_test.exs
+++ b/lib/mix/test/mix/tasks/compile.yecc_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Compile.YeccTest do

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.CompileTest do

--- a/lib/mix/test/mix/tasks/deps.git_test.exs
+++ b/lib/mix/test/mix/tasks/deps.git_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.DepsGitTest do

--- a/lib/mix/test/mix/tasks/deps.path_test.exs
+++ b/lib/mix/test/mix/tasks/deps.path_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.DepsPathTest do

--- a/lib/mix/test/mix/tasks/deps.tree_test.exs
+++ b/lib/mix/test/mix/tasks/deps.tree_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Deps.TreeTest do

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.DepsTest do

--- a/lib/mix/test/mix/tasks/do_test.exs
+++ b/lib/mix/test/mix/tasks/do_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.DoTest do

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.EscriptTest do

--- a/lib/mix/test/mix/tasks/eval_test.exs
+++ b/lib/mix/test/mix/tasks/eval_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.EvalTest do

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.FormatTest do

--- a/lib/mix/test/mix/tasks/help_test.exs
+++ b/lib/mix/test/mix/tasks/help_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.HelpTest do

--- a/lib/mix/test/mix/tasks/iex_test.exs
+++ b/lib/mix/test/mix/tasks/iex_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.IExTest do

--- a/lib/mix/test/mix/tasks/loadconfig_test.exs
+++ b/lib/mix/test/mix/tasks/loadconfig_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.LoadconfigTest do

--- a/lib/mix/test/mix/tasks/local.public_keys_test.exs
+++ b/lib/mix/test/mix/tasks/local.public_keys_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Local.PublicKeysTest do

--- a/lib/mix/test/mix/tasks/local_test.exs
+++ b/lib/mix/test/mix/tasks/local_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.LocalTest do

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.NewTest do

--- a/lib/mix/test/mix/tasks/profile.cprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.cprof_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Profile.CprofTest do

--- a/lib/mix/test/mix/tasks/profile.eprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.eprof_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Profile.EprofTest do

--- a/lib/mix/test/mix/tasks/profile.fprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.fprof_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Profile.FprofTest do

--- a/lib/mix/test/mix/tasks/profile.tprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.tprof_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Profile.TprofTest do

--- a/lib/mix/test/mix/tasks/release.init_test.exs
+++ b/lib/mix/test/mix/tasks/release.init_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Release.InitTest do

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.ReleaseTest do

--- a/lib/mix/test/mix/tasks/run_test.exs
+++ b/lib/mix/test/mix/tasks/run_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.RunTest do

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.TestTest do

--- a/lib/mix/test/mix/tasks/will_recompile_test.exs
+++ b/lib/mix/test/mix/tasks/will_recompile_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.WillRecompileTest do

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.XrefTest do

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.UmbrellaTest do

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Cheers do

--- a/lib/mix/test/mix_test.exs
+++ b/lib/mix/test/mix_test.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule MixTest do

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
 home = Path.expand("../tmp/.home", __DIR__)
 File.mkdir_p!(home)
 System.put_env("HOME", home)


### PR DESCRIPTION
Follow up of #14241

* Inlines Licence Info & Copyright for all test files.
* Fixes line numbers in tests

Does not include Test Fixtures, I will add a specific ignore rule to those files in an upcoming PR.