### PR TITLE
Remove redundant memory-per-call test

### DIFF
--- a/lib/mix/test/mix/tasks/profile.tprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.tprof_test.exs
@@ -81,14 +81,6 @@ defmodule Mix.Tasks.Profile.TprofTest do
     end)
   end
 
-  test "sorts based on memory per call", context do
-    in_tmp(context.test, fn ->
-      assert capture_io(fn ->
-               Tprof.run(["--type", "memory", "--sort", "calls", "-e", @expr])
-             end) =~ ~r/Enum\.each\/2\s+1\s+.*\n:erlang\.integer_to_binary\/1\s+5\s+/s
-    end)
-  end
-
   test "aggregates totals over all processes", context do
     in_tmp(context.test, fn ->
       assert capture_io(fn ->


### PR DESCRIPTION
In https://github.com/elixir-lang/elixir/pull/14565, we changed the memory "per-call" sorted test to be memory "calls" sorted, which is exactly the same as the previous test.
If we don't want to test per call sorting, we could just remove it?