### PR TITLE
Add ANSI codes to turn off conceal and crossed_out

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -180,6 +180,12 @@ defmodule IO.ANSI do
   @doc "Image: positive. Normal foreground and background."
   defsequence.(:reverse_off, 27, "m")
 
+  @doc "Reveal: Not concealed."
+  defsequence.(:reveal, 28, "m")
+
+  @doc "Not crossed-out."
+  defsequence.(:not_crossed_out, 29, "m")
+
   colors = [:black, :red, :green, :yellow, :blue, :magenta, :cyan, :white]
 
   for {color, code} <- Enum.with_index(colors) do


### PR DESCRIPTION
Here's what it looks like:

<img width="833" alt="image" src="https://github.com/user-attachments/assets/3ad546dc-85c3-4bb1-921b-73484a1eece9" />

The main reason for this is that the alternative is to `:reset` and restore the color settings which isn't ideal in code that doesn't care about colors.