### PR TITLE
Do not use Access protocol on values that may be structs when normalizing erlang errors

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -2541,7 +2541,7 @@ defmodule ErlangError do
             is_map(module) and is_atom(function) and is_map_key(module, function) ->
               "you attempted to apply a function named #{inspect(function)} on a map/struct. " <>
                 "If you are using Kernel.apply/3, make sure the module is an atom. " <>
-                if is_function(module[function]) do
+                if is_function(Map.get(module, function)) do
                   "If you are trying to invoke an anonymous function in a map/struct, " <>
                     "add a dot between the function name and the parenthesis: map.#{function}.()"
                 else


### PR DESCRIPTION
I noticed this this error in ElixirLS. I don't know what code triggered it but the `ErlangError.normalize` implementation doesn't seem correct in assuming that Access protocol can be used on unknown value coming from stack trace.

```
** (UndefinedFunctionError) function Foo.fetch_2 is undefined (Foo does not implement the Access behaviour

You can use the "struct.field" syntax to access struct fields. You can also use Access.key/1 to access struct fields dynamically inside <REDACTED: user-file-path>)
    (foo_tools 0.1.0) Foo.fetch(%Foo{direct: MapSet.new([]), transient: %{}, all: MapSet.new([])}, :transient)
    (elixir 1.17.3) <REDACTED: user-file-path>:322: Access.get/3
    (elixir 1.17.3) <REDACTED: user-file-path>:2288: ErlangError.normalize/2
    (elixir 1.17.3) <REDACTED: user-file-path>:192: Exception.blame/3
```

While working on that change I started wondering what is the contract on `Exception.blame`. `Exception.message` callback does use try rescue pattern so the call should be safe. `blame` invokes client module code with no guarantees so a faulty implementation might throw/raise. https://github.com/elixir-lang/elixir/blob/main/lib/elixir/lib/exception.ex#L214
Shouldn't `blame` catch the error and fall back to the provided argument values if the callback crashes? Without that guarantees `blame` is at least cumbersome to use as the correct way would be
```
try do
  some_code()
catch kind, payload ->
  {payload, stacktrace} = try do
    Exception.blame(kind, payload, __STACKTRACE__)
  catch
     _, _ ->
       {payload, __STACKTRACE__}
  end

  Exception.format(kind, payload, stacktrace)
end
```