### PR TITLE
Add Regex.to_embed/2

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -419,8 +419,9 @@ defmodule Regex do
   as an embeddable modifier in the current version of PCRE and strict is true
   (the default) then an ArgumentError exception will be raised.
 
-  When strict is false the pattern will be returned as though any offending
-  options had not be used and the function will not raise any exceptions.
+  When the `:strict` option is false the pattern will be returned as though
+  any offending options had not be used and the function will not raise any
+  exceptions.
 
   Embeddable modifiers/options are currently:
 
@@ -429,13 +430,14 @@ defmodule Regex do
     * 's' - `:dotall, {:newline, :anycrlf}`
     * 'x' - `:extended`
 
-  And unembeddable modifiers are:
+  Unembeddable modifiers are:
 
     * 'f' - `:firstline`
     * 'U' - `:ungreedy`
     * 'u' - `:unicode, :ucp`
 
-  Any other regex compilation option not listed here is considered unembeddable.
+  Any other regex compilation option not listed here is considered unembeddable
+  and will raise an exception unless the `:strict` option is false.
 
   ## Examples
       iex> Regex.to_embed(~r/foo/)

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -457,7 +457,7 @@ defmodule Regex do
 
   """
   @doc since: "1.19.0"
-  @spec to_embed(t, [strict: boolean()]) :: String.t()
+  @spec to_embed(t, strict: boolean()) :: String.t()
   def to_embed(%Regex{source: source, opts: regex_opts}, embed_opts \\ []) do
     strict = Keyword.get(embed_opts, :strict, true)
 

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -457,7 +457,7 @@ defmodule Regex do
 
   """
   @doc since: "1.19.0"
-  @spec to_embed(t, [term]) :: String.t()
+  @spec to_embed(t, [strict: boolean()]) :: String.t()
   def to_embed(%Regex{source: source, opts: regex_opts}, embed_opts \\ []) do
     strict = Keyword.get(embed_opts, :strict, true)
 

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -476,13 +476,12 @@ defmodule Regex do
           end
       end
 
-    disabled = List.to_string([?i, ?m, ?s, ?x] -- modifiers)
+    disabled = [?i, ?m, ?s, ?x] -- modifiers
 
-    disabled = if disabled != "", do: "-#{disabled}", else: ""
+    disabled = if disabled != [], do: "-#{disabled}", else: ""
 
-    modifiers =
-      Enum.sort(modifiers)
-      |> List.to_string()
+    # Future proof option ordering consistency by sorting
+    modifiers = Enum.sort(modifiers)
 
     nl = if Enum.member?(regex_opts, :extended), do: "\n", else: ""
 

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -423,15 +423,17 @@ defmodule Regex do
   options had not be used and the function will not raise any exceptions.
 
   Embeddable modifiers/options are currently:
-    * 'i' - :caseless
-    * 'm' - :multiline
-    * 's' - :dotall, :newline, :anycrlf})
-    * 'x' - :extended
 
-  And unembeddable modifiers are
-    * 'f' - :firstline
-    * 'U' - :ungreedy
-    * 'u' - :unicode, :ucp
+    * 'i' - `:caseless`
+    * 'm' - `:multiline`
+    * 's' - `:dotall, {:newline, :anycrlf}`
+    * 'x' - `:extended`
+
+  And unembeddable modifiers are:
+
+    * 'f' - `:firstline`
+    * 'U' - `:ungreedy`
+    * 'u' - `:unicode, :ucp`
 
   Any other regex compilation option not listed here is considered unembeddable.
 
@@ -452,6 +454,7 @@ defmodule Regex do
       "(?imsx:foo\\n)"
 
   """
+  @doc since: "1.19.0"
   @spec to_embed(t, [term]) :: String.t()
   def to_embed(%Regex{source: source, opts: regex_opts}, embed_opts \\ []) do
     strict = Keyword.get(embed_opts, :strict, true)
@@ -471,9 +474,7 @@ defmodule Regex do
           end
       end
 
-    disabled =
-      Enum.reject([?i, ?m, ?s, ?x], &(&1 in modifiers))
-      |> List.to_string()
+    disabled = List.to_string([?i, ?m, ?s, ?x] -- modifiers)
 
     disabled = if disabled != "", do: "-#{disabled}", else: ""
 


### PR DESCRIPTION
This patch, which works on 1.18.x but does not work on 1.19 is an attempt to implement String.Chars protocol and also a Regex.to_string() and Regex.modifiers() and Regex.to_string!() and Regex.modifiers!() functions.

The idea is to make it possible to safely embed precompiled regexes into other regexes in a similar way as that supported by perl.  The general idea is that ~r/foo/x turns into "(?x-ims:foo\n)", and etc. Thus it should match the same as it would have in its original form when it is embedded into a pattern which has a different set of modifiers.

For review by Jose.