### PR TITLE
Update ORT Action & Executable

### DIFF
--- a/.github/workflows/ort/action.yml
+++ b/.github/workflows/ort/action.yml
@@ -78,14 +78,9 @@ runs:
 
     - name: Run OSS Review Toolkit
       id: ort
-      # TODO: Use released version once the following issue has been released:
-      # * https://github.com/oss-review-toolkit/ort-ci-github-action/issues/37
-      # * https://github.com/oss-review-toolkit/ort-ci-github-action/pull/41
-      # * https://github.com/oss-review-toolkit/ort-ci-github-action/pull/43
-      # * https://github.com/oss-review-toolkit/ort-ci-github-action/pull/45
-      uses: oss-review-toolkit/ort-ci-github-action@1805edcf1f4f55f35ae6e4d2d9795ccfb29b6021 # main
+      uses: oss-review-toolkit/ort-ci-github-action@1805edcf1f4f55f35ae6e4d2d9795ccfb29b6021 # v1.1.0
       with:
-        image: ghcr.io/oss-review-toolkit/ort-minimal:51.1.0
+        image: ghcr.io/oss-review-toolkit/ort-minimal:54.0.0
         run: >-
           labels,
           cache-dependencies,

--- a/.ort.yml
+++ b/.ort.yml
@@ -83,11 +83,6 @@ curations:
       concluded_license: "LicenseRef-scancode-unicode"
 
     # Wrongly Identified
-    - path: "LICENSES/LicenseRef-elixir-trademark-policy.txt"
-      reason: "INCORRECT"
-      comment: "Correct LicenseRef"
-      detected_license: "LicenseRef-scancode-proprietary-license"
-      concluded_license: "LicenseRef-elixir-trademark-policy"
     - path: "lib/elixir/pages/references/library-guidelines.md"
       reason: "INCORRECT"
       comment: |

--- a/.ort/config/evaluator.rules.kts
+++ b/.ort/config/evaluator.rules.kts
@@ -24,6 +24,7 @@ val whitelistedLicenses = listOf(
   "Apache-2.0",
   // License for the Elixir Logo
   "LicenseRef-elixir-trademark-policy",
+  "LicenseRef-scancode-elixir-trademark-policy",
   // License for included Unicode Files
   "LicenseRef-scancode-unicode",
   // DCO for committers


### PR DESCRIPTION
Also removes superfluous ORT evaluator rule since the Elixir TM license was fully propagated: https://github.com/aboutcode-org/scancode-toolkit/pull/4165