### PR TITLE
Recompile regexes when escaped from module attributes

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3727,7 +3727,7 @@ defmodule Kernel do
           {_, doc} when doc_attr? ->
             do_at_escape(name, doc)
 
-          %{__struct__: Regex, source: source, opts: opts} ->
+          %{__struct__: Regex, source: source, opts: opts} = regex ->
             # TODO: Remove this in Elixir v2.0
             IO.warn(
               "storing and reading regexes from module attributes is deprecated, " <>
@@ -3735,7 +3735,11 @@ defmodule Kernel do
               env
             )
 
-            quote(do: Regex.compile!(unquote(source), unquote(opts)))
+            if :erlang.system_info(:otp_release) < [?2, ?8] do
+              do_at_escape(name, regex)
+            else
+              quote(do: Regex.compile!(unquote(source), unquote(opts)))
+            end 
 
           value ->
             do_at_escape(name, value)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3738,7 +3738,7 @@ defmodule Kernel do
             case :erlang.system_info(:otp_release) < [?2, ?8] do
               true -> do_at_escape(name, regex)
               false -> quote(do: Regex.compile!(unquote(source), unquote(opts)))
-            end 
+            end
 
           value ->
             do_at_escape(name, value)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3735,10 +3735,9 @@ defmodule Kernel do
               env
             )
 
-            if :erlang.system_info(:otp_release) < [?2, ?8] do
-              do_at_escape(name, regex)
-            else
-              quote(do: Regex.compile!(unquote(source), unquote(opts)))
+            case :erlang.system_info(:otp_release) < [?2, ?8] do
+              true -> do_at_escape(name, regex)
+              false -> quote(do: Regex.compile!(unquote(source), unquote(opts)))
             end 
 
           value ->

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3723,26 +3723,29 @@ defmodule Kernel do
 
     case function? do
       true ->
-        value =
-          case Module.__get_attribute__(env.module, name, line, false) do
-            {_, doc} when doc_attr? -> doc
-            other -> other
-          end
+        case Module.__get_attribute__(env.module, name, line, false) do
+          {_, doc} when doc_attr? ->
+            do_at_escape(name, doc)
 
-        try do
-          :elixir_quote.escape(value, :none, false)
-        rescue
-          ex in [ArgumentError] ->
-            raise ArgumentError,
-                  "cannot inject attribute @#{name} into function/macro because " <>
-                    Exception.message(ex)
+          %{__struct__: Regex, source: source, opts: opts} ->
+            # TODO: Remove this in Elixir v2.0
+            IO.warn(
+              "storing and reading regexes from module attributes is deprecated, " <>
+                "inline the regex inside the function definition instead",
+              env
+            )
+
+            quote(do: Regex.compile!(unquote(source), unquote(opts)))
+
+          value ->
+            do_at_escape(name, value)
         end
 
       false when doc_attr? ->
         quote do
           case Module.__get_attribute__(__MODULE__, unquote(name), unquote(line), false) do
             {_, doc} -> doc
-            other -> other
+            value -> value
           end
         end
 
@@ -3775,6 +3778,17 @@ defmodule Kernel do
 
   defp do_at(args, _meta, name, _function?, _env) do
     raise ArgumentError, "expected 0 or 1 argument for @#{name}, got: #{length(args)}"
+  end
+
+  defp do_at_escape(name, value) do
+    try do
+      :elixir_quote.escape(value, :none, false)
+    rescue
+      ex in [ArgumentError] ->
+        raise ArgumentError,
+              "cannot inject attribute @#{name} into function/macro because " <>
+                Exception.message(ex)
+    end
   end
 
   # Those are always compile-time dependencies, so we can skip the trace.
@@ -6500,6 +6514,7 @@ defmodule Kernel do
   end
 
   defp compile_regex(binary_or_tuple, options) do
+    # TODO: Remove this when we require Erlang/OTP 28+
     case is_binary(binary_or_tuple) and :erlang.system_info(:otp_release) < [?2, ?8] do
       true ->
         Macro.escape(Regex.compile!(binary_or_tuple, :binary.list_to_bin(options)))

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -12,19 +12,19 @@ defmodule RegexTest do
   if System.otp_release() >= "28" do
     test "module attribute" do
       assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
-        defmodule ModAttr do
-          @regex ~r/example/
-          def regex, do: @regex
+               defmodule ModAttr do
+                 @regex ~r/example/
+                 def regex, do: @regex
 
-          @bare_regex :erlang.term_to_binary(@regex)
-          def bare_regex, do: :erlang.binary_to_term(@bare_regex)
+                 @bare_regex :erlang.term_to_binary(@regex)
+                 def bare_regex, do: :erlang.binary_to_term(@bare_regex)
 
-          # We don't rewrite outside of functions
-          assert @regex.re_pattern == :erlang.binary_to_term(@bare_regex).re_pattern
-        end
+                 # We don't rewrite outside of functions
+                 assert @regex.re_pattern == :erlang.binary_to_term(@bare_regex).re_pattern
+               end
 
-        assert ModAttr.regex().re_pattern != ModAttr.bare_regex().re_pattern
-      end) =~ "storing and reading regexes from module attributes is deprecated"
+               assert ModAttr.regex().re_pattern != ModAttr.bare_regex().re_pattern
+             end) =~ "storing and reading regexes from module attributes is deprecated"
     end
   end
 

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -9,6 +9,25 @@ defmodule RegexTest do
 
   doctest Regex
 
+  if System.otp_release() >= "28" do
+    test "module attribute" do
+      assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        defmodule ModAttr do
+          @regex ~r/example/
+          def regex, do: @regex
+
+          @bare_regex :erlang.term_to_binary(@regex)
+          def bare_regex, do: :erlang.binary_to_term(@bare_regex)
+
+          # We don't rewrite outside of functions
+          assert @regex.re_pattern == :erlang.binary_to_term(@bare_regex).re_pattern
+        end
+
+        assert ModAttr.regex().re_pattern != ModAttr.bare_regex().re_pattern
+      end) =~ "storing and reading regexes from module attributes is deprecated"
+    end
+  end
+
   test "multiline" do
     refute Regex.match?(~r/^b$/, "a\nb\nc")
     assert Regex.match?(~r/^b$/m, "a\nb\nc")


### PR DESCRIPTION
Elixir has historically relied on a behaviour that, when regexes were compiled, its native parts were compiled to a binary. Erlang/OTP 28 changes this and emits a reference, which means they can no longer be inlined at compile-time. In other words, you can no longer define a regex in a module body and store it in a module attribute or escape it inside a function.

In order to avoid breakage, we are adding a special case to module attributes that recompiles injected regexes, however, we are also attaching a deprecation to it. We could theoretically fix this generally by introducing some sort of `Macro.Escape` protocol, which we could be used by projects like Explorer and similar, but I think keeping a distinction between those would be important. For example, similar issues would happen when transferring those data types between nodes.

This patch should be backported to v1.18 however, when backporting, I would remove the deprecation notice.