### PR TITLE
Load modules lazily and only if needed

### DIFF
--- a/lib/elixir/lib/kernel/error_handler.ex
+++ b/lib/elixir/lib/kernel/error_handler.ex
@@ -41,7 +41,15 @@ defmodule Kernel.ErrorHandler do
     :erlang.garbage_collect(self())
 
     receive do
-      {^ref, value} -> value
+      {^ref, {:loading, pid}} ->
+        ref = :erlang.monitor(:process, pid)
+
+        receive do
+          {:DOWN, ^ref, _, _, _} -> :found
+        end
+
+      {^ref, value} ->
+        value
     end
   end
 end

--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -660,6 +660,7 @@ defmodule Kernel.ParallelCompiler do
 
       {:module_available, child, ref, file, module, binary, loaded?} ->
         state.each_module.(file, module, binary)
+        send(child, {ref, :ack})
 
         {available, load_status} =
           case Map.get(result, {:module, module}) do
@@ -675,9 +676,6 @@ defmodule Kernel.ParallelCompiler do
             _ ->
               {[], loaded?}
           end
-
-        # Release the module loader which is waiting for an ack
-        send(child, {ref, :ack})
 
         spawn_workers(
           available ++ queue,

--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -198,7 +198,7 @@ defmodule Kernel.ParallelCompiler do
           {:ok, [atom], [warning] | info()}
           | {:error, [error] | [Code.diagnostic(:error)], [warning] | info()}
   def compile_to_path(files, path, options \\ []) when is_binary(path) and is_list(options) do
-    spawn_workers(files, {:compile, path}, options)
+    spawn_workers(files, {:compile, path}, Keyword.put(options, :dest, path))
   end
 
   @doc """
@@ -338,6 +338,9 @@ defmodule Kernel.ParallelCompiler do
   end
 
   defp write_module_binaries(result, {:compile, path}, timestamp) do
+    File.mkdir_p!(path)
+    Code.prepend_path(path)
+
     Enum.flat_map(result, fn
       {{:module, module}, binary} when is_binary(binary) ->
         full_path = Path.join(path, Atom.to_string(module) <> ".beam")
@@ -439,8 +442,8 @@ defmodule Kernel.ParallelCompiler do
 
         try do
           case output do
-            {:compile, path} -> compile_file(file, path, parent)
-            :compile -> compile_file(file, dest, parent)
+            {:compile, _} -> compile_file(file, dest, false, parent)
+            :compile -> compile_file(file, dest, true, parent)
             :require -> require_file(file, parent)
           end
         catch
@@ -546,9 +549,9 @@ defmodule Kernel.ParallelCompiler do
     wait_for_messages([], spawned, waiting, files, result, warnings, errors, state)
   end
 
-  defp compile_file(file, path, parent) do
+  defp compile_file(file, path, force_load?, parent) do
     :erlang.process_flag(:error_handler, Kernel.ErrorHandler)
-    :erlang.put(:elixir_compiler_dest, path)
+    :erlang.put(:elixir_compiler_dest, {path, force_load?})
     :elixir_compiler.file(file, &each_file(&1, &2, parent))
   end
 
@@ -649,19 +652,30 @@ defmodule Kernel.ParallelCompiler do
           state
         )
 
-      {:module_available, child, ref, file, module, binary} ->
+      {:module_available, child, ref, file, module, binary, loaded?} ->
         state.each_module.(file, module, binary)
+
+        available =
+          case Map.get(result, {:module, module}) do
+            [_ | _] = pids ->
+              # We prefer to load in the client, if possible,
+              # to avoid locking the compilation server.
+              loaded? or load_module(module, binary, state)
+              Enum.map(pids, &{&1, :found})
+
+            _ ->
+              []
+          end
 
         # Release the module loader which is waiting for an ack
         send(child, {ref, :ack})
-        {available, result} = update_result(result, :module, module, binary)
 
         spawn_workers(
           available ++ queue,
           spawned,
           waiting,
           files,
-          result,
+          Map.put(result, {:module, module}, binary),
           warnings,
           errors,
           state
@@ -680,6 +694,8 @@ defmodule Kernel.ParallelCompiler do
 
         {waiting, files, result} =
           if not is_list(available_or_pending) or on in defining do
+            # If what we are waiting on was defined but not loaded, we do it now.
+            load_pending(kind, on, result, state)
             send(child_pid, {ref, :found})
             {waiting, files, result}
           else
@@ -772,6 +788,30 @@ defmodule Kernel.ParallelCompiler do
 
     info = %{compile_warnings: Enum.reverse(warnings), runtime_warnings: []}
     {{:error, Enum.reverse(errors, fun.()), info}, state}
+  end
+
+  defp load_pending(kind, module, result, state) do
+    with true <- kind in [:module, :struct],
+         %{{:module, ^module} => binary} when is_binary(binary) <- result,
+         false <- :erlang.module_loaded(module) do
+      load_module(module, binary, state)
+    end
+  end
+
+  defp load_module(module, binary, state) do
+    beam_location =
+      case state.dest do
+        nil ->
+          []
+
+        dest ->
+          :filename.join(
+            :elixir_utils.characters_to_list(dest),
+            Atom.to_charlist(module) ++ ~c".beam"
+          )
+      end
+
+    :code.load_binary(module, beam_location, binary)
   end
 
   defp update_result(result, kind, module, value) do

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1210,7 +1210,7 @@ defmodule Module do
   @spec defines?(module, definition) :: boolean
   def defines?(module, {name, arity} = tuple)
       when is_atom(module) and is_atom(name) and is_integer(arity) and arity >= 0 and arity <= 255 do
-    {set, _bag} = data_tables_for(module, __ENV__.function, @extra_error_msg_defines?)
+    {set, _bag} = data_tables_for!(module, __ENV__.function, @extra_error_msg_defines?)
     :ets.member(set, {:def, tuple})
   end
 
@@ -1237,7 +1237,7 @@ defmodule Module do
   def defines?(module, {name, arity} = tuple, def_kind)
       when is_atom(module) and is_atom(name) and is_integer(arity) and arity >= 0 and arity <= 255 and
              def_kind in [:def, :defp, :defmacro, :defmacrop] do
-    {set, _bag} = data_tables_for(module, __ENV__.function, @extra_error_msg_defines?)
+    {set, _bag} = data_tables_for!(module, __ENV__.function, @extra_error_msg_defines?)
 
     case :ets.lookup(set, {:def, tuple}) do
       [{_, ^def_kind, _, _, _, _}] -> true
@@ -1291,7 +1291,7 @@ defmodule Module do
   @doc since: "1.13.0"
   @spec attributes_in(module) :: [atom]
   def attributes_in(module) when is_atom(module) do
-    {set, _} = data_tables_for(module, __ENV__.function, "")
+    {set, _} = data_tables_for!(module, __ENV__.function, "")
     :ets.select(set, [{{:"$1", :_, :_, :_}, [{:is_atom, :"$1"}], [:"$1"]}])
   end
 
@@ -1344,7 +1344,7 @@ defmodule Module do
   """
   @spec definitions_in(module) :: [definition]
   def definitions_in(module) when is_atom(module) do
-    {_, bag} = data_tables_for(module, __ENV__.function, @extra_error_msg_definitions_in)
+    {_, bag} = data_tables_for!(module, __ENV__.function, @extra_error_msg_definitions_in)
     bag_lookup_element(bag, :defs, 2)
   end
 
@@ -1368,7 +1368,7 @@ defmodule Module do
   @spec definitions_in(module, def_kind) :: [definition]
   def definitions_in(module, kind)
       when is_atom(module) and kind in [:def, :defp, :defmacro, :defmacrop] do
-    {set, _} = data_tables_for(module, __ENV__.function, @extra_error_msg_definitions_in)
+    {set, _} = data_tables_for!(module, __ENV__.function, @extra_error_msg_definitions_in)
     :ets.select(set, [{{{:def, :"$1"}, kind, :_, :_, :_, :_}, [], [:"$1"]}])
   end
 
@@ -1402,7 +1402,7 @@ defmodule Module do
   @doc since: "1.12.0"
   def get_definition(module, {name, arity}, options \\ [])
       when is_atom(module) and is_atom(name) and is_integer(arity) and is_list(options) do
-    {set, bag} = data_tables_for(module, __ENV__.function, "")
+    {set, bag} = data_tables_for!(module, __ENV__.function, "")
 
     case :ets.lookup(set, {:def, {name, arity}}) do
       [{_key, kind, meta, _, _, _}] ->
@@ -1472,7 +1472,7 @@ defmodule Module do
 
   @spec make_overridable(module, module) :: :ok
   def make_overridable(module, behaviour) when is_atom(module) and is_atom(behaviour) do
-    {_, bag} = data_tables_for(module, __ENV__.function, "")
+    {_, bag} = data_tables_for!(module, __ENV__.function, "")
 
     case check_module_for_overridable(bag, behaviour) do
       :ok ->
@@ -1652,7 +1652,7 @@ defmodule Module do
   @doc since: "1.10.0"
   @spec has_attribute?(module, atom) :: boolean
   def has_attribute?(module, key) when is_atom(module) and is_atom(key) do
-    {set, _bag} = data_tables_for(module, __ENV__.function, "")
+    {set, _bag} = data_tables_for!(module, __ENV__.function, "")
     :ets.member(set, key)
   end
 
@@ -1676,7 +1676,7 @@ defmodule Module do
   """
   @spec delete_attribute(module, atom) :: term
   def delete_attribute(module, key) when is_atom(module) and is_atom(key) do
-    {set, bag} = data_tables_for(module, __ENV__.function, "")
+    {set, bag} = data_tables_for!(module, __ENV__.function, "")
 
     case :ets.lookup(set, key) do
       [{_, _, :accumulate, traces}] ->
@@ -1730,7 +1730,7 @@ defmodule Module do
   @spec register_attribute(module, atom, [{:accumulate, boolean}, {:persist, boolean}]) :: :ok
   def register_attribute(module, attribute, options)
       when is_atom(module) and is_atom(attribute) and is_list(options) do
-    {set, bag} = data_tables_for(module, __ENV__.function, "")
+    {set, bag} = data_tables_for!(module, __ENV__.function, "")
 
     if Keyword.get(options, :persist) do
       :ets.insert(bag, {:persisted_attributes, attribute})
@@ -1789,7 +1789,7 @@ defmodule Module do
     if kind in [:defp, :defmacrop, :typep] do
       if doc, do: {:error, :private_doc}, else: :ok
     else
-      {set, _bag} = data_tables_for(module, __ENV__.function, "")
+      {set, _bag} = data_tables_for!(module, __ENV__.function, "")
       compile_doc(set, nil, line, kind, name, arity, signature, nil, doc, %{}, __ENV__, false)
       :ok
     end
@@ -1800,7 +1800,7 @@ defmodule Module do
   # This function is private and must be used only internally.
   def compile_definition_attributes(env, kind, name, args, _guards, body) do
     %{module: module} = env
-    {set, bag} = data_tables_for(module, __ENV__.function, "")
+    {set, bag} = data_tables_for!(module, __ENV__.function, "")
     {arity, defaults} = args_count(args, 0, 0)
 
     context = Keyword.get(:ets.lookup_element(set, {:def, {name, arity}}, 3), :context)
@@ -1986,7 +1986,7 @@ defmodule Module do
          function_name_arity
        ) do
     {set, bag} =
-      data_tables_for(
+      data_tables_for!(
         module,
         function_name_arity,
         "Use the Module.__info__/1 callback or Code.fetch_docs/1 instead"
@@ -2079,8 +2079,8 @@ defmodule Module do
   # Used internally by Kernel's @.
   # This function is private and must be used only internally.
   def __put_attribute__(module, key, value, warn_line, traces) when is_atom(key) do
-    {set, bag} = data_tables_for(module, {:put_attribute, 3}, "")
     assert_not_compiled!({:put_attribute, 3}, module, :writeable)
+    {set, bag} = data_tables_for!(module, {:put_attribute, 3}, "")
     put_attribute(module, key, value, warn_line, traces, set, bag)
     :ok
   end
@@ -2371,7 +2371,7 @@ defmodule Module do
     end
   end
 
-  defp data_tables_for(module, function_name_arity, message) do
+  defp data_tables_for!(module, function_name_arity, message) do
     try do
       :elixir_module.data_tables(module)
     catch

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -421,6 +421,12 @@ defmodule Module do
         end
       end
 
+  The function given to `on_load` should avoid calling functions from
+  other modules. If you must call functions in other modules and those
+  modules are defined within the same project, the called modules must
+  have the `@compile {:autoload, true}` annotation, so they are loaded
+  upfront (and not from within the `@on_load` callback).
+
   ### `@vsn`
 
   Specify the module version. Accepts any valid Elixir value, for example:

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -590,9 +590,11 @@ defmodule Module do
       name/arity pairs. Inlining is applied locally, calls from another
       module are not affected by this option
 
-    * `@compile {:autoload, false}` - disables automatic loading of
-      modules after compilation. Instead, the module will be loaded after
-      it is dispatched to
+    * `@compile {:autoload, true}` - configures if modules are automatically
+      loaded after definition. It defaults to `false` when compiling modules
+      to `.beam` files in disk (as the modules are then lazily loaded from
+      disk). If modules are not compiled to disk, then they are always loaded,
+      regardless of this flag
 
     * `@compile {:no_warn_undefined, Mod}` or
       `@compile {:no_warn_undefined, {Mod, fun, arity}}` - does not warn if

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -865,7 +865,7 @@ defmodule Module do
   end
 
   defp validated_eval_quoted(module, quoted, binding, env_or_opts) do
-    assert_not_compiled!({:eval_quoted, 4}, module)
+    assert_not_compiled!({:eval_quoted, 4}, module, :all)
     :elixir_def.reset_last(module)
     env = :elixir.env_for_eval(env_or_opts)
     {value, binding, _env} = :elixir.eval_quoted(quoted, binding, %{env | module: module})
@@ -1210,8 +1210,7 @@ defmodule Module do
   @spec defines?(module, definition) :: boolean
   def defines?(module, {name, arity} = tuple)
       when is_atom(module) and is_atom(name) and is_integer(arity) and arity >= 0 and arity <= 255 do
-    assert_not_compiled!(__ENV__.function, module, @extra_error_msg_defines?)
-    {set, _bag} = data_tables_for(module)
+    {set, _bag} = data_tables_for(module, __ENV__.function, @extra_error_msg_defines?)
     :ets.member(set, {:def, tuple})
   end
 
@@ -1238,9 +1237,7 @@ defmodule Module do
   def defines?(module, {name, arity} = tuple, def_kind)
       when is_atom(module) and is_atom(name) and is_integer(arity) and arity >= 0 and arity <= 255 and
              def_kind in [:def, :defp, :defmacro, :defmacrop] do
-    assert_not_compiled!(__ENV__.function, module, @extra_error_msg_defines?)
-
-    {set, _bag} = data_tables_for(module)
+    {set, _bag} = data_tables_for(module, __ENV__.function, @extra_error_msg_defines?)
 
     case :ets.lookup(set, {:def, tuple}) do
       [{_, ^def_kind, _, _, _, _}] -> true
@@ -1294,8 +1291,7 @@ defmodule Module do
   @doc since: "1.13.0"
   @spec attributes_in(module) :: [atom]
   def attributes_in(module) when is_atom(module) do
-    assert_not_compiled!(__ENV__.function, module)
-    {set, _} = data_tables_for(module)
+    {set, _} = data_tables_for(module, __ENV__.function, "")
     :ets.select(set, [{{:"$1", :_, :_, :_}, [{:is_atom, :"$1"}], [:"$1"]}])
   end
 
@@ -1323,7 +1319,7 @@ defmodule Module do
   @doc since: "1.13.0"
   @spec overridables_in(module) :: [atom]
   def overridables_in(module) when is_atom(module) do
-    assert_not_compiled!(__ENV__.function, module)
+    assert_not_compiled!(__ENV__.function, module, :all)
     :elixir_overridable.overridables_for(module)
   end
 
@@ -1348,8 +1344,7 @@ defmodule Module do
   """
   @spec definitions_in(module) :: [definition]
   def definitions_in(module) when is_atom(module) do
-    assert_not_compiled!(__ENV__.function, module, @extra_error_msg_definitions_in)
-    {_, bag} = data_tables_for(module)
+    {_, bag} = data_tables_for(module, __ENV__.function, @extra_error_msg_definitions_in)
     bag_lookup_element(bag, :defs, 2)
   end
 
@@ -1373,8 +1368,7 @@ defmodule Module do
   @spec definitions_in(module, def_kind) :: [definition]
   def definitions_in(module, kind)
       when is_atom(module) and kind in [:def, :defp, :defmacro, :defmacrop] do
-    assert_not_compiled!(__ENV__.function, module, @extra_error_msg_definitions_in)
-    {set, _} = data_tables_for(module)
+    {set, _} = data_tables_for(module, __ENV__.function, @extra_error_msg_definitions_in)
     :ets.select(set, [{{{:def, :"$1"}, kind, :_, :_, :_, :_}, [], [:"$1"]}])
   end
 
@@ -1408,8 +1402,7 @@ defmodule Module do
   @doc since: "1.12.0"
   def get_definition(module, {name, arity}, options \\ [])
       when is_atom(module) and is_atom(name) and is_integer(arity) and is_list(options) do
-    assert_not_compiled!(__ENV__.function, module, "")
-    {set, bag} = data_tables_for(module)
+    {set, bag} = data_tables_for(module, __ENV__.function, "")
 
     case :ets.lookup(set, {:def, {name, arity}}) do
       [{_key, kind, meta, _, _, _}] ->
@@ -1435,7 +1428,7 @@ defmodule Module do
   @spec delete_definition(module, definition) :: boolean()
   def delete_definition(module, {name, arity})
       when is_atom(module) and is_atom(name) and is_integer(arity) do
-    assert_not_readonly!(__ENV__.function, module)
+    assert_not_compiled!(__ENV__.function, module, :writeable)
     :elixir_def.take_definition(module, {name, arity}) != false
   end
 
@@ -1453,7 +1446,7 @@ defmodule Module do
   """
   @spec make_overridable(module, [definition]) :: :ok
   def make_overridable(module, tuples) when is_atom(module) and is_list(tuples) do
-    assert_not_readonly!(__ENV__.function, module)
+    assert_not_compiled!(__ENV__.function, module, :writeable)
 
     func = fn
       {function_name, arity} = tuple
@@ -1479,7 +1472,9 @@ defmodule Module do
 
   @spec make_overridable(module, module) :: :ok
   def make_overridable(module, behaviour) when is_atom(module) and is_atom(behaviour) do
-    case check_module_for_overridable(module, behaviour) do
+    {_, bag} = data_tables_for(module, __ENV__.function, "")
+
+    case check_module_for_overridable(bag, behaviour) do
       :ok ->
         :ok
 
@@ -1499,8 +1494,7 @@ defmodule Module do
     make_overridable(module, tuples)
   end
 
-  defp check_module_for_overridable(module, behaviour) do
-    {_, bag} = data_tables_for(module)
+  defp check_module_for_overridable(bag, behaviour) do
     behaviour_definitions = bag_lookup_element(bag, {:accumulate, :behaviour}, 2)
 
     cond do
@@ -1658,9 +1652,7 @@ defmodule Module do
   @doc since: "1.10.0"
   @spec has_attribute?(module, atom) :: boolean
   def has_attribute?(module, key) when is_atom(module) and is_atom(key) do
-    assert_not_compiled!(__ENV__.function, module)
-    {set, _bag} = data_tables_for(module)
-
+    {set, _bag} = data_tables_for(module, __ENV__.function, "")
     :ets.member(set, key)
   end
 
@@ -1684,8 +1676,7 @@ defmodule Module do
   """
   @spec delete_attribute(module, atom) :: term
   def delete_attribute(module, key) when is_atom(module) and is_atom(key) do
-    assert_not_readonly!(__ENV__.function, module)
-    {set, bag} = data_tables_for(module)
+    {set, bag} = data_tables_for(module, __ENV__.function, "")
 
     case :ets.lookup(set, key) do
       [{_, _, :accumulate, traces}] ->
@@ -1739,8 +1730,7 @@ defmodule Module do
   @spec register_attribute(module, atom, [{:accumulate, boolean}, {:persist, boolean}]) :: :ok
   def register_attribute(module, attribute, options)
       when is_atom(module) and is_atom(attribute) and is_list(options) do
-    assert_not_readonly!(__ENV__.function, module)
-    {set, bag} = data_tables_for(module)
+    {set, bag} = data_tables_for(module, __ENV__.function, "")
 
     if Keyword.get(options, :persist) do
       :ets.insert(bag, {:persisted_attributes, attribute})
@@ -1796,12 +1786,10 @@ defmodule Module do
   @doc false
   @deprecated "Use @doc instead"
   def add_doc(module, line, kind, {name, arity}, signature \\ [], doc) do
-    assert_not_compiled!(__ENV__.function, module)
-
     if kind in [:defp, :defmacrop, :typep] do
       if doc, do: {:error, :private_doc}, else: :ok
     else
-      {set, _bag} = data_tables_for(module)
+      {set, _bag} = data_tables_for(module, __ENV__.function, "")
       compile_doc(set, nil, line, kind, name, arity, signature, nil, doc, %{}, __ENV__, false)
       :ok
     end
@@ -1812,7 +1800,7 @@ defmodule Module do
   # This function is private and must be used only internally.
   def compile_definition_attributes(env, kind, name, args, _guards, body) do
     %{module: module} = env
-    {set, bag} = data_tables_for(module)
+    {set, bag} = data_tables_for(module, __ENV__.function, "")
     {arity, defaults} = args_count(args, 0, 0)
 
     context = Keyword.get(:ets.lookup_element(set, {:def, {name, arity}}, 3), :context)
@@ -1997,13 +1985,12 @@ defmodule Module do
          default,
          function_name_arity
        ) do
-    assert_not_compiled!(
-      function_name_arity,
-      module,
-      "Use the Module.__info__/1 callback or Code.fetch_docs/1 instead"
-    )
-
-    {set, bag} = data_tables_for(module)
+    {set, bag} =
+      data_tables_for(
+        module,
+        function_name_arity,
+        "Use the Module.__info__/1 callback or Code.fetch_docs/1 instead"
+      )
 
     case :ets.lookup(set, key) do
       [{_, _, :unset, _}] ->
@@ -2092,8 +2079,8 @@ defmodule Module do
   # Used internally by Kernel's @.
   # This function is private and must be used only internally.
   def __put_attribute__(module, key, value, warn_line, traces) when is_atom(key) do
-    assert_not_readonly!({:put_attribute, 3}, module)
-    {set, bag} = data_tables_for(module)
+    {set, bag} = data_tables_for(module, {:put_attribute, 3}, "")
+    assert_not_compiled!({:put_attribute, 3}, module, :writeable)
     put_attribute(module, key, value, warn_line, traces, set, bag)
     :ok
   end
@@ -2384,8 +2371,13 @@ defmodule Module do
     end
   end
 
-  defp data_tables_for(module) do
-    :elixir_module.data_tables(module)
+  defp data_tables_for(module, function_name_arity, message) do
+    try do
+      :elixir_module.data_tables(module)
+    catch
+      :error, :badarg ->
+        raise ArgumentError, assert_not_compiled_message(function_name_arity, module, message)
+    end
   end
 
   defp bag_lookup_element(table, key, pos) do
@@ -2394,18 +2386,15 @@ defmodule Module do
     :error, :badarg -> []
   end
 
-  defp assert_not_compiled!(function_name_arity, module, extra_msg \\ "") do
-    open?(module) ||
-      raise ArgumentError,
-            assert_not_compiled_message(function_name_arity, module, extra_msg)
-  end
-
-  defp assert_not_readonly!({function_name, arity}, module) do
+  defp assert_not_compiled!({function_name, arity}, module, mode) do
     case :elixir_module.mode(module) do
       :all ->
         :ok
 
-      :readonly ->
+      :readonly when mode == :all ->
+        :ok
+
+      :readonly when mode == :writeable ->
         raise ArgumentError,
               "could not call Module.#{function_name}/#{arity} because the module " <>
                 "#{inspect(module)} is in read-only mode (@after_compile)"

--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -1041,6 +1041,8 @@ defmodule Module.Types.Apply do
   end
 
   def format_diagnostic({:undefined, {:badfunction, _}, module, fun, arity}) do
+    _ = Code.ensure_loaded(module)
+
     %{
       message:
         IO.iodata_to_binary([

--- a/lib/elixir/src/elixir_erl_compiler.erl
+++ b/lib/elixir/src/elixir_erl_compiler.erl
@@ -8,6 +8,7 @@
 
 spawn(Fun) ->
   CompilerInfo = get(elixir_compiler_info),
+  {error_handler, ErrorHandler} = erlang:process_info(self(), error_handler),
 
   CodeDiagnostics =
     case get(elixir_code_diagnostics) of
@@ -17,6 +18,7 @@ spawn(Fun) ->
 
   {_, Ref} =
     spawn_monitor(fun() ->
+      erlang:process_flag(error_handler, ErrorHandler),
       put(elixir_compiler_info, CompilerInfo),
       put(elixir_code_diagnostics, CodeDiagnostics),
 

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -159,7 +159,7 @@ compile(Meta, Module, ModuleAsCharlist, Block, Vars, Prune, E) ->
     put_compiler_modules([Module | CompilerModules]),
     {Result, ModuleE, CallbackE} = eval_form(Line, Module, DataBag, Block, Vars, Prune, E),
     CheckerInfo = checker_info(),
-    BeamLocation = beam_location(ModuleAsCharlist),
+    {BeamLocation, Forceload} = beam_location(ModuleAsCharlist),
 
     {Binary, PersistedAttributes, Autoload} =
       elixir_erl_compiler:spawn(fun() ->
@@ -219,7 +219,7 @@ compile(Meta, Module, ModuleAsCharlist, Block, Vars, Prune, E) ->
 
         compile_error_if_tainted(DataSet, E),
         Binary = elixir_erl:compile(ModuleMap),
-        Autoload = proplists:get_value(autoload, CompileOpts, false) or load_module(Module),
+        Autoload = Forceload or proplists:get_value(autoload, CompileOpts, false),
         spawn_parallel_checker(CheckerInfo, Module, ModuleMap, BeamLocation),
         {Binary, PersistedAttributes, Autoload}
       end),
@@ -550,10 +550,11 @@ bag_lookup_element(Table, Name, Pos) ->
 
 beam_location(ModuleAsCharlist) ->
   case get(elixir_compiler_dest) of
-    Dest when is_binary(Dest) ->
-      filename:join(elixir_utils:characters_to_list(Dest), ModuleAsCharlist ++ ".beam");
+    {Dest, Forceload} when is_binary(Dest) ->
+      {filename:join(elixir_utils:characters_to_list(Dest), ModuleAsCharlist ++ ".beam"),
+       Forceload};
     _ ->
-      ""
+      {"", true}
   end.
 
 %% Integration with elixir_compiler that makes the module available
@@ -589,16 +590,6 @@ make_module_available(Module, Binary, Loaded) ->
       Ref = make_ref(),
       PID ! {module_available, self(), Ref, get(elixir_compiler_file), Module, Binary, Loaded},
       receive {Ref, ack} -> ok end
-  end.
-
-load_module(Module) ->
-  case get(elixir_compiler_info) of
-    undefined ->
-      true;
-    {PID, _} ->
-      Ref = make_ref(),
-      PID ! {'load_module?', self(), Ref, Module},
-      receive {Ref, Boolean} -> Boolean end
   end.
 
 %% Error handling and helpers.

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -203,14 +203,6 @@ defmodule ModuleTest do
     assert @other_attribute == [3, 2, 1]
   end
 
-  test "@compile autoload attribute" do
-    defmodule NoAutoload do
-      @compile {:autoload, false}
-    end
-
-    refute Code.loaded?(NoAutoload)
-  end
-
   ## Naming
 
   test "concat" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1712,7 +1712,7 @@ defmodule IEx.HelpersTest do
     Enum.each(mods, fn mod ->
       File.rm("#{mod}.beam")
       :code.purge(mod)
-      true = :code.delete(mod)
+      :code.delete(mod)
     end)
   end
 

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -611,7 +611,7 @@ defmodule Mix.Compilers.Elixir do
           for {module, _} <- dep_modules, reduce: {exports, []} do
             {exports, new_exports} ->
               export =
-                if function_exported?(module, :__info__, 1) do
+                if Code.ensure_loaded?(module) and function_exported?(module, :__info__, 1) do
                   module.__info__(:exports_md5)
                 end
 

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -180,9 +180,6 @@ defmodule Mix.Compilers.Elixir do
       end
 
       Mix.Project.ensure_structure()
-
-      # We don't want to cache this path as we will write to it
-      true = Code.prepend_path(dest)
       previous_opts = set_compiler_opts(opts)
 
       try do

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -56,6 +56,7 @@ defmodule Mix.Compilers.Elixir do
     # Prepend ourselves early because of __mix_recompile__? checks
     # and also that, in case of nothing compiled, we already need
     # ourselves available in the path.
+    File.mkdir_p!(dest)
     Code.prepend_path(dest)
 
     # If modules have been added or removed from the Erlang compiler,

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -316,7 +316,7 @@ defmodule Mix.Tasks.Deps.Compile do
   defp do_make(dep, config) do
     command = make_command(dep)
     shell_cmd!(dep, config, command, [{"IS_DEP", "1"}])
-    build_structure(dep, config)
+    build_symlink_structure(dep, config)
     true
   end
 
@@ -345,7 +345,7 @@ defmodule Mix.Tasks.Deps.Compile do
   defp do_compile(%Mix.Dep{opts: opts} = dep, config) do
     if command = opts[:compile] do
       shell_cmd!(dep, config, command)
-      build_structure(dep, config)
+      build_symlink_structure(dep, config)
       true
     else
       false
@@ -369,7 +369,7 @@ defmodule Mix.Tasks.Deps.Compile do
     [env: env, cd: opts[:dest]]
   end
 
-  defp build_structure(%Mix.Dep{opts: opts}, config) do
+  defp build_symlink_structure(%Mix.Dep{opts: opts}, config) do
     config = Keyword.put(config, :deps_app_path, opts[:build])
     Mix.Project.build_structure(config, symlink_ebin: true, source: opts[:dest])
     Code.prepend_path(Path.join(opts[:build], "ebin"), cache: true)

--- a/lib/mix/test/mix/tasks/app.config_test.exs
+++ b/lib/mix/test/mix/tasks/app.config_test.exs
@@ -84,7 +84,7 @@ defmodule Mix.Tasks.App.ConfigTest do
       Mix.Project.push(MixTest.Case.Sample)
 
       Mix.Task.run("app.config", ["--no-compile"])
-      refute Code.loaded?(A)
+      refute Code.ensure_loaded?(A)
       refute File.regular?("_build/dev/lib/sample/ebin/Elixir.A.beam")
       refute File.regular?("_build/dev/lib/sample/ebin/sample.app")
 
@@ -92,7 +92,7 @@ defmodule Mix.Tasks.App.ConfigTest do
       assert File.regular?("_build/dev/lib/sample/ebin/Elixir.A.beam")
       assert File.regular?("_build/dev/lib/sample/ebin/sample.app")
 
-      assert Code.loaded?(A)
+      assert Code.ensure_loaded?(A)
       purge([A])
 
       Mix.Task.rerun("app.config", [])

--- a/lib/mix/test/mix/tasks/app.start_test.exs
+++ b/lib/mix/test/mix/tasks/app.start_test.exs
@@ -36,10 +36,9 @@ defmodule Mix.Tasks.App.StartTest do
       assert File.regular?("_build/dev/lib/app_start_sample/ebin/Elixir.A.beam")
       assert File.regular?("_build/dev/lib/app_start_sample/ebin/app_start_sample.app")
 
-      assert Code.loaded?(A)
+      refute Code.loaded?(A)
       refute List.keyfind(Application.started_applications(), :app_start_sample, 0)
       assert List.keyfind(Application.started_applications(), :logger, 0)
-      purge([A])
 
       Mix.Task.reenable("app.config")
       Mix.Task.reenable("app.start")

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -155,6 +155,8 @@ defmodule Mix.Tasks.ArchiveTest do
       true = Application.compile_env!(:git_repo, :archive_config)
 
       defmodule GitRepo.Archive do
+        @compile {:autoload, true}
+
         def hello do
           "World"
         end

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -1200,7 +1200,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       assert Mix.Tasks.Compile.Elixir.run(["--verbose", "--ignore-module-conflict"]) == {:ok, []}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
-      refute function_exported?(A, :one, 0)
+      refute Code.ensure_loaded?(A) and function_exported?(A, :one, 0)
 
       Mix.shell().flush()
       purge([A])
@@ -1209,7 +1209,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       Mix.Tasks.Compile.Elixir.run(["--verbose"])
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
-      assert function_exported?(A, :one, 0)
+      assert Code.ensure_loaded?(A) and function_exported?(A, :one, 0)
     end)
   end
 

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -1278,19 +1278,10 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       end
       """)
 
-      File.write!("lib/c.ex", """
-      defmodule C do
-        @compile {:autoload, false}
-
-        def __mix_recompile__?(), do: true
-      end
-      """)
-
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
-      assert_received {:mix_shell, :info, ["Compiling 3 files (.ex)"]}
+      assert_received {:mix_shell, :info, ["Compiling 2 files (.ex)"]}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
-      assert_received {:mix_shell, :info, ["Compiled lib/c.ex"]}
 
       # Mix recompile should work even if the compile path
       # was removed and the module purged


### PR DESCRIPTION
Prior to this pull request, Elixir would load modules as soon as
they were defined. However, because Erlang code loading
happens within a single process (the code server), this would
make it a bottleneck, reducing the amount of parallelization.

This pull request makes it so modules are loaded lazily. This
reduces the pressure on the code server, making compilation
up to 2x faster for large projects, and also reduces the amount
of overall work done.

Implementation wise, the parallel compiler already acts as a
mechanism to resolve modules during compilation, so we build
on that. This has the additional benefit of making compilation more
consistent: `Code.ensure_loaded` will be less dependent on the
order code is compiled.

The only potential regression in this approach happens if you
have `@on_load` callbacks which depends on other modules
defined in the same project and is loaded at compile-time.
Setting `@compile {:autoload, true}` addresses those cases
in a forward and backwards compatible manner.