### PR TITLE
Use t:Calendar.microsecond/0 in Duration docs

### DIFF
--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -116,7 +116,7 @@ defmodule Duration do
           hour: integer,
           minute: integer,
           second: integer,
-          microsecond: {integer, 0..6}
+          microsecond: Calendar.microsecond()
         }
 
   @typedoc """
@@ -130,7 +130,7 @@ defmodule Duration do
           | {:hour, integer}
           | {:minute, integer}
           | {:second, integer}
-          | {:microsecond, {integer, 0..6}}
+          | {:microsecond, Calendar.microsecond()}
 
   @typedoc """
   The duration type specifies a `%Duration{}` struct or a keyword list of valid duration unit pairs.


### PR DESCRIPTION
The "circular dependency" is only for Dialyzer for now so I think this is okay.