### PR TITLE
Limit GH Actions Token Permissions

### DIFF
--- a/.github/workflows/ci-markdown.yml
+++ b/.github/workflows/ci-markdown.yml
@@ -14,6 +14,9 @@ on:
       - 'lib/**/*.md'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint Markdown content

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ env:
   LANG: C.UTF-8
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
   create_draft_release:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -122,6 +122,9 @@ jobs:
 
     runs-on: ${{ matrix.flavor == 'linux' && 'ubuntu-22.04' || 'windows-2022' }}
 
+    permissions:
+      contents: write
+
     steps:
       - name: "Download build"
         uses: actions/download-artifact@v4
@@ -180,6 +183,11 @@ jobs:
     needs: [build, sign]
 
     runs-on: ubuntu-24.04
+
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Use HTTPS instead of SSH for Git cloning
@@ -254,6 +262,9 @@ jobs:
   upload-release:
     needs: [create_draft_release, build, sign, sbom]
     runs-on: ubuntu-22.04
+
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
## Change

Sets top level permissions for each GH Action workflow to `contents: read` and gives more permissions to jobs where necessary.

## Reason

Each job should have the minimal set of permissions available so that it can't access / manipulate information in case of a malicious action or if a user manages to inject code into the CI.

This is also recommended by ScoreCard: https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions