### PR TITLE
Fix URI.merge/2 to handle base URIs with scheme but without host

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -903,7 +903,7 @@ defmodule URI do
   @spec merge(t | binary, t | binary) :: t
   def merge(uri, rel)
 
-  def merge(%URI{host: nil}, _rel) do
+  def merge(%URI{scheme: nil}, _rel) do
     raise ArgumentError, "you must merge onto an absolute URI"
   end
 

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -460,6 +460,11 @@ defmodule URITest do
              "https://images.example.com/t/1600x/https://images.example.com/foo.jpg"
   end
 
+  test "merge/2 with host-less URIs" do
+    assert URI.merge("tag:example", "foo") |> to_string == "tag:foo"
+    assert URI.merge("tag:example", "#fragment") |> to_string == "tag:example#fragment"
+  end
+
   test "merge/2 (with RFC examples)" do
     # These are examples from:
     #


### PR DESCRIPTION
Here's another fix for a `URI.merge/2` issue that was uncovered by the W3C JSON-LD 1.1 Test suite.

The current implementation incorrectly rejects base URIs with a scheme but without a host:

```elixir
iex> URI.merge("tag:example", "foo")
** (ArgumentError) you must merge onto an absolute URI
    (elixir 1.18.2) lib/uri.ex:903: URI.merge/2
```