### PR TITLE
types.ex - improve warning message about defp defaults

### DIFF
--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -464,14 +464,16 @@ defmodule Module.Types do
   ## Module errors
 
   def format_error({:unused_args, {name, arity}}),
-    do: "default values for the optional arguments in #{name}/#{arity} are never used"
+    do:
+      "default values for the optional arguments in the private function #{name}/#{arity} are never used"
 
   def format_error({:unused_args, {name, arity}, count}) when arity - count == 1,
-    do: "the default value for the last optional argument in #{name}/#{arity} is never used"
+    do:
+      "the default value for the last optional argument in the private function #{name}/#{arity} is never used"
 
   def format_error({:unused_args, {name, arity}, count}),
     do:
-      "the default values for the last #{arity - count} optional arguments in #{name}/#{arity} are never used"
+      "the default values for the last #{arity - count} optional arguments in the private function #{name}/#{arity} are never used"
 
   def format_error({:unused_def, {name, arity}, :defp}),
     do: "function #{name}/#{arity} is unused"

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -716,7 +716,10 @@ defmodule Kernel.WarningTest do
 
   test "unused default args" do
     assert_warn_eval(
-      ["nofile:3:8: ", "default values for the optional arguments in b/3 are never used"],
+      [
+        "nofile:3:8: ",
+        "default values for the optional arguments in the private function b/3 are never used"
+      ],
       ~S"""
       defmodule Sample1 do
         def a, do: b(1, 2, 3)
@@ -728,7 +731,7 @@ defmodule Kernel.WarningTest do
     assert_warn_eval(
       [
         "nofile:3:8: ",
-        "the default value for the last optional argument in b/3 is never used"
+        "the default value for the last optional argument in the private function b/3 is never used"
       ],
       ~S"""
       defmodule Sample2 do
@@ -741,7 +744,7 @@ defmodule Kernel.WarningTest do
     assert_warn_eval(
       [
         "nofile:3:8: ",
-        "the default values for the last 2 optional arguments in b/4 are never used"
+        "the default values for the last 2 optional arguments in the private function b/4 are never used"
       ],
       ~S"""
       defmodule Sample3 do
@@ -759,7 +762,10 @@ defmodule Kernel.WarningTest do
            """) == ""
 
     assert_warn_eval(
-      ["nofile:3:8: ", "the default value for the last optional argument in b/3 is never used"],
+      [
+        "nofile:3:8: ",
+        "the default value for the last optional argument in the private function b/3 is never used"
+      ],
       ~S"""
       defmodule Sample5 do
         def a, do: b(1, 2)


### PR DESCRIPTION
This adds some text to the warning explaining it only affects private functions and that making the function public will silence the warning.