### PR TITLE
Add MIX_OS_DEPS_COMPILE_PARTITION_COUNT for concurrent deps compilation

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -359,7 +359,11 @@ defmodule Mix do
     * `MIX_OS_CONCURRENCY_LOCK` - when set to `0` or `false`, disables mix compilation locking.
       While not recommended, this may be necessary in cases where hard links or TCP sockets are
       not available. When opting for this behaviour, make sure to not start concurrent compilations
-      of the same project.
+      of the same project
+
+    * `MIX_OS_DEPS_COMPILE_PARTITION_COUNT` - when set to a number greater than 1, it enables
+      compilation of dependencies over multiple operating system processes. See `mix help deps.compile`
+      for more information
 
     * `MIX_PATH` - appends extra code paths
 

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -83,12 +83,12 @@ defmodule Mix.Tasks.Deps.Compile do
       |> reject_umbrella_children(options)
       |> reject_local_deps(options)
 
-    count = System.get_env("MIX_DEPS_COMPILE_PARALLEL_COUNT", "0") |> String.to_integer()
+    count = System.get_env("MIX_OS_DEPS_COMPILE_PARTITION_COUNT", "0") |> String.to_integer()
 
     compiled? =
       if count > 1 and length(deps) > count do
-        Mix.shell().info("mix deps.compile running in parallel with count=#{count}")
-        Mix.Tasks.Deps.Parallel.server(deps, count, force?)
+        Mix.shell().info("mix deps.compile running across #{count} OS processes")
+        Mix.Tasks.Deps.Partition.server(deps, count, force?)
       else
         config = Mix.Project.deps_config()
         true in Enum.map(deps, &compile_single(&1, force?, config))

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -35,13 +35,13 @@ defmodule Mix.Tasks.Deps.Compile do
   recompiled without propagating those changes upstream. To ensure
   `b` is included in the compilation step, pass `--include-children`.
 
-  ## Compiling dependencies across multiple OSes processes
+  ## Compiling dependencies across multiple OS processes
 
   If you set the environment variable `MIX_OS_DEPS_COMPILE_PARTITION_COUNT`
   to a number greater than 1, Mix will start multiple operating system
   processes to compile your dependencies concurrently.
 
-  While Mix and Rebar will compile all files in a given project in parallel,
+  While Mix and Rebar compile all files within a given project in parallel,
   enabling this environment variable can still yield useful gains in several
   cases, such as when compiling dependencies with native code, dependencies
   that must download assets, or dependencies where the compilation time is not

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -75,86 +75,82 @@ defmodule Mix.Tasks.Deps.Compile do
 
   @doc false
   def compile(deps, options \\ []) do
-    shell = Mix.shell()
-    config = Mix.Project.deps_config()
     Mix.Task.run("deps.precompile")
+    force? = Keyword.get(options, :force, false)
 
-    compiled =
+    deps =
       deps
       |> reject_umbrella_children(options)
       |> reject_local_deps(options)
-      |> Enum.map(fn %Mix.Dep{app: app, status: status, opts: opts, scm: scm} = dep ->
-        check_unavailable!(app, scm, status)
-        maybe_clean(dep, options)
 
-        compiled? =
-          cond do
-            not is_nil(opts[:compile]) ->
-              do_compile(dep, config)
+    count = System.get_env("MIX_DEPS_COMPILE_PARALLEL_COUNT", "0") |> String.to_integer()
 
-            Mix.Dep.mix?(dep) ->
-              do_mix(dep, config)
+    compiled? =
+      if count > 1 and length(deps) > count do
+        Mix.shell().info("mix deps.compile running in parallel with count=#{count}")
+        Mix.Tasks.Deps.Parallel.server(deps, count, force?)
+      else
+        config = Mix.Project.deps_config()
+        true in Enum.map(deps, &compile_single(&1, force?, config))
+      end
 
-            Mix.Dep.make?(dep) ->
-              do_make(dep, config)
-
-            dep.manager == :rebar3 ->
-              do_rebar3(dep, config)
-
-            true ->
-              shell.error(
-                "Could not compile #{inspect(app)}, no \"mix.exs\", \"rebar.config\" or \"Makefile\" " <>
-                  "(pass :compile as an option to customize compilation, set it to \"false\" to do nothing)"
-              )
-
-              false
-          end
-
-        if compiled? do
-          build_path = Mix.Project.build_path(config)
-
-          lazy_message = fn ->
-            info = %{
-              app: dep.app,
-              scm: dep.scm,
-              manager: dep.manager,
-              os_pid: System.pid()
-            }
-
-            {:dep_compiled, info}
-          end
-
-          Mix.Sync.PubSub.broadcast(build_path, lazy_message)
-        end
-
-        # We should touch fetchable dependencies even if they
-        # did not compile otherwise they will always be marked
-        # as stale, even when there is nothing to do.
-        fetchable? = touch_fetchable(scm, opts[:build])
-
-        compiled? and fetchable?
-      end)
-
-    if true in compiled, do: Mix.Task.run("will_recompile"), else: :ok
+    if compiled?, do: Mix.Task.run("will_recompile"), else: :ok
   end
 
-  defp maybe_clean(dep, opts) do
+  @doc false
+  def compile_single(%Mix.Dep{} = dep, force?, config) do
+    %{app: app, status: status, opts: opts, scm: scm} = dep
+    check_unavailable!(app, scm, status)
+
     # If a dependency was marked as fetched or with an out of date lock
     # or missing the app file, we always compile it from scratch.
-    if Keyword.get(opts, :force, false) or Mix.Dep.compilable?(dep) do
+    if force? or Mix.Dep.compilable?(dep) do
       File.rm_rf!(Path.join([Mix.Project.build_path(), "lib", Atom.to_string(dep.app)]))
     end
-  end
 
-  defp touch_fetchable(scm, path) do
-    if scm.fetchable?() do
-      path = Path.join(path, ".mix")
-      File.mkdir_p!(path)
-      File.touch!(Path.join(path, "compile.fetch"))
-      true
-    else
-      false
+    compiled? =
+      cond do
+        not is_nil(opts[:compile]) ->
+          do_compile(dep, config)
+
+        Mix.Dep.mix?(dep) ->
+          do_mix(dep, config)
+
+        Mix.Dep.make?(dep) ->
+          do_make(dep, config)
+
+        dep.manager == :rebar3 ->
+          do_rebar3(dep, config)
+
+        true ->
+          Mix.shell().error(
+            "Could not compile #{inspect(app)}, no \"mix.exs\", \"rebar.config\" or \"Makefile\" " <>
+              "(pass :compile as an option to customize compilation, set it to \"false\" to do nothing)"
+          )
+
+          false
+      end
+
+    if compiled? do
+      config
+      |> Mix.Project.build_path()
+      |> Mix.Sync.PubSub.broadcast(fn ->
+        info = %{
+          app: dep.app,
+          scm: dep.scm,
+          manager: dep.manager,
+          os_pid: System.pid()
+        }
+
+        {:dep_compiled, info}
+      end)
     end
+
+    # We should touch fetchable dependencies even if they
+    # did not compile otherwise they will always be marked
+    # as stale, even when there is nothing to do.
+    fetchable? = touch_fetchable(scm, opts[:build])
+    compiled? and fetchable?
   end
 
   defp check_unavailable!(app, scm, {:unavailable, path}) do
@@ -174,6 +170,17 @@ defmodule Mix.Tasks.Deps.Compile do
 
   defp check_unavailable!(_, _, _) do
     :ok
+  end
+
+  defp touch_fetchable(scm, path) do
+    if scm.fetchable?() do
+      path = Path.join(path, ".mix")
+      File.mkdir_p!(path)
+      File.touch!(Path.join(path, "compile.fetch"))
+      true
+    else
+      false
+    end
   end
 
   defp do_mix(dep, _config) do

--- a/lib/mix/lib/mix/tasks/deps.loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/deps.loadpaths.ex
@@ -139,11 +139,7 @@ defmodule Mix.Tasks.Deps.Loadpaths do
   defp partition([dep | deps], not_ok, compile) do
     cond do
       Mix.Dep.compilable?(dep) or (Mix.Dep.ok?(dep) and local?(dep)) ->
-        if from_umbrella?(dep) do
-          partition(deps, not_ok, compile)
-        else
-          partition(deps, not_ok, [dep | compile])
-        end
+        partition(deps, not_ok, [dep | compile])
 
       Mix.Dep.ok?(dep) ->
         partition(deps, not_ok, compile)
@@ -161,11 +157,6 @@ defmodule Mix.Tasks.Deps.Loadpaths do
     deps
     |> Enum.map(& &1.app)
     |> Mix.Dep.filter_by_name(Mix.Dep.load_and_cache())
-  end
-
-  # Those are compiled by umbrella.
-  defp from_umbrella?(dep) do
-    dep.opts[:from_umbrella]
   end
 
   # Every local dependency (i.e. that are not fetchable)

--- a/lib/mix/lib/mix/tasks/deps.parallel.ex
+++ b/lib/mix/lib/mix/tasks/deps.parallel.ex
@@ -1,0 +1,192 @@
+defmodule Mix.Tasks.Deps.Parallel do
+  @moduledoc false
+  use Mix.Task
+
+  ## Server
+
+  def server(deps, count, force?) do
+    elixir =
+      System.find_executable("elixir") ||
+        raise "cannot find elixir executable for parallel compilation"
+
+    {:ok, socket} = :gen_tcp.listen(0, [:binary, packet: :line, active: true, reuseaddr: true])
+    {:ok, {ip, port}} = :inet.sockname(socket)
+    ansi_flag = if IO.ANSI.enabled?(), do: ~c"--color", else: ~c"--no-color"
+    force_flag = if force?, do: ~c"--force", else: ~c"--no-force"
+
+    args = [
+      ansi_flag,
+      ~c"-e",
+      ~c"Mix.CLI.main()",
+      ~c"deps.parallel",
+      force_flag,
+      ~c"--port",
+      Integer.to_charlist(port),
+      ~c"--host",
+      :inet.ntoa(ip)
+    ]
+
+    options = [
+      :binary,
+      :hide,
+      :use_stdio,
+      :stderr_to_stdout,
+      line: 1_000_000,
+      args: args,
+      env: [{~c"MIX_OS_CONCURRENCY_LOCK", ~c"false"}]
+    ]
+
+    clients =
+      Enum.map(1..count//1, fn index ->
+        if Mix.debug?() do
+          IO.puts("-> Starting mix deps.parallel ##{index}")
+        end
+
+        port = Port.open({:spawn_executable, String.to_charlist(elixir)}, options)
+
+        case :gen_tcp.accept(socket, 15000) do
+          {:ok, client} ->
+            %{port: port, index: index, socket: client}
+
+          error ->
+            raise """
+            could not start parallel dependency compiler, no connection made to TCP port: #{inspect(error)}
+
+            The spawned operating system process wrote the following output:
+            #{collect_data(port, "")}
+            """
+        end
+      end)
+
+    send_deps_and_server_loop(clients, [], deps, [])
+  end
+
+  defp send_deps_and_server_loop(available, busy, deps, completed) do
+    {available, busy, deps} = send_deps(available, busy, deps, completed)
+    server_loop(available, busy, deps, completed)
+  end
+
+  defp send_deps([client | available], busy, deps, completed) do
+    case pop_with(deps, fn dep -> Enum.all?(dep.deps, &Keyword.has_key?(completed, &1.app)) end) do
+      :error ->
+        {[client | available], busy, deps}
+
+      {dep, deps} ->
+        if Mix.debug?() do
+          Mix.shell().info("-- Sending #{dep.app} to mix deps.parallel #{client.index}")
+        end
+
+        :gen_tcp.send(client.socket, "#{dep.app}\n")
+        send_deps(available, [client | busy], deps, completed)
+    end
+  end
+
+  defp send_deps([], busy, deps, _completed) do
+    {[], busy, deps}
+  end
+
+  defp server_loop(available, _busy = [], _deps = [], completed) do
+    shutdown_clients(available)
+    Enum.any?(completed, &(elem(&1, 1) == true))
+  end
+
+  defp server_loop(available, busy, deps, completed) do
+    receive do
+      {:tcp, socket, data} ->
+        [app, status] = data |> String.trim() |> String.split(":") |> Enum.map(&String.to_atom/1)
+        deps = Enum.reject(deps, &(&1.app == app))
+        {client, busy} = pop_with(busy, &(&1.socket == socket))
+
+        if Mix.debug?() do
+          Mix.shell().info("-- mix deps.parallel #{client.index} compiled #{app}")
+        end
+
+        send_deps_and_server_loop([client | available], busy, deps, [{app, status} | completed])
+
+      {:tcp_closed, socket} ->
+        shutdown_clients(available ++ busy)
+        raise "socket #{inspect(socket)} closed unexpectedly"
+
+      {:tcp_error, socket, error} ->
+        shutdown_clients(available ++ busy)
+        raise "socket #{inspect(socket)} errored: #{inspect(error)}"
+
+      {port, {:data, {eol, data}}} ->
+        with %{index: index} <-
+               Enum.find(busy, &(&1.port == port)) || Enum.find(available, &(&1.port == port)) do
+          terminator = if eol == :eol, do: "\n", else: ""
+          IO.write([Integer.to_string(index), "> ", data, terminator])
+        end
+
+        server_loop(available, busy, deps, completed)
+    end
+  end
+
+  defp pop_with(list, fun) do
+    case Enum.split_while(list, &(not fun.(&1))) do
+      {_, []} -> :error
+      {pre, [result | post]} -> {result, pre ++ post}
+    end
+  end
+
+  defp shutdown_clients(clients) do
+    Enum.each(clients, fn %{socket: socket, port: port, index: index} ->
+      if Mix.debug?() do
+        IO.puts("-> Closing mix deps.parallel ##{index}")
+      end
+
+      _ = :gen_tcp.close(socket)
+      IO.write(collect_data(port, "#{index}> "))
+    end)
+  end
+
+  defp collect_data(port, prefix) do
+    receive do
+      {^port, {:data, {:eol, data}}} -> [prefix, data, ?\n | collect_data(port, prefix)]
+      {^port, {:data, {:noeol, data}}} -> [data | collect_data(port, prefix)]
+    after
+      0 -> []
+    end
+  end
+
+  ## Client
+
+  @switches [port: :integer, host: :string, force: :boolean]
+
+  @impl true
+  def run(args) do
+    # If stdin closes, we shutdown the VM
+    spawn(fn ->
+      _ = IO.gets("")
+      System.halt(0)
+    end)
+
+    {opts, []} = OptionParser.parse!(args, strict: @switches)
+    host = Keyword.fetch!(opts, :host)
+    port = Keyword.fetch!(opts, :port)
+    force? = Keyword.get(opts, :force, false)
+
+    {:ok, socket} =
+      :gen_tcp.connect(String.to_charlist(host), port, [:binary, packet: :line, active: false])
+
+    deps = Mix.Dep.load_and_cache()
+    client_loop(socket, deps, force?, Mix.Project.deps_config())
+  end
+
+  def client_loop(socket, deps, force?, config) do
+    case :gen_tcp.recv(socket, 0, :infinity) do
+      {:ok, app} ->
+        app = app |> String.trim() |> String.to_atom()
+
+        dep =
+          Enum.find(deps, &(&1.app == app)) || raise "could not find dependency #{inspect(app)}"
+
+        compiled? = Mix.Tasks.Deps.Compile.compile_single(dep, force?, config)
+        :ok = :gen_tcp.send(socket, "#{app}:#{compiled?}\n")
+        client_loop(socket, deps, force?, config)
+
+      {:error, :closed} ->
+        :ok
+    end
+  end
+end

--- a/lib/mix/lib/mix/tasks/deps.parallel.ex
+++ b/lib/mix/lib/mix/tasks/deps.parallel.ex
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 defmodule Mix.Tasks.Deps.Parallel do
   @moduledoc false
   use Mix.Task

--- a/lib/mix/lib/mix/tasks/deps.partition.ex
+++ b/lib/mix/lib/mix/tasks/deps.partition.ex
@@ -57,7 +57,7 @@ defmodule Mix.Tasks.Deps.Partition do
     args = [
       ansi_flag,
       ~c"-e",
-      ~c"Mix.CLI.main()",
+      ~c"Mix.CLI.main",
       ~c"deps.partition",
       force_flag,
       ~c"--port",

--- a/lib/mix/lib/mix/tasks/deps.partition.ex
+++ b/lib/mix/lib/mix/tasks/deps.partition.ex
@@ -79,7 +79,7 @@ defmodule Mix.Tasks.Deps.Partition do
   end
 
   defp send_deps([client | available], busy, deps, completed) do
-    case pop_with(deps, fn dep -> Enum.all?(dep.deps, &Keyword.has_key?(completed, &1.app)) end) do
+    case pop_with(deps, fn dep -> Enum.all?(dep.deps, &not_pending?(&1.app, deps, completed)) end) do
       :error ->
         {[client | available], busy, deps}
 
@@ -95,6 +95,10 @@ defmodule Mix.Tasks.Deps.Partition do
 
   defp send_deps([], busy, deps, _completed) do
     {[], busy, deps}
+  end
+
+  defp not_pending?(app, deps, completed) do
+    Keyword.has_key?(completed, app) or not Enum.any?(deps, &(&1.app == app))
   end
 
   defp server_loop(available, _busy = [], _deps = [], completed) do

--- a/lib/mix/lib/mix/tasks/deps.partition.ex
+++ b/lib/mix/lib/mix/tasks/deps.partition.ex
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Deps.Partition do
     clients =
       Enum.map(1..count//1, fn _ ->
         with {:ok, client} <- :gen_tcp.accept(socket, 15000),
-             {:ok, message} <- :gen_tcp.recv(socket, 0, 15000) do
+             {:ok, message} <- :gen_tcp.recv(client, 0, 15000) do
           :inet.setopts(client, active: true)
           index = message |> String.trim() |> String.to_integer()
           %{port: Map.fetch!(ports, index), index: index, socket: client}

--- a/lib/mix/lib/mix/tasks/deps.partition.ex
+++ b/lib/mix/lib/mix/tasks/deps.partition.ex
@@ -21,7 +21,8 @@ defmodule Mix.Tasks.Deps.Partition do
 
   defp server(socket, deps, count, force?) do
     elixir =
-      System.find_executable("elixir") ||
+      System.get_env("MIX_OS_DEPS_COMPILE_PARTITION_ELIXIR_EXECUTABLE") ||
+        System.find_executable("elixir") ||
         raise "cannot find elixir executable for partition compilation"
 
     {:ok, {ip, port}} = :inet.sockname(socket)

--- a/lib/mix/lib/mix/tasks/deps.partition.ex
+++ b/lib/mix/lib/mix/tasks/deps.partition.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Deps.Partition do
         System.find_executable("elixir") ||
         raise "cannot find elixir executable for partition compilation"
 
-    {:ok, {ip, port}} = :inet.sockname(socket)
+    {:ok, {_ip, port}} = :inet.sockname(socket)
     ansi_flag = if IO.ANSI.enabled?(), do: ~c"--color", else: ~c"--no-color"
     force_flag = if force?, do: ~c"--force", else: ~c"--no-force"
 
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.Deps.Partition do
       ~c"--port",
       Integer.to_charlist(port),
       ~c"--host",
-      :inet.ntoa(ip)
+      ~c"127.0.0.1"
     ]
 
     options = [

--- a/lib/mix/lib/mix/tasks/loadconfig.ex
+++ b/lib/mix/lib/mix/tasks/loadconfig.ex
@@ -40,10 +40,10 @@ defmodule Mix.Tasks.Loadconfig do
   end
 
   defp load_default do
-    config = Mix.Project.config()
+    config_path = Mix.Project.config()[:config_path]
 
-    if File.regular?(config[:config_path]) or config[:config_path] != "config/config.exs" do
-      load_compile(config[:config_path])
+    if config_path != nil and (File.regular?(config_path) or config_path != "config/config.exs") do
+      load_compile(config_path)
     else
       []
     end

--- a/lib/mix/test/fixtures/umbrella_dep/mix.exs
+++ b/lib/mix/test/fixtures/umbrella_dep/mix.exs
@@ -4,6 +4,7 @@ defmodule UmbrellaDep.MixProject do
   def project do
     [
       app: :umbrella_dep,
+      version: "0.1.0",
       deps: deps()
     ]
   end

--- a/lib/mix/test/mix/tasks/loadconfig_test.exs
+++ b/lib/mix/test/mix/tasks/loadconfig_test.exs
@@ -67,6 +67,11 @@ defmodule Mix.Tasks.LoadconfigTest do
     end)
   end
 
+  test "is a no-op with nil custom config_path" do
+    Mix.ProjectStack.post_config(config_path: nil)
+    assert Mix.Task.run("loadconfig", []) == []
+  end
+
   test "updates config files and config mtime", context do
     in_tmp(context.test, fn ->
       Mix.Project.push(MixTest.Case.Sample)

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -49,14 +49,6 @@ ExUnit.start(
   include: line_include
 )
 
-# Clear environment variables that may affect tests
-Enum.each(
-  ~w(http_proxy https_proxy HTTP_PROXY HTTPS_PROXY) ++
-    ~w(MIX_ENV MIX_OS_DEPS_COMPILE_PARTITION_COUNT MIX_TARGET) ++
-    ~w(XDG_DATA_HOME XDG_CONFIG_HOME),
-  &System.delete_env/1
-)
-
 defmodule MixTest.Case do
   use ExUnit.CaseTemplate
 
@@ -248,6 +240,20 @@ defmodule MixTest.Case do
     end)
   end
 end
+
+# Prepare and clear environment variables
+System.put_env(
+  "MIX_OS_DEPS_COMPILE_PARTITION_ELIXIR_EXECUTABLE",
+  MixTest.Case.elixir_executable()
+)
+
+# Clear environment variables that may affect tests
+Enum.each(
+  ~w(http_proxy https_proxy HTTP_PROXY HTTPS_PROXY) ++
+    ~w(MIX_ENV MIX_OS_DEPS_COMPILE_PARTITION_COUNT MIX_TARGET) ++
+    ~w(XDG_DATA_HOME XDG_CONFIG_HOME),
+  &System.delete_env/1
+)
 
 ## Set up Rebar fixtures
 

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -10,9 +10,6 @@ mix = Path.expand("../tmp/.mix", __DIR__)
 File.mkdir_p!(mix)
 System.put_env("MIX_HOME", mix)
 
-System.delete_env("XDG_DATA_HOME")
-System.delete_env("XDG_CONFIG_HOME")
-
 # Load protocols to make sure they are not unloaded during tests
 [Collectable, Enumerable, Inspect, String.Chars, List.Chars]
 |> Enum.each(& &1.__protocol__(:module))
@@ -53,12 +50,12 @@ ExUnit.start(
 )
 
 # Clear environment variables that may affect tests
-System.delete_env("http_proxy")
-System.delete_env("https_proxy")
-System.delete_env("HTTP_PROXY")
-System.delete_env("HTTPS_PROXY")
-System.delete_env("MIX_ENV")
-System.delete_env("MIX_TARGET")
+Enum.each(
+  ~w(http_proxy https_proxy HTTP_PROXY HTTPS_PROXY) ++
+    ~w(MIX_ENV MIX_OS_DEPS_COMPILE_PARTITION_COUNT MIX_TARGET) ++
+    ~w(XDG_DATA_HOME XDG_CONFIG_HOME),
+  &System.delete_env/1
+)
 
 defmodule MixTest.Case do
   use ExUnit.CaseTemplate

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -221,11 +221,11 @@ defmodule MixTest.Case do
     File.write!(file, File.read!(file) <> "\n")
   end
 
-  defp mix_executable do
+  def mix_executable do
     Path.expand("../../../bin/mix", __DIR__)
   end
 
-  defp elixir_executable do
+  def elixir_executable do
     Path.expand("../../../bin/elixir", __DIR__)
   end
 


### PR DESCRIPTION
The implementation uses a TCP port to distribute the work. We chose to not use the Erlang distribution as that may affect the user app running afterwards.

When compiling Livebook on 10 core machine:

```
livebook$ rm -rf _build/; time mix deps.compile
real	0m25.865s
user	0m48.625s
sys	0m10.504s
```

```
livebook$ rm -rf _build/; time MIX_OS_DEPS_COMPILE_PARTITION_COUNT=4  mix deps.compile
real	0m12.337s
user	0m0.417s
sys	0m0.533s
```

In this case, increasing more than 4 did not decrease compilation times (perhaps expected due to the cost of starting new instances and that compilation itself is already parallel within the same dependency). Closes #14200.