### PR TITLE
Inline function in Base.valid16? implementation

### DIFF
--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -384,6 +384,7 @@ defmodule Base do
 
     defp unquote(validate_name)(<<_char, _rest::binary>>), do: false
 
+    @compile {:inline, [{valid_char_name, 1}]}
     defp unquote(valid_char_name)(char)
          when elem({unquote_splicing(decoded)}, char - unquote(min)) != nil,
          do: true


### PR DESCRIPTION
I realized I had a mistake in my previous benchmark for https://github.com/elixir-lang/elixir/pull/14429 - I was using an invalid string so it was measuring the case the function bails early 🤦

For valid strings, the speedup was almost non-existent as is - but provided we inline the `valid_char_name` function we can still achieve a ~2x speedup for valid strings over the pre-optimization implementation.

Updated benchmark:
https://github.com/sabiwara/elixir_benches/commit/af34130fed193bde6503103bb581ab08ab6fe815