### PR TITLE
Document that multi-line strings are heredocs

### DIFF
--- a/lib/elixir/pages/references/syntax-reference.md
+++ b/lib/elixir/pages/references/syntax-reference.md
@@ -43,7 +43,7 @@ To learn more about all Unicode characters allowed in atom, see the [Unicode syn
 
 Single-line strings in Elixir are written between double-quotes, such as `"foo"`. Any double-quote inside the string must be escaped with `\ `. Strings support Unicode characters and are stored as UTF-8 encoded binaries.
 
-Multi-line strings in Elixir are written with three double-quotes, and can have unescaped quotes within them. The resulting string will end with a newline. The indentation of the last `"""` is used to strip indentation from the inner string. For example:
+Multi-line strings in Elixir are called heredocs. They are written with three double-quotes, and can have unescaped quotes within them. The resulting string will end with a newline. The indentation of the last `"""` is used to strip indentation from the inner string. For example:
 
 ```elixir
 iex> test = """


### PR DESCRIPTION
In multiple places in the docs, multi-line strings are referred to as heredocs, such as the following:

From: [https://hexdocs.pm/elixir/1.18.3/module-attributes.html#:~:text=Elixir promotes the use of Markdown with heredocs to write readable documentation](<https://hexdocs.pm/elixir/1.18.3/module-attributes.html#:~:text=Elixir promotes the use of Markdown with heredocs to write readable documentation>)
> Elixir promotes the use of Markdown with heredocs to write readable documentation. Heredocs are multi-line strings, they start and end with triple double-quotes, keeping the formatting of the inner text

From: [https://hexdocs.pm/elixir/1.18.3/sigils.html#:~:text=Sigils also support heredocs](<https://hexdocs.pm/elixir/1.18.3/sigils.html#:~:text=Sigils also support heredocs>)
> Sigils also support heredocs, that is, three double-quotes or single-quotes as separators

But currently in the main place multi-line strings are introduced (in the syntax reference), they are not given the name heredocs. This PR adds the name heredocs to the syntax reference so that it can more easily be found.