### PR TITLE
Relax assertions when both PER CALL values are equal (Erlang/OTP 28) 

### DIFF
--- a/lib/mix/test/mix/tasks/profile.tprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.tprof_test.exs
@@ -83,9 +83,22 @@ defmodule Mix.Tasks.Profile.TprofTest do
 
   test "sorts based on memory per call", context do
     in_tmp(context.test, fn ->
-      assert capture_io(fn ->
-               Tprof.run(["--type", "memory", "--sort", "per_call", "-e", @expr])
-             end) =~ ~r/\n:erlang\.integer_to_binary\/1.*\nEnum\.each\/2/s
+      result = capture_io(fn ->
+        Tprof.run(["--type", "memory", "--sort", "per_call", "-e", @expr])
+      end)
+
+      # TODO: Remove when we require Erlang 28 exclusively
+      otp_release =
+        :otp_release
+        |> :erlang.system_info()
+        |> List.to_integer()
+
+      if otp_release < 28 do
+        assert result =~ ~r/\n:erlang\.integer_to_binary\/1.*\nEnum\.each\/2/s
+      else
+        assert result =~ ~r/\n:erlang\.integer_to_binary\/1[^\n]+3\.\d{2}\n/
+        assert result =~ ~r/\nEnum\.each\/2[^\n]+3\.\d{2}\n/
+      end
     end)
   end
 

--- a/lib/mix/test/mix/tasks/profile.tprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.tprof_test.exs
@@ -85,7 +85,7 @@ defmodule Mix.Tasks.Profile.TprofTest do
     in_tmp(context.test, fn ->
       result =
         capture_io(fn ->
-          Tprof.run(["--type", "memory", "--sort", "per_call", "-e", @expr])
+          Tprof.run(["--type", "memory", "--sort", "calls", "-e", @expr])
         end)
 
       [_warmup, _profile_results, _columns, _total, first, second, _profile_done, ""] =
@@ -93,13 +93,12 @@ defmodule Mix.Tasks.Profile.TprofTest do
 
       list =
         Enum.map([first, second], fn row ->
-          [mfa, _calls, _percent, _words, per_call] = String.split(row, ~r/\s+/)
-          {mfa, String.to_float(per_call)}
+          [mfa, calls, _percent, _words, _per_call] = String.split(row, ~r/\s+/)
+          {String.to_integer(calls), mfa}
         end)
 
-      assert list == Enum.sort_by(list, &elem(&1, 1))
-      assert List.keymember?(list, "Enum.each/2", 0)
-      assert List.keymember?(list, ":erlang.integer_to_binary/1", 0)
+      assert list == Enum.sort(list)
+      assert list == [{1, "Enum.each/2"}, {5, ":erlang.integer_to_binary/1"}]
     end)
   end
 

--- a/lib/mix/test/mix/tasks/profile.tprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.tprof_test.exs
@@ -83,22 +83,9 @@ defmodule Mix.Tasks.Profile.TprofTest do
 
   test "sorts based on memory per call", context do
     in_tmp(context.test, fn ->
-      result =
-        capture_io(fn ->
-          Tprof.run(["--type", "memory", "--sort", "calls", "-e", @expr])
-        end)
-
-      [_warmup, _profile_results, _columns, _total, first, second, _profile_done, ""] =
-        String.split(result, ~r/\n+/)
-
-      list =
-        Enum.map([first, second], fn row ->
-          [mfa, calls, _percent, _words, _per_call] = String.split(row, ~r/\s+/)
-          {String.to_integer(calls), mfa}
-        end)
-
-      assert list == Enum.sort(list)
-      assert list == [{1, "Enum.each/2"}, {5, ":erlang.integer_to_binary/1"}]
+      assert capture_io(fn ->
+               Tprof.run(["--type", "memory", "--sort", "calls", "-e", @expr])
+             end) =~ ~r/Enum\.each\/2\s+1\s+.*\n:erlang\.integer_to_binary\/1\s+5\s+/s
     end)
   end
 

--- a/lib/mix/test/mix/tasks/profile.tprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.tprof_test.exs
@@ -83,19 +83,20 @@ defmodule Mix.Tasks.Profile.TprofTest do
 
   test "sorts based on memory per call", context do
     in_tmp(context.test, fn ->
-      result = capture_io(fn ->
-        Tprof.run(["--type", "memory", "--sort", "per_call", "-e", @expr])
-      end)
-      
+      result =
+        capture_io(fn ->
+          Tprof.run(["--type", "memory", "--sort", "per_call", "-e", @expr])
+        end)
+
       [_warmup, _profile_results, _columns, _total, first, second, _profile_done, ""] =
         String.split(result, ~r/\n+/)
-      
+
       list =
         Enum.map([first, second], fn row ->
           [mfa, _calls, _percent, _words, per_call] = String.split(row, ~r/\s+/)
           {mfa, String.to_float(per_call)}
         end)
-      
+
       assert list == Enum.sort_by(list, &elem(&1, 1))
       assert List.keymember?(list, "Enum.each/2", 0)
       assert List.keymember?(list, ":erlang.integer_to_binary/1", 0)


### PR DESCRIPTION
Fixes: #14564

This fix implements `Erlang/OTP` version check. The alternative solution could be:
```elixir
# extract results
[_warmup, _profile_results, _columns, _total, first, second, _profile_done, ""] =
  String.split(result, ~r/\n+/)

# split columns
list = Enum.map([first, second], &String.split(&1, ~r/\s+/))

sort_func = fn result_colls ->
  result_colls
  |> List.last()
  |> String.to_float()
end

list == Enum.sort_by(list, sort_func)
```

The alternative solution additionally does not relies on `3.\d{2}` value pattern of `PER CALL` column.