### PR TITLE
Rework if/2 docs and mention variable scope

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3898,48 +3898,40 @@ defmodule Kernel do
 
   ## One-liner examples
 
-      if(foo, do: bar)
+      iex> if 7 > 5, do: "yes"
+      "yes"
 
   In the example above, `bar` will be returned if `foo` evaluates to
   a truthy value (neither `false` nor `nil`). Otherwise, `nil` will be
   returned.
 
+      iex> if 3 > 5, do: "yes"
+      nil
+
   An `else` option can be given to specify the opposite:
 
-      if(foo, do: bar, else: baz)
+      iex> if 3 > 5, do: "yes", else: "no"
+      "no"
 
   ## Blocks examples
 
   It's also possible to pass a block to the `if/2` macro. The first
   example above would be translated to:
 
-      if foo do
-        bar
-      end
+      iex> if 7 > 5 do
+      ...>   "yes"
+      ...> end
+      "yes"
 
   Note that `do`-`end` become delimiters. The second example would
   translate to:
 
-      if foo do
-        bar
-      else
-        baz
-      end
-
-  ## Examples
-
-      iex> if 5 > 7 do
-      ...>   "This will never be returned"
+      iex> if 3 > 5 do
+      ...>   "yes"
       ...> else
-      ...>   "This will be returned"
+      ...>   "no"
       ...> end
-      "This will be returned"
-
-      iex> if 2 + 2 == 4, do: :correct
-      :correct
-
-      iex> if 2 + 2 == 5, do: :correct
-      nil
+      "no"
 
   If you find yourself nesting conditionals inside conditionals,
   consider using `cond/1`.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3944,7 +3944,7 @@ defmodule Kernel do
 
   ## Variables scope
 
-  Variables can be defined or rebound in `do`/`else` blocks, but these will not leak to the outer context:
+  Variables set within `do`/`else` blocks do not leak to the outer context:
 
       x = 1
       if x > 0 do
@@ -3953,7 +3953,7 @@ defmodule Kernel do
       end
       x  # 1
 
-  Variables can be defined in the condition as well, but they are available in the outer context:
+  Variables set in the condition are available in the outer context:
 
       fruits = %{oranges: 3}
       if count = fruits[:apples] do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3901,11 +3901,17 @@ defmodule Kernel do
       iex> if 7 > 5, do: "yes"
       "yes"
 
-  In the example above, `bar` will be returned if `foo` evaluates to
-  a truthy value (neither `false` nor `nil`). Otherwise, `nil` will be
-  returned.
+      iex> if "truthy value", do: "yes"
+      "yes"
+
+  In the examples above, `"yes"` will be returned because the condition
+  evaluates to a truthy value (neither `false` nor `nil`). Otherwise, `nil`
+  will be returned:
 
       iex> if 3 > 5, do: "yes"
+      nil
+
+      iex> if nil, do: "yes"
       nil
 
   An `else` option can be given to specify the opposite:

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3953,7 +3953,7 @@ defmodule Kernel do
       if count = fruits[:apples] do
         IO.puts(count + 1)
       end
-      counts  # nil
+      count  # nil
 
   """
   defmacro if(condition, clauses) do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3904,14 +3904,14 @@ defmodule Kernel do
       iex> if "truthy value", do: "yes"
       "yes"
 
-  In the examples above, `"yes"` will be returned because the condition
-  evaluates to a truthy value (neither `false` nor `nil`). Otherwise, `nil`
-  will be returned:
+  In the examples above, the `do` clause is evaluated and `"yes"` will be returned
+  because the condition evaluates to a truthy value (neither `false` nor `nil`).
+  Otherwise, the clause is not evaluated and `nil` will be returned:
 
       iex> if 3 > 5, do: "yes"
       nil
 
-      iex> if nil, do: "yes"
+      iex> if nil, do: IO.puts("this won't be printed")
       nil
 
   An `else` option can be given to specify the opposite:
@@ -3929,7 +3929,7 @@ defmodule Kernel do
       ...> end
       "yes"
 
-  Note that `do`-`end` become delimiters. The second example would
+  Note that `do`-`end` become delimiters. The third example would
   translate to:
 
       iex> if 3 > 5 do
@@ -3957,6 +3957,7 @@ defmodule Kernel do
 
       fruits = %{oranges: 3}
       if count = fruits[:apples] do
+        # won't be evaluated
         IO.puts(count + 1)
       end
       count  # nil

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3935,6 +3935,26 @@ defmodule Kernel do
 
   If you find yourself nesting conditionals inside conditionals,
   consider using `cond/1`.
+
+  ## Variables scope
+
+  Variables can be defined or rebound in `do`/`else` blocks, but these will not leak to the outer context:
+
+      x = 1
+      if x > 0 do
+        x = x + 1
+        IO.puts(x)  # prints 2
+      end
+      x  # 1
+
+  Variables can be defined in the condition as well, but they are available in the outer context:
+
+      fruits = %{oranges: 3}
+      if count = fruits[:apples] do
+        IO.puts(count + 1)
+      end
+      counts  # nil
+
   """
   defmacro if(condition, clauses) do
     build_if(condition, clauses)


### PR DESCRIPTION
The structure of the `if` doc was a bit hard to understand, since:
- we now had the following 3 sections: "One-liner examples" / "Blocks examples" / "Examples"
- some examples were far away from the points they were illustrating (e.g. "Otherwise, `nil` will be
  returned.")
- mixing of the `if(foo, do: bar)` and `if foo, do: bar` form, but AFAIK the former is less common and idiomatic nowadays?

I also noticed that the fact we can define a variable in the `if` condition wasn't explicitly documented, as well as scope rules more broadly (even if they aren't specific to `if`, it's probably the more common place people encounter it). Inspired from  [this](https://hexdocs.pm/elixir/1.18.3/try-catch-and-rescue.html#variables-scope)
