### PR TITLE
More precise error message when escaping a regex with a ref

### DIFF
--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -143,7 +143,7 @@ defmodule MacroTest do
 
     test "inspects container when a reference cannot be escaped" do
       assert_raise ArgumentError, ~r"~r/foo/ contains a reference", fn ->
-        Macro.escape(%{~r/foo/ | re_pattern: make_ref()})
+        Macro.escape(%{~r/foo/ | re_pattern: {:re_pattern, 0, 0, 0, make_ref()}})
       end
     end
   end


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/14497

This approach might be overkill, maybe making it regex aware is better here. I'm not sure.