### PR TITLE
Do not pass invalid option case: :lower to url_encode64

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -903,7 +903,7 @@ defmodule Mix do
       {deps, config, system_env, consolidate_protocols?}
       |> :erlang.term_to_binary()
       |> :erlang.md5()
-      |> Base.url_encode64(case: :lower, padding: false)
+      |> Base.url_encode64(padding: false)
 
     force? = System.get_env("MIX_INSTALL_FORCE") in ["1", "true"] or Keyword.fetch!(opts, :force)
 


### PR DESCRIPTION
Dialyzer found this thanks to a typespec on `Base.url_encode64/2` (although it reported it as confusing "no return"...)