### PR TITLE
Add missing `parameters` field to `ExUnit.Test.t()`

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -118,7 +118,8 @@ defmodule ExUnit do
             state: ExUnit.state(),
             time: non_neg_integer,
             tags: map,
-            logs: String.t()
+            logs: String.t(),
+            parameters: map
           }
   end
 


### PR DESCRIPTION
The documented field `parameters` is missing from `ExUnit.Test.t()`.