### PR TITLE
Fix CHANGELOG typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,7 +252,7 @@ You may also prefer to write using guards:
 
 #### IEx
 
-  * [IEx.Autocomplete] Fix crashing whhen autocompleting structs with runtime values
+  * [IEx.Autocomplete] Fix crashing when autocompleting structs with runtime values
 
 #### Mix
 


### PR DESCRIPTION
Reading the 1.18.2 changelog, I noticed a small typo.

Even though there's no code involved here, I'm not sure if there's anything special about contributing to a past release branch. Please inform me if there's anything I should know :) thanks!