### PR TITLE
Add String.lines/1

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -574,6 +574,38 @@ defmodule String do
     end
   end
 
+  @doc ~S"""
+  Returns the list of lines in a string, preserving their line endings.
+
+  If you would like the lines without their line endings, use
+  `String.split(string, ["\r\n", "\n"])`.
+
+  ## Examples
+
+      iex> String.lines("foo\r\nbar\r\nbaz")
+      ["foo\r\n", "bar\r\n", "baz"]
+
+      iex> String.lines("foo\nbar\nbaz")
+      ["foo\n", "bar\n", "baz"]
+
+      iex> String.lines("")
+      [""]
+
+  """
+  @doc since: "1.19.0"
+  def lines(string) do
+    lines(string, <<>>)
+  end
+
+  def lines(<<?\n, rest::binary>>, acc),
+    do: [<<acc::binary, ?\n>> | lines(rest, <<>>)]
+
+  def lines(<<char, rest::binary>>, acc),
+    do: lines(rest, <<acc::binary, char>>)
+
+  def lines(<<>>, acc),
+    do: [acc]
+
   @doc """
   Returns an enumerable that splits a string on demand.
 


### PR DESCRIPTION
Inspired by `String#lines` in Ruby and `string.splitlines(True)` in Python.