### PR TITLE
Fix autocomplete crash when expanding struct with `__MODULE__`

### DIFF
--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -381,7 +381,8 @@ defmodule IEx.Autocomplete do
     case Code.Fragment.container_cursor_to_quoted(code) do
       {:ok, quoted} ->
         case Macro.path(quoted, &match?({:__cursor__, _, []}, &1)) do
-          [cursor, {:%{}, _, pairs}, {:%, _, [{:__aliases__, _, aliases}, _map]} | _] ->
+          [cursor, {:%{}, _, pairs}, {:%, _, [{:__aliases__, _, aliases = [h | _]}, _map]} | _]
+          when is_atom(h) ->
             container_context_struct(cursor, pairs, aliases, shell)
 
           [
@@ -389,8 +390,9 @@ defmodule IEx.Autocomplete do
             pairs,
             {:|, _, _},
             {:%{}, _, _},
-            {:%, _, [{:__aliases__, _, aliases}, _map]} | _
-          ] ->
+            {:%, _, [{:__aliases__, _, aliases = [h | _]}, _map]} | _
+          ]
+          when is_atom(h) ->
             container_context_struct(cursor, pairs, aliases, shell)
 
           [cursor, pairs, {:|, _, [{variable, _, nil} | _]}, {:%{}, _, _} | _] ->

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -430,6 +430,9 @@ defmodule IEx.AutocompleteTest do
     assert {:yes, ~c"ry: ", []} = expand(~c"%URI{path: \"foo\", que")
     assert {:no, [], []} = expand(~c"%URI{path: \"foo\", unkno")
     assert {:no, [], []} = expand(~c"%Unknown{path: \"foo\", unkno")
+
+    assert {:yes, [], _} = expand(~c"%__MODULE__{")
+    assert {:yes, [], _} = expand(~c"%__MODULE__.Some{")
   end
 
   test "completion for struct keys in update syntax" do


### PR DESCRIPTION
This PR fixes

```
*** ERROR: Shell process terminated! (^G to start new job) ***

21:39:55.166 [error] Process #PID<0.70.0> raised an exception
** (FunctionClauseError) no function clause matching in Module.concat/2
    (elixir 1.18.2) lib/module.ex:961: Module.concat(Elixir, {:__MODULE__, [line: 1], nil})
    (iex 1.18.2) lib/iex/autocomplete.ex:471: IEx.Autocomplete.value_from_alias/2
    (iex 1.18.2) lib/iex/autocomplete.ex:422: IEx.Autocomplete.container_context_struct/4
    (iex 1.18.2) lib/iex/autocomplete.ex:334: IEx.Autocomplete.expand_container_context/4
    (iex 1.18.2) lib/iex/autocomplete.ex:82: IEx.Autocomplete.expand_code/2
    (kernel 9.2.4.6) group.erl:685: :group.get_line1/5
    (kernel 9.2.4.6) group.erl:517: :group.get_chars_loop/10
    (kernel 9.2.4.6) group.erl:213: :group.io_request/6
iex(1)> %__MODULE__.Sd{
```