### PR TITLE
Optimize Base.valid16?/2

### DIFF
--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -355,14 +355,10 @@ defmodule Base do
 
   def valid16?(string, opts) when is_binary(string) and rem(byte_size(string), 2) == 0 do
     case Keyword.get(opts, :case, :upper) do
-      :upper -> validate16upper!(string)
-      :lower -> validate16lower!(string)
-      :mixed -> validate16mixed!(string)
+      :upper -> validate16upper?(string)
+      :lower -> validate16lower?(string)
+      :mixed -> validate16mixed?(string)
     end
-
-    true
-  rescue
-    ArgumentError -> false
   end
 
   def valid16?(string, _opts) when is_binary(string) do
@@ -373,21 +369,26 @@ defmodule Base do
 
   for {base, alphabet} <- [upper: upper, lower: to_lower_dec.(upper), mixed: to_mixed_dec.(upper)] do
     decode_name = :"decode16#{base}!"
-    validate_name = :"validate16#{base}!"
+    validate_name = :"validate16#{base}?"
+    valid_char_name = :"valid_char16#{base}?"
 
     {min, decoded} = to_decode_list.(alphabet)
 
-    defp unquote(validate_name)(<<>>), do: :ok
+    defp unquote(validate_name)(<<>>), do: true
 
     defp unquote(validate_name)(<<c1, c2, rest::binary>>) do
-      unquote(decode_name)(c1)
-      unquote(decode_name)(c2)
-      unquote(validate_name)(rest)
+      unquote(valid_char_name)(c1) and
+        unquote(valid_char_name)(c2) and
+        unquote(validate_name)(rest)
     end
 
-    defp unquote(validate_name)(<<char, _rest::binary>>) do
-      bad_character!(char)
-    end
+    defp unquote(validate_name)(<<_char, _rest::binary>>), do: false
+
+    defp unquote(valid_char_name)(char)
+         when elem({unquote_splicing(decoded)}, char - unquote(min)) != nil,
+         do: true
+
+    defp unquote(valid_char_name)(_char), do: false
 
     defp unquote(decode_name)(char) do
       try do


### PR DESCRIPTION
- Using `and` instead of relying on a global `rescue` has a significant impact
- Using a guard instead of a local `rescue` to check if the char is a non-nil member of a tuple also has almost as big of an impact

I haven't benched/done other functions yet, wanted to first share this one and wait for the feedback.

Reusing @whatyouhide 's `big_string` [benchmark](https://github.com/elixir-lang/elixir/pull/14417#issuecomment-2789524253):

```elixir
##### With input big string #####
Name                      ips        average  deviation         median         99th %
bool_plus_guard       11.97 M       83.56 ns ±13110.49%       20.90 ns      104.20 ns
bool                   4.72 M      212.01 ns ±19289.61%          84 ns         250 ns
original               1.31 M      765.72 ns  ±3523.35%         500 ns        1417 ns

Comparison: 
bool_plus_guard       11.97 M
bool                   4.72 M - 2.54x slower +128.46 ns
original               1.31 M - 9.16x slower +682.17 ns

Memory usage statistics:

Name               Memory usage
bool_plus_guard            40 B
bool                      288 B - 7.20x memory usage +248 B
original                 1216 B - 30.40x memory usage +1176 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name            Reduction count
bool_plus_guard               8
bool                          8 - 1.00x reduction count +0
original                     73 - 9.13x reduction count +65

**All measurements for reduction count were the same**
```