### PR TITLE
Fix infinite loop when dispatching protocols for %{__struct__: nil}

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -1000,6 +1000,8 @@ defmodule Protocol do
       end
 
       # Internal handler for Structs
+      Kernel.defp(struct_impl_for(nil), do: unquote(any_impl_for))
+
       Kernel.defp struct_impl_for(struct) do
         case Code.ensure_compiled(Module.concat(__MODULE__, struct)) do
           {:module, module} -> module

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -444,6 +444,12 @@ defmodule Inspect.MapTest do
              "%{__struct__: Inspect.MapTest.Private, key: 1}"
   end
 
+  test "invalid struct" do
+    assert inspect(%{__struct__: nil}) == "%{__struct__: nil}"
+    assert inspect(%{__struct__: false}) == "%{__struct__: false}"
+    assert inspect(%{__struct__: "foo"}) == "%{__struct__: \"foo\"}"
+  end
+
   defmodule Failing do
     @enforce_keys [:name]
     defstruct @enforce_keys

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -106,6 +106,7 @@ defmodule ProtocolTest do
     assert is_nil(Sample.impl_for(self()))
     assert is_nil(Sample.impl_for(hd(:erlang.ports())))
     assert is_nil(Sample.impl_for(make_ref()))
+    assert is_nil(Sample.impl_for(%{__struct__: nil}))
 
     assert Sample.impl_for(%ImplStruct{}) == Sample.ProtocolTest.ImplStruct
     assert Sample.impl_for(%ImplStructExplicitFor{}) == Sample.ProtocolTest.ImplStructExplicitFor
@@ -117,6 +118,7 @@ defmodule ProtocolTest do
     # Derived
     assert WithAny.impl_for(%ImplStruct{}) == ProtocolTest.WithAny.ProtocolTest.ImplStruct
     assert WithAny.impl_for(%{__struct__: "foo"}) == WithAny.Map
+    assert WithAny.impl_for(%{__struct__: nil}) == WithAny.Any
     assert WithAny.impl_for(%{}) == WithAny.Map
     assert WithAny.impl_for(self()) == WithAny.Any
   end


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/14311

To backport after merge.

Perhaps a better long-term fix would be to fix `%struct{}` / `is_struct` to check for `nil` / booleans.