### PR TITLE
Handle non-binary bitstring in struct default values

### DIFF
--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -400,7 +400,8 @@ defmodule MapTest do
       defstruct bitstring: <<255, 127::7>>
     end
 
-    assert struct!(WithBitstring).bitstring == <<255, 127::7>>
+    info = Macro.struct_info!(WithBitstring, __ENV__)
+    assert info == [%{default: <<255, 127::7>>, field: :bitstring}]
   end
 
   test "defstruct can only be used once in a module" do

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -395,6 +395,14 @@ defmodule MapTest do
     assert quoted == {:%, [], [User, {:%{}, [], [{:foo, 1}]}]}
   end
 
+  test "structs with bitstring defaults" do
+    defmodule WithBitstring do
+      defstruct bitstring: <<255, 127::7>>
+    end
+
+    assert struct!(WithBitstring).bitstring == <<255, 127::7>>
+  end
+
   test "defstruct can only be used once in a module" do
     message =
       "defstruct has already been called for TestMod, " <>


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/14362

For instance, the erlang AST for `<<255, 127::7>>` is:
```elixir
{:bin, 1,
 [
   {:bin_element, 1, {:integer, 1, 255}, :default, [:integer]},
   {:bin_element, 1, {:integer, 1, 127}, {:integer, 1, 7}, [:integer]}
 ]}
```

To be backported after merge.