### PR TITLE
Mention the type system in quote :generated doc

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -834,8 +834,8 @@ defmodule Kernel.SpecialForms do
     * `:context` - sets the resolution context.
 
     * `:generated` - marks the given chunk as generated so it does not emit warnings.
-      It is also useful to avoid dialyzer reporting errors when macros generate
-      unused clauses.
+      It is also useful to prevent the type system or dialyzer from reporting errors
+      when macros generate unused clauses.
 
     * `:file` - sets the quoted expressions to have the given file.
 


### PR DESCRIPTION
https://github.com/elixir-lang/elixir/issues/14300 made me realize that the fact `:generated` also works for the new type system wasn't explicitly documented.