### PR TITLE
Drop otp log events if `handle_otp_reports` is set to false

### DIFF
--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -8,7 +8,6 @@ defmodule Logger.Utils do
   @doc """
   A filter for default translation and handling of reports.
   """
-  def translator(%{domain: [:elixir | _]}, %{otp: false}), do: :stop
   def translator(%{meta: %{domain: [:otp | _]}}, %{otp: false}), do: :stop
   def translator(%{meta: %{domain: [:otp, :sasl | _]}}, %{sasl: false}), do: :stop
   def translator(%{meta: %{domain: [:supervisor_report | _]}}, %{sasl: false}), do: :stop

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -9,6 +9,7 @@ defmodule Logger.Utils do
   A filter for default translation and handling of reports.
   """
   def translator(%{domain: [:elixir | _]}, %{otp: false}), do: :stop
+  def translator(%{meta: %{domain: [:otp | _]}}, %{otp: false}), do: :stop
   def translator(%{meta: %{domain: [:otp, :sasl | _]}}, %{sasl: false}), do: :stop
   def translator(%{meta: %{domain: [:supervisor_report | _]}}, %{sasl: false}), do: :stop
   def translator(%{msg: {:string, _}}, _config), do: :ignore


### PR DESCRIPTION
Currently `handle_otp_reports` logger option doesn't seem to have any effect. It's passed as `otp` option to `Logger.Utils.translator/2` (which is always attached as a primary logger) and the only clause that uses this option seemingly can never match. Here's an example:

```elixir
:logger.remove_primary_filter(:logger_translator)

:logger.add_primary_filter(
  :logger_translator,
  {&Logger.Utils.translator/2, %{otp: false, sasl: false, translators: [{Logger.Translator, :translate}]}}
)

Task.start(fn -> exit("Exit") end)

Process.sleep(1_000)
```
```
12:25:45.123 [error] Task #PID<0.97.0> started from #PID<0.94.0> terminating
** (stop) "Exit"
    logger.exs:8: anonymous fn/0 in :elixir_compiler_0.__FILE__/1
    (elixir 1.18.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
Function: #Function<0.18661568 in file:logger.exs>
    Args: []
```

The error is both logged and formatted.

This PR changes the clause to drop all events with `:otp` domain if `handle_otp_reports` is set to false.