### PR TITLE
Fix Inspect.Algebra.next_break_fits/1 spec

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -746,7 +746,7 @@ defmodule Inspect.Algebra do
   """
   # TODO: Deprecate me on Elixir v1.23
   @doc deprecated: "Pass the optimistic/pessimistic type to group/2 instead"
-  @spec next_break_fits(t, :enabled | :disabled) :: doc_group
+  @spec next_break_fits(t, :enabled | :disabled) :: doc_fits
   def next_break_fits(doc, mode \\ :enabled)
       when is_doc(doc) and mode in [:enabled, :disabled] do
     doc_fits(doc, mode)


### PR DESCRIPTION
I think it was changed by mistake in
https://github.com/elixir-lang/elixir/pull/14403/files#diff-c39f084ee74a44527298ef9e4b035e263913b9f07dc9940823bb1b8504fad600R749