### PR TITLE
Add :single_column option to IEx.Helpers.exports (exports/2)

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -906,10 +906,10 @@ defmodule IEx.Helpers do
         Atom.to_string(name) <> "/" <> Integer.to_string(arity)
       end)
   
-    if Keyword.get(opts, :single_column, false) do
-      Enum.each(list, &IO.puts/1)
-    else
+    if not Keyword.get(opts, :single_column, false) do
       print_table(list)
+    else
+      Enum.each(list, &IO.puts/1)
     end
   
     dont_display_result()

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -878,17 +878,40 @@ defmodule IEx.Helpers do
 
   @doc """
   Prints a list of all the functions and macros exported by the given module.
+  
+  ## Examples
+  
+      iex> exports(String)
+      # at/2              bag_distance/2     byte_slice/3       ...
+      # capitalize/2      chunk/2            codepoints/1       ...
+  
+      iex> exports(String, single_column: true)
+      # at/2
+      # bag_distance/2
+      # byte_slice/3
+      # capitalize/1
+      # capitalize/2
+      # chunk/2
+      # ...
+  
+  ## Options
+  - `:single_column` - When `true`, prints one function per line. Default: `false`.
   """
   @doc since: "1.5.0"
-  def exports(module \\ Kernel) do
+  def exports(module \\ Kernel, opts \\ []) do
     exports = IEx.Autocomplete.exports(module)
-
+  
     list =
       Enum.map(exports, fn {name, arity} ->
         Atom.to_string(name) <> "/" <> Integer.to_string(arity)
       end)
-
-    print_table(list)
+  
+    if Keyword.get(opts, :single_column, false) do
+      Enum.each(list, &IO.puts/1)
+    else
+      print_table(list)
+    end
+  
     dont_display_result()
   end
 


### PR DESCRIPTION
Adds a `:single_column` option to `IEx.Helpers.exports/2` to print exported functions/macros in a single column. This improves readability for modules with long function names or when working in terminals with limited horizontal space.