### PR TITLE
Fix Stream.concat/2 bug when used in async_stream

### DIFF
--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -904,6 +904,16 @@ defmodule TaskTest do
              |> Enum.to_list() == [ok: :ok]
     end
 
+    test "stream concatenation edge case" do
+      result =
+        Stream.take([:foo, :bar], 1)
+        |> Stream.concat([1, 2])
+        |> Task.async_stream(& &1)
+        |> Enum.to_list()
+
+      assert result == [ok: :foo, ok: 1, ok: 2]
+    end
+
     test "with $callers" do
       grandparent = self()
 


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/14277

Or should we fix this upstream by making sure we only emit length-one `:suspended` tuples?
I'm not familiar enough with the internals of streams.