### PR TITLE
Fix a typo in types.ex

### DIFF
--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -417,7 +417,7 @@ defmodule Module.Types do
       mode: mode,
       # The function for handling local calls
       local_handler: handler,
-      # Control if variable refinment is enabled.
+      # Control if variable refinement is enabled.
       # It is disabled only on dynamic dispatches.
       refine_vars: true
     }


### PR DESCRIPTION
Found a typo in a comment in `types.ex`. This PR fixes it.