### PR TITLE
Relative tokenizer

### DIFF
--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -1195,7 +1195,8 @@ defmodule Code.Fragment do
 
   defp reverse_tokens(line, column, tokens, terminators) do
     {terminators, _} =
-      Enum.map_reduce(terminators, column, fn {start, _, _}, column ->
+      Enum.map_reduce(terminators, column, fn {start, _, _, _}, column ->
+        # TODO handle relative positions
         atom = :elixir_tokenizer.terminator(start)
 
         {{atom, {line, column, nil}}, column + length(Atom.to_charlist(atom))}

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -1198,10 +1198,13 @@ defmodule Code.Fragment do
     {terminators, _} =
       Enum.map_reduce(terminators, {column, 1}, fn {start, _, _, _}, {column, prev_length} ->
         atom = :elixir_tokenizer.terminator(start)
-        meta = case mode do
-          :relative -> {0, prev_length, nil}
-          _ -> {line, column, nil}
-        end
+
+        meta =
+          case mode do
+            :relative -> {0, prev_length, nil}
+            _ -> {line, column, nil}
+          end
+
         length = length(Atom.to_charlist(atom))
         {{atom, meta}, {column + length, length}}
       end)

--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -77,5 +77,7 @@
   indentation=0,
   column=1,
   mismatch_hints=[],
-  warnings=[]
+  warnings=[],
+  mode=absolute,
+  prev_pos={1, 1}
 }).

--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -133,7 +133,7 @@ strip_horizontal_space(T, Buffer, Counter) ->
 cursor_complete(Line, Column, Terminators) ->
   % TODO handle relative position in inserted cursor
   lists:mapfoldl(
-    fun({Start, _, _}, AccColumn) ->
+    fun({Start, _, _, _StartPos}, AccColumn) ->
       End = elixir_tokenizer:terminator(Start),
       {{End, {Line, AccColumn, nil}}, AccColumn + length(erlang:atom_to_list(End))}
     end,

--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -123,6 +123,7 @@ strip_horizontal_space(T, Buffer, Counter) ->
   {T, Buffer, Counter}.
 
 cursor_complete(Line, Column, Terminators) ->
+  % TODO handle relative position in inserted cursor
   lists:mapfoldl(
     fun({Start, _, _}, AccColumn) ->
       End = elixir_tokenizer:terminator(Start),

--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -57,7 +57,7 @@ extract([$\\, $#, ${ | Rest], Buffer, Output, Line, Column, Scope, true, Last) -
 
 extract([$#, ${ | Rest], Buffer, Output, Line, Column, Scope, true, Last) ->
   Output1 = build_string(Buffer, Output),
-  case elixir_tokenizer:tokenize(Rest, Line, Column + 2, Scope#elixir_tokenizer{terminators=[], prev_pos={Line, Column}}) of
+  case elixir_tokenizer:tokenize(Rest, Line, Column + 2, Scope#elixir_tokenizer{terminators=[]}) of
     {error, {Location, _, "}"}, [$} | NewRest], Warnings, Tokens} ->
       NewScope = Scope#elixir_tokenizer{warnings=Warnings},
       {line, EndLine} = lists:keyfind(line, 1, Location),

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -153,7 +153,10 @@ tokenize([], Line, Column, #elixir_tokenizer{cursor_completion=Cursor} = Scope, 
   {CursorColumn, AccTerminators, AccTokens} =
     add_cursor(Line, Column, Cursor, Scope, Terminators, Tokens),
 
-  AllWarnings = maybe_unicode_lint_warnings(Ascii, Tokens, Warnings),
+  AllWarnings = maybe_unicode_lint_warnings(Ascii, case Scope of
+    #elixir_tokenizer{mode=relative} -> lists:reverse(to_absolute_tokens(lists:reverse(Tokens), {1, 1}));
+    _ -> Tokens
+    end, Warnings),
   {ok, Line, CursorColumn, AllWarnings, AccTokens, AccTerminators};
 
 tokenize([], EndLine, EndColumn, #elixir_tokenizer{terminators=[{Start, {StartLine, StartColumn, _}, _, {StartPrevLine, StartPrevColumn}} | _]} = Scope, Tokens) ->
@@ -181,7 +184,10 @@ tokenize([], EndLine, EndColumn, #elixir_tokenizer{terminators=[{Start, {StartLi
 
 tokenize([], Line, Column, #elixir_tokenizer{} = Scope, Tokens) ->
   #elixir_tokenizer{ascii_identifiers_only=Ascii, warnings=Warnings} = Scope,
-  AllWarnings = maybe_unicode_lint_warnings(Ascii, Tokens, Warnings),
+  AllWarnings = maybe_unicode_lint_warnings(Ascii, case Scope of
+    #elixir_tokenizer{mode=relative} -> lists:reverse(to_absolute_tokens(lists:reverse(Tokens), {1, 1}));
+    _ -> Tokens
+    end, Warnings),
   {ok, Line, Column, AllWarnings, Tokens, []};
 
 % VC merge conflict

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1945,7 +1945,7 @@ add_cursor(Line, Column, prune_and_cursor, Scope, Terminators, Tokens) ->
   end,
   {Column + 12, Terminators, CursorTokens}.
 
-revert_prev_pos(Token, #elixir_tokenizer{prev_pos={PrevLine, PrevColumn, mode=relative}} = Scope) ->
+revert_prev_pos(Token, #elixir_tokenizer{prev_pos={PrevLine, PrevColumn}, mode=relative} = Scope) ->
   Info = element(2, Token),
   Line = element(1, Info),
   Column = element(2, Info),

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -156,7 +156,7 @@ tokenize([], Line, Column, #elixir_tokenizer{cursor_completion=Cursor} = Scope, 
   AllWarnings = maybe_unicode_lint_warnings(Ascii, Tokens, Warnings),
   {ok, Line, CursorColumn, AllWarnings, AccTokens, AccTerminators};
 
-tokenize([], EndLine, EndColumn, #elixir_tokenizer{terminators=[{Start, {StartLine, StartColumn, _}, _} | _]} = Scope, Tokens) ->
+tokenize([], EndLine, EndColumn, #elixir_tokenizer{terminators=[{Start, {StartLine, StartColumn, _}, _, _} | _]} = Scope, Tokens) ->
   End = terminator(Start),
   Hint = missing_terminator_hint(Start, End, Scope),
   Message = "missing terminator: ~ts",

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -5,7 +5,7 @@
 -module(elixir_tokenizer).
 -include("elixir.hrl").
 -include("elixir_tokenizer.hrl").
--export([tokenize/1, tokenize/3, tokenize/4, invalid_do_error/1, terminator/1, to_absolute_tokens/2]).
+-export([tokenize/1, tokenize/3, tokenize/4, invalid_do_error/1, terminator/1, to_absolute_tokens/2, to_absolute_terminators/1]).
 
 -define(at_op(T),
   T =:= $@).
@@ -2061,3 +2061,9 @@ to_absolute_interpolation([{{BeginLine, BeginColumn, nil}, {EndLine, EndColumn, 
   NewEnd = {EndLine + CurrentLine, EndColumn + CurrentCol, nil},
   NewTokens = to_absolute_tokens(Tokens, {CurrentLine, CurrentCol}),
   to_absolute_interpolation(Rest, {CurrentLine, CurrentCol}, [{NewBegin, NewEnd, NewTokens} | Acc]).
+
+to_absolute_terminators(List) -> to_absolute_terminators(List, []).
+
+to_absolute_terminators([], Acc) -> lists:reverse(Acc);
+to_absolute_terminators([{Terminator, {_Line, _Column, nil}, X, {PrevLine, PrevColumn}} | Rest], Acc) ->
+  to_absolute_terminators(Rest, [{Terminator, {PrevLine, PrevColumn, nil}, X, {1, 1}} | Acc]).

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -862,11 +862,11 @@ handle_strings(T, Line, Column, H, Scope, Tokens) ->
         {ok, [Part]} when is_binary(Part) ->
           case unsafe_to_atom(Part, Line, Column - 1, Scope) of
             {ok, Atom} ->
-              {{Line1, Column1}, NewScope1} = token_position({Line, Column - 1}, NewScope),
+              {{Line1, Column1}, NewScope1} = token_position({Line, Column - 1}, NewScope#elixir_tokenizer{prev_pos=Scope#elixir_tokenizer.prev_pos}),
               Token = {kw_identifier, {Line1, Column1, H}, Atom},
               tokenize(Rest, NewLine, NewColumn + 1, NewScope1, [Token | Tokens]);
             {error, Reason} ->
-              error(Reason, Rest, NewScope, Tokens)
+              error(Reason, Rest, NewScope#elixir_tokenizer{prev_pos=Scope#elixir_tokenizer.prev_pos}, Tokens)
           end;
 
         {ok, Unescaped} ->

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -2000,7 +2000,7 @@ to_absolute_tokens([Token | Rest], {CurrLine, CurrCol}, Acc) ->
     NewInfo2 = setelement(2, NewInfo1, NewCol),
     NewToken = setelement(2, Token, NewInfo2),
     NewTokenWithSubtokens = case NewToken of
-        {Key, Meta, Unescaped} when key =:= atom_safe; Key =:= atom_unsafe; Key =:= kw_identifier_safe; Key =:= kw_identifier_unsafe; Key =:= bin_string; Key =:= list_string ->
+        {Key, Meta, Unescaped} when Key =:= atom_safe; Key =:= atom_unsafe; Key =:= kw_identifier_safe; Key =:= kw_identifier_unsafe; Key =:= bin_string; Key =:= list_string ->
           NewUnescaped = to_absolute_interpolation(Unescaped, {NewLine, NewCol}),
           {Key, Meta, NewUnescaped};
         {Key, Meta, Indentation, Unescaped} when Key =:= bin_heredoc; Key =:= list_heredoc ->

--- a/lib/elixir/test/erlang/string_test.erl
+++ b/lib/elixir/test/erlang/string_test.erl
@@ -14,8 +14,13 @@ eval(Content) ->
 extract_interpolations(String) ->
   case elixir_interpolation:extract(1, 1, #elixir_tokenizer{}, true, String ++ [$"], $") of
     {error, Error} ->
+      {error, RelError} = elixir_interpolation:extract(1, 1, #elixir_tokenizer{mode=relative, prev_pos={1, 1}}, true, String ++ [$"], $"),
+      ?assertEqual(Error, RelError),
       Error;
     {_, _, Parts, _, _} ->
+      {_, _, PartsRel, _, _} = elixir_interpolation:extract(1, 1, #elixir_tokenizer{mode=relative, prev_pos={1, 1}}, true, String ++ [$"], $"),
+      [{bin_string, {1, 1, nil}, PartsRelConverted}] = elixir_tokenizer:to_absolute_tokens([{bin_string, {0, 0, nil}, PartsRel}], {1, 1}),
+      ?assertEqual(Parts, PartsRelConverted),
       Parts
    end.
 

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -10,7 +10,12 @@ tokenize(String) ->
 
 tokenize(String, Opts) ->
   {ok, _Line, _Column, _Warnings, Result, []} = elixir_tokenizer:tokenize(String, 1, Opts),
-  lists:reverse(Result).
+  ReversedResult = lists:reverse(Result),
+  {ok, _Line1, _Column1, _Warnings1, ResultRelative, []} = elixir_tokenizer:tokenize(String, 1, [{mode, relative} | Opts]),
+  ReversedResultRelative = lists:reverse(ResultRelative),
+  Converted = elixir_tokenizer:to_absolute_tokens(ReversedResultRelative, {1, 1}),
+  ?assertEqual(ReversedResult, Converted),
+  ReversedResult.
 
 tokenize_error(String) ->
   {error, Error, _, _, _} = elixir_tokenizer:tokenize(String, 1, []),


### PR DESCRIPTION
This is an attempt at making the tokenizer produce relative tokens. My intention is to enable building an incremental parsers better suited to LSP use case. With relative tokenization and parsing it may be possible to build a parser that does not need to rebuild the entire AST on each document edit.

Design choices:
- In relative mode token line and column represents a difference from the last token position
- In case of interpolated binaries, charlists and sigils the parts are relative to the position of the token itself
- Inside interpolation the positions are relative to the begin of interpolation `#{`

The current state:
- the relative mode produces valid relative tokens that after conversion to absolute via `:elixir_tokenizer.to_absolute_tokens` are identical to the ones produced by absolute mode. I verified this over elixir source as well as a number of other projects.
- all tests pass
- parser and errors tests return the same tokens and errors/warnings

Examples:
```
iex(2)> :elixir_tokenizer.tokenize(~c'fun(x + 1)', 1, 1, [mode: :absolute]) |> elem(4) |> Enum.reverse
[
  {:paren_identifier, {1, 1, ~c"fun"}, :fun},
  {:"(", {1, 4, nil}},
  {:identifier, {1, 5, ~c"x"}, :x},
  {:dual_op, {1, 7, nil}, :+},
  {:int, {1, 9, 1}, ~c"1"},
  {:")", {1, 10, nil}}
]
iex(3)> :elixir_tokenizer.tokenize(~c'fun(x + 1)', 1, 1, [mode: :relative]) |> elem(4) |> Enum.reverse
[
  {:paren_identifier, {0, 0, ~c"fun"}, :fun},
  {:"(", {0, 3, nil}},
  {:identifier, {0, 1, ~c"x"}, :x},
  {:dual_op, {0, 2, nil}, :+},
  {:int, {0, 2, 1}, ~c"1"},
  {:")", {0, 1, nil}}
]
```

```
iex(7)> :elixir_tokenizer.tokenize(~c'"\#{fun(x + 1)}" <> ""', 1, 1, [mode: :absolute]) |> elem(4) |> Enum.reverse
[
  {:bin_string, {1, 1, nil},
   [
     {{1, 2, nil}, {1, 14, nil},
      [
        {:paren_identifier, {1, 4, ~c"fun"}, :fun},
        {:"(", {1, 7, nil}},
        {:identifier, {1, 8, ~c"x"}, :x},
        {:dual_op, {1, 10, nil}, :+},
        {:int, {1, 12, 1}, ~c"1"},
        {:")", {1, 13, nil}}
      ]}
   ]},
  {:concat_op, {1, 17, nil}, :<>},
  {:bin_string, {1, 20, nil}, [""]}
]
iex(8)> :elixir_tokenizer.tokenize(~c'"\#{fun(x + 1)}" <> ""', 1, 1, [mode: :relative]) |> elem(4) |> Enum.reverse
[
  {:bin_string, {0, 0, nil},
   [
     {{0, 1, nil}, {0, 13, nil},
      [
        {:paren_identifier, {0, 3, ~c"fun"}, :fun},
        {:"(", {0, 3, nil}},
        {:identifier, {0, 1, ~c"x"}, :x},
        {:dual_op, {0, 2, nil}, :+},
        {:int, {0, 2, 1}, ~c"1"},
        {:")", {0, 1, nil}}
      ]}
   ]},
  {:concat_op, {0, 16, nil}, :<>},
  {:bin_string, {0, 3, nil}, [""]}
]
```