### PR TITLE
Enable usage of mermaid in ExUnit &co

### DIFF
--- a/lib/elixir/scripts/mix_docs.exs
+++ b/lib/elixir/scripts/mix_docs.exs
@@ -13,5 +13,41 @@ canonical = System.fetch_env!("CANONICAL")
     logger: "https://hexdocs.pm/logger/#{canonical}",
     mix: "https://hexdocs.pm/mix/#{canonical}"
   ],
-  formatters: ["html", "epub"]
+  formatters: ["html", "epub"],
+  before_closing_body_tag: fn
+    :html ->
+      """
+      <script defer src="https://cdn.jsdelivr.net/npm/mermaid@10.2.3/dist/mermaid.min.js"></script>
+      <script>
+        let initialized = false;
+
+        window.addEventListener("exdoc:loaded", () => {
+          if (!initialized) {
+            mermaid.initialize({
+              startOnLoad: false,
+              theme: document.body.className.includes("dark") ? "dark" : "default"
+            });
+            initialized = true;
+          }
+
+          let id = 0;
+          for (const codeEl of document.querySelectorAll("pre code.mermaid")) {
+            const preEl = codeEl.parentElement;
+            const graphDefinition = codeEl.textContent;
+            const graphEl = document.createElement("div");
+            const graphId = "mermaid-graph-" + id++;
+            mermaid.render(graphId, graphDefinition).then(({svg, bindFunctions}) => {
+              graphEl.innerHTML = svg;
+              bindFunctions?.(graphEl);
+              preEl.insertAdjacentElement("afterend", graphEl);
+              preEl.remove();
+            });
+          }
+        });
+      </script>
+      """
+
+    _ ->
+      ""
+  end
 ]


### PR DESCRIPTION
It seems mermaid was only added to Elixir docs itself, not ExUnit/Mix/etc.

https://hexdocs.pm/ex_unit/main/ExUnit.Case.html#module-process-architecture

![Screenshot 2025-03-28 at 8 00 02](https://github.com/user-attachments/assets/b27c1bc4-dce3-4e54-9ee3-24e45b36fd2f)

Copy pasting the config from elixir_docs.exs did the trick, but there might be a nicer way that avoids the duplication there.

This PR just enables mermaid, but it seems the chart above doesn't work on the latest version (couldn't figure out why):

![Screenshot 2025-03-28 at 8 03 06](https://github.com/user-attachments/assets/cf4becad-3af1-4dc1-a730-75451c4b8975)

