### PR TITLE
mix release: Fix RELEASE_SYS_CONFIG for Windows 11

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -362,8 +362,8 @@ defmodule Mix.Tasks.Release.Init do
     if not "!REL_GOTO!" == "" (
       findstr "RUNTIME_CONFIG=true" "!RELEASE_SYS_CONFIG!.config" >nul 2>&1 && (
         set DEFAULT_SYS_CONFIG=!RELEASE_SYS_CONFIG!
-        for /f "skip=1" %%X in ('wmic os get localdatetime') do if not defined TIMESTAMP set TIMESTAMP=%%X
-        set RELEASE_SYS_CONFIG=!RELEASE_TMP!\!RELEASE_NAME!-!RELEASE_VSN!-!TIMESTAMP:~0,11!-!RANDOM!.runtime
+        set "TIMESTAMP=%TIME::=%"
+        set RELEASE_SYS_CONFIG=!RELEASE_TMP!\!RELEASE_NAME!-!RELEASE_VSN!-!TIMESTAMP!-!RANDOM!.runtime
         mkdir "!RELEASE_TMP!" >nul 2>&1
         copy /y "!DEFAULT_SYS_CONFIG!.config" "!RELEASE_SYS_CONFIG!.config" >nul || (
           echo Cannot start release because it could not write to "!RELEASE_SYS_CONFIG!.config"


### PR DESCRIPTION
wmic is no longer available on Windows 11.

As a reminder, this codepath is only hit when setting:

    reboot_system_after_config: true

So I'd guess few users were affected.
