### PR TITLE
Add a doc reference that helps identify the possible values for Logger :translator_inspect_opts

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -341,7 +341,8 @@ defmodule Logger do
     * `:translator_inspect_opts` - when translating OTP reports and
       errors, the last message and state must be inspected in the
       error reports. This configuration allow developers to change
-      how much and how the data should be inspected.
+      how much and how the data should be inspected. See `Kernel.inspect/2`
+      for more information on the available options.
 
   For example, to configure the `:level` options in a `config/config.exs`
   file:


### PR DESCRIPTION
I came across the `Logger`  runtime config param `:translator_inspect_opts` and there is no mention in the docs of what are the allowed options. I had to look through the source code to figure out that these options are later passed to a call to `Kernel.inspect/2`.

This PR helps remediate that by adding a reference to the docs for `Kernel.inspect/2` in the documentation of the runtime config param `:translator_inspect_opts`. We could link to the `Inspect.Opts` module directly perhaps, but I figured that this can be a problem if for any reason the `Kernel.inspect/2` function changes its spec at some point, and/or the options are moved elsewhere.