### PR TITLE
Fix for ex_unit diff bug 

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -377,12 +377,8 @@ defmodule ExUnit.Diff do
     {parsed_left, improper_left, operators_left, length_left} =
       split_left_list(left, 0, env.context)
 
-    {parsed_right, improper_right} =
-      if improper_left != [] do
-        split_right_list(right, length_left, [])
-      else
-        split_right_list(right, -1, [])
-      end
+    element_limit = if improper_left == [], do: -1, else: length_left
+    {parsed_right, improper_right} = split_right_list(right, element_limit, [])
 
     {parsed_diff, parsed_post_env} = myers_difference_list(parsed_left, parsed_right, env)
 

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -377,8 +377,6 @@ defmodule ExUnit.Diff do
     {parsed_left, improper_left, operators_left, length_left} =
       split_left_list(left, 0, env.context)
 
-    # For improper lists, we split based on the left side's structure
-    # For proper lists, we process the entire right side
     {parsed_right, improper_right} =
       if improper_left != [] do
         split_right_list(right, length_left, [])

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -374,10 +374,10 @@ defmodule ExUnit.Diff do
   # are handled as quoted expressions. Improper lists on the right side are
   # handled as runtime improper lists.
   defp diff_maybe_improper_list(left, right, env) do
-    {parsed_left, improper_left, operators_left, length_left} =
+    {parsed_left, improper_left, operators_left, _length_left} =
       split_left_list(left, 0, env.context)
 
-    {parsed_right, improper_right} = split_right_list(right, length_left, [])
+    {parsed_right, improper_right} = split_right_list(right, [])
     {parsed_diff, parsed_post_env} = myers_difference_list(parsed_left, parsed_right, env)
 
     {improper_diff, improper_post_env} =
@@ -410,10 +410,10 @@ defmodule ExUnit.Diff do
     diff(left, right, env)
   end
 
-  defp split_right_list([head | tail], length, acc) when length > 0,
-    do: split_right_list(tail, length - 1, [head | acc])
+  defp split_right_list([head | tail], acc),
+    do: split_right_list(tail, [head | acc])
 
-  defp split_right_list(rest, _length, acc),
+  defp split_right_list(rest, acc),
     do: {Enum.reverse(acc), rest}
 
   defp rebuild_right_list(left, right) do

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -418,14 +418,12 @@ defmodule ExUnit.Diff do
     diff(left, right, env)
   end
 
-  # When matching improper lists, split right list up to the length of left list's proper part
   defp split_right_list([head | tail], length, acc) when length > 0,
     do: split_right_list(tail, length - 1, [head | acc])
 
   defp split_right_list(rest, length, acc) when is_integer(length),
     do: {Enum.reverse(acc), rest}
 
-  # For proper lists, process the entire list
   defp split_right_list([head | tail], acc),
     do: split_right_list(tail, [head | acc])
 

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -381,7 +381,7 @@ defmodule ExUnit.Diff do
       if improper_left != [] do
         split_right_list(right, length_left, [])
       else
-        split_right_list(right, [])
+        split_right_list(right, -1, [])
       end
 
     {parsed_diff, parsed_post_env} = myers_difference_list(parsed_left, parsed_right, env)
@@ -416,16 +416,10 @@ defmodule ExUnit.Diff do
     diff(left, right, env)
   end
 
-  defp split_right_list([head | tail], length, acc) when length > 0,
+  defp split_right_list([head | tail], length, acc) when length != 0,
     do: split_right_list(tail, length - 1, [head | acc])
 
-  defp split_right_list(rest, length, acc) when is_integer(length),
-    do: {Enum.reverse(acc), rest}
-
-  defp split_right_list([head | tail], acc),
-    do: split_right_list(tail, [head | acc])
-
-  defp split_right_list(rest, acc),
+  defp split_right_list(rest, _length, acc),
     do: {Enum.reverse(acc), rest}
 
   defp rebuild_right_list(left, right) do

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -117,7 +117,6 @@ defmodule ExUnit.DiffTest do
 
   defp refute_diff(left, right, expected_left, expected_right, context) do
     {diff, _env} = Diff.compute(left, right, context)
-
     assert diff.equivalent? == false
 
     diff_left = to_diff(diff.left, "-")

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -117,6 +117,7 @@ defmodule ExUnit.DiffTest do
 
   defp refute_diff(left, right, expected_left, expected_right, context) do
     {diff, _env} = Diff.compute(left, right, context)
+
     assert diff.equivalent? == false
 
     diff_left = to_diff(diff.left, "-")
@@ -237,6 +238,7 @@ defmodule ExUnit.DiffTest do
     refute_diff([:a, :b, :c] = [:a, :b, :x], "[:a, :b, -:c-]", "[:a, :b, +:x+]")
     refute_diff([:a, :x, :c] = [:a, :b, :c], "[:a, -:x-, :c]", "[:a, +:b+, :c]")
     refute_diff([:a, :d, :b, :c] = [:a, :b, :c, :d], "[:a, -:d-, :b, :c]", "[:a, :b, :c, +:d+]")
+    refute_diff([:b, :c] = [:a, :b, :c], "[:b, :c]", "[+:a+, :b, :c]")
 
     refute_diff([:a, :b, :c] = [:a, :b, []], "[:a, :b, -:c-]", "[:a, :b, +[]+]")
     refute_diff([:a, :b, []] = [:a, :b, :c], "[:a, :b, -[]-]", "[:a, :b, +:c+]")
@@ -318,7 +320,7 @@ defmodule ExUnit.DiffTest do
       "[:a, +:b+, :c | +:d+]"
     )
 
-    refute_diff([:a | :d] = [:a, :b, :c | :d], "[:a | -:d-]", "[:a, +:b+, +:c+ | +:d+]")
+    refute_diff([:a | :d] = [:a, :b, :c | :d], "[:a | :d]", "[:a, +:b+, +:c+ | :d]")
 
     refute_diff(
       [[:a | :x], :x | :d] = [[:a | :b], :c | :d],
@@ -354,7 +356,7 @@ defmodule ExUnit.DiffTest do
     )
 
     refute_diff([:a, :b | [:c]] = [:a, :b], "[:a, :b | [-:c-]]", "[:a, :b]")
-    refute_diff([:a, :b | []] = [:a, :b, :c], "[:a, :b | -[]-]", "[:a, :b, +:c+]")
+    refute_diff([:a, :b | []] = [:a, :b, :c], "[:a, :b | []]", "[:a, :b, +:c+]")
     refute_diff([:a, :b | [:c, :d]] = [:a, :b, :c], "[:a, :b | [:c, -:d-]]", "[:a, :b, :c]")
     refute_diff([:a, :b | [:c, :d]] = [:a], "[:a, -:b- | [-:c-, -:d-]]", "[:a]")
 

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -339,7 +339,6 @@ defmodule ExUnit.DiffTest do
   end
 
   test "proper lists" do
-    assert [:a | _x] = [:a, :b | :c]
     assert_diff([:a | [:b]] = [:a, :b], [])
     assert_diff([:a | [:b, :c]] = [:a, :b, :c], [])
 

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -320,7 +320,7 @@ defmodule ExUnit.DiffTest do
       "[:a, +:b+, :c | +:d+]"
     )
 
-    refute_diff([:a | :d] = [:a, :b, :c | :d], "[:a | :d]", "[:a, +:b+, +:c+ | :d]")
+    refute_diff([:a | :d] = [:a, :b, :c | :d], "[:a | -:d-]", "[:a, +:b+, +:c+ | +:d+]")
 
     refute_diff(
       [[:a | :x], :x | :d] = [[:a | :b], :c | :d],
@@ -339,6 +339,7 @@ defmodule ExUnit.DiffTest do
   end
 
   test "proper lists" do
+    assert [:a | _x] = [:a, :b | :c]
     assert_diff([:a | [:b]] = [:a, :b], [])
     assert_diff([:a | [:b, :c]] = [:a, :b, :c], [])
 


### PR DESCRIPTION
I found the reason of #14268 
we passed the length of left list and then the code looked like this:
```
left = [:b, :c]
right = [:a, :b, :c]
{parsed_right = [:a, :b], improper_right = [:c]} = split_right_list(right, length(left), [])
```
I added one test, and fixed ~~two~~ one, which looks like it's invalid currently.
~~There are still two failing tests - I may need a hand with this.~~