### PR TITLE
Add two missed assertions to application tests

### DIFF
--- a/lib/elixir/test/elixir/application_test.exs
+++ b/lib/elixir/test/elixir/application_test.exs
@@ -82,6 +82,7 @@ defmodule ApplicationTest do
       assert Application.put_env(:elixir, :unknown, nested: [key: :value]) == :ok
 
       assert compile_env(@app, :unknown, :default) == [nested: [key: :value]]
+      assert_received {:compile_env, :elixir, [:unknown], {:ok, [nested: [key: :value]]}}
       assert compile_env(:elixir, :unknown, :default) == [nested: [key: :value]]
       assert_received {:compile_env, :elixir, [:unknown], {:ok, [nested: [key: :value]]}}
 
@@ -89,6 +90,7 @@ defmodule ApplicationTest do
       assert_received {:compile_env, :elixir, [:unknown], {:ok, [nested: [key: :value]]}}
 
       assert compile_env!(@app, :unknown) == [nested: [key: :value]]
+      assert_received {:compile_env, :elixir, [:unknown], {:ok, [nested: [key: :value]]}}
       assert compile_env!(:elixir, :unknown) == [nested: [key: :value]]
       assert_received {:compile_env, :elixir, [:unknown], {:ok, [nested: [key: :value]]}}
 


### PR DESCRIPTION
I'm not sure why here are two identical tests(with `@app` and `:elixir`, which the same), but we expect the message only once, and if something bad is sent from `assert compile_env(:elixir, :unknown, :default) == [nested: [key: :value]]`, we will check the right message from `assert compile_env(@app, :unknown, :default) == [nested: [key: :value]]` and this will be a false positive result.