### PR TITLE
Add except if exists to inspect

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -64,6 +64,9 @@ defprotocol Inspect do
 
     * `:except` - remove the given fields when inspecting.
 
+    * `:except_if_exists` - (since v1.XX.X) does the same thing as
+      above, but it doesn't raise an error on unknown fields.
+
     * `:optional` - (since v1.14.0) do not include a field if it
       matches its default value. This can be used to simplify the
       struct representation at the cost of hiding information.

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -161,7 +161,7 @@ defprotocol Inspect do
     :ok = validate_option(:optional, optional, fields, module)
 
     inspect_module =
-      if fields == Enum.sort(only) and (except == [] or except_if_exists == []) do
+      if fields == Enum.sort(only) and except == [] and except_if_exists == [] do
         Inspect.Map
       else
         Inspect.Any

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -150,6 +150,7 @@ defprotocol Inspect do
 
     only = Keyword.get(options, :only, fields)
     except = Keyword.get(options, :except, [])
+    except_if_exists = Keyword.get(options, :except_if_exists, [])
     optional = Keyword.get(options, :optional, [])
 
     :ok = validate_option(:only, only, fields, module)
@@ -157,7 +158,7 @@ defprotocol Inspect do
     :ok = validate_option(:optional, optional, fields, module)
 
     inspect_module =
-      if fields == Enum.sort(only) and except == [] do
+      if fields == Enum.sort(only) and (except == [] or except_if_exists == []) do
         Inspect.Map
       else
         Inspect.Any
@@ -166,6 +167,7 @@ defprotocol Inspect do
     filtered_fields =
       fields
       |> Enum.reject(&(&1 in except))
+      |> Enum.reject(&(&1 in except_if_exists))
       |> Enum.filter(&(&1 in only))
 
     filtered_guard =

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -728,6 +728,19 @@ defmodule Inspect.MapTest do
              "#Inspect.MapTest.StructWithExceptOption<\n  a: 1,\n  d: 4,\n  ...\n>"
   end
 
+  defmodule StructWithBothOnlyAndExceptIfExistsOptions do
+    @derive {Inspect, except_if_exists: [:b, :c, :y, :z]}
+    defstruct [:a, :b, :c, :d]
+  end
+
+  test "struct with :except_if_exists options" do
+    struct = %StructWithBothOnlyAndExceptIfExistsOptions{a: 1, b: 2, c: 3, d: 4}
+    assert inspect(struct) == "#Inspect.MapTest.StructWithBothOnlyAndExceptIfExistsOptions<a: 1, ...>"
+
+    assert inspect(struct, pretty: true, width: 1) ==
+             "#Inspect.MapTest.StructWithBothOnlyAndExceptIfExistsOptions<\n  a: 1,\n  ...\n>"
+  end
+
   defmodule StructWithBothOnlyAndExceptOptions do
     @derive {Inspect, only: [:a, :b], except: [:b, :c]}
     defstruct [:a, :b, :c, :d]
@@ -739,6 +752,19 @@ defmodule Inspect.MapTest do
 
     assert inspect(struct, pretty: true, width: 1) ==
              "#Inspect.MapTest.StructWithBothOnlyAndExceptOptions<\n  a: 1,\n  ...\n>"
+  end
+
+  defmodule StructWithBothOnlyAndExceptIfExistsOptions do
+    @derive {Inspect, only: [:a, :b], except_if_exists: [:b, :c, :y, :z]}
+    defstruct [:a, :b, :c, :d]
+  end
+
+  test "struct with both :only and :except_if_exists options" do
+    struct = %StructWithBothOnlyAndExceptIfExistsOptions{a: 1, b: 2, c: 3, d: 4}
+    assert inspect(struct) == "#Inspect.MapTest.StructWithBothOnlyAndExceptIfExistsOptions<a: 1, ...>"
+
+    assert inspect(struct, pretty: true, width: 1) ==
+             "#Inspect.MapTest.StructWithBothOnlyAndExceptIfExistsOptions<\n  a: 1,\n  ...\n>"
   end
 
   defmodule StructWithOptionalAndOrder do

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -728,17 +728,17 @@ defmodule Inspect.MapTest do
              "#Inspect.MapTest.StructWithExceptOption<\n  a: 1,\n  d: 4,\n  ...\n>"
   end
 
-  defmodule StructWithBothOnlyAndExceptIfExistsOptions do
+  defmodule StructWithExceptIfExistsOption do
     @derive {Inspect, except_if_exists: [:b, :c, :y, :z]}
     defstruct [:a, :b, :c, :d]
   end
 
-  test "struct with :except_if_exists options" do
-    struct = %StructWithBothOnlyAndExceptIfExistsOptions{a: 1, b: 2, c: 3, d: 4}
-    assert inspect(struct) == "#Inspect.MapTest.StructWithBothOnlyAndExceptIfExistsOptions<a: 1, ...>"
+  test "struct with :except_if_exists option" do
+    struct = %StructWithExceptIfExistsOption{a: 1, b: 2, c: 3, d: 4}
+    assert inspect(struct) == "#Inspect.MapTest.StructWithExceptIfExistsOption<a: 1, d: 4, ...>"
 
     assert inspect(struct, pretty: true, width: 1) ==
-             "#Inspect.MapTest.StructWithBothOnlyAndExceptIfExistsOptions<\n  a: 1,\n  ...\n>"
+             "#Inspect.MapTest.StructWithExceptIfExistsOption<\n  a: 1,\n  d: 4,\n  ...\n>"
   end
 
   defmodule StructWithBothOnlyAndExceptOptions do
@@ -761,7 +761,9 @@ defmodule Inspect.MapTest do
 
   test "struct with both :only and :except_if_exists options" do
     struct = %StructWithBothOnlyAndExceptIfExistsOptions{a: 1, b: 2, c: 3, d: 4}
-    assert inspect(struct) == "#Inspect.MapTest.StructWithBothOnlyAndExceptIfExistsOptions<a: 1, ...>"
+
+    assert inspect(struct) ==
+             "#Inspect.MapTest.StructWithBothOnlyAndExceptIfExistsOptions<a: 1, ...>"
 
     assert inspect(struct, pretty: true, width: 1) ==
              "#Inspect.MapTest.StructWithBothOnlyAndExceptIfExistsOptions<\n  a: 1,\n  ...\n>"


### PR DESCRIPTION
Hello there,
This is a proposal to add a `except_if_exists` option when deriving Inspect, so that we may specify a list of fields that we absolutely want to avoid leaking into logs and ttys, in all circumstances, which may not be present on most of our structs.

This would allow, for example, defining a single `MyApp.Schema` over `Ecto.Schema`, masking fields like `hashed_password` and such.

Context (issue raised by @s3cur3):
https://bsky.app/profile/tylerayoung.com/post/3llqwumud4s2z