### PR TITLE
Add more docs about :already_started for DynamicSupervisor

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -230,7 +230,14 @@ defmodule DynamicSupervisor do
   @typedoc "Supported strategies"
   @type strategy :: :one_for_one
 
-  @typedoc "Return values of `start_child` functions"
+  @typedoc """
+  Return values of `start_child` functions.
+
+  Unlike `Supervisor`, this module ignores the child spec ids, so
+  `{:error, {:already_started, pid}}` is not returned for child specs given with the same id.
+  `{:error, {:already_started, pid}}` is returned however if a duplicate name is used when using
+  [name registration](`m:GenServer#module-name-registration`).
+  """
   @type on_start_child ::
           {:ok, pid}
           | {:ok, pid, info :: term}
@@ -404,7 +411,10 @@ defmodule DynamicSupervisor do
   "Child specification" section of the documentation for `Supervisor`. The child
   process will be started as defined in the child specification. Note that while
   the `:id` field is still required in the spec, the value is ignored and
-  therefore does not need to be unique.
+  therefore does not need to be unique. Unlike `Supervisor`, this module does not
+  return `{:error, {:already_started, pid}}` for child specs given with the same id.
+  `{:error, {:already_started, pid}}` is returned however if a duplicate name is
+  used when using [name registration](`m:GenServer#module-name-registration`).
 
   If the child process start function returns `{:ok, child}` or `{:ok, child,
   info}`, then child specification and PID are added to the supervisor and

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -407,9 +407,8 @@ defmodule DynamicSupervisor do
   @doc """
   Dynamically adds a child specification to `supervisor` and starts that child.
 
-  `child_spec` should be a valid child specification as detailed in the
-  "Child specification" section of the documentation for `Supervisor`. The child
-  process will be started as defined in the child specification. Note that while
+  `child_spec` should be a valid [child specification](`m:Supervisor#module-child-specification`).
+  The child process will be started as defined in the child specification. Note that while
   the `:id` field is still required in the spec, the value is ignored and
   therefore does not need to be unique. Unlike `Supervisor`, this module does not
   return `{:error, {:already_started, pid}}` for child specs given with the same id.


### PR DESCRIPTION
While playing around with DynamicSupervisor, I got confused because the typespec mentions `{:error, :already_started}`, although unlike Supervisor, DynamicSupervisor ignores the child spec ids that would normally cause this value to be returned.

This PR expands the docs for Dynamic Supervisor's `start_child` function and `on_start_child` typespec to explain that although the `id` is ignored, `:already_started` can still be returned when using name registration.

<img width="840" alt="image" src="https://github.com/user-attachments/assets/5be6902a-7d7c-4af3-8709-0ebb1066c522" />
<img width="838" alt="image" src="https://github.com/user-attachments/assets/404eae0b-2245-4197-bc37-cef32479a9dc" />
