### PR TITLE
docs: fix inverted markdown link format in Mix.Tasks.Xref

### DIFF
--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -383,7 +383,7 @@ defmodule Mix.Tasks.Xref do
           lib/b.ex
           lib/a.ex (compile)
 
-  More precisely, `xref` is printing the (strongly connected components)[https://en.wikipedia.org/wiki/Strongly_connected_component]
+  More precisely, `xref` is printing the [strongly connected components](https://en.wikipedia.org/wiki/Strongly_connected_component)
   in the dependency graph, which is (roughly speaking) the largest set of
   files which are part of a dependency cycle involving these files.
 


### PR DESCRIPTION
Fix the markdown link syntax for "strongly connected components" on line 386. The link was incorrectly formatted as (text)[url] instead of the proper markdown format [text](url), which caused it to render incorrectly in the generated documentation.

This fix ensures the link will properly render as a clickable hyperlink when the documentation is generated, improving the user experience for developers consulting the Mix.Tasks.Xref documentation.