### PR TITLE
Fix URI.merge/2 handling of authorityless base

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -919,6 +919,15 @@ defmodule URI do
     %{base | query: rel.query || base.query, fragment: rel.fragment}
   end
 
+  def merge(%URI{host: nil, path: nil} = base, %URI{} = rel) do
+    %{
+      base
+      | path: remove_dot_segments_from_path(rel.path),
+        query: rel.query,
+        fragment: rel.fragment
+    }
+  end
+
   def merge(%URI{} = base, %URI{} = rel) do
     new_path = merge_paths(base.path, rel.path)
     %{base | path: new_path, query: rel.query, fragment: rel.fragment}

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -465,6 +465,15 @@ defmodule URITest do
     assert URI.merge("tag:example", "#fragment") |> to_string == "tag:example#fragment"
   end
 
+  test "merge/2 with non-hierarchical base without host and path" do
+    assert URI.merge("ex:", "test") |> to_string() == "ex:test"
+    assert URI.merge("ex:", "a/b/c") |> to_string() == "ex:a/b/c"
+    assert URI.merge("ex:", "a/b/./../c") |> to_string() == "ex:a/c"
+    assert URI.merge("ex:", "test?query=value") |> to_string() == "ex:test?query=value"
+    assert URI.merge("mailto:", "user@example.com") |> to_string() == "mailto:user@example.com"
+    assert URI.merge("urn:isbn", "0451450523") |> to_string() == "urn:0451450523"
+  end
+
   test "merge/2 (with RFC examples)" do
     # These are examples from:
     #

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -377,321 +377,325 @@ defmodule URITest do
                  fn -> %URI{host: "foo.com", path: "hello/123"} |> URI.to_string() end
   end
 
-  test "merge/2" do
-    assert_raise ArgumentError, "you must merge onto an absolute URI", fn ->
-      URI.merge("/relative", "")
+  describe "merge/2" do
+    test "with valid paths" do
+      assert URI.merge("http://google.com/foo", "http://example.com/baz")
+             |> to_string() == "http://example.com/baz"
+
+      assert URI.merge("http://google.com/foo", "http://example.com/.././bar/../../baz")
+             |> to_string() == "http://example.com/baz"
+
+      assert URI.merge("http://google.com/foo", "//example.com/baz")
+             |> to_string() == "http://example.com/baz"
+
+      assert URI.merge("http://google.com/foo", URI.new!("//example.com/baz"))
+             |> to_string() == "http://example.com/baz"
+
+      assert URI.merge("http://google.com/foo", "//example.com/.././bar/../../../baz")
+             |> to_string() == "http://example.com/baz"
+
+      assert URI.merge("http://example.com", URI.new!("/foo"))
+             |> to_string() == "http://example.com/foo"
+
+      assert URI.merge("http://example.com", URI.new!("/.././bar/../../../baz"))
+             |> to_string() == "http://example.com/baz"
+
+      base = URI.new!("http://example.com/foo/bar")
+      assert URI.merge(base, "") |> to_string() == "http://example.com/foo/bar"
+      assert URI.merge(base, "#fragment") |> to_string() == "http://example.com/foo/bar#fragment"
+      assert URI.merge(base, "?query") |> to_string() == "http://example.com/foo/bar?query"
+      assert URI.merge(base, %URI{}) |> to_string() == "http://example.com/foo/bar"
+
+      assert URI.merge(base, %URI{fragment: "fragment"})
+             |> to_string() == "http://example.com/foo/bar#fragment"
+
+      base = URI.new!("http://example.com")
+      assert URI.merge(base, "/foo") |> to_string() == "http://example.com/foo"
+      assert URI.merge(base, "foo") |> to_string() == "http://example.com/foo"
+
+      base = URI.new!("http://example.com/foo/bar")
+      assert URI.merge(base, "/baz") |> to_string() == "http://example.com/baz"
+      assert URI.merge(base, "baz") |> to_string() == "http://example.com/foo/baz"
+      assert URI.merge(base, "../baz") |> to_string() == "http://example.com/baz"
+      assert URI.merge(base, ".././baz") |> to_string() == "http://example.com/baz"
+      assert URI.merge(base, "./baz") |> to_string() == "http://example.com/foo/baz"
+      assert URI.merge(base, "bar/./baz") |> to_string() == "http://example.com/foo/bar/baz"
+
+      base = URI.new!("http://example.com/foo/bar/")
+      assert URI.merge(base, "/baz") |> to_string() == "http://example.com/baz"
+      assert URI.merge(base, "baz") |> to_string() == "http://example.com/foo/bar/baz"
+      assert URI.merge(base, "../baz") |> to_string() == "http://example.com/foo/baz"
+      assert URI.merge(base, ".././baz") |> to_string() == "http://example.com/foo/baz"
+      assert URI.merge(base, "./baz") |> to_string() == "http://example.com/foo/bar/baz"
+      assert URI.merge(base, "bar/./baz") |> to_string() == "http://example.com/foo/bar/bar/baz"
+
+      base = URI.new!("http://example.com/foo/bar/baz")
+      assert URI.merge(base, "../../foobar") |> to_string() == "http://example.com/foobar"
+      assert URI.merge(base, "../../../foobar") |> to_string() == "http://example.com/foobar"
+
+      assert URI.merge(base, "../../../../../../foobar") |> to_string() ==
+               "http://example.com/foobar"
+
+      base = URI.new!("http://example.com/foo/../bar")
+      assert URI.merge(base, "baz") |> to_string() == "http://example.com/baz"
+
+      base = URI.new!("http://example.com/foo/./bar")
+      assert URI.merge(base, "baz") |> to_string() == "http://example.com/foo/baz"
+
+      base = URI.new!("http://example.com/foo?query1")
+      assert URI.merge(base, "?query2") |> to_string() == "http://example.com/foo?query2"
+      assert URI.merge(base, "") |> to_string() == "http://example.com/foo?query1"
+
+      base = URI.new!("http://example.com/foo#fragment1")
+      assert URI.merge(base, "#fragment2") |> to_string() == "http://example.com/foo#fragment2"
+      assert URI.merge(base, "") |> to_string() == "http://example.com/foo"
+
+      page_url = "https://example.com/guide/"
+      image_url = "https://images.example.com/t/1600x/https://images.example.com/foo.jpg"
+
+      assert URI.merge(URI.new!(page_url), URI.new!(image_url)) |> to_string() ==
+               "https://images.example.com/t/1600x/https://images.example.com/foo.jpg"
     end
 
-    assert URI.merge("http://google.com/foo", "http://example.com/baz")
-           |> to_string() == "http://example.com/baz"
-
-    assert URI.merge("http://google.com/foo", "http://example.com/.././bar/../../baz")
-           |> to_string() == "http://example.com/baz"
-
-    assert URI.merge("http://google.com/foo", "//example.com/baz")
-           |> to_string() == "http://example.com/baz"
-
-    assert URI.merge("http://google.com/foo", URI.new!("//example.com/baz"))
-           |> to_string() == "http://example.com/baz"
-
-    assert URI.merge("http://google.com/foo", "//example.com/.././bar/../../../baz")
-           |> to_string() == "http://example.com/baz"
-
-    assert URI.merge("http://example.com", URI.new!("/foo"))
-           |> to_string() == "http://example.com/foo"
-
-    assert URI.merge("http://example.com", URI.new!("/.././bar/../../../baz"))
-           |> to_string() == "http://example.com/baz"
-
-    base = URI.new!("http://example.com/foo/bar")
-    assert URI.merge(base, "") |> to_string() == "http://example.com/foo/bar"
-    assert URI.merge(base, "#fragment") |> to_string() == "http://example.com/foo/bar#fragment"
-    assert URI.merge(base, "?query") |> to_string() == "http://example.com/foo/bar?query"
-    assert URI.merge(base, %URI{}) |> to_string() == "http://example.com/foo/bar"
-
-    assert URI.merge(base, %URI{fragment: "fragment"})
-           |> to_string() == "http://example.com/foo/bar#fragment"
-
-    base = URI.new!("http://example.com")
-    assert URI.merge(base, "/foo") |> to_string() == "http://example.com/foo"
-    assert URI.merge(base, "foo") |> to_string() == "http://example.com/foo"
-
-    base = URI.new!("http://example.com/foo/bar")
-    assert URI.merge(base, "/baz") |> to_string() == "http://example.com/baz"
-    assert URI.merge(base, "baz") |> to_string() == "http://example.com/foo/baz"
-    assert URI.merge(base, "../baz") |> to_string() == "http://example.com/baz"
-    assert URI.merge(base, ".././baz") |> to_string() == "http://example.com/baz"
-    assert URI.merge(base, "./baz") |> to_string() == "http://example.com/foo/baz"
-    assert URI.merge(base, "bar/./baz") |> to_string() == "http://example.com/foo/bar/baz"
-
-    base = URI.new!("http://example.com/foo/bar/")
-    assert URI.merge(base, "/baz") |> to_string() == "http://example.com/baz"
-    assert URI.merge(base, "baz") |> to_string() == "http://example.com/foo/bar/baz"
-    assert URI.merge(base, "../baz") |> to_string() == "http://example.com/foo/baz"
-    assert URI.merge(base, ".././baz") |> to_string() == "http://example.com/foo/baz"
-    assert URI.merge(base, "./baz") |> to_string() == "http://example.com/foo/bar/baz"
-    assert URI.merge(base, "bar/./baz") |> to_string() == "http://example.com/foo/bar/bar/baz"
-
-    base = URI.new!("http://example.com/foo/bar/baz")
-    assert URI.merge(base, "../../foobar") |> to_string() == "http://example.com/foobar"
-    assert URI.merge(base, "../../../foobar") |> to_string() == "http://example.com/foobar"
-
-    assert URI.merge(base, "../../../../../../foobar") |> to_string() ==
-             "http://example.com/foobar"
-
-    base = URI.new!("http://example.com/foo/../bar")
-    assert URI.merge(base, "baz") |> to_string() == "http://example.com/baz"
-
-    base = URI.new!("http://example.com/foo/./bar")
-    assert URI.merge(base, "baz") |> to_string() == "http://example.com/foo/baz"
-
-    base = URI.new!("http://example.com/foo?query1")
-    assert URI.merge(base, "?query2") |> to_string() == "http://example.com/foo?query2"
-    assert URI.merge(base, "") |> to_string() == "http://example.com/foo?query1"
-
-    base = URI.new!("http://example.com/foo#fragment1")
-    assert URI.merge(base, "#fragment2") |> to_string() == "http://example.com/foo#fragment2"
-    assert URI.merge(base, "") |> to_string() == "http://example.com/foo"
-
-    page_url = "https://example.com/guide/"
-    image_url = "https://images.example.com/t/1600x/https://images.example.com/foo.jpg"
-
-    assert URI.merge(URI.new!(page_url), URI.new!(image_url)) |> to_string() ==
-             "https://images.example.com/t/1600x/https://images.example.com/foo.jpg"
-  end
-
-  test "merge/2 with host-less URIs" do
-    assert URI.merge("tag:example", "foo") |> to_string == "tag:foo"
-    assert URI.merge("tag:example", "#fragment") |> to_string == "tag:example#fragment"
-  end
-
-  test "merge/2 with non-hierarchical base without host and path" do
-    assert URI.merge("ex:", "test") |> to_string() == "ex:test"
-    assert URI.merge("ex:", "a/b/c") |> to_string() == "ex:a/b/c"
-    assert URI.merge("ex:", "a/b/./../c") |> to_string() == "ex:a/c"
-    assert URI.merge("ex:", "test?query=value") |> to_string() == "ex:test?query=value"
-    assert URI.merge("mailto:", "user@example.com") |> to_string() == "mailto:user@example.com"
-    assert URI.merge("urn:isbn", "0451450523") |> to_string() == "urn:0451450523"
-  end
-
-  test "merge/2 (with RFC examples)" do
-    # These are examples from:
-    #
-    # https://www.rfc-editor.org/rfc/rfc3986#section-5.4.1
-    # https://www.rfc-editor.org/rfc/rfc3986#section-5.4.2
-    #
-    # They are taken verbatim from the above document for easy comparison
-
-    base = "http://a/b/c/d;p?q"
-
-    rel_and_result = %{
-      "g:h" => "g:h",
-      "g" => "http://a/b/c/g",
-      "./g" => "http://a/b/c/g",
-      "g/" => "http://a/b/c/g/",
-      "/g" => "http://a/g",
-      "//g" => "http://g",
-      "?y" => "http://a/b/c/d;p?y",
-      "g?y" => "http://a/b/c/g?y",
-      "#s" => "http://a/b/c/d;p?q#s",
-      "g#s" => "http://a/b/c/g#s",
-      "g?y#s" => "http://a/b/c/g?y#s",
-      ";x" => "http://a/b/c/;x",
-      "g;x" => "http://a/b/c/g;x",
-      "g;x?y#s" => "http://a/b/c/g;x?y#s",
-      "" => "http://a/b/c/d;p?q",
-      "." => "http://a/b/c/",
-      "./" => "http://a/b/c/",
-      ".." => "http://a/b/",
-      "../" => "http://a/b/",
-      "../g" => "http://a/b/g",
-      "../.." => "http://a/",
-      "../../" => "http://a/",
-      "../../g" => "http://a/g",
-      "../../../g" => "http://a/g",
-      "../../../../g" => "http://a/g",
-      "/./g" => "http://a/g",
-      "/../g" => "http://a/g",
-      "g." => "http://a/b/c/g.",
-      ".g" => "http://a/b/c/.g",
-      "g.." => "http://a/b/c/g..",
-      "..g" => "http://a/b/c/..g",
-      "./../g" => "http://a/b/g",
-      "./g/." => "http://a/b/c/g/",
-      "g/./h" => "http://a/b/c/g/h",
-      "g/../h" => "http://a/b/c/h",
-      "g;x=1/./y" => "http://a/b/c/g;x=1/y",
-      "g;x=1/../y" => "http://a/b/c/y",
-      "g?y/./x" => "http://a/b/c/g?y/./x",
-      "g?y/../x" => "http://a/b/c/g?y/../x",
-      "g#s/./x" => "http://a/b/c/g#s/./x",
-      "g#s/../x" => "http://a/b/c/g#s/../x",
-      "http:g" => "http:g"
-    }
-
-    for {rel, result} <- rel_and_result do
-      assert URI.merge(base, rel) |> URI.to_string() == result
-    end
-  end
-
-  test "merge/2 (with W3C examples)" do
-    # These examples are from the W3C JSON-LD test suite:
-    #
-    # https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124
-    # https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0125
-    # https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0123
-
-    base1 = "http://a/bb/ccc/."
-
-    rel_and_result1 = %{
-      "g:h" => "g:h",
-      "g" => "http://a/bb/ccc/g",
-      "./g" => "http://a/bb/ccc/g",
-      "g/" => "http://a/bb/ccc/g/",
-      "/g" => "http://a/g",
-      "//g" => "http://g",
-      "?y" => "http://a/bb/ccc/.?y",
-      "g?y" => "http://a/bb/ccc/g?y",
-      "#s" => "http://a/bb/ccc/.#s",
-      "g#s" => "http://a/bb/ccc/g#s",
-      "g?y#s" => "http://a/bb/ccc/g?y#s",
-      ";x" => "http://a/bb/ccc/;x",
-      "g;x" => "http://a/bb/ccc/g;x",
-      "g;x?y#s" => "http://a/bb/ccc/g;x?y#s",
-      "" => "http://a/bb/ccc/.",
-      "." => "http://a/bb/ccc/",
-      "./" => "http://a/bb/ccc/",
-      ".." => "http://a/bb/",
-      "../" => "http://a/bb/",
-      "../g" => "http://a/bb/g",
-      "../.." => "http://a/",
-      "../../" => "http://a/",
-      "../../g" => "http://a/g",
-      "../../../g" => "http://a/g",
-      "../../../../g" => "http://a/g",
-      "/./g" => "http://a/g",
-      "/../g" => "http://a/g",
-      "g." => "http://a/bb/ccc/g.",
-      ".g" => "http://a/bb/ccc/.g",
-      "g.." => "http://a/bb/ccc/g..",
-      "..g" => "http://a/bb/ccc/..g",
-      "./../g" => "http://a/bb/g",
-      "./g/." => "http://a/bb/ccc/g/",
-      "g/./h" => "http://a/bb/ccc/g/h",
-      "g/../h" => "http://a/bb/ccc/h",
-      "g;x=1/./y" => "http://a/bb/ccc/g;x=1/y",
-      "g;x=1/../y" => "http://a/bb/ccc/y",
-      "g?y/./x" => "http://a/bb/ccc/g?y/./x",
-      "g?y/../x" => "http://a/bb/ccc/g?y/../x",
-      "g#s/./x" => "http://a/bb/ccc/g#s/./x",
-      "g#s/../x" => "http://a/bb/ccc/g#s/../x",
-      "http:g" => "http:g"
-    }
-
-    for {rel, result} <- rel_and_result1 do
-      assert URI.merge(base1, rel) |> URI.to_string() == result
+    test "error on relative base" do
+      assert_raise ArgumentError, "you must merge onto an absolute URI", fn ->
+        URI.merge("/relative", "")
+      end
     end
 
-    base2 = "http://a/bb/ccc/.."
-
-    rel_and_result2 = %{
-      "g:h" => "g:h",
-      "g" => "http://a/bb/ccc/g",
-      "./g" => "http://a/bb/ccc/g",
-      "g/" => "http://a/bb/ccc/g/",
-      "/g" => "http://a/g",
-      "//g" => "http://g",
-      "?y" => "http://a/bb/ccc/..?y",
-      "g?y" => "http://a/bb/ccc/g?y",
-      "#s" => "http://a/bb/ccc/..#s",
-      "g#s" => "http://a/bb/ccc/g#s",
-      "g?y#s" => "http://a/bb/ccc/g?y#s",
-      ";x" => "http://a/bb/ccc/;x",
-      "g;x" => "http://a/bb/ccc/g;x",
-      "g;x?y#s" => "http://a/bb/ccc/g;x?y#s",
-      "" => "http://a/bb/ccc/..",
-      "." => "http://a/bb/ccc/",
-      "./" => "http://a/bb/ccc/",
-      ".." => "http://a/bb/",
-      "../" => "http://a/bb/",
-      "../g" => "http://a/bb/g",
-      "../.." => "http://a/",
-      "../../" => "http://a/",
-      "../../g" => "http://a/g",
-      "../../../g" => "http://a/g",
-      "../../../../g" => "http://a/g",
-      "/./g" => "http://a/g",
-      "/../g" => "http://a/g",
-      "g." => "http://a/bb/ccc/g.",
-      ".g" => "http://a/bb/ccc/.g",
-      "g.." => "http://a/bb/ccc/g..",
-      "..g" => "http://a/bb/ccc/..g",
-      "./../g" => "http://a/bb/g",
-      "./g/." => "http://a/bb/ccc/g/",
-      "g/./h" => "http://a/bb/ccc/g/h",
-      "g/../h" => "http://a/bb/ccc/h",
-      "g;x=1/./y" => "http://a/bb/ccc/g;x=1/y",
-      "g;x=1/../y" => "http://a/bb/ccc/y",
-      "g?y/./x" => "http://a/bb/ccc/g?y/./x",
-      "g?y/../x" => "http://a/bb/ccc/g?y/../x",
-      "g#s/./x" => "http://a/bb/ccc/g#s/./x",
-      "g#s/../x" => "http://a/bb/ccc/g#s/../x",
-      "http:g" => "http:g"
-    }
-
-    for {rel, result} <- rel_and_result2 do
-      assert URI.merge(base2, rel) |> URI.to_string() == result
+    test "base without host" do
+      assert URI.merge("tag:example", "foo") |> to_string == "tag:foo"
+      assert URI.merge("tag:example", "#fragment") |> to_string == "tag:example#fragment"
     end
 
-    base3 = "http://a/bb/ccc/../d;p?q"
+    test "base without host and path" do
+      assert URI.merge("ex:", "test") |> to_string() == "ex:test"
+      assert URI.merge("ex:", "a/b/c") |> to_string() == "ex:a/b/c"
+      assert URI.merge("ex:", "a/b/./../c") |> to_string() == "ex:a/c"
+      assert URI.merge("ex:", "test?query=value") |> to_string() == "ex:test?query=value"
+      assert URI.merge("mailto:", "user@example.com") |> to_string() == "mailto:user@example.com"
+      assert URI.merge("urn:isbn", "0451450523") |> to_string() == "urn:0451450523"
+    end
 
-    rel_and_result = %{
-      "g:h" => "g:h",
-      "g" => "http://a/bb/g",
-      "./g" => "http://a/bb/g",
-      "g/" => "http://a/bb/g/",
-      "/g" => "http://a/g",
-      "//g" => "http://g",
-      "?y" => "http://a/bb/ccc/../d;p?y",
-      "g?y" => "http://a/bb/g?y",
-      "#s" => "http://a/bb/ccc/../d;p?q#s",
-      "g#s" => "http://a/bb/g#s",
-      "g?y#s" => "http://a/bb/g?y#s",
-      ";x" => "http://a/bb/;x",
-      "g;x" => "http://a/bb/g;x",
-      "g;x?y#s" => "http://a/bb/g;x?y#s",
-      "" => "http://a/bb/ccc/../d;p?q",
-      "." => "http://a/bb/",
-      "./" => "http://a/bb/",
-      ".." => "http://a/",
-      "../" => "http://a/",
-      "../g" => "http://a/g",
-      "../.." => "http://a/",
-      "../../" => "http://a/",
-      "../../g" => "http://a/g",
-      "../../../g" => "http://a/g",
-      "../../../../g" => "http://a/g",
-      "/./g" => "http://a/g",
-      "/../g" => "http://a/g",
-      "g." => "http://a/bb/g.",
-      ".g" => "http://a/bb/.g",
-      "g.." => "http://a/bb/g..",
-      "..g" => "http://a/bb/..g",
-      "./../g" => "http://a/g",
-      "./g/." => "http://a/bb/g/",
-      "g/./h" => "http://a/bb/g/h",
-      "g/../h" => "http://a/bb/h",
-      "g;x=1/./y" => "http://a/bb/g;x=1/y",
-      "g;x=1/../y" => "http://a/bb/y",
-      "g?y/./x" => "http://a/bb/g?y/./x",
-      "g?y/../x" => "http://a/bb/g?y/../x",
-      "g#s/./x" => "http://a/bb/g#s/./x",
-      "g#s/../x" => "http://a/bb/g#s/../x",
-      "http:g" => "http:g"
-    }
+    test "with RFC examples" do
+      # These are examples from:
+      #
+      # https://www.rfc-editor.org/rfc/rfc3986#section-5.4.1
+      # https://www.rfc-editor.org/rfc/rfc3986#section-5.4.2
+      #
+      # They are taken verbatim from the above document for easy comparison
 
-    for {rel, result} <- rel_and_result do
-      assert URI.merge(base3, rel) |> URI.to_string() == result
+      base = "http://a/b/c/d;p?q"
+
+      rel_and_result = %{
+        "g:h" => "g:h",
+        "g" => "http://a/b/c/g",
+        "./g" => "http://a/b/c/g",
+        "g/" => "http://a/b/c/g/",
+        "/g" => "http://a/g",
+        "//g" => "http://g",
+        "?y" => "http://a/b/c/d;p?y",
+        "g?y" => "http://a/b/c/g?y",
+        "#s" => "http://a/b/c/d;p?q#s",
+        "g#s" => "http://a/b/c/g#s",
+        "g?y#s" => "http://a/b/c/g?y#s",
+        ";x" => "http://a/b/c/;x",
+        "g;x" => "http://a/b/c/g;x",
+        "g;x?y#s" => "http://a/b/c/g;x?y#s",
+        "" => "http://a/b/c/d;p?q",
+        "." => "http://a/b/c/",
+        "./" => "http://a/b/c/",
+        ".." => "http://a/b/",
+        "../" => "http://a/b/",
+        "../g" => "http://a/b/g",
+        "../.." => "http://a/",
+        "../../" => "http://a/",
+        "../../g" => "http://a/g",
+        "../../../g" => "http://a/g",
+        "../../../../g" => "http://a/g",
+        "/./g" => "http://a/g",
+        "/../g" => "http://a/g",
+        "g." => "http://a/b/c/g.",
+        ".g" => "http://a/b/c/.g",
+        "g.." => "http://a/b/c/g..",
+        "..g" => "http://a/b/c/..g",
+        "./../g" => "http://a/b/g",
+        "./g/." => "http://a/b/c/g/",
+        "g/./h" => "http://a/b/c/g/h",
+        "g/../h" => "http://a/b/c/h",
+        "g;x=1/./y" => "http://a/b/c/g;x=1/y",
+        "g;x=1/../y" => "http://a/b/c/y",
+        "g?y/./x" => "http://a/b/c/g?y/./x",
+        "g?y/../x" => "http://a/b/c/g?y/../x",
+        "g#s/./x" => "http://a/b/c/g#s/./x",
+        "g#s/../x" => "http://a/b/c/g#s/../x",
+        "http:g" => "http:g"
+      }
+
+      for {rel, result} <- rel_and_result do
+        assert URI.merge(base, rel) |> URI.to_string() == result
+      end
+    end
+
+    test "with W3C examples" do
+      # These examples are from the W3C JSON-LD test suite:
+      #
+      # https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124
+      # https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0125
+      # https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0123
+
+      base1 = "http://a/bb/ccc/."
+
+      rel_and_result1 = %{
+        "g:h" => "g:h",
+        "g" => "http://a/bb/ccc/g",
+        "./g" => "http://a/bb/ccc/g",
+        "g/" => "http://a/bb/ccc/g/",
+        "/g" => "http://a/g",
+        "//g" => "http://g",
+        "?y" => "http://a/bb/ccc/.?y",
+        "g?y" => "http://a/bb/ccc/g?y",
+        "#s" => "http://a/bb/ccc/.#s",
+        "g#s" => "http://a/bb/ccc/g#s",
+        "g?y#s" => "http://a/bb/ccc/g?y#s",
+        ";x" => "http://a/bb/ccc/;x",
+        "g;x" => "http://a/bb/ccc/g;x",
+        "g;x?y#s" => "http://a/bb/ccc/g;x?y#s",
+        "" => "http://a/bb/ccc/.",
+        "." => "http://a/bb/ccc/",
+        "./" => "http://a/bb/ccc/",
+        ".." => "http://a/bb/",
+        "../" => "http://a/bb/",
+        "../g" => "http://a/bb/g",
+        "../.." => "http://a/",
+        "../../" => "http://a/",
+        "../../g" => "http://a/g",
+        "../../../g" => "http://a/g",
+        "../../../../g" => "http://a/g",
+        "/./g" => "http://a/g",
+        "/../g" => "http://a/g",
+        "g." => "http://a/bb/ccc/g.",
+        ".g" => "http://a/bb/ccc/.g",
+        "g.." => "http://a/bb/ccc/g..",
+        "..g" => "http://a/bb/ccc/..g",
+        "./../g" => "http://a/bb/g",
+        "./g/." => "http://a/bb/ccc/g/",
+        "g/./h" => "http://a/bb/ccc/g/h",
+        "g/../h" => "http://a/bb/ccc/h",
+        "g;x=1/./y" => "http://a/bb/ccc/g;x=1/y",
+        "g;x=1/../y" => "http://a/bb/ccc/y",
+        "g?y/./x" => "http://a/bb/ccc/g?y/./x",
+        "g?y/../x" => "http://a/bb/ccc/g?y/../x",
+        "g#s/./x" => "http://a/bb/ccc/g#s/./x",
+        "g#s/../x" => "http://a/bb/ccc/g#s/../x",
+        "http:g" => "http:g"
+      }
+
+      for {rel, result} <- rel_and_result1 do
+        assert URI.merge(base1, rel) |> URI.to_string() == result
+      end
+
+      base2 = "http://a/bb/ccc/.."
+
+      rel_and_result2 = %{
+        "g:h" => "g:h",
+        "g" => "http://a/bb/ccc/g",
+        "./g" => "http://a/bb/ccc/g",
+        "g/" => "http://a/bb/ccc/g/",
+        "/g" => "http://a/g",
+        "//g" => "http://g",
+        "?y" => "http://a/bb/ccc/..?y",
+        "g?y" => "http://a/bb/ccc/g?y",
+        "#s" => "http://a/bb/ccc/..#s",
+        "g#s" => "http://a/bb/ccc/g#s",
+        "g?y#s" => "http://a/bb/ccc/g?y#s",
+        ";x" => "http://a/bb/ccc/;x",
+        "g;x" => "http://a/bb/ccc/g;x",
+        "g;x?y#s" => "http://a/bb/ccc/g;x?y#s",
+        "" => "http://a/bb/ccc/..",
+        "." => "http://a/bb/ccc/",
+        "./" => "http://a/bb/ccc/",
+        ".." => "http://a/bb/",
+        "../" => "http://a/bb/",
+        "../g" => "http://a/bb/g",
+        "../.." => "http://a/",
+        "../../" => "http://a/",
+        "../../g" => "http://a/g",
+        "../../../g" => "http://a/g",
+        "../../../../g" => "http://a/g",
+        "/./g" => "http://a/g",
+        "/../g" => "http://a/g",
+        "g." => "http://a/bb/ccc/g.",
+        ".g" => "http://a/bb/ccc/.g",
+        "g.." => "http://a/bb/ccc/g..",
+        "..g" => "http://a/bb/ccc/..g",
+        "./../g" => "http://a/bb/g",
+        "./g/." => "http://a/bb/ccc/g/",
+        "g/./h" => "http://a/bb/ccc/g/h",
+        "g/../h" => "http://a/bb/ccc/h",
+        "g;x=1/./y" => "http://a/bb/ccc/g;x=1/y",
+        "g;x=1/../y" => "http://a/bb/ccc/y",
+        "g?y/./x" => "http://a/bb/ccc/g?y/./x",
+        "g?y/../x" => "http://a/bb/ccc/g?y/../x",
+        "g#s/./x" => "http://a/bb/ccc/g#s/./x",
+        "g#s/../x" => "http://a/bb/ccc/g#s/../x",
+        "http:g" => "http:g"
+      }
+
+      for {rel, result} <- rel_and_result2 do
+        assert URI.merge(base2, rel) |> URI.to_string() == result
+      end
+
+      base3 = "http://a/bb/ccc/../d;p?q"
+
+      rel_and_result = %{
+        "g:h" => "g:h",
+        "g" => "http://a/bb/g",
+        "./g" => "http://a/bb/g",
+        "g/" => "http://a/bb/g/",
+        "/g" => "http://a/g",
+        "//g" => "http://g",
+        "?y" => "http://a/bb/ccc/../d;p?y",
+        "g?y" => "http://a/bb/g?y",
+        "#s" => "http://a/bb/ccc/../d;p?q#s",
+        "g#s" => "http://a/bb/g#s",
+        "g?y#s" => "http://a/bb/g?y#s",
+        ";x" => "http://a/bb/;x",
+        "g;x" => "http://a/bb/g;x",
+        "g;x?y#s" => "http://a/bb/g;x?y#s",
+        "" => "http://a/bb/ccc/../d;p?q",
+        "." => "http://a/bb/",
+        "./" => "http://a/bb/",
+        ".." => "http://a/",
+        "../" => "http://a/",
+        "../g" => "http://a/g",
+        "../.." => "http://a/",
+        "../../" => "http://a/",
+        "../../g" => "http://a/g",
+        "../../../g" => "http://a/g",
+        "../../../../g" => "http://a/g",
+        "/./g" => "http://a/g",
+        "/../g" => "http://a/g",
+        "g." => "http://a/bb/g.",
+        ".g" => "http://a/bb/.g",
+        "g.." => "http://a/bb/g..",
+        "..g" => "http://a/bb/..g",
+        "./../g" => "http://a/g",
+        "./g/." => "http://a/bb/g/",
+        "g/./h" => "http://a/bb/g/h",
+        "g/../h" => "http://a/bb/h",
+        "g;x=1/./y" => "http://a/bb/g;x=1/y",
+        "g;x=1/../y" => "http://a/bb/y",
+        "g?y/./x" => "http://a/bb/g?y/./x",
+        "g?y/../x" => "http://a/bb/g?y/../x",
+        "g#s/./x" => "http://a/bb/g#s/./x",
+        "g#s/../x" => "http://a/bb/g#s/../x",
+        "http:g" => "http:g"
+      }
+
+      for {rel, result} <- rel_and_result do
+        assert URI.merge(base3, rel) |> URI.to_string() == result
+      end
     end
   end
 


### PR DESCRIPTION
Yet another fix of an issue in `URI.merge/2`. The problem concerns merging against a base with non-hierarchical URI schemes without authority (like "urn:"). According to the RFC 3986 merging algorithm, when dealing with base URIs that have a scheme but no authority, the path should be directly resolved. The current behavior however prepends a leading slash, which is neither standards-compliant nor useful in practice.

Example:

```elixir
URI.merge("ex:", "test") |> to_string()
# Current: "ex:/test"  (incorrect)
# Expected: "ex:test"  (correct)
```

This should be the last fix in the series of corrections to the `URI.merge/2` algorithm, as this makes the last failing test related to URI merging of the W3C JSON-LD 1.1 test suite pass.

Additionally, this PR reorganizes the grown `URI.merge/2` tests into a `describe` block for better structure and readability.