### PR TITLE
Minor documentation update - explicit mention of PID in `GenServer.call/3`

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -1112,8 +1112,8 @@ defmodule GenServer do
   arrives or a timeout occurs. `c:handle_call/3` will be called on the server
   to handle the request.
 
-  `server` can be any of the values described in the "Name registration"
-  section of the documentation for this module.
+  `server` can be a PID or any of the other values described in the
+  "Name registration" section of the documentation for this module.
 
   ## Timeouts
 


### PR DESCRIPTION
This PR comes as a result of discussion in [elixirforum thread](https://elixirforum.com/t/multiple-liveviews-on-the-same-page-sharing-data/70941) where the documentation for `GenServer.call/3` was found to be lacking explicit mention of PID as a valid value for the `server` argument. Documentation sends reader to "Name registration" section, which in its vast majority covers the subject of naming and registering GenServers. While it in fact mentions the possibility of using PID in one of the paragraphs, it is arguably better to make a distinction as PID is neither a "name" nor something that the user can "register". This change should make it clear for situations where only PID is available, without deep referring to another section of the documentation, potentially overlooking the single mention of PID there.