### PR TITLE
Prevent exits from leaking in ExUnit.CaptureServer

### DIFF
--- a/lib/ex_unit/lib/ex_unit/capture_server.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_server.ex
@@ -231,6 +231,8 @@ defmodule ExUnit.CaptureServer do
   ## :logger handler callback.
 
   def log(event, _config) do
+    trap_exits = Process.flag(:trap_exit, false)
+
     :ets.tab2list(@ets)
     |> Enum.filter(fn {_ref, _string_io, level, _formatter_mod, _formatter_config} ->
       :logger.compare_levels(event.level, level) in [:gt, :eq]
@@ -254,6 +256,8 @@ defmodule ExUnit.CaptureServer do
       end)
     end)
     |> Task.await_many(:infinity)
+
+    Process.flag(:trap_exit, trap_exits)
 
     :ok
   end

--- a/lib/ex_unit/test/ex_unit/capture_log_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_log_test.exs
@@ -95,6 +95,16 @@ defmodule ExUnit.CaptureLogTest do
     end)
   end
 
+  test "exits don't leak" do
+    Process.flag(:trap_exit, true)
+
+    capture_log(fn ->
+      Logger.error("oh no!")
+    end)
+
+    refute_receive {:EXIT, _, _}
+  end
+
   describe "with_log/2" do
     test "returns the result and the log" do
       {result, log} =


### PR DESCRIPTION
When a process that traps exits used ExUnit's log capture functionality, it would receive stray exits from the Tasks started inside it that could lead to issues if not handled. We fix this by disabling exit trapping while awaiting the tasks in the CaptureServer's log handler.