### PR TITLE
Add OpenSSF Best Practices Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 </h1>
 
 [![CI](https://github.com/elixir-lang/elixir/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/elixir-lang/elixir/actions/workflows/ci.yml?query=branch%3Amain)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10187/badge)](https://www.bestpractices.dev/projects/10187)
 
 Elixir is a dynamic, functional language designed for building scalable
 and maintainable applications.


### PR DESCRIPTION
## Changes

* Adds the passing badge to the README

## Best Practices

I've filled out the form to the best of my knowledge, the answers can be seen here: https://www.bestpractices.dev/en/projects/10187

Approving this PR is also about making sure that the info there is correct.

### Unmet SUGGESTED practices

For `SUGGESTED` best practices, we can decide to ignore them and still pass the badge. The following have been marked as `UNMET`:

* > `test_most` - It is SUGGESTED that the test suite cover most (or ideally all) the code branches, input fields, and functionality.
  
  We currently do not have any test coverage reporting, it would be good to add a coverage reporter to the setup. - I have started exploring this here: #14343
  
* > `static_analysis_common_vulnerabilities` - It is SUGGESTED that at least one of the static analysis tools used for the static_analysis criterion include rules or approaches to look for common vulnerabilities in the analyzed language or environment.
  > `static_analysis_often` - It is SUGGESTED that static source code analysis occur on every commit or at least daily.
  
  We're currently using dialyzer, as well as various small tools like shellcheck and markdown lint. But we're not employing any static analysis on the Erlang / Elixir code focused on security. While there is tools in the ecosystem, such as elvis, sobelow, credo etc. I'm not convinced that they would have an impact on this repository.
  
* > `dynamic_analysis` - It is SUGGESTED that at least one dynamic analysis tool be applied to any proposed major production release of the software before its release.
  > `dynamic_analysis_enable_assertions` - It is SUGGESTED that the project use a configuration for at least some dynamic analysis (such as testing or fuzzing) which enables many assertions. In many cases these assertions should not be enabled in production builds.
  
  To my knowledge we're not employing any dynamic analysis tools, and I also can't think of one that would make sense to use.