### PR TITLE
Improve function head error to be clear that pattern matching is not allowed

### DIFF
--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -508,6 +508,8 @@ format_error({invalid_def, Kind, NameAndArgs}) ->
 format_error(invalid_args_for_function_head) ->
   "only variables and \\\\ are allowed as arguments in function head.\n"
   "\n"
+  "Check that there is no use of pattern matching in the function head.\n"
+  "\n"
   "If you did not intend to define a function head, make sure your function "
   "definition has the proper syntax by wrapping the arguments in parentheses "
   "and using the do instruction accordingly:\n\n"


### PR DESCRIPTION
The inspiration for this change was this post: https://elixirforum.com/t/beginner-question-regarding-default-args-in-functions/70867

Specifically this comment from the original poster: https://elixirforum.com/t/beginner-question-regarding-default-args-in-functions/70867/5

While the error message excludes pattern matching in a function head by virtue of it not being in the list of allowed values, it's clear that this can be overlooked as people can see the pattern matched variables as variables and overlook the pattern matching constructs.

I've added a brief line to the error message to clarify that pattern matching is not allowed in function heads.