### PR TITLE
Fix invalid warning on no parens call on true

### DIFF
--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -718,7 +718,7 @@ generate_struct_name_guard([Field | Rest], Acc, S) ->
 %% TODO: Make this a runtime error on Elixir v2.0
 no_parens_remote(nil, _Key) -> {error, {badmap, nil}};
 no_parens_remote(false, _Key) -> {error, {badmap, false}};
-no_parens_remote(true, _Key) -> {error, {badmap, false}};
+no_parens_remote(true, _Key) -> {error, {badmap, true}};
 no_parens_remote(Atom, Fun) when is_atom(Atom) ->
   Message = fun() ->
     io_lib:format(


### PR DESCRIPTION
Fixes
```
true.asd
** (BadMapError) expected a map, got:

    false
    iex:2: (file)
```