### PR TITLE
Rewrite SpecialForms doc examples as doctests

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -2110,7 +2110,7 @@ defmodule Kernel.SpecialForms do
       iex> try do
       ...>   1 / 0
       ...> rescue
-      ...>   x in [ArithmeticError] -> [:rescued, is_exception(x)]
+      ...>   x -> [:rescued, is_exception(x)]
       ...> end
       [:rescued, true]
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -2373,30 +2373,32 @@ defmodule Kernel.SpecialForms do
   Any new and existing messages that do not match will remain in the mailbox.
 
   ## Examples
-
-      receive do
-        {:selector, number, name} when is_integer(number) ->
-          name
-        name when is_atom(name) ->
-          name
-        _ ->
-          IO.puts(:stderr, "Unexpected message received")
-      end
+      iex> send(self(), {:selector, 5, :quantity})
+      iex> receive do
+      ...>   {:selector, number, name} when is_integer(number) ->
+      ...>     name
+      ...>   name when is_atom(name) ->
+      ...>     name
+      ...>   _ ->
+      ...>     IO.puts(:stderr, "Unexpected message received")
+      ...> end
+      :quantity
 
   An optional `after` clause can be given in case no matching message is
   received during the given timeout period, specified in milliseconds:
 
-      receive do
-        {:selector, number, name} when is_integer(number) ->
-          name
-        name when is_atom(name) ->
-          name
-        _ ->
-          IO.puts(:stderr, "Unexpected message received")
-      after
-        5000 ->
-          IO.puts(:stderr, "No message in 5 seconds")
-      end
+      iex> receive do
+      ...>   {:selector, number, name} when is_integer(number) ->
+      ...>     name
+      ...>   name when is_atom(name) ->
+      ...>     name
+      ...>   _ ->
+      ...>     IO.puts(:stderr, "Unexpected message received")
+      ...> after
+      ...>   10 ->
+      ...>     "return this after 10 milliseconds"
+      ...> end
+      "return this after 10 milliseconds"
 
   The `after` clause can be specified even if there are no match clauses.
   The timeout value given to `after` can be any expression evaluating to

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -2067,7 +2067,7 @@ defmodule Kernel.SpecialForms do
   exception by its name. All the following formats are valid patterns
   in `rescue` clauses:
 
-  Rescue a single exception without binding the exception to a variable
+  Rescue a single exception without binding the exception to a variable:
 
       iex> try do
       ...>   1 / 0
@@ -2076,7 +2076,7 @@ defmodule Kernel.SpecialForms do
       ...> end
       :rescued
 
-  Rescue any of the given exception without binding
+  Rescue any of the given exception without binding:
 
       iex> try do
       ...>   1 / 0
@@ -2085,7 +2085,7 @@ defmodule Kernel.SpecialForms do
       ...> end
       :rescued
 
-  Rescue and bind the exception to the variable "x"
+  Rescue and bind the exception to the variable `x`:
 
       iex> try do
       ...>   1 / 0
@@ -2094,7 +2094,7 @@ defmodule Kernel.SpecialForms do
       ...> end
       [:rescued, true]
 
-  Rescue several errors differently
+  Rescue different errors with separate clauses:
 
       iex> try do
       ...>   1 / 0
@@ -2105,7 +2105,7 @@ defmodule Kernel.SpecialForms do
       :rescued_arithmetic_error
 
   Rescue all kinds of exceptions and bind the rescued exception
-  to the variable "x"
+  to the variable `x`:
 
       iex> try do
       ...>   1 / 0
@@ -2216,33 +2216,26 @@ defmodule Kernel.SpecialForms do
       end
 
   Although `after` clauses are invoked whether or not there was an error, they do not
-  modify the return value. Both of the following examples return `:returned`:
+  modify the return value. Both of the following examples print a message to STDOUT
+  and return `:returned`:
 
-      iex> try do
-      ...>   :returned
-      ...> after
-      ...>   send(self(), :send_from_after_block)
-      ...>   :not_returned
-      ...> end
-      :returned
-      iex> receive do
-      ...>   :send_from_after_block -> :message_received
-      ...> end
-      :message_received
+      try do
+        :returned
+      after
+        IO.puts("This message will be printed")
+        :not_returned
+      end
+      #=> :returned
 
-      iex> try do
-      ...>   raise "boom"
-      ...> rescue
-      ...>   _ -> :returned
-      ...> after
-      ...>   send(self(), :send_from_after_block)
-      ...>   :not_returned
-      ...> end
-      :returned
-      iex> receive do
-      ...>   :send_from_after_block -> :message_received
-      ...> end
-      :message_received
+      try do
+        raise "boom"
+      rescue
+        _ -> :returned
+      after
+        IO.puts("This message will be printed")
+        :not_returned
+      end
+      #=> :returned
 
   ## `else` clauses
 
@@ -2395,9 +2388,9 @@ defmodule Kernel.SpecialForms do
       ...>     IO.puts(:stderr, "Unexpected message received")
       ...> after
       ...>   10 ->
-      ...>     "return this after 10 milliseconds"
+      ...>     "No message in 10 milliseconds"
       ...> end
-      "return this after 10 milliseconds"
+      "No message in 10 milliseconds"
 
   The `after` clause can be specified even if there are no match clauses.
   The timeout value given to `after` can be any expression evaluating to

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -2007,25 +2007,21 @@ defmodule Kernel.SpecialForms do
   The following example has a single clause that always evaluates
   to true:
 
-      cond do
-        hd([1, 2, 3]) ->
-          "1 is considered as true"
-      end
-      #=> "1 is considered as true"
+      iex> cond do
+      ...>   hd([1, 2, 3]) -> "1 is considered as true"
+      ...> end
+      "1 is considered as true"
 
   If all clauses evaluate to `nil` or `false`, `cond` raises an error.
   For this reason, it may be necessary to add a final always-truthy condition
   (anything non-`false` and non-`nil`), which will always match:
 
-      cond do
-        1 + 1 == 1 ->
-          "This will never match"
-        2 * 2 != 4 ->
-          "Nor this"
-        true ->
-          "This will"
-      end
-      #=> "This will"
+      iex> cond do
+      ...>   1 + 1 == 1 -> "This will never match"
+      ...>   2 * 2 != 4 -> "Nor this"
+      ...>   true -> "This will"
+      ...> end
+      "This will"
 
 
   If your `cond` has two clauses, and the last one falls back to

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -2094,7 +2094,7 @@ defmodule Kernel.SpecialForms do
       ...> end
       [:rescued, true]
 
-  Rescue different errors differently
+  Rescue several errors differently
 
       iex> try do
       ...>   1 / 0
@@ -2267,8 +2267,7 @@ defmodule Kernel.SpecialForms do
       iex> try do
       ...>   1 / x
       ...> rescue
-      ...>   ArithmeticError ->
-      ...>     :infinity
+      ...>   ArithmeticError -> :infinity
       ...> end
       0.2
 


### PR DESCRIPTION
Rewrote some code snippets to remove side effects and compiler warnings. Also added a couple of tests and made them more consistent in `try/1`