### PR TITLE
Module docs: make section references into links

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -23,20 +23,20 @@ defmodule Module do
   ### `@after_compile`
 
   A hook that will be invoked right after the current module is compiled.
-  Accepts a module or a `{module, function_name}`. See the "Compile callbacks"
+  Accepts a module or a `{module, function_name}`. See the ["Compile callbacks"](#module-compile-callbacks)
   section below.
 
   ### `@after_verify` (since v1.14.0)
 
   A hook that will be invoked right after the current module is verified for
   undefined functions, deprecations, etc. Accepts a module or a `{module, function_name}`.
-  See the "Compile callbacks" section below.
+  See the ["Compile callbacks"](#module-compile-callbacks) section below.
 
   ### `@before_compile`
 
   A hook that will be invoked before the module is compiled.
   Accepts a module or a `{module, function_or_macro_name}` tuple.
-  See the "Compile callbacks" section below.
+  See the ["Compile callbacks"](#module-compile-callbacks) section below.
 
   ### `@behaviour`
 
@@ -124,7 +124,7 @@ defmodule Module do
   ### `@compile`
 
   Defines options for module compilation. This is used to configure
-  both Elixir and Erlang compilers, as any other compilation pass
+  both Elixir and Erlang compilers, as well as any other compilation pass
   added by external tools. For example:
 
       defmodule MyModule do
@@ -136,7 +136,7 @@ defmodule Module do
       end
 
   Multiple uses of `@compile` will accumulate instead of overriding
-  previous ones. See the "Compile options" section below.
+  previous ones. See the ["Compile options"](#module-compile-options) section below.
 
   ### `@deprecated` (since v1.6.0)
 
@@ -726,7 +726,7 @@ defmodule Module do
   @doc """
   Returns information about module attributes used by Elixir.
 
-  See the "Module attributes" section in the module documentation for more
+  See the ["Module attributes"](#module-module-attributes) section in the module documentation for more
   information on each attribute.
 
   ## Examples


### PR DESCRIPTION
also corrects a typo

verified the section links are formatted correctly with local spin through `make docs`