### PR TITLE
Add CVE CHANGELOG disclosure requirement to `RELEASE.md`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,10 +12,7 @@
 
 2. Ensure /CHANGELOG.md is updated, versioned and add the current date
    - If this release addresses any publicly known security vulnerabilities with
-     assigned CVEs, add a "Security" section to `CHANGELOG.md`.
-     - List all fixed vulnerabilities along with their CVE identifiers.
-     - If there are no known security vulnerabilities addressed in this release, this section may be omitted.
-   - For example:
+     assigned CVEs, add a "Security" section to `CHANGELOG.md`. For example:
      ```md
      ## Security
      - Fixed CVE-2025-00000: Description of the vulnerability

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,15 @@
 1. Update version in /VERSION, bin/elixir, bin/elixir.bat, and bin/elixir.ps1
 
 2. Ensure /CHANGELOG.md is updated, versioned and add the current date
+   - If this release addresses any publicly known security vulnerabilities with
+     assigned CVEs, add a "Security" section to `CHANGELOG.md`.
+     - List all fixed vulnerabilities along with their CVE identifiers.
+     - If there are no known security vulnerabilities addressed in this release, this section may be omitted.
+   - For example:
+     ```md
+     ## Security
+     - Fixed CVE-2025-00000: Description of the vulnerability
+     ```
 
 3. Update "Compatibility and Deprecations" if a new OTP version is supported
 


### PR DESCRIPTION
Fulfills the [release_notes_vulns](https://www.bestpractices.dev/en/criteria/0#0.release_notes_vulns) OpenSSF Best Practices Badge requirements.