### PR TITLE
Document `Map.fetch!/2` exception in the doc test

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -316,6 +316,9 @@ defmodule Map do
 
       iex> Map.fetch!(%{a: 1}, :a)
       1
+      iex> Map.fetch!(%{a: 1}, :b)
+      ** (KeyError) key :b not found in:
+      ...
 
   """
   @spec fetch!(map, key) :: value


### PR DESCRIPTION
:wave: Thank you all for your excellent work!

This mirrors `Map.fetch/2` and thought it was nice to have there for easy & quick overview purposes - so I quickly added it.

Couple of points:
* I couldn't figure out how to correctly show the map of `not found in` - seems difficult due to the `\n\n` in the error messages, grabbed the `...` trick from the doc tests of `Access.key!/1`.
* The type system now warns that this will error in this specific test which is annoying and I'm not sure how to get rid of it:

```
tobi@qiqi:~/github/elixir(main)$ make test_stdlib
==> elixir (compile)
==> elixir (ex_unit)
warning: the call to map_get/2 will fail with a '{badkey,b}' exception
└─ (for doctest at) lib/map.ex:319

Running ExUnit with seed: 618006, max_cases: 48
Excluding tags: [windows: true]

```

I understand this isn't crucial so if the annoyance of dealing with the warning is big enough I'm happy to have this closed :) 

Thanks y'all! :green_heart: 