### PR TITLE
pretty format terms in errors

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -517,8 +517,8 @@ defmodule Access do
   An error is raised if the accessed structure is not a map or a struct:
 
       iex> get_in([], [Access.key(:foo)])
-      ** (BadMapError) expected a map, got: []
-
+      ** (BadMapError) expected a map, got:
+      ...
   """
   @spec key(key, term) :: access_fun(data :: struct | map, current_value :: term)
   def key(key, default \\ nil) do
@@ -556,7 +556,8 @@ defmodule Access do
       iex> pop_in(map, [Access.key!(:user), Access.key!(:name)])
       {"john", %{user: %{}}}
       iex> get_in(map, [Access.key!(:user), Access.key!(:unknown)])
-      ** (KeyError) key :unknown not found in: %{name: \"john\"}
+      ** (KeyError) key :unknown not found in:
+      ...
 
   The examples above could be partially written as:
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -183,8 +183,11 @@ defmodule Exception do
     inspected =
       term
       |> inspect(pretty: true)
-      |> String.split("\n", trim: true)
-      |> Enum.map(&("    " <> &1))
+      |> String.split("\n")
+      |> Enum.map(fn
+        "" -> ""
+        line -> "    " <> line
+      end)
       |> Enum.join("\n")
 
     message <> "\n\n" <> inspected

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -177,8 +177,9 @@ defmodule Exception do
     end
   end
 
-  @spec format(String.t(), any) :: String.t()
-  def format_message_with_term(message, term) do
+  @doc false
+  @spec _format_message_with_term(String.t(), any) :: String.t()
+  def _format_message_with_term(message, term) do
     inspected =
       term
       |> inspect(pretty: true)
@@ -1441,7 +1442,7 @@ defmodule BadStructError do
 
   @impl true
   def message(exception) do
-    Exception.format_message_with_term(
+    Exception._format_message_with_term(
       "expected a struct named #{inspect(exception.struct)}, got:",
       exception.term
     )
@@ -1464,7 +1465,7 @@ defmodule BadMapError do
 
   @impl true
   def message(exception) do
-    Exception.format_message_with_term(
+    Exception._format_message_with_term(
       "expected a map, got:",
       exception.term
     )
@@ -1486,7 +1487,7 @@ defmodule BadBooleanError do
 
   @impl true
   def message(exception) do
-    Exception.format_message_with_term(
+    Exception._format_message_with_term(
       "expected a boolean on left-side of \"#{exception.operator}\", got:",
       exception.term
     )
@@ -1511,7 +1512,7 @@ defmodule MatchError do
 
   @impl true
   def message(exception) do
-    Exception.format_message_with_term(
+    Exception._format_message_with_term(
       "no match of right hand side value:",
       exception.term
     )
@@ -1540,7 +1541,7 @@ defmodule CaseClauseError do
 
   @impl true
   def message(exception) do
-    Exception.format_message_with_term(
+    Exception._format_message_with_term(
       "no case clause matching:",
       exception.term
     )
@@ -1573,7 +1574,7 @@ defmodule WithClauseError do
 
   @impl true
   def message(exception) do
-    Exception.format_message_with_term(
+    Exception._format_message_with_term(
       "no with clause matching:",
       exception.term
     )
@@ -1626,7 +1627,7 @@ defmodule TryClauseError do
 
   @impl true
   def message(exception) do
-    Exception.format_message_with_term(
+    Exception._format_message_with_term(
       "no try clause matching:",
       exception.term
     )
@@ -2191,7 +2192,7 @@ defmodule KeyError do
           "make sure to add parentheses after the function name)"
 
       true ->
-        Exception.format_message_with_term(
+        Exception._format_message_with_term(
           message <> " in:",
           term
         )

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -2242,7 +2242,7 @@ defmodule KeyError do
 
     case suggestions do
       [] -> []
-      suggestions -> [". Did you mean:\n\n" | format_suggestions(suggestions)]
+      suggestions -> ["\n\nDid you mean:\n\n" | format_suggestions(suggestions)]
     end
   end
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -183,7 +183,7 @@ defmodule Exception do
     inspected =
       term
       |> inspect(pretty: true)
-      |> String.split("\n")
+      |> String.split("\n", trim: true)
       |> Enum.map(&("    " <> &1))
       |> Enum.join("\n")
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -183,7 +183,9 @@ defmodule Exception do
     inspected =
       term
       |> inspect(pretty: true)
-      |> String.replace(~r/^(?=.+)/m, "    ")
+      |> String.split("\n")
+      |> Enum.map(&("    " <> &1))
+      |> Enum.join("\n")
 
     message <> "\n\n" <> inspected
   end

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -177,6 +177,16 @@ defmodule Exception do
     end
   end
 
+  @spec format(String.t(), any) :: String.t()
+  def format_message_with_term(message, term) do
+    inspected =
+      term
+      |> inspect(pretty: true)
+      |> String.replace(~r/^(?=.+)/m, "    ")
+
+    message <> "\n\n" <> inspected
+  end
+
   @doc """
   Attaches information to exceptions for extra debugging.
 
@@ -1431,7 +1441,10 @@ defmodule BadStructError do
 
   @impl true
   def message(exception) do
-    "expected a struct named #{inspect(exception.struct)}, got: #{inspect(exception.term)}"
+    Exception.format_message_with_term(
+      "expected a struct named #{inspect(exception.struct)}, got:",
+      exception.term
+    )
   end
 end
 
@@ -1451,7 +1464,10 @@ defmodule BadMapError do
 
   @impl true
   def message(exception) do
-    "expected a map, got: #{inspect(exception.term)}"
+    Exception.format_message_with_term(
+      "expected a map, got:",
+      exception.term
+    )
   end
 end
 
@@ -1470,7 +1486,10 @@ defmodule BadBooleanError do
 
   @impl true
   def message(exception) do
-    "expected a boolean on left-side of \"#{exception.operator}\", got: #{inspect(exception.term)}"
+    Exception.format_message_with_term(
+      "expected a boolean on left-side of \"#{exception.operator}\", got:",
+      exception.term
+    )
   end
 end
 
@@ -1492,11 +1511,10 @@ defmodule MatchError do
 
   @impl true
   def message(exception) do
-    """
-    no match of right hand side value:
-
-    #{inspect(exception.term, pretty: true, limit: :infinity)}
-    """
+    Exception.format_message_with_term(
+      "no match of right hand side value:",
+      exception.term
+    )
   end
 end
 
@@ -1522,7 +1540,10 @@ defmodule CaseClauseError do
 
   @impl true
   def message(exception) do
-    "no case clause matching: #{inspect(exception.term)}"
+    Exception.format_message_with_term(
+      "no case clause matching:",
+      exception.term
+    )
   end
 end
 
@@ -1552,7 +1573,10 @@ defmodule WithClauseError do
 
   @impl true
   def message(exception) do
-    "no with clause matching: #{inspect(exception.term)}"
+    Exception.format_message_with_term(
+      "no with clause matching:",
+      exception.term
+    )
   end
 end
 
@@ -1602,7 +1626,10 @@ defmodule TryClauseError do
 
   @impl true
   def message(exception) do
-    "no try clause matching: #{inspect(exception.term)}"
+    Exception.format_message_with_term(
+      "no try clause matching:",
+      exception.term
+    )
   end
 end
 
@@ -2164,7 +2191,10 @@ defmodule KeyError do
           "make sure to add parentheses after the function name)"
 
       true ->
-        message <> " in: #{inspect(term, pretty: true, limit: :infinity)}"
+        Exception.format_message_with_term(
+          message <> " in:",
+          term
+        )
     end
   end
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1492,7 +1492,11 @@ defmodule MatchError do
 
   @impl true
   def message(exception) do
-    "no match of right hand side value: #{inspect(exception.term)}"
+    """
+    no match of right hand side value:
+
+    #{inspect(exception.term, pretty: true, limit: :infinity)}
+    """
   end
 end
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -742,7 +742,8 @@ defmodule Kernel.SpecialForms do
       iex> x = 1
       iex> ^x = List.first([1])
       iex> ^x = List.first([2])
-      ** (MatchError) no match of right hand side value: 2
+      ** (MatchError) no match of right hand side value:
+      ...
 
   Note that `^x` always refers to the value of `x` prior to the match. The
   following example will match:

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -742,7 +742,7 @@ defmodule Kernel.SpecialForms do
       iex> x = 1
       iex> ^x = List.first([1])
       iex> ^x = List.first([2])
-      ** (MatchError) No match of right hand side value: 2
+      ** (MatchError) no match of right hand side value: 2
 
   Note that `^x` always refers to the value of `x` prior to the match. The
   following example will match:

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -742,7 +742,7 @@ defmodule Kernel.SpecialForms do
       iex> x = 1
       iex> ^x = List.first([1])
       iex> ^x = List.first([2])
-      ** (MatchError) no match of right hand side value: 2
+      ** (MatchError) No match of right hand side value: 2
 
   Note that `^x` always refers to the value of `x` prior to the match. The
   following example will match:

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -529,7 +529,8 @@ defmodule Keyword do
       iex> Keyword.get_and_update!([a: 1], :b, fn current_value ->
       ...>   {current_value, "new value!"}
       ...> end)
-      ** (KeyError) key :b not found in: [a: 1]
+      ** (KeyError) key :b not found in:
+      ...
 
       iex> Keyword.get_and_update!([a: 1], :a, fn _ ->
       ...>   :pop
@@ -596,7 +597,8 @@ defmodule Keyword do
       iex> Keyword.fetch!([a: 1], :a)
       1
       iex> Keyword.fetch!([a: 1], :b)
-      ** (KeyError) key :b not found in: [a: 1]
+      ** (KeyError) key :b not found in:
+      ...
 
   """
   @spec fetch!(t, key) :: value
@@ -879,7 +881,8 @@ defmodule Keyword do
       [a: 1, b: :new, c: 3]
 
       iex> Keyword.replace!([a: 1], :b, 2)
-      ** (KeyError) key :b not found in: [a: 1]
+      ** (KeyError) key :b not found in:
+      ...
 
   """
   @doc since: "1.5.0"
@@ -1135,7 +1138,8 @@ defmodule Keyword do
       [a: 1, b: 4, c: 3]
 
       iex> Keyword.update!([a: 1], :b, &(&1 * 2))
-      ** (KeyError) key :b not found in: [a: 1]
+      ** (KeyError) key :b not found in:
+      ...
 
   """
   @spec update!(t, key, (current_value :: value -> new_value :: value)) :: t
@@ -1348,7 +1352,8 @@ defmodule Keyword do
       iex> Keyword.pop!([a: 1, a: 2], :a)
       {1, []}
       iex> Keyword.pop!([a: 1], :b)
-      ** (KeyError) key :b not found in: [a: 1]
+      ** (KeyError) key :b not found in:
+      ...
 
   """
   @doc since: "1.10.0"

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -54,7 +54,8 @@ defmodule Map do
       map.foo
       #=> "bar"
       map.non_existing_key
-      ** (KeyError) key :non_existing_key not found in: %{baz: "bong", foo: "bar"}
+      ** (KeyError) key :non_existing_key not found in:
+      ...
 
   > #### Avoid parentheses {: .warning}
   >
@@ -388,7 +389,8 @@ defmodule Map do
       %{a: 3, b: 2}
 
       iex> Map.replace!(%{a: 1}, :b, 2)
-      ** (KeyError) key :b not found in: %{a: 1}
+      ** (KeyError) key :b not found in:
+      ...
 
   """
   @doc since: "1.5.0"
@@ -725,7 +727,8 @@ defmodule Map do
       iex> Map.pop!(%{a: 1, b: 2}, :a)
       {1, %{b: 2}}
       iex> Map.pop!(%{a: 1}, :b)
-      ** (KeyError) key :b not found in: %{a: 1}
+      ** (KeyError) key :b not found in:
+      ...
 
   """
   @doc since: "1.10.0"
@@ -911,7 +914,8 @@ defmodule Map do
       %{a: 2}
 
       iex> Map.update!(%{a: 1}, :b, &(&1 * 2))
-      ** (KeyError) key :b not found in: %{a: 1}
+      ** (KeyError) key :b not found in:
+      ...
 
   """
   @spec update!(map, key, (existing_value :: value -> new_value :: value)) :: map
@@ -986,7 +990,8 @@ defmodule Map do
       iex> Map.get_and_update!(%{a: 1}, :b, fn current_value ->
       ...>   {current_value, "new value!"}
       ...> end)
-      ** (KeyError) key :b not found in: %{a: 1}
+      ** (KeyError) key :b not found in:
+      ...
 
       iex> Map.get_and_update!(%{a: 1}, :a, fn _ ->
       ...>   :pop

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -701,25 +701,26 @@ defmodule ExceptionTest do
       message = blame_message(%{first: nil, second: nil}, fn map -> map.firts end)
 
       assert message == """
-             key :firts not found in: %{first: nil, second: nil}. Did you mean:
+             key :firts not found in:\n\n    %{first: nil, second: nil}. Did you mean:
 
                    * :first
              """
 
       message = blame_message(%{"first" => nil, "second" => nil}, fn map -> map.firts end)
 
-      assert message == "key :firts not found in: %{\"first\" => nil, \"second\" => nil}"
+      assert message == "key :firts not found in:\n\n    %{\"first\" => nil, \"second\" => nil}"
 
       message =
         blame_message(%{"first" => nil, "second" => nil}, fn map -> Map.fetch!(map, "firts") end)
 
-      assert message == "key \"firts\" not found in: %{\"first\" => nil, \"second\" => nil}"
+      assert message ==
+               "key \"firts\" not found in:\n\n    %{\"first\" => nil, \"second\" => nil}"
 
       message =
         blame_message([first: nil, second: nil], fn kwlist -> Keyword.fetch!(kwlist, :firts) end)
 
       assert message == """
-             key :firts not found in: [first: nil, second: nil]. Did you mean:
+             key :firts not found in:\n\n    [first: nil, second: nil]. Did you mean:
 
                    * :first
              """
@@ -727,7 +728,7 @@ defmodule ExceptionTest do
 
     test "annotates key error with suggestions for structs" do
       message = blame_message(%URI{}, fn map -> map.schema end)
-      assert message =~ "key :schema not found in: %URI{"
+      assert message =~ "key :schema not found in:\n\n    %URI{"
       assert message =~ "Did you mean:"
       assert message =~ "* :scheme"
     end

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -729,33 +729,31 @@ defmodule ExceptionTest do
       message =
         blame_message(
           [
-            first: nil,
-            second: nil,
-            third: nil,
-            fourth: nil,
-            fifth: nil,
-            sixth: nil,
-            seventh: nil
+            created_at: nil,
+            updated_at: nil,
+            deleted_at: nil,
+            started_at: nil,
+            finished_at: nil
           ],
           fn kwlist ->
-            Keyword.fetch!(kwlist, :firts)
+            Keyword.fetch!(kwlist, :inserted_at)
           end
         )
 
       assert message == """
-             key :firts not found in:
+             key :inserted_at not found in:
 
                  [
-                   first: nil,
-                   second: nil,
-                   third: nil,
-                   fourth: nil,
-                   fifth: nil,
-                   sixth: nil,
-                   seventh: nil
+                   created_at: nil,
+                   updated_at: nil,
+                   deleted_at: nil,
+                   started_at: nil,
+                   finished_at: nil
                  ]. Did you mean:
 
-                   * :first
+                   * :created_at
+                   * :finished_at
+                   * :started_at
              """
     end
 

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -703,7 +703,9 @@ defmodule ExceptionTest do
       assert message == """
              key :firts not found in:
 
-                 %{first: nil, second: nil}. Did you mean:
+                 %{first: nil, second: nil}
+
+             Did you mean:
 
                    * :first
              """
@@ -749,7 +751,9 @@ defmodule ExceptionTest do
                    deleted_at: nil,
                    started_at: nil,
                    finished_at: nil
-                 ]. Did you mean:
+                 ]
+
+             Did you mean:
 
                    * :created_at
                    * :finished_at

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -701,26 +701,59 @@ defmodule ExceptionTest do
       message = blame_message(%{first: nil, second: nil}, fn map -> map.firts end)
 
       assert message == """
-             key :firts not found in:\n\n    %{first: nil, second: nil}. Did you mean:
+             key :firts not found in:
+
+                 %{first: nil, second: nil}. Did you mean:
 
                    * :first
              """
 
       message = blame_message(%{"first" => nil, "second" => nil}, fn map -> map.firts end)
 
-      assert message == "key :firts not found in:\n\n    %{\"first\" => nil, \"second\" => nil}"
+      assert message == """
+             key :firts not found in:
+
+                 %{"first" => nil, "second" => nil}\
+             """
 
       message =
         blame_message(%{"first" => nil, "second" => nil}, fn map -> Map.fetch!(map, "firts") end)
 
       assert message ==
-               "key \"firts\" not found in:\n\n    %{\"first\" => nil, \"second\" => nil}"
+               """
+               key "firts" not found in:
+
+                   %{"first" => nil, "second" => nil}\
+               """
 
       message =
-        blame_message([first: nil, second: nil], fn kwlist -> Keyword.fetch!(kwlist, :firts) end)
+        blame_message(
+          [
+            first: nil,
+            second: nil,
+            third: nil,
+            fourth: nil,
+            fifth: nil,
+            sixth: nil,
+            seventh: nil
+          ],
+          fn kwlist ->
+            Keyword.fetch!(kwlist, :firts)
+          end
+        )
 
       assert message == """
-             key :firts not found in:\n\n    [first: nil, second: nil]. Did you mean:
+             key :firts not found in:
+
+                 [
+                   first: nil,
+                   second: nil,
+                   third: nil,
+                   fourth: nil,
+                   fifth: nil,
+                   sixth: nil,
+                   seventh: nil
+                 ]. Did you mean:
 
                    * :first
              """

--- a/lib/elixir/test/elixir/kernel/raise_test.exs
+++ b/lib/elixir/test/elixir/kernel/raise_test.exs
@@ -450,16 +450,20 @@ defmodule Kernel.RaiseTest do
     end
 
     test "badmatch error" do
-      x = :example
-
       result =
         try do
-          ^x = Process.get(:unused, 0)
+          [] = Range.to_list(1000_000..1_000_009)
         rescue
           x in [MatchError] -> Exception.message(x)
         end
 
-      assert result == "no match of right hand side value: 0"
+      assert result ==
+               """
+               no match of right hand side value:
+
+               [1000000, 1000001, 1000002, 1000003, 1000004, 1000005, 1000006, 1000007,
+                1000008, 1000009]
+               """
     end
 
     test "bad key error" do

--- a/lib/elixir/test/elixir/kernel/raise_test.exs
+++ b/lib/elixir/test/elixir/kernel/raise_test.exs
@@ -461,8 +461,8 @@ defmodule Kernel.RaiseTest do
                """
                no match of right hand side value:
 
-               [1000000, 1000001, 1000002, 1000003, 1000004, 1000005, 1000006, 1000007,
-                1000008, 1000009]
+                   [1000000, 1000001, 1000002, 1000003, 1000004, 1000005, 1000006, 1000007,
+                    1000008, 1000009]\
                """
     end
 
@@ -483,7 +483,7 @@ defmodule Kernel.RaiseTest do
           x in [KeyError] -> Exception.message(x)
         end
 
-      assert result == "key :foo not found in: %{}"
+      assert result == "key :foo not found in:\n\n    %{}"
     end
 
     test "bad map error" do
@@ -494,7 +494,7 @@ defmodule Kernel.RaiseTest do
           x in [BadMapError] -> Exception.message(x)
         end
 
-      assert result == "expected a map, got: 0"
+      assert result == "expected a map, got:\n\n    0"
     end
 
     test "bad boolean error" do
@@ -505,7 +505,7 @@ defmodule Kernel.RaiseTest do
           x in [BadBooleanError] -> Exception.message(x)
         end
 
-      assert result == "expected a boolean on left-side of \"and\", got: 1"
+      assert result == "expected a boolean on left-side of \"and\", got:\n\n    1"
     end
 
     test "case clause error" do
@@ -520,7 +520,7 @@ defmodule Kernel.RaiseTest do
           x in [CaseClauseError] -> Exception.message(x)
         end
 
-      assert result == "no case clause matching: 0"
+      assert result == "no case clause matching:\n\n    0"
     end
 
     test "cond clause error" do
@@ -554,7 +554,7 @@ defmodule Kernel.RaiseTest do
           x in [TryClauseError] -> Exception.message(x)
         end
 
-      assert result == "no try clause matching: :example"
+      assert result == "no try clause matching:\n\n    :example"
     end
 
     test "undefined function error as Erlang error" do

--- a/lib/elixir/test/elixir/kernel/with_test.exs
+++ b/lib/elixir/test/elixir/kernel/with_test.exs
@@ -153,7 +153,7 @@ defmodule Kernel.WithTest do
   end
 
   test "else conditions with match error" do
-    assert_raise WithClauseError, "no with clause matching: :error", fn ->
+    assert_raise WithClauseError, "no with clause matching:\n\n    :error", fn ->
       with({:ok, res} <- error(), do: res, else: ({:error, error} -> error))
     end
   end

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -70,11 +70,11 @@ defmodule KeywordTest do
     assert Keyword.replace!([a: 1, b: 2, a: 3, b: 4], :a, 1) == [a: 1, b: 2, b: 4]
     assert Keyword.replace!([a: 1, b: 2, c: 3, b: 4], :b, :new) == [a: 1, b: :new, c: 3]
 
-    assert_raise KeyError, "key :b not found in: []", fn ->
+    assert_raise KeyError, "key :b not found in:\n\n    []", fn ->
       Keyword.replace!([], :b, :new)
     end
 
-    assert_raise KeyError, "key :c not found in: [a: 1, b: 2, a: 3]", fn ->
+    assert_raise KeyError, "key :c not found in:\n\n    [a: 1, b: 2, a: 3]", fn ->
       Keyword.replace!([a: 1, b: 2, a: 3], :c, :new)
     end
   end

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -225,11 +225,11 @@ defmodule MapTest do
     assert Map.replace!(map, :b, 10) == %{c: 3, b: 10, a: 1}
     assert Map.replace!(map, :a, 1) == map
 
-    assert_raise KeyError, ~r/key :x not found in: %{.*a: 1.*}/, fn ->
+    assert_raise KeyError, ~r/key :x not found in:\n\n    %{.*a: 1.*}/, fn ->
       Map.replace!(map, :x, 10)
     end
 
-    assert_raise KeyError, "key :x not found in: %{}", fn ->
+    assert_raise KeyError, "key :x not found in:\n\n    %{}", fn ->
       Map.replace!(%{}, :x, 10)
     end
   end

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -106,7 +106,7 @@ defmodule ExUnit.CallbacksTest do
     end
 
     assert capture_io(fn -> ExUnit.run() end) =~
-             "** (MatchError) no match of right hand side value: :error"
+             "** (MatchError) no match of right hand side value:"
   end
 
   test "doesn't choke on setup_all errors" do
@@ -125,7 +125,7 @@ defmodule ExUnit.CallbacksTest do
     end
 
     assert capture_io(fn -> ExUnit.run() end) =~
-             "** (MatchError) no match of right hand side value: :error"
+             "** (MatchError) no match of right hand side value:"
   end
 
   test "doesn't choke on setup_all exits" do
@@ -175,7 +175,7 @@ defmodule ExUnit.CallbacksTest do
     end
 
     assert capture_io(fn -> ExUnit.run() end) =~
-             "** (MatchError) no match of right hand side value: :error"
+             "** (MatchError) no match of right hand side value:"
   end
 
   test "doesn't choke when on_exit exits" do


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8b6e9a48-9ee6-4f36-af21-7c9991da3c3d)
It would be ideal if the exception would contain the left part of the match but just pretty printing it makes much difference. 
I'm just not sure what to do with the doctest?