### PR TITLE
Expose Packages in SBoM

### DIFF
--- a/.github/workflows/ort/action.yml
+++ b/.github/workflows/ort/action.yml
@@ -54,13 +54,21 @@ runs:
         mkdir -p "/$HOME/.ort/"
 
         # Move Fetched Default Config into Place
-        mv .ort-config "/$HOME/.ort/config"
+        mv .ort-config "$HOME/.ort/config"
         
         # Append Global ORT Config
         cat .ort/config/config.yml >> "$HOME/.ort/config/config.yml"
         
         # Override Default Evaluator Rules
         cp .ort/config/evaluator.rules.kts "$HOME/.ort/config/evaluator.rules.kts"
+
+        # Set Version in SPDX & Config
+        sed -i "s/# elixir-version-insert/versionInfo: '${ELIXIR_VERSION}'/" project.spdx.yml
+        sed -i -E "s/(\"SpdxDocumentFile:The Elixir Team:.+:)\"/\1${ELIXIR_VERSION}\"/" .ort.yml
+        sed -i "s|https://github.com/elixir-lang/elixir.git|${ELIXIR_REPO}@${ELIXIR_VERSION}|" project.spdx.yml
+      env:
+        ELIXIR_VERSION: "${{ inputs.version }}"
+        ELIXIR_REPO: "${{ github.server_url }}/${{ github.repository }}.git"
 
     - name: "Cache ScanCode"
       uses: actions/cache@v4
@@ -74,10 +82,10 @@ runs:
       # * https://github.com/oss-review-toolkit/ort-ci-github-action/issues/37
       # * https://github.com/oss-review-toolkit/ort-ci-github-action/pull/41
       # * https://github.com/oss-review-toolkit/ort-ci-github-action/pull/43
-      uses: maennchen/ort-ci-github-action@action-output
+      uses: oss-review-toolkit/ort-ci-github-action@2cda885c8eefaf92bab9f3e979b5d5a42970dfa4 # main
       with:
-        image: ghcr.io/oss-review-toolkit/ort-minimal:latest
-        run: >
+        image: ghcr.io/oss-review-toolkit/ort-minimal:51.1.0
+        run: >-
           labels,
           cache-dependencies,
           cache-scan-results,
@@ -89,5 +97,7 @@ runs:
           ${{ inputs.upload-reports == 'true' && 'upload-results' || '' }}
         fail-on: "${{ inputs.fail-on-violation == 'true' && 'violations,issues' || '' }}"
         report-formats: "${{ inputs.report-formats }}"
-        ort-cli-report-args: '-O CycloneDX=output.file.formats=json,xml -O SpdxDocument=outputFileFormats=JSON,YAML'
+        ort-cli-report-args: >-
+          -O CycloneDX=output.file.formats=json,xml
+          -O SpdxDocument=outputFileFormats=JSON,YAML
         sw-version: "${{ inputs.version }}"

--- a/.ort.yml
+++ b/.ort.yml
@@ -18,10 +18,10 @@ excludes:
     - pattern: "man/*"
       reason: "DOCUMENTATION_OF"
       comment: "Documentation"
-    - pattern: ".github/*"
+    - pattern: ".github/**/*"
       reason: "BUILD_TOOL_OF"
       comment: "Documentation"
-    - pattern: ".ort/*"
+    - pattern: ".ort/**/*"
       reason: "BUILD_TOOL_OF"
       comment: "Documentation"
 
@@ -109,3 +109,32 @@ curations:
       comment: "Ignored by ScanCode"
       detected_license: "NONE"
       concluded_license: "Apache-2.0"
+  
+  packages:
+    - id: "SpdxDocumentFile:The Elixir Team:elixir-lang:"
+      curations:
+        concluded_license: "Apache-2.0 AND LicenseRef-scancode-unicode"
+    - id: "SpdxDocumentFile:The Elixir Team:eex:"
+      curations:
+        concluded_license: "Apache-2.0"
+        is_metadata_only: true
+    - id: "SpdxDocumentFile:The Elixir Team:elixir:"
+      curations:
+        concluded_license: "Apache-2.0 AND LicenseRef-scancode-unicode"
+        is_metadata_only: true
+    - id: "SpdxDocumentFile:The Elixir Team:exunit:"
+      curations:
+        concluded_license: "Apache-2.0"
+        is_metadata_only: true
+    - id: "SpdxDocumentFile:The Elixir Team:iex:"
+      curations:
+        concluded_license: "Apache-2.0"
+        is_metadata_only: true
+    - id: "SpdxDocumentFile:The Elixir Team:logger:"
+      curations:
+        concluded_license: "Apache-2.0"
+        is_metadata_only: true
+    - id: "SpdxDocumentFile:The Elixir Team:mix:"
+      curations:
+        concluded_license: "Apache-2.0"
+        is_metadata_only: true

--- a/.ort/config/config.yml
+++ b/.ort/config/config.yml
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: 2021 The Elixir Team
 
 ort:
+  enableRepositoryPackageCurations: true
+
   scanner:
     skipConcluded: false
     includeFilesWithoutFindings: true

--- a/project.spdx.yml
+++ b/project.spdx.yml
@@ -9,20 +9,184 @@ name: "elixir"
 dataLicense: "CC0-1.0"
 documentNamespace: "https://github.com/elixir-lang/elixir"
 documentDescribes:
-- "SPDXRef-Package-elixir"
+- "SPDXRef-Project-elixir-lang"
 packages:
-- SPDXID: "SPDXRef-Package-elixir"
+- SPDXID: "SPDXRef-Project-elixir-lang"
   summary: "About Elixir is a dynamic, functional language for building scalable and maintainable applications"
   copyrightText: "Copyright (c) 2012 Plataformatec. Copyright (c) 2021 The Elixir Team. All Rights Reserved."
   downloadLocation: "git+https://github.com/elixir-lang/elixir.git"
   filesAnalyzed: false
   homepage: "https://elixir-lang.org/"
-  licenseConcluded: "Apache-2.0 AND LicenseRef-scancode-unicode"
-  licenseDeclared: "Apache-2.0 AND LicenseRef-scancode-unicode"
-  name: "elixir"
-  packageFileName: "./"
+  licenseConcluded: "Apache-2.0 AND LicenseRef-scancode-unicode AND LicenseRef-elixir-trademark-policy"
+  licenseDeclared: "Apache-2.0 AND LicenseRef-scancode-unicode AND LicenseRef-elixir-trademark-policy"
+  name: "elixir-lang"
+  originator: "Organization: The Elixir Team"
+  supplier: "Organization: The Elixir Team"
+  packageFileName: "."
   externalRefs:
     - referenceCategory: PACKAGE-MANAGER
       referenceType: "purl"
       referenceLocator: "pkg:github/elixir-lang/elixir"
       comment: "GitHub PURL"
+  # elixir-version-insert
+- SPDXID: "SPDXRef-Package-eex"
+  summary: "About Elixir is a dynamic, functional language for building scalable and maintainable applications"
+  copyrightText: "Copyright (c) 2012 Plataformatec. Copyright (c) 2021 The Elixir Team. All Rights Reserved."
+  downloadLocation: "git+https://github.com/elixir-lang/elixir.git#lib/eex"
+  filesAnalyzed: false
+  homepage: "https://elixir-lang.org/"
+  licenseConcluded: "Apache-2.0"
+  licenseDeclared: "Apache-2.0"
+  name: "eex"
+  originator: "Organization: The Elixir Team"
+  supplier: "Organization: The Elixir Team"
+  packageFileName: "./lib/eex"
+  externalRefs:
+    - referenceCategory: PACKAGE-MANAGER
+      referenceType: "purl"
+      referenceLocator: "pkg:otp/eex"
+      comment: "OTP PURL"
+  # elixir-version-insert
+- SPDXID: "SPDXRef-Package-elixir"
+  summary: "About Elixir is a dynamic, functional language for building scalable and maintainable applications"
+  copyrightText: "Copyright (c) 2012 Plataformatec. Copyright (c) 2021 The Elixir Team. All Rights Reserved."
+  downloadLocation: "git+https://github.com/elixir-lang/elixir.git#lib/elixir"
+  filesAnalyzed: false
+  homepage: "https://elixir-lang.org/"
+  licenseConcluded: "Apache-2.0 AND LicenseRef-scancode-unicode"
+  licenseDeclared: "Apache-2.0 AND LicenseRef-scancode-unicode"
+  name: "elixir"
+  originator: "Organization: The Elixir Team"
+  supplier: "Organization: The Elixir Team"
+  packageFileName: "./lib/elixir"
+  externalRefs:
+    - referenceCategory: PACKAGE-MANAGER
+      referenceType: "purl"
+      referenceLocator: "pkg:otp/elixir"
+      comment: "OTP PURL"
+  # elixir-version-insert
+- SPDXID: "SPDXRef-Package-exunit"
+  summary: "About Elixir is a dynamic, functional language for building scalable and maintainable applications"
+  copyrightText: "Copyright (c) 2012 Plataformatec. Copyright (c) 2021 The Elixir Team. All Rights Reserved."
+  downloadLocation: "git+https://github.com/elixir-lang/elixir.git#lib/ex_unit"
+  filesAnalyzed: false
+  homepage: "https://elixir-lang.org/"
+  licenseConcluded: "Apache-2.0"
+  licenseDeclared: "Apache-2.0"
+  name: "exunit"
+  originator: "Organization: The Elixir Team"
+  supplier: "Organization: The Elixir Team"
+  packageFileName: "./lib/ex_unit"
+  externalRefs:
+    - referenceCategory: PACKAGE-MANAGER
+      referenceType: "purl"
+      referenceLocator: "pkg:otp/ex_unit"
+      comment: "OTP PURL"
+  # elixir-version-insert
+- SPDXID: "SPDXRef-Package-iex"
+  summary: "About Elixir is a dynamic, functional language for building scalable and maintainable applications"
+  copyrightText: "Copyright (c) 2012 Plataformatec. Copyright (c) 2021 The Elixir Team. All Rights Reserved."
+  downloadLocation: "git+https://github.com/elixir-lang/elixir.git#lib/iex"
+  filesAnalyzed: false
+  homepage: "https://elixir-lang.org/"
+  licenseConcluded: "Apache-2.0"
+  licenseDeclared: "Apache-2.0"
+  name: "iex"
+  originator: "Organization: The Elixir Team"
+  supplier: "Organization: The Elixir Team"
+  packageFileName: "./lib/iex"
+  externalRefs:
+    - referenceCategory: PACKAGE-MANAGER
+      referenceType: "purl"
+      referenceLocator: "pkg:otp/iex"
+      comment: "OTP PURL"
+  # elixir-version-insert
+- SPDXID: "SPDXRef-Package-logger"
+  summary: "About Elixir is a dynamic, functional language for building scalable and maintainable applications"
+  copyrightText: "Copyright (c) 2012 Plataformatec. Copyright (c) 2021 The Elixir Team. All Rights Reserved."
+  downloadLocation: "git+https://github.com/elixir-lang/elixir.git/lib/logger"
+  filesAnalyzed: false
+  homepage: "https://elixir-lang.org/"
+  licenseConcluded: "Apache-2.0"
+  licenseDeclared: "Apache-2.0"
+  name: "logger"
+  originator: "Organization: The Elixir Team"
+  supplier: "Organization: The Elixir Team"
+  packageFileName: "./lib/logger"
+  externalRefs:
+    - referenceCategory: PACKAGE-MANAGER
+      referenceType: "purl"
+      referenceLocator: "pkg:otp/logger"
+      comment: "OTP PURL"
+  # elixir-version-insert
+- SPDXID: "SPDXRef-Package-mix"
+  summary: "About Elixir is a dynamic, functional language for building scalable and maintainable applications"
+  copyrightText: "Copyright (c) 2012 Plataformatec. Copyright (c) 2021 The Elixir Team. All Rights Reserved."
+  downloadLocation: "git+https://github.com/elixir-lang/elixir.git#lib/mix"
+  filesAnalyzed: false
+  homepage: "https://elixir-lang.org/"
+  licenseConcluded: "Apache-2.0"
+  licenseDeclared: "Apache-2.0"
+  name: "mix"
+  originator: "Organization: The Elixir Team"
+  supplier: "Organization: The Elixir Team"
+  packageFileName: "./lib/mix"
+  externalRefs:
+    - referenceCategory: PACKAGE-MANAGER
+      referenceType: "purl"
+      referenceLocator: "pkg:otp/mix"
+      comment: "OTP PURL"
+  # elixir-version-insert
+- SPDXID: "SPDXRef-Project-erlang"
+  description: "Erlang is a programming language and runtime system for building massively scalable soft real-time systems with requirements on high availability."
+  copyrightText: "Copyright Ericsson AB 2010-2024. All Rights Reserved."
+  downloadLocation: "git+https://github.com/erlang/otp.git"
+  filesAnalyzed: false
+  homepage: "https://www.erlang.org/"
+  licenseConcluded: "Apache-2.0"
+  licenseDeclared: "Apache-2.0"
+  name: "erlang"
+  originator: "Organization: Ericsson AB"
+  supplier: "Organization: Ericsson AB"
+  externalRefs:
+    - referenceCategory: PACKAGE-MANAGER
+      referenceType: "purl"
+      referenceLocator: "pkg:github/erlang/otp"
+      comment: "GitHub PURL"
+relationships:
+- spdxElementId: "SPDXRef-Project-elixir-lang"
+  relatedSpdxElement: "SPDXRef-Package-eex"
+  relationshipType: "STATIC_LINK" # Should be CONTAINS, issue with ORT
+- spdxElementId: "SPDXRef-Project-elixir-lang"
+  relatedSpdxElement: "SPDXRef-Package-elixir"
+  relationshipType: "STATIC_LINK" # Should be CONTAINS, issue with ORT
+- spdxElementId: "SPDXRef-Project-elixir-lang"
+  relatedSpdxElement: "SPDXRef-Package-exunit"
+  relationshipType: "STATIC_LINK" # Should be CONTAINS, issue with ORT
+- spdxElementId: "SPDXRef-Project-elixir-lang"
+  relatedSpdxElement: "SPDXRef-Package-iex"
+  relationshipType: "STATIC_LINK" # Should be CONTAINS, issue with ORT
+- spdxElementId: "SPDXRef-Project-elixir-lang"
+  relatedSpdxElement: "SPDXRef-Package-logger"
+  relationshipType: "STATIC_LINK" # Should be CONTAINS, issue with ORT
+- spdxElementId: "SPDXRef-Project-elixir-lang"
+  relatedSpdxElement: "SPDXRef-Package-mix"
+  relationshipType: "STATIC_LINK" # Should be CONTAINS, issue with ORT
+- spdxElementId: "SPDXRef-Package-elixir"
+  relatedSpdxElement: "SPDXRef-Project-erlang"
+  relationshipType: "RUNTIME_DEPENDENCY_OF"
+- spdxElementId: "SPDXRef-Package-eex"
+  relatedSpdxElement: "SPDXRef-Package-elixir"
+  relationshipType: "STATIC_LINK"
+- spdxElementId: "SPDXRef-Package-exunit"
+  relatedSpdxElement: "SPDXRef-Package-elixir"
+  relationshipType: "STATIC_LINK"
+- spdxElementId: "SPDXRef-Package-iex"
+  relatedSpdxElement: "SPDXRef-Package-elixir"
+  relationshipType: "STATIC_LINK"
+- spdxElementId: "SPDXRef-Package-logger"
+  relatedSpdxElement: "SPDXRef-Package-elixir"
+  relationshipType: "STATIC_LINK"
+- spdxElementId: "SPDXRef-Package-mix"
+  relatedSpdxElement: "SPDXRef-Package-elixir"
+  relationshipType: "STATIC_LINK"


### PR DESCRIPTION
Follow up of #14241

* Declares Erlang Dependency
* Declares elixir applications (required for `purl` to identify in case of elixir vulnerabilities)
* Switches back to the official ORT action repo
* Will pass the [NTIA SBoM checker](https://github.com/spdx/ntia-conformance-checker?tab=readme-ov-file)
  * Does not yet pass since https://github.com/aboutcode-org/scancode-toolkit/issues/4131 is not yet done
* The CI will inject the version info into the ORT config & SPDX file at runtime. The way this is implemented allows:
  * If somebody declares Elixir as a dependency, everything should scan as expected, but will not contain any version information
  * When the CI uses it, all version info is injected and present in the resulting SBoM