### PR TITLE
Fix handling of ErlangError when :general key is chardata

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -2718,7 +2718,7 @@ defmodule ErlangError do
           {:ok, reason, IO.iodata_to_binary([":\n\n" | Enum.map(args_errors, &arg_error/1)])}
 
         general = extra[:general] ->
-          {:ok, reason, ": " <> general}
+          {:ok, reason, ": " <> IO.chardata_to_string(general)}
 
         true ->
           :error

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -50,6 +50,19 @@ defmodule ExceptionTest do
                {:io, :put_chars, [self(), <<222>>],
                 [error_info: %{module: __MODULE__, function: :dummy_error_extras}]}
              ])
+
+    assert %ErlangError{
+             original: {:failed_load_cacerts, :enoent},
+             reason: ": Failed to load cacerts: operating system CA bundle could not be located"
+           } =
+             Exception.normalize(:error, {:failed_load_cacerts, :enoent}, [
+               {:pubkey_os_cacerts, :get, 0,
+                [
+                  file: ~c"pubkey_os_cacerts.erl",
+                  line: 53,
+                  error_info: %{cause: :enoent, module: :pubkey_os_cacerts}
+                ]}
+             ])
   end
 
   test "format/2 without stacktrace" do

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -51,17 +51,10 @@ defmodule ExceptionTest do
                 [error_info: %{module: __MODULE__, function: :dummy_error_extras}]}
              ])
 
-    assert %ErlangError{
-             original: {:failed_load_cacerts, :enoent},
-             reason: ": Failed to load cacerts: operating system CA bundle could not be located"
-           } =
+    assert %ErlangError{original: {:failed_load_cacerts, :enoent}, reason: ": this is chardata"} =
              Exception.normalize(:error, {:failed_load_cacerts, :enoent}, [
                {:pubkey_os_cacerts, :get, 0,
-                [
-                  file: ~c"pubkey_os_cacerts.erl",
-                  line: 53,
-                  error_info: %{cause: :enoent, module: :pubkey_os_cacerts}
-                ]}
+                [error_info: %{module: __MODULE__, function: :dummy_error_chardata}]}
              ])
   end
 
@@ -1079,4 +1072,8 @@ defmodule ExceptionTest do
   end
 
   def dummy_error_extras(_exception, _stacktrace), do: %{general: "foo"}
+
+  def dummy_error_chardata(_exception, _stacktrace) do
+    %{general: ~c"this is " ++ [~c"chardata"], reason: ~c"this " ++ [~c"too"]}
+  end
 end


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/14322

https://github.com/erlang/otp/blob/57cee857031cc08a47c7d2f4f21a6fac87781f91/lib/public_key/src/pubkey_os_cacerts.erl#L300

Before

![Screenshot 2025-03-15 at 8 42 23](https://github.com/user-attachments/assets/7be363c9-1a24-4fd2-b047-68fca282a18d)

After

![Screenshot 2025-03-15 at 8 42 14](https://github.com/user-attachments/assets/befe68ff-c638-4310-9125-4abde071fff1)
