### PR TITLE
Add block_keyword_or_binary_operator to Code.Fragment

### DIFF
--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -46,10 +46,8 @@ defmodule Code.Fragment do
       or `{:local_or_var, charlist}` and `charlist` is a static part
       Examples are `__MODULE__.Submodule` or `@hello.Submodule`
 
-    * `:block_keyword_or_binary_operator` - may be a block keyword (do, end, after,
+    * `{:block_keyword_or_binary_operator, charlist}` - may be a block keyword (do, end, after,
       catch, else, rescue) or a binary operator
-
-    * `{:block_keyword, charlist}` - the context is a block keyword
 
     * `{:dot, inside_dot, charlist}` - the context is a dot
       where `inside_dot` is either a `{:var, charlist}`, `{:alias, charlist}`,
@@ -144,8 +142,7 @@ defmodule Code.Fragment do
   @spec cursor_context(List.Chars.t(), keyword()) ::
           {:alias, charlist}
           | {:alias, inside_alias, charlist}
-          | :block_keyword_or_binary_operator
-          | {:block_keyword, charlist}
+          | {:block_keyword_or_binary_operator, charlist}
           | {:dot, inside_dot, charlist}
           | {:dot_arity, inside_dot, charlist}
           | {:dot_call, inside_dot, charlist}
@@ -278,7 +275,7 @@ defmodule Code.Fragment do
 
   defp closing_or_call_to_cursor_context({reverse, spaces}) do
     if closing?(reverse) do
-      {:block_keyword_or_binary_operator, 0}
+      {{:block_keyword_or_binary_operator, ~c""}, 0}
     else
       call_to_cursor_context({reverse, spaces})
     end
@@ -337,7 +334,9 @@ defmodule Code.Fragment do
 
           {rest, rest_count} ->
             response =
-              if rest_count > count and closing?(rest), do: :block_keyword, else: :local_or_var
+              if rest_count > count and closing?(rest),
+                do: :block_keyword_or_binary_operator,
+                else: :local_or_var
 
             {{response, acc}, count}
         end

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -373,21 +373,21 @@ defmodule CodeFragmentTest do
 
     test "keyword or binary operator" do
       # Literals
-      assert CF.cursor_context("Foo.Bar ") == :block_keyword_or_binary_operator
-      assert CF.cursor_context("Foo ") == :block_keyword_or_binary_operator
-      assert CF.cursor_context(":foo ") == :block_keyword_or_binary_operator
-      assert CF.cursor_context("123 ") == :block_keyword_or_binary_operator
-      assert CF.cursor_context("nil ") == :block_keyword_or_binary_operator
-      assert CF.cursor_context("true ") == :block_keyword_or_binary_operator
-      assert CF.cursor_context("false ") == :block_keyword_or_binary_operator
-      assert CF.cursor_context("\"foo\" ") == :block_keyword_or_binary_operator
-      assert CF.cursor_context("'foo' ") == :block_keyword_or_binary_operator
+      assert CF.cursor_context("Foo.Bar ") == {:block_keyword_or_binary_operator, ~c""}
+      assert CF.cursor_context("Foo ") == {:block_keyword_or_binary_operator, ~c""}
+      assert CF.cursor_context(":foo ") == {:block_keyword_or_binary_operator, ~c""}
+      assert CF.cursor_context("123 ") == {:block_keyword_or_binary_operator, ~c""}
+      assert CF.cursor_context("nil ") == {:block_keyword_or_binary_operator, ~c""}
+      assert CF.cursor_context("true ") == {:block_keyword_or_binary_operator, ~c""}
+      assert CF.cursor_context("false ") == {:block_keyword_or_binary_operator, ~c""}
+      assert CF.cursor_context("\"foo\" ") == {:block_keyword_or_binary_operator, ~c""}
+      assert CF.cursor_context("'foo' ") == {:block_keyword_or_binary_operator, ~c""}
 
       # Containers
-      assert CF.cursor_context("(foo) ") == :block_keyword_or_binary_operator
-      assert CF.cursor_context("[foo] ") == :block_keyword_or_binary_operator
-      assert CF.cursor_context("{foo} ") == :block_keyword_or_binary_operator
-      assert CF.cursor_context("<<foo>> ") == :block_keyword_or_binary_operator
+      assert CF.cursor_context("(foo) ") == {:block_keyword_or_binary_operator, ~c""}
+      assert CF.cursor_context("[foo] ") == {:block_keyword_or_binary_operator, ~c""}
+      assert CF.cursor_context("{foo} ") == {:block_keyword_or_binary_operator, ~c""}
+      assert CF.cursor_context("<<foo>> ") == {:block_keyword_or_binary_operator, ~c""}
 
       # False positives
       assert CF.cursor_context("foo ~>> ") == {:operator_call, ~c"~>>"}
@@ -396,21 +396,22 @@ defmodule CodeFragmentTest do
 
     test "keyword from keyword or binary operator" do
       # Literals
-      assert CF.cursor_context("Foo.Bar d") == {:block_keyword, ~c"d"}
-      assert CF.cursor_context("Foo d") == {:block_keyword, ~c"d"}
-      assert CF.cursor_context(":foo d") == {:block_keyword, ~c"d"}
-      assert CF.cursor_context("123 d") == {:block_keyword, ~c"d"}
-      assert CF.cursor_context("nil d") == {:block_keyword, ~c"d"}
-      assert CF.cursor_context("true d") == {:block_keyword, ~c"d"}
-      assert CF.cursor_context("false d") == {:block_keyword, ~c"d"}
-      assert CF.cursor_context("\"foo\" d") == {:block_keyword, ~c"d"}
-      assert CF.cursor_context("'foo' d") == {:block_keyword, ~c"d"}
+      assert CF.cursor_context("Foo.Bar do") == {:block_keyword_or_binary_operator, ~c"do"}
+      assert CF.cursor_context("Foo.Bar d") == {:block_keyword_or_binary_operator, ~c"d"}
+      assert CF.cursor_context("Foo d") == {:block_keyword_or_binary_operator, ~c"d"}
+      assert CF.cursor_context(":foo d") == {:block_keyword_or_binary_operator, ~c"d"}
+      assert CF.cursor_context("123 d") == {:block_keyword_or_binary_operator, ~c"d"}
+      assert CF.cursor_context("nil d") == {:block_keyword_or_binary_operator, ~c"d"}
+      assert CF.cursor_context("true d") == {:block_keyword_or_binary_operator, ~c"d"}
+      assert CF.cursor_context("false d") == {:block_keyword_or_binary_operator, ~c"d"}
+      assert CF.cursor_context("\"foo\" d") == {:block_keyword_or_binary_operator, ~c"d"}
+      assert CF.cursor_context("'foo' d") == {:block_keyword_or_binary_operator, ~c"d"}
 
       # Containers
-      assert CF.cursor_context("(foo) d") == {:block_keyword, ~c"d"}
-      assert CF.cursor_context("[foo] d") == {:block_keyword, ~c"d"}
-      assert CF.cursor_context("{foo} d") == {:block_keyword, ~c"d"}
-      assert CF.cursor_context("<<foo>> d") == {:block_keyword, ~c"d"}
+      assert CF.cursor_context("(foo) d") == {:block_keyword_or_binary_operator, ~c"d"}
+      assert CF.cursor_context("[foo] d") == {:block_keyword_or_binary_operator, ~c"d"}
+      assert CF.cursor_context("{foo} d") == {:block_keyword_or_binary_operator, ~c"d"}
+      assert CF.cursor_context("<<foo>> d") == {:block_keyword_or_binary_operator, ~c"d"}
 
       # False positives
       assert CF.cursor_context("foo ~>> d") == {:local_or_var, ~c"d"}

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -184,6 +184,21 @@ defmodule IEx.AutocompleteTest do
     assert expand(~c"IEx.Xyz") == {:no, ~c"", []}
   end
 
+  test "block keywords" do
+    assert expand(~c"if true do") == {:yes, ~c"", [~c"do"]}
+    assert expand(~c"if true a") == {:yes, ~c"", [~c"after", ~c"and/2"]}
+    assert expand(~c"if true d") == {:yes, ~c"o", []}
+    assert expand(~c"if true e") == {:yes, ~c"", [~c"end", ~c"else"]}
+  end
+
+  test "block keywords or operators" do
+    {:yes, ~c"", hints} = expand(~c"if true ")
+    assert ~c"do" in hints
+    assert ~c"else" in hints
+    assert ~c"+/2" in hints
+    assert ~c"and/2" in hints
+  end
+
   test "function completion" do
     assert expand(~c"System.ve") == {:yes, ~c"rsion", []}
     assert expand(~c":ets.fun2") == {:yes, ~c"ms", []}


### PR DESCRIPTION
This makes it so suggestions after `)`, `]`, `}`, and literals
only include block keywords and binary operators.
For example, `if true d|`, where `|` is the cursor position,
should only suggest `do`.

Closes #14392.