### PR TITLE
Added doctest for unquote_splicing in block context

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3392,7 +3392,7 @@ defmodule Kernel do
   Converts the argument to a string according to the
   `String.Chars` protocol.
 
-  This is the macro invoked when there is string interpolation.
+  This is invoked when there is string interpolation.
 
   ## Examples
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3392,7 +3392,7 @@ defmodule Kernel do
   Converts the argument to a string according to the
   `String.Chars` protocol.
 
-  This is the function invoked when there is string interpolation.
+  This is the macro invoked when there is string interpolation.
 
   ## Examples
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1372,6 +1372,18 @@ defmodule Kernel.SpecialForms do
       ...> end
       {:sum, [], [1, 2, 3, 4, 5]}
 
+  Also can be used in block context, outside of function arguments.
+  Though, it is still required to be wrapped into parentheses.
+
+      iex> requires = for module <- [Integer, Logger] do
+      ...>   quote do
+      ...>     require unquote(module)
+      ...>   end
+      ...> end
+      iex> block = quote do: (unquote_splicing(requires))
+      iex> Macro.to_string(block)
+      "require Integer\\nrequire Logger"
+
   """
   defmacro unquote(:unquote_splicing)(expr), do: error!([expr])
 


### PR DESCRIPTION
I don't like the doctest because of `Macro.to_string/1`, but I can't find a more appropriate example without using `context`(which is `Kernel.SpecialFormsTest` in this case) and with sense for a doc-reader