### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/ci-markdown.yml
+++ b/.github/workflows/ci-markdown.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 10
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v19.1.0
+        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19.1.0
         with:
           globs: |
             lib/elixir/pages/**/*.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
             development: true
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 50
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
         with:
           otp-version: ${{ matrix.otp_version }}
       - name: Set ERL_COMPILER_OPTIONS
@@ -88,10 +88,10 @@ jobs:
     steps:
       - name: Configure Git
         run: git config --global core.autocrlf input
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 50
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
         with:
           otp-version: ${{ matrix.otp_version }}
       - name: Compile Elixir
@@ -113,7 +113,7 @@ jobs:
     name: Check POSIX-compliant
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 50
       - name: Install Shellcheck
@@ -139,7 +139,7 @@ jobs:
 
       - name: Checkout project
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Run OSS Review Toolkit"
         id: ort

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-20.04
     name: Notify
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 50
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
         with:
           otp-version: '25.0'
           elixir-version: '1.14.0'

--- a/.github/workflows/ort/action.yml
+++ b/.github/workflows/ort/action.yml
@@ -41,7 +41,7 @@ runs:
   steps:
     - name: Fetch Default ORT Config
       id: fetch-default-ort-config
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         repository: oss-review-toolkit/ort-config
         ref: "main"
@@ -71,7 +71,7 @@ runs:
         ELIXIR_REPO: "${{ github.server_url }}/${{ github.repository }}.git"
 
     - name: "Cache ScanCode"
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: "~/.cache/scancode-tk"
         key: ${{ runner.os }}-scancode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             --draft \
             ${{ github.ref_name }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: github.ref_type == 'branch'
         with:
           fetch-depth: 50
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 50
 
@@ -91,19 +91,19 @@ jobs:
           shasum -a 256 Docs.zip > Docs.zip.sha256sum
 
       - name: "Upload linux release artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: build-linux-elixir-otp-${{ matrix.otp }}
           path: elixir-otp-${{ matrix.otp }}.zip
 
       - name: "Upload windows release artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: build-windows-elixir-otp-${{ matrix.otp }}
           path: elixir-otp-${{ matrix.otp }}.exe
 
       - name: "Upload doc artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: matrix.build_docs
         with:
           name: Docs
@@ -124,12 +124,12 @@ jobs:
 
     steps:
       - name: "Download build"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: build-${{ matrix.flavor }}-elixir-otp-${{ matrix.otp }}
 
       - name: "Sign files with Trusted Signing"
-        uses: azure/trusted-signing-action@v0.5.1
+        uses: azure/trusted-signing-action@0d74250c661747df006298d0fb49944c10f16e03 # v0.5.1
         if: github.repository == 'elixir-lang/elixir' && matrix.flavor == 'windows'
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -169,7 +169,7 @@ jobs:
           shasum -a 256 "$RELEASE_FILE" > "${RELEASE_FILE}.sha256sum"
 
       - name: "Upload linux release artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: sign-${{ matrix.flavor }}-elixir-otp-${{ matrix.otp }}
           path: ${{ env.RELEASE_FILE }}*
@@ -189,11 +189,11 @@ jobs:
   
       - name: Checkout project
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   
       - name: "Download Build Artifacts"
         id: download-build-artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           pattern: "{sign-*-elixir-otp-*,Docs}"
           merge-multiple: true
@@ -208,7 +208,7 @@ jobs:
 
       - name: Attest Distribution Assets with SBoM
         id: attest-sbom
-        uses: actions/attest-sbom@v2
+        uses: actions/attest-sbom@115c3be05ff3974bcbd596578934b3f9ce39bf68 # v2.2.0
         with:
           subject-path: |
             /tmp/build-artifacts/{elixir-otp-*.*,Docs.zip}
@@ -236,7 +236,7 @@ jobs:
           ATTESTATION: "${{ steps.attest-sbom.outputs.bundle-path }}"
 
       - name: "Assemble Release SBoM Artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: "SBoM"
           path: |
@@ -246,7 +246,7 @@ jobs:
             ${{ steps.ort.outputs.results-sbom-spdx-json-path }}
 
       - name: "Assemble Distribution Attestations"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: "Attestations"
           path: "attestations/*.sigstore"
@@ -256,7 +256,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           pattern: "{sign-*-elixir-otp-*,Docs,SBoM,Attestations}"
           merge-multiple: true
@@ -301,7 +301,7 @@ jobs:
       FASTLY_KEY: ${{ secrets.HEX_FASTLY_KEY }}
       OTP_GENERIC_VERSION: "25"
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           pattern: "{sign-*-elixir-otp-*,Docs}"
           merge-multiple: true

--- a/.github/workflows/release_pre_built/action.yml
+++ b/.github/workflows/release_pre_built/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: erlef/setup-beam@v1
+    - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
       with:
         otp-version: ${{ inputs.otp_version }}
         version-type: strict
@@ -45,7 +45,7 @@ runs:
           ref=v$(curl -s https://hex.pm/api/packages/ex_doc | jq --raw-output '.latest_stable_version')
         fi
         echo "EX_DOC_REF=$ref" >> $GITHUB_ENV
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       if: ${{ inputs.build_docs }}
       with:
         repository: elixir-lang/ex_doc


### PR DESCRIPTION
## Change

This PR pins all GH Actions to a specific commit sha.

All actions invocations are written as `uses: [REPO]/[NAME]@[SHA] # [VERSION]`. This is supported by dependabot and it will automatically create PRs with both the SHA and version change in the comment.

## Reason

As seen with [`tj-actions/changed-files`](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/) last week, any version (even if using a tag) can compromise a repository. The only way to prevent this, is to pin the version to a specific SHA.

This is also recommended by ScoreCard: https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

## Recommendation

This will potentially create a lot of dependabot update PRs with the current configuration. In the projects I maintain and pinned the dependencies, I added a grouping rule to reduce the noise:

```yml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
    groups:
      github-actions:
        applies-to: version-updates
        patterns:
          - "*"
```