### PR TITLE
Fix doc for text-base match operator

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2271,7 +2271,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Text-based match operator. Matches the term on the `left`
+  Text-based match operator. Matches the string on the `left`
   against the regular expression or string on the `right`.
 
   If `right` is a regular expression, returns `true` if `left` matches right.


### PR DESCRIPTION
Since elixir has built-in type `term()`, it may mislead to thoughts that `left` can be of any type. But it must be a string, so I guess it's better to say it explicit