### PR TITLE
Make `--min-cycle-size` in `mix xref graph` inclusive

### DIFF
--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -1213,7 +1213,7 @@ defmodule Mix.Tasks.Xref do
 
     cycles =
       if min = opts[:min_cycle_size] do
-        Enum.filter(cycles, &(elem(&1, 0) > min))
+        Enum.filter(cycles, &(elem(&1, 0) >= min))
       else
         cycles
       end

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -539,17 +539,28 @@ defmodule Mix.Tasks.XrefTest do
         assert_graph(["--format", "cycles", "--fail-above", "0"], """
         1 cycles found. Showing them in decreasing size:
 
-        Cycle of length 3:
+        Cycle of length 2:
 
-            lib/b.ex
-            lib/a.ex
+            lib/a.ex (compile)
             lib/b.ex
 
         """)
       end
     end
 
-    test "cycles with min cycle size" do
+    test "cycles with min_cycle_size matching actual length" do
+      assert_graph(["--format", "cycles", "--min-cycle-size", "2"], """
+      1 cycles found. Showing them in decreasing size:
+
+      Cycle of length 2:
+
+          lib/a.ex (compile)
+          lib/b.ex
+
+      """)
+    end
+
+    test "cycles with min_cycle_size greater than actual length" do
       assert_graph(["--format", "cycles", "--min-cycle-size", "3"], """
       No cycles found
       """)


### PR DESCRIPTION
This pull request fixes the behavior of the `--min-cycle-size` option in `mix xref graph --format cycles`.

Previously, cycles with a size equal to the specified minimum were excluded.
For example, running `mix xref graph --format cycles --min-cycle-size 2` would only include cycles of size >= 3, which is unintuitive and inconsistent with the option name.

This change updates the behavior to be inclusive, so that `--min-cycle-size 2` includes **all cycles of size >= 2**, as expected.

Fixes: #14474