### PR TITLE
exunit.case docs: parameterize violates the "never run concurrently" async docs

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -12,7 +12,8 @@ defmodule ExUnit.Case do
   When used, it accepts the following options:
 
     * `:async` - configures tests in this module to run concurrently with
-      tests in other modules. Tests in the same module never run concurrently.
+      tests in other modules. Tests in the same module never run concurrently
+      (with the exception of tests run via the `:parameterize` option - see below).
       It should be enabled only if tests do not change any global state.
       Defaults to `false`.
 


### PR DESCRIPTION
the strong "never" in async is contradicted by the new `parameterize` setting