### PR TITLE
Adjust examples in `String.codepoints/1`

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1802,8 +1802,8 @@ defmodule String do
       iex> String.codepoints("olá")
       ["o", "l", "á"]
 
-      iex> String.codepoints("оптими зации")
-      ["о", "п", "т", "и", "м", "и", " ", "з", "а", "ц", "и", "и"]
+      iex> String.codepoints("оптимі зації")
+      ["о", "п", "т", "и", "м", "і", " ", "з", "а", "ц", "і", "ї"]
 
       iex> String.codepoints("ἅἪῼ")
       ["ἅ", "Ἢ", "ῼ"]


### PR DESCRIPTION
Replace Russian "оптимизации" (eng. optimisations, added [here](https://github.com/elixir-lang/elixir/commit/802d5ebc00cb9ad47992d0ac624af83bba8afc32)) with Ukrainian "оптимізації" in `String.codepoints/1` examples.

It includes more Cyrillic characters like "ї" and "і" (distinct from the Latin "i" in Unicode), and will also bring a tiny smile to Ukrainian developers during these difficult times 💙💛