### PR TITLE
mix xref graph - add json support and related changes

### DIFF
--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -977,7 +977,7 @@ defmodule Mix.Tasks.Xref do
             png_file_spec = (file_spec |> Path.rootname() |> Path.basename()) <> ".png"
 
             """
-            Generated '#{Path.relative_to_cwd(file_spec)}'. To generate a PNG:
+            Generated "#{Path.relative_to_cwd(file_spec)}". To generate a PNG:
 
                dot -Tpng #{inspect(file_spec)} -o #{inspect(png_file_spec)}
 
@@ -1004,7 +1004,7 @@ defmodule Mix.Tasks.Xref do
             Mix.Utils.write_json_tree!("xref_graph.json", Enum.sort(roots), callback, opts)
 
           if file_spec != "-" do
-            Mix.shell().info("Generated '#{file_spec}'.")
+            Mix.shell().info("Generated \"#{file_spec}\".")
           end
 
           {:references, count}

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -274,6 +274,7 @@ defmodule Mix.Utils do
   if there is an error.
 
   Returns the name of the file written to, or "-" if the output was to STDOUT.
+  This function is made public mostly for testing.
   """
   @spec write_according_to_opts!(Path.t(), iodata(), keyword) :: Path.t()
   def write_according_to_opts!(default_file_spec, contents, opts) do

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -217,16 +217,14 @@ defmodule Mix.UtilsTest do
     end
 
     test "verify that writing to STDOUT works as expected" do
-      in_tmp("make sure we don't actually write to disk", fn ->
-        output =
-          ExUnit.CaptureIO.capture_io(fn ->
-            Mix.Utils.write_according_to_opts!("the_file.txt", ["some text"], output: "-")
-          end)
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          Mix.Utils.write_according_to_opts!("the_file.txt", ["some text"], output: "-")
+        end)
 
-        assert output == "some text"
+      assert output == "some text"
 
-        assert File.exists?("the_file.txt") == false
-      end)
+      refute File.exists?("the_file.txt")
     end
   end
 

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -178,6 +178,53 @@ defmodule Mix.UtilsTest do
     end
   end
 
+  test "verify that write_according_to_opts/3 works as expected" do
+    # ignore any error from this call.
+
+    test_out = "test.out"
+    test_out_bak = "test.out.bak"
+    hello_world = "Hello World!"
+    new_hello_world = "New Hello World!"
+    default_out = "default.out"
+
+    # make sure none of the files exist - ignore errors
+    File.rm(test_out)
+    File.rm(test_out_bak)
+    File.rm(default_out)
+
+    # no optional override - write to the specified default file
+    assert Mix.Utils.write_according_to_opts!(test_out, [hello_world], []) == test_out
+    assert File.read!(test_out) == hello_world
+
+    # no optional override - write to the specified default file again, with old file backed up
+    assert Mix.Utils.write_according_to_opts!(test_out, [new_hello_world], []) == test_out
+    assert File.read!(test_out) == new_hello_world
+    assert File.read!(test_out_bak) == hello_world
+
+    # cleanup
+    File.rm!(test_out)
+    File.rm!(test_out_bak)
+
+    # with optional override - write to the specified default file
+    assert Mix.Utils.write_according_to_opts!(default_out, [hello_world], output: test_out) ==
+             test_out
+
+    assert File.read!(test_out) == hello_world
+
+    # with optional override - write to the specified default file again, with old file backed up
+    assert Mix.Utils.write_according_to_opts!(default_out, [new_hello_world], output: test_out) ==
+             test_out
+
+    assert File.read!(test_out) == new_hello_world
+    assert File.read!(test_out_bak) == hello_world
+
+    # cleanup again
+    File.rm!(test_out)
+    File.rm!(test_out_bak)
+
+    # we don't test the handling of "-" here, we test it implicitly in xref_test.exs
+  end
+
   defp assert_ebin_symlinked_or_copied(result) do
     case result do
       {:ok, paths} ->


### PR DESCRIPTION
This patch adds support for output the xref graph as a two level Map of Maps which can be trivially loaded by anything that can process JSON data. The top level Map contains keys which specify source files whose values are maps contain sink files as keys, and dependency type data as values. Source files with no dependencies have empty maps as values. For example a if "lib/foo.ex" has a compile time dependency on "lib/bar.ex" which had no dependencies at all, then the output would look like this:

```
   {
     "lib/foo.ex": { "lib/bar.ex": "compile" },
     "lib/bar.ex": {},
   }
```

At the same time it adds support for renaming existing xref_graph.dot and xref_graph.json files to have a .bak extension instead of overwriting them.

This patch also includes logic to fix some misleading verbiage output by the 'dot' format when the output file is not in the current working directory. This change is included with the JSON changes because I refactored the logic for writing to a file so that both the 'json' and 'dot' formats would use the same code.

This patch also includes some new test functions to make it easier to test the behavior of the 'dot' and 'json' functions. It also includes documentation changes to reflect the above changes.

This patch fixes the bugs reported in #14324, with the exception that it does not include a way to control/silence the additional verbiage produced by the 'dot' format.