### PR TITLE
Fix zipping on cycle stream

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1447,7 +1447,7 @@ defmodule Stream do
   defp check_cycle_first_element(reduce) do
     fn acc ->
       case reduce.(acc) do
-        {state, []} when state in [:done, :halted] ->
+        {:done, []} ->
           raise ArgumentError, "cannot cycle over an empty enumerable"
 
         other ->

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -1521,6 +1521,18 @@ defmodule EnumTest do
     assert Enum.zip([], []) == []
   end
 
+  test "zip/2 with infinite streams" do
+    assert Enum.zip([], Stream.cycle([1, 2])) == []
+    assert Enum.zip([], Stream.cycle(1..2)) == []
+    assert Enum.zip(.., Stream.cycle([1, 2])) == []
+    assert Enum.zip(.., Stream.cycle(1..2)) == []
+
+    assert Enum.zip(Stream.cycle([1, 2]), ..) == []
+    assert Enum.zip(Stream.cycle(1..2), ..) == []
+    assert Enum.zip(Stream.cycle([1, 2]), ..) == []
+    assert Enum.zip(Stream.cycle(1..2), ..) == []
+  end
+
   test "zip/1" do
     assert Enum.zip([[:a, :b], [1, 2], ["foo", "bar"]]) == [{:a, 1, "foo"}, {:b, 2, "bar"}]
 

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -245,6 +245,10 @@ defmodule StreamTest do
       Stream.cycle(%{}) |> Enum.to_list()
     end
 
+    assert_raise ArgumentError, "cannot cycle over an empty enumerable", fn ->
+      Stream.cycle(..) |> Enum.to_list()
+    end
+
     assert Stream.cycle([1, 2, 3]) |> Stream.take(5) |> Enum.to_list() == [1, 2, 3, 1, 2]
     assert Enum.take(stream, 5) == [1, 2, 3, 1, 2]
   end


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/14306

Copying explanation from https://github.com/elixir-lang/elixir/issues/14306#issuecomment-2692487865
- we reach [this point](https://github.com/elixir-lang/elixir/blob/main/lib/elixir/lib/stream/reducers.ex#L113-L116) when the first enumerable is empty
- we try to close the remaining enums, that is our Stream.cycle, [with `{:halt, []}`](https://github.com/elixir-lang/elixir/blob/main/lib/elixir/lib/stream/reducers.ex#L142)
- this causes a `{:halted, []}` explicitly guarded against [here](https://github.com/elixir-lang/elixir/blob/ba43db786a05404e113fa0a0c7a90e436719c5e6/lib/elixir/lib/stream.ex#L1450)

I couldn't find or write any test that fails if we remove this guard.