### PR TITLE
Optimize Enum.count_until/2-3

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -4337,13 +4337,19 @@ defmodule Enum do
   end
 
   defp count_until_enum(enumerable, limit) do
-    Enumerable.reduce(enumerable, {:cont, 0}, fn _entry, acc ->
-      case acc + 1 do
-        ^limit -> {:halt, limit}
-        acc -> {:cont, acc}
-      end
-    end)
-    |> elem(1)
+    case Enumerable.count(enumerable) do
+      {:ok, value} ->
+        Kernel.min(value, limit)
+
+      {:error, module} ->
+        module.reduce(enumerable, {:cont, 0}, fn _entry, acc ->
+          case acc + 1 do
+            ^limit -> {:halt, limit}
+            acc -> {:cont, acc}
+          end
+        end)
+        |> elem(1)
+    end
   end
 
   @compile {:inline, count_until_list: 4}


### PR DESCRIPTION
Benchmarks show an important impact for both [count_until/2](https://github.com/sabiwara/elixir_benches/commit/b2e3f35f0df44dfbad8cd5c4a3b80fc2) and [count_until/3](https://github.com/sabiwara/elixir_benches/commit/d3bfaf575889c10317508905b3f5034e7a0eb3aa)