### PR TITLE
fix: check for duplicates in keyword validate

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -281,7 +281,15 @@ defmodule Keyword do
   end
 
   defp validate([], values1, values2, acc, []) do
-    {:ok, move_pairs!(values1, move_pairs!(values2, acc))}
+    list = move_pairs!(values1, move_pairs!(values2, acc))
+
+    {has_duplicate, duplicate_key} = find_duplicate_keys(list)
+
+    if has_duplicate do
+      {:error, [duplicate_key]}
+    else
+      {:ok, list}
+    end
   end
 
   defp validate([], _values1, _values2, _acc, bad_keys) do
@@ -310,6 +318,29 @@ defmodule Keyword do
   defp move_pairs!([other | _], _) do
     raise ArgumentError,
           "expected the second argument to be a list of atoms or tuples, got: #{inspect(other)}"
+  end
+
+  defp find_duplicate_keys([]) do
+    {false, nil}
+  end
+
+  defp find_duplicate_keys(l) do
+    [{k, _} | t] = List.keysort(l, 0)
+    # on a sorted list, we'll only have to check consecutive elements
+    # for duplicates
+    find_duplicate_keys(t, k)
+  end
+
+  defp find_duplicate_keys([], _k) do
+    {false, nil}
+  end
+
+  defp find_duplicate_keys([{k, _} | _t], k) do
+    {true, k}
+  end
+
+  defp find_duplicate_keys([{h, _} | t], _k) do
+    find_duplicate_keys(t, h)
   end
 
   @doc """


### PR DESCRIPTION
closes #14584

I've run benchmarks with Benchee and to me the solution is acceptable.
Results below, but the conclusion is that there's a loss of 1 to 5% IPS with the check,
but the average execution times are very close to each other in absolute values.

## Benchee results with the duplicate check

```elixir
Benchee.run(
  %{
    "duplicate at the end" => fn len ->
      l1 = Enum.map(1..len, &{:"#{&1}", &1})
      l2 = l1 ++ [{:"#{len}", 2}]
      {:error, _} = Keyword.validate(l1, l2)
    end,
    "duplicate at the start" => fn len ->
      l1 = Enum.map(1..len, &{:"#{&1}", &1})
      l2 = ["1": 1] ++ l1
      {:error, _} = Keyword.validate(l1, l2)
    end
  },
  inputs: %{"10" => 10, "1000" => 1000, "10_000" => 10_000}
)
```

Warning: the benchmark duplicate at the end is using an evaluated function.
  Evaluated functions perform slower than compiled functions.
  You can move the Benchee caller to a function in a module and invoke `Mod.fun()` instead.
  Alternatively, you can move the benchmark into a benchmark.exs file and run mix run benchmark.exs

Warning: the benchmark duplicate at the start is using an evaluated function.
  Evaluated functions perform slower than compiled functions.
  You can move the Benchee caller to a function in a module and invoke `Mod.fun()` instead.
  Alternatively, you can move the benchmark into a benchmark.exs file and run mix run benchmark.exs

Operating System: macOS
CPU Information: Apple M1 Pro
Number of Available Cores: 10
Available memory: 32 GB
Elixir 1.20.0-dev
Erlang 27.2.1
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: 10, 1000, 10_000
Estimated total run time: 42 s

Benchmarking duplicate at the end with input 10 ...
Benchmarking duplicate at the end with input 1000 ...
Benchmarking duplicate at the end with input 10_000 ...
Benchmarking duplicate at the start with input 10 ...
Benchmarking duplicate at the start with input 1000 ...
Benchmarking duplicate at the start with input 10_000 ...
Calculating statistics...
Formatting results...

##### With input 10 #####
Name                             ips        average  deviation         median         99th %
duplicate at the start       66.90 K       14.95 μs    ±69.59%       13.50 μs       36.25 μs
duplicate at the end         63.05 K       15.86 μs    ±49.89%       14.54 μs       35.08 μs

Comparison: 
duplicate at the start       66.90 K
duplicate at the end         63.05 K - 1.06x slower +0.91 μs

##### With input 1000 #####
Name                             ips        average  deviation         median         99th %
duplicate at the end          718.86        1.39 ms     ±5.05%        1.38 ms        1.57 ms
duplicate at the start        686.39        1.46 ms    ±30.78%        1.42 ms        1.79 ms

Comparison: 
duplicate at the end          718.86
duplicate at the start        686.39 - 1.05x slower +0.0658 ms

##### With input 10_000 #####
Name                             ips        average  deviation         median         99th %
duplicate at the end           68.89       14.52 ms    ±10.77%       14.31 ms       20.11 ms
duplicate at the start         67.22       14.88 ms    ±22.36%       14.43 ms       41.19 ms

Comparison: 
duplicate at the end           68.89
duplicate at the start         67.22 - 1.02x slower +0.36 ms


## Benchee results without the duplicate check

```elixir
Benchee.run(
  %{
    "duplicate at the end" => fn len ->
      l1 = Enum.map(1..len, &{:"#{&1}", &1})
      l2 = l1 ++ [{:"#{len}", 2}]
      {:ok, _} = Keyword.validate(l1, l2)
    end,
    "duplicate at the start" => fn len ->
      l1 = Enum.map(1..len, &{:"#{&1}", &1})
      l2 = ["1": 1] ++ l1
      {:ok, _} = Keyword.validate(l1, l2)
    end
  },
  inputs: %{"10" => 10, "1000" => 1000, "10_000" => 10_000}
)
```
Warning: the benchmark duplicate at the end is using an evaluated function.
  Evaluated functions perform slower than compiled functions.
  You can move the Benchee caller to a function in a module and invoke `Mod.fun()` instead.
  Alternatively, you can move the benchmark into a benchmark.exs file and run mix run benchmark.exs

Warning: the benchmark duplicate at the start is using an evaluated function.
  Evaluated functions perform slower than compiled functions.
  You can move the Benchee caller to a function in a module and invoke `Mod.fun()` instead.
  Alternatively, you can move the benchmark into a benchmark.exs file and run mix run benchmark.exs

Operating System: macOS
CPU Information: Apple M1 Pro
Number of Available Cores: 10
Available memory: 32 GB
Elixir 1.20.0-dev
Erlang 27.2.1
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: 10, 1000, 10_000
Estimated total run time: 42 s

Benchmarking duplicate at the end with input 10 ...
Benchmarking duplicate at the end with input 1000 ...
Benchmarking duplicate at the end with input 10_000 ...
Benchmarking duplicate at the start with input 10 ...
Benchmarking duplicate at the start with input 1000 ...
Benchmarking duplicate at the start with input 10_000 ...
Calculating statistics...
Formatting results...

##### With input 10 #####
Name                             ips        average  deviation         median         99th %
duplicate at the start       70.79 K       14.13 μs    ±32.93%       13.08 μs       30.71 μs
duplicate at the end         64.04 K       15.62 μs    ±62.27%       14.21 μs       36.01 μs

Comparison: 
duplicate at the start       70.79 K
duplicate at the end         64.04 K - 1.11x slower +1.49 μs

##### With input 1000 #####
Name                             ips        average  deviation         median         99th %
duplicate at the end          730.23        1.37 ms    ±27.59%        1.34 ms        1.59 ms
duplicate at the start        722.60        1.38 ms     ±4.93%        1.37 ms        1.61 ms

Comparison: 
duplicate at the end          730.23
duplicate at the start        722.60 - 1.01x slower +0.0145 ms

##### With input 10_000 #####
Name                             ips        average  deviation         median         99th %
duplicate at the end           71.04       14.08 ms     ±2.99%       14.01 ms       15.29 ms
duplicate at the start         65.83       15.19 ms     ±9.21%       15.01 ms       20.13 ms

Comparison: 
duplicate at the end           71.04
duplicate at the start         65.83 - 1.08x slower +1.11 ms
