### PR TITLE
Simplify algebra rendering

### DIFF
--- a/lib/elixir/lib/calendar/date_range.ex
+++ b/lib/elixir/lib/calendar/date_range.ex
@@ -171,8 +171,12 @@ defmodule Date.Range do
          when step < 0 and first_days < last_days,
          do: 0
 
-    defp size(%Date.Range{first_in_iso_days: first_days, last_in_iso_days: last_days, step: step}),
-      do: abs(div(last_days - first_days, step)) + 1
+    defp size(%Date.Range{
+           first_in_iso_days: first_days,
+           last_in_iso_days: last_days,
+           step: step
+         }),
+         do: abs(div(last_days - first_days, step)) + 1
 
     # TODO: Remove me on v2.0
     defp size(

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1264,7 +1264,7 @@ defmodule Code.Formatter do
         args_doc =
           if skip_parens? do
             left_doc
-            |> concat(group(right_doc, :flex))
+            |> concat(group(right_doc, :optimistic))
             |> nest(:cursor, :break)
           else
             right_doc =
@@ -1272,7 +1272,7 @@ defmodule Code.Formatter do
               |> nest(2, :break)
               |> concat(break(""))
               |> concat(")")
-              |> group(:flex)
+              |> group(:optimistic)
 
             concat(nest(left_doc, 2, :break), right_doc)
           end
@@ -1330,7 +1330,7 @@ defmodule Code.Formatter do
       end
 
     if next_break_fits? do
-      {group(doc, :strict), state}
+      {group(doc, :pessimistic), state}
     else
       {group(doc), state}
     end
@@ -1805,7 +1805,7 @@ defmodule Code.Formatter do
             concat_to_last_group(doc, ",")
 
           [] when last_arg_mode == :next_break_fits ->
-            doc |> ungroup_if_group() |> group(:flex)
+            doc |> ungroup_if_group() |> group(:optimistic)
 
           [] when last_arg_mode == :none ->
             doc
@@ -2326,9 +2326,9 @@ defmodule Code.Formatter do
   defp with_next_break_fits(condition, doc, fun) do
     if condition do
       doc
-      |> group(:flex)
+      |> group(:optimistic)
       |> fun.()
-      |> group(:strict)
+      |> group(:pessimistic)
     else
       doc
       |> group()

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1264,7 +1264,7 @@ defmodule Code.Formatter do
         args_doc =
           if skip_parens? do
             left_doc
-            |> concat(next_break_fits(group(right_doc, :inherit), :enabled))
+            |> concat(group(right_doc, :flex))
             |> nest(:cursor, :break)
           else
             right_doc =
@@ -1272,8 +1272,7 @@ defmodule Code.Formatter do
               |> nest(2, :break)
               |> concat(break(""))
               |> concat(")")
-              |> group(:inherit)
-              |> next_break_fits(:enabled)
+              |> group(:flex)
 
             concat(nest(left_doc, 2, :break), right_doc)
           end
@@ -1316,13 +1315,11 @@ defmodule Code.Formatter do
           |> concat(args_doc)
           |> nest(2)
           |> concat(extra)
-          |> group()
 
         skip_parens? ->
           " "
           |> concat(args_doc)
           |> concat(extra)
-          |> group()
 
         true ->
           "("
@@ -1330,13 +1327,12 @@ defmodule Code.Formatter do
           |> nest(2, :break)
           |> concat(args_doc)
           |> concat(extra)
-          |> group()
       end
 
     if next_break_fits? do
-      {next_break_fits(doc, :disabled), state}
+      {group(doc, :strict), state}
     else
-      {doc, state}
+      {group(doc), state}
     end
   end
 
@@ -1809,10 +1805,7 @@ defmodule Code.Formatter do
             concat_to_last_group(doc, ",")
 
           [] when last_arg_mode == :next_break_fits ->
-            doc
-            |> ungroup_if_group()
-            |> group()
-            |> next_break_fits(:enabled)
+            doc |> ungroup_if_group() |> group(:flex)
 
           [] when last_arg_mode == :none ->
             doc
@@ -2333,11 +2326,9 @@ defmodule Code.Formatter do
   defp with_next_break_fits(condition, doc, fun) do
     if condition do
       doc
-      |> group()
-      |> next_break_fits(:enabled)
+      |> group(:flex)
       |> fun.()
-      |> group()
-      |> next_break_fits(:disabled)
+      |> group(:strict)
     else
       doc
       |> group()

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -917,8 +917,6 @@ defmodule Inspect.Algebra do
         # TODO: Deprecate :self and :inherit on Elixir v1.23
         :self -> :normal
         :inherit -> :inherit
-        :flex -> :optimistic
-        :strict -> :pessimistic
         mode -> mode
       end
     )

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -849,7 +849,13 @@ defmodule Inspect.Algebra do
       width. However, when nested within another group, the parent
       group will assume this group fits as long as it has a single
       break, even if the optimistic group has a `force_unfit/1`
-      document within it
+      document within it. Overall, this has an effect similar
+      to swapping the order groups break. For example, if you have
+      a `parent_group(child_group)` and they do not fit, the parent
+      will convert breaks into newlines, hoping the child group fits.
+      However, if the child group is optimistic, then the parent can
+      assume that it will fit, leaving the overall fitting decision
+      to the child
 
     * `:pessimistic` - the group fits if it fits within the given
       width. However it disables any optimistic group within it

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -918,7 +918,7 @@ defmodule Inspect.Algebra do
         # TODO: Deprecate :self and :inherit on Elixir v1.23
         :self -> :normal
         :inherit -> :inherit
-        mode -> mode
+        mode when mode in [:normal, :optimistic, :pessimistic] -> mode
       end
     )
   end

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -852,10 +852,10 @@ defmodule Inspect.Algebra do
       document within it. Overall, this has an effect similar
       to swapping the order groups break. For example, if you have
       a `parent_group(child_group)` and they do not fit, the parent
-      will convert breaks into newlines, hoping the child group fits.
-      However, if the child group is optimistic, then the parent can
-      assume that it will fit, leaving the overall fitting decision
-      to the child
+      converts breaks into newlines first, allowing the child to compute
+      if it fits. However, if the child group is optimistic and it
+      has breaks, then the parent assumes it fits, leaving the overall
+      fitting decision to the child
 
     * `:pessimistic` - the group fits if it fits within the given
       width. However it disables any optimistic group within it

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -846,7 +846,8 @@ defmodule Inspect.Algebra do
     * `:optimistic` - the group fits if it fits within the given
       width. However, when nested within another group, the parent
       group will assume this group fits as long as it has a single
-      break, even ignoring any `force_unfit/1` document
+      break, even if the optimistic group has a `force_unfit/1`
+      document within it
 
     * `:pessimistic` - the group fits if it fits within the given
       width. However it disables any optimistic group within it

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -1213,7 +1213,7 @@ defmodule Inspect.Algebra do
 
   defp format(w, k, [{i, :flat, doc_group(x, :flex)} | t]) do
     if w == :infinity or fits?(w, k, false, [{i, :flat, x} | t]) do
-      format(w, k, [{i, :flat, x} | t])
+      format(w, k, [{i, :flat, x}, :group_over | t])
     else
       format(w, k, [{i, :break, x}, :group_over | t])
     end
@@ -1221,7 +1221,7 @@ defmodule Inspect.Algebra do
 
   defp format(w, k, [{i, _, doc_group(x, _)} | t]) do
     if w == :infinity or fits?(w, k, false, [{i, :flat, x}]) do
-      format(w, k, [{i, :flat, x} | t])
+      format(w, k, [{i, :flat, x}, :group_over | t])
     else
       format(w, k, [{i, :break, x}, :group_over | t])
     end

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -252,11 +252,11 @@ defmodule Inspect.AlgebraTest do
     assert render(doc |> glue("c") |> group(), 20) ==
              "hello\na\nb\nc"
 
-    assert render(doc |> group(:optimistic) |> group() |> glue("c"), 20) ==
-             "hello\na\nb c"
+    assert render(doc |> group(:optimistic) |> glue("c") |> group() |> glue("d"), 20) ==
+             "hello\na\nb c d"
 
-    assert render(doc |> group(:optimistic) |> group(:pessimistic) |> glue("c"), 20) ==
-             "hello\na\nb\nc"
+    assert render(doc |> group(:optimistic) |> glue("c") |> group(:pessimistic) |> glue("d"), 20) ==
+             "hello\na\nb c\nd"
   end
 
   test "formatting groups with lines" do

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -196,25 +196,12 @@ defmodule Inspect.AlgebraTest do
 
   test "group doc" do
     # Consistent with definitions
-    assert group("ab") == {:doc_group, "ab", :self}
-    assert group(empty()) == {:doc_group, empty(), :self}
+    assert group("ab") == {:doc_group, "ab", :normal}
+    assert group(empty()) == {:doc_group, empty(), :normal}
 
     # Consistent formatting
     doc = concat(glue(glue(glue("hello", "a"), "b"), "c"), "d")
     assert render(group(doc), 5) == "hello\na\nb\ncd"
-  end
-
-  test "group doc with inherit" do
-    # Consistent with definitions
-    assert group("ab", :inherit) == {:doc_group, "ab", :inherit}
-    assert group(empty(), :inherit) == {:doc_group, empty(), :inherit}
-
-    # Consistent formatting
-    doc = concat(glue(glue(group(glue("a", "b"), :self), "c"), "d"), "hello")
-    assert render(group(doc), 5) == "a b\nc\ndhello"
-
-    doc = concat(glue(glue(group(glue("a", "b"), :inherit), "c"), "d"), "hello")
-    assert render(group(doc), 5) == "a\nb\nc\ndhello"
   end
 
   test "no limit doc" do
@@ -258,19 +245,16 @@ defmodule Inspect.AlgebraTest do
     assert force_unfit("ab") == {:doc_force, "ab"}
     assert force_unfit(empty()) == {:doc_force, empty()}
 
-    # Consistent with definitions
-    assert next_break_fits("ab") == {:doc_fits, "ab", :enabled}
-    assert next_break_fits(empty()) == {:doc_fits, empty(), :enabled}
-    assert next_break_fits("ab", :disabled) == {:doc_fits, "ab", :disabled}
-    assert next_break_fits(empty(), :disabled) == {:doc_fits, empty(), :disabled}
-
     # Consistent formatting
-    doc = force_unfit(concat(glue(glue(glue("hello", "a"), "b"), "c"), "d"))
-    assert render(doc, 20) == "hello\na\nb\ncd"
-    assert render(next_break_fits(doc, :enabled), 20) == "hello a b cd"
+    doc = force_unfit(glue(glue("hello", "a"), "b"))
+    assert render(doc, 20) == "hello\na\nb"
+    assert render(doc |> glue("c") |> group(), 20) == "hello\na\nb\nc"
 
-    assert render(next_break_fits(next_break_fits(doc, :enabled), :disabled), 20) ==
-             "hello\na\nb\ncd"
+    assert render(doc |> group(:optimistic) |> glue("c") |> group(), 20) ==
+             "hello\na\nb c"
+
+    assert render(doc |> group(:optimistic) |> glue("c") |> group(:pessimistic), 20) ==
+             "hello\na\nb c"
   end
 
   test "formatting groups with lines" do

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -204,6 +204,20 @@ defmodule Inspect.AlgebraTest do
     assert render(group(doc), 5) == "hello\na\nb\ncd"
   end
 
+  test "group modes doc" do
+    doc = glue(glue("hello", "a"), "b")
+    assert render(doc, 10) == "hello a b"
+
+    assert render(doc |> glue("c") |> group(), 10) ==
+             "hello\na\nb\nc"
+
+    assert render(doc |> group(:optimistic) |> glue("c") |> group() |> glue("d"), 10) ==
+             "hello\na\nb c d"
+
+    assert render(doc |> group(:optimistic) |> glue("c") |> group(:pessimistic) |> glue("d"), 10) ==
+             "hello\na\nb c\nd"
+  end
+
   test "no limit doc" do
     doc = no_limit(group(glue(glue("hello", "a"), "b")))
     assert render(doc, 5) == "hello a b"

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -211,6 +211,9 @@ defmodule Inspect.AlgebraTest do
     assert render(doc |> glue("c") |> group(), 10) ==
              "hello\na\nb\nc"
 
+    assert render(doc |> group() |> glue("c") |> group() |> glue("d"), 10) ==
+             "hello a b\nc\nd"
+
     assert render(doc |> group(:optimistic) |> glue("c") |> group() |> glue("d"), 10) ==
              "hello\na\nb c d"
 

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -248,13 +248,15 @@ defmodule Inspect.AlgebraTest do
     # Consistent formatting
     doc = force_unfit(glue(glue("hello", "a"), "b"))
     assert render(doc, 20) == "hello\na\nb"
-    assert render(doc |> glue("c") |> group(), 20) == "hello\na\nb\nc"
 
-    assert render(doc |> group(:optimistic) |> glue("c") |> group(), 20) ==
+    assert render(doc |> glue("c") |> group(), 20) ==
+             "hello\na\nb\nc"
+
+    assert render(doc |> group(:optimistic) |> group() |> glue("c"), 20) ==
              "hello\na\nb c"
 
-    assert render(doc |> group(:optimistic) |> glue("c") |> group(:pessimistic), 20) ==
-             "hello\na\nb c"
+    assert render(doc |> group(:optimistic) |> group(:pessimistic) |> glue("c"), 20) ==
+             "hello\na\nb\nc"
   end
 
   test "formatting groups with lines" do


### PR DESCRIPTION
Before we had `doc_fits` and `doc_group` which could be nested arbitrarily and complicated the formatting and fitting logic. By merging them into optimistic/pessimistic groups, we can simplify the API and logic.