### PR TITLE
Enum scan improvements

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -247,7 +247,7 @@ defmodule Application do
   invoked if it hasn't been done yet. Then, it checks if the dependencies listed
   in the `applications` key of the resource file are already started. Having at
   least one dependency not started is an error condition. Functions like
-  `ensure_all_started/1` takes care of starting an application and all of its
+  `ensure_all_started/1` take care of starting an application and all of its
   dependencies for you.
 
   If the application does not have a callback module configured, starting is

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2903,6 +2903,7 @@ defmodule Enum do
   Passes the given `acc` as the second argument for the `fun` with the first element.
 
   ## Examples
+
       iex> Enum.scan(["a", "b", "c", "d", "e"], "_", &(&1 <> String.first(&2)))
       ["a_", "ba", "cb", "dc", "ed"]
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2864,12 +2864,15 @@ defmodule Enum do
   end
 
   @doc """
-  Applies the given function to each element in the `enumerable`,
-  storing the result in a list and passing it as the accumulator
-  for the next computation. Uses the first element in the `enumerable`
-  as the starting value.
+  Passes each element from `enumerable` to the `fun` as the first argument,
+  stores the `fun` result in a list and passes the result as the second argument
+  for the next computation. The `fun` isn't applied for the first element
+  of the `enumerable`, the element is taken as it is.
 
   ## Examples
+
+      iex> Enum.scan(["a", "b", "c", "d", "e"], &(&1 <> String.first(&2)))
+      ["a", "ba", "cb", "dc", "ed"]
 
       iex> Enum.scan(1..5, &(&1 + &2))
       [1, 3, 6, 10, 15]

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2896,11 +2896,15 @@ defmodule Enum do
   end
 
   @doc """
-  Applies the given function to each element in the `enumerable`,
-  storing the result in a list and passing it as the accumulator
-  for the next computation. Uses the given `acc` as the starting value.
+  Passes each element from `enumerable` to the `fun` as the first argument,
+  stores the `fun` result in a list and passes the result as the second argument
+  for the next computation.
+
+  Passes the given `acc` as the second argument for the `fun` with the first element.
 
   ## Examples
+      iex> Enum.scan(["a", "b", "c", "d", "e"], "_", &(&1 <> String.first(&2)))
+      ["a_", "ba", "cb", "dc", "ed"]
 
       iex> Enum.scan(1..5, 0, &(&1 + &2))
       [1, 3, 6, 10, 15]

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2873,10 +2873,10 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.scan(["a", "b", "c", "d", "e"], &(&1 <> String.first(&2)))
+      iex> Enum.scan(["a", "b", "c", "d", "e"], fn element, acc -> element <> String.first(acc) end)
       ["a", "ba", "cb", "dc", "ed"]
 
-      iex> Enum.scan(1..5, &(&1 + &2))
+      iex> Enum.scan(1..5, fn element, acc -> element + acc end)
       [1, 3, 6, 10, 15]
 
   """
@@ -2904,10 +2904,10 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.scan(["a", "b", "c", "d", "e"], "_", &(&1 <> String.first(&2)))
+      iex> Enum.scan(["a", "b", "c", "d", "e"], "_", fn element, acc -> element <> String.first(acc) end)
       ["a_", "ba", "cb", "dc", "ed"]
 
-      iex> Enum.scan(1..5, 0, &(&1 + &2))
+      iex> Enum.scan(1..5, 0, fn element, acc -> element + acc end)
       [1, 3, 6, 10, 15]
 
   """

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2866,8 +2866,10 @@ defmodule Enum do
   @doc """
   Passes each element from `enumerable` to the `fun` as the first argument,
   stores the `fun` result in a list and passes the result as the second argument
-  for the next computation. The `fun` isn't applied for the first element
-  of the `enumerable`, the element is taken as it is.
+  for the next computation.
+
+  The `fun` isn't applied for the first element of the `enumerable`,
+  the element is taken as it is.
 
   ## Examples
 


### PR DESCRIPTION
It wasn't available to define arguments order in `fun` from docs and doctests, so I think it should be said excplicitly