### PR TITLE
JSON encode supports encoding keyword lists to objects

### DIFF
--- a/lib/elixir/src/elixir_json.erl
+++ b/lib/elixir/src/elixir_json.erl
@@ -304,6 +304,8 @@ encode_list(List, Encode) when is_list(List) ->
 
 do_encode_list([], _Encode) ->
     <<"[]">>;
+do_encode_list([{Key, _Value} | _Rest] = List, Encode) when is_atom(Key) ->
+    encode_key_value_list(List, Encode);
 do_encode_list([First | Rest], Encode) when is_function(Encode, 2) ->
     [$[, Encode(First, Encode) | list_loop(Rest, Encode)].
 

--- a/lib/elixir/src/elixir_json.erl
+++ b/lib/elixir/src/elixir_json.erl
@@ -305,7 +305,7 @@ encode_list(List, Encode) when is_list(List) ->
 do_encode_list([], _Encode) ->
     <<"[]">>;
 do_encode_list([{Key, _Value} | _Rest] = List, Encode) when is_atom(Key) ->
-    encode_key_value_list(List, Encode);
+    encode_key_value_list_checked(List, Encode);
 do_encode_list([First | Rest], Encode) when is_function(Encode, 2) ->
     [$[, Encode(First, Encode) | list_loop(Rest, Encode)].
 
@@ -343,6 +343,8 @@ do_encode_checked([{Key, Value} | Rest], Encode, Visited0) ->
             Visited = Visited0#{EncodedKey => true},
             [[$,, EncodedKey, $: | Encode(Value, Encode)] | do_encode_checked(Rest, Encode, Visited)]
     end;
+do_encode_checked([NotKV | _Rest], _Encode, _Visited) ->
+  error({invalid_keyword_list_element, NotKV});
 do_encode_checked([], _, _) ->
     [].
 

--- a/lib/elixir/test/elixir/json_test.exs
+++ b/lib/elixir/test/elixir/json_test.exs
@@ -45,6 +45,18 @@ defmodule JSONTest do
                "[1,1.0,\"one\",{\"1\":2,\"3.0\":4.0,\"key\":\"bar\"}]"
     end
 
+    test "keyword lists" do
+      ex =
+        assert_raise(Protocol.UndefinedError, fn ->
+          JSON.encode!([1, :a, k1: "a", k2: "b"])
+        end)
+
+      assert ex.value == {:k1, "a"}
+
+      assert JSON.encode!(k1: "a", k2: 123, k3: ["b", %{k4: "c"}, 123.456, [k5: [k6: :d]]]) ==
+               "{\"k1\":\"a\",\"k2\":123,\"k3\":[\"b\",{\"k4\":\"c\"},123.456,{\"k5\":{\"k6\":\"d\"}}]}"
+    end
+
     test "structs" do
       assert JSON.encode!(%Token{value: :example}) == "[\"example\"]"
       assert JSON.encode!(%Token{value: "hello\0world"}) == "[\"hello\\u0000world\"]"
@@ -91,6 +103,18 @@ defmodule JSONTest do
     test "lists" do
       assert protocol_encode([1, 1.0, "one", %{1 => 2, 3.0 => 4.0, key: :bar}]) ==
                "[1,1.0,\"one\",{\"1\":2,\"3.0\":4.0,\"key\":\"bar\"}]"
+    end
+
+    test "keyword lists" do
+      ex =
+        assert_raise(Protocol.UndefinedError, fn ->
+          assert protocol_encode(JSON.encode!([1, :a, k1: "a", k2: "b"]))
+        end)
+
+      assert ex.value == {:k1, "a"}
+
+      assert protocol_encode(k1: 2, k2: 4.0, k3: ~c"list", k4: :bar) ==
+               "{\"k1\":2,\"k2\":4.0,\"k3\":[108,105,115,116],\"k4\":\"bar\"}"
     end
 
     test "structs" do

--- a/lib/elixir/test/elixir/json_test.exs
+++ b/lib/elixir/test/elixir/json_test.exs
@@ -46,6 +46,20 @@ defmodule JSONTest do
     end
 
     test "keyword lists" do
+      invalid_kw_list_error =
+        assert_raise(ErlangError, fn ->
+          assert JSON.encode!([{:a, 1}, {:b, 2}, "bar"]) == "foobar"
+        end)
+
+      assert invalid_kw_list_error.original == {:invalid_keyword_list_element, "bar"}
+
+      duplicate_key_error =
+        assert_raise(ErlangError, fn ->
+          JSON.encode!(a: 1, b: 2, a: "BAD")
+        end)
+
+      assert duplicate_key_error.original == {:duplicate_key, :a}
+
       ex =
         assert_raise(Protocol.UndefinedError, fn ->
           JSON.encode!([1, :a, k1: "a", k2: "b"])


### PR DESCRIPTION
Allow keyword lists with atom keys to be encoding with `JSON` module

Current:

```
Interactive Elixir (1.18.3) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> JSON.encode!([a: "foo", b: "bar"])
** (Protocol.UndefinedError) protocol JSON.Encoder not implemented for type Tuple, the protocol must be explicitly implemented.
...
```

With change:
```
Interactive Elixir (1.19.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> JSON.encode!([a: "foo", b: "bar"])
"{\"a\":\"foo\",\"b\":\"bar\"}"
```