### PR TITLE
Update ORT Scanner

### DIFF
--- a/.github/workflows/ort/action.yml
+++ b/.github/workflows/ort/action.yml
@@ -62,6 +62,16 @@ runs:
         # Override Default Evaluator Rules
         cp .ort/config/evaluator.rules.kts "$HOME/.ort/config/evaluator.rules.kts"
 
+        # Add Package Configurations
+        mkdir -p "$HOME/.ort/config/package-configurations/SpdxDocumentFile/The Elixir Team"
+        for FILE in .ort/package-configurations/*.yml; do
+          COMPONENT="$(basename "$FILE")"
+          cp "$FILE" "$HOME/.ort/config/package-configurations/SpdxDocumentFile/The Elixir Team/$COMPONENT"
+          sed -i -E \
+            "s/(\"SpdxDocumentFile:The Elixir Team:.+:)\"/\1${ELIXIR_VERSION}\"/" \
+            "$HOME/.ort/config/package-configurations/SpdxDocumentFile/The Elixir Team/$COMPONENT"
+        done
+
         # Set Version in SPDX & Config
         sed -i "s/# elixir-version-insert/versionInfo: '${ELIXIR_VERSION}'/" project.spdx.yml
         sed -i -E "s/(\"SpdxDocumentFile:The Elixir Team:.+:)\"/\1${ELIXIR_VERSION}\"/" .ort.yml
@@ -80,7 +90,9 @@ runs:
       id: ort
       uses: oss-review-toolkit/ort-ci-github-action@1805edcf1f4f55f35ae6e4d2d9795ccfb29b6021 # v1.1.0
       with:
-        image: ghcr.io/oss-review-toolkit/ort-minimal:54.0.0
+        # TODO: Put official image once available
+        # https://github.com/oss-review-toolkit/ort/pull/10502
+        image: ghcr.io/maennchen/ort-minimal:sha-fa6fc8d
         run: >-
           labels,
           cache-dependencies,

--- a/.ort.yml
+++ b/.ort.yml
@@ -3,18 +3,6 @@
 
 excludes:
   paths:
-    - pattern: "lib/elixir/pages/**/*"
-      reason: "DOCUMENTATION_OF"
-      comment: "Documentation"
-    - pattern: "lib/elixir/scripts/**/*"
-      reason: "BUILD_TOOL_OF"
-      comment: "Build Tool"
-    - pattern: "lib/ex_unit/examples/**/*"
-      reason: "EXAMPLE_OF"
-      comment: "Example"
-    - pattern: "lib/*/test/**/*"
-      reason: "TEST_OF"
-      comment: "Tests"
     - pattern: "man/*"
       reason: "DOCUMENTATION_OF"
       comment: "Documentation"
@@ -25,8 +13,64 @@ excludes:
       reason: "BUILD_TOOL_OF"
       comment: "Documentation"
 
+    # Unfortunately we'll have to repeat all package level excludes here
+    # Make sure to keep them in sync with the package configuration in
+    # .ort/package-configurations
+    - pattern: "lib/*/pages/**/*"
+      reason: "DOCUMENTATION_OF"
+      comment: "Documentation"
+    - pattern: "lib/*/test/**/*"
+      reason: "TEST_OF"
+      comment: "Tests"
+    - pattern: "lib/*/scripts/**/*"
+      reason: "BUILD_TOOL_OF"
+      comment: "Build Tool"
+    - pattern: "lib/*/examples/**/*"
+      reason: "EXAMPLE_OF"
+      comment: "Example"
+
 curations:
   license_findings:
+    # Version File
+    - path: "VERSION"
+      reason: "NOT_DETECTED"
+      comment: "Apply Trademark Policy to VERSION file"
+      detected_license: "NONE"
+      concluded_license: "Apache-2.0"
+
+    # Wrongly Identified
+    - path: ".gitignore"
+      reason: "INCORRECT"
+      comment: "Ignored by ScanCode"
+      detected_license: "NONE"
+      concluded_license: "Apache-2.0"
+    - path: ".gitattributes"
+      reason: "INCORRECT"
+      comment: "Ignored by ScanCode"
+      detected_license: "NONE"
+      concluded_license: "Apache-2.0"
+    - path: "CONTRIBUTING.md"
+      reason: "INCORRECT"
+      comment: "Wrongly identified TSL license"
+      detected_license: "Apache-2.0 OR NOASSERTION OR LicenseRef-scancode-tsl-2020"
+      concluded_license: "Apache-2.0"
+    - path: "OPEN_SOURCE_POLICY.md"
+      reason: "INCORRECT"
+      comment: "Wrongly identified NOASSERTION"
+      detected_license: "NOASSERTION"
+      concluded_license: "Apache-2.0"
+
+    # Unfortunately we'll have to repeat all package level license curations here
+    # Make sure to keep them in sync with the package configuration in
+    # .ort/package-configurations
+
+    # Test Fixtures
+    - path: "lib/*/test/fixtures/**/*"
+      reason: "NOT_DETECTED"
+      comment: "Apply default license to test fixtures"
+      detected_license: "NONE"
+      concluded_license: "Apache-2.0"
+
     # Logos
     - path: "lib/elixir/pages/images/logo.png"
       reason: "NOT_DETECTED"
@@ -39,13 +83,6 @@ curations:
       detected_license: "NONE"
       concluded_license: "LicenseRef-elixir-trademark-policy"
 
-    # Version File
-    - path: "VERSION"
-      reason: "NOT_DETECTED"
-      comment: "Apply Trademark Policy to VERSION file"
-      detected_license: "NONE"
-      concluded_license: "Apache-2.0"
-
     # Documentation Images
     - path: "lib/elixir/pages/images/**/*.png"
       reason: "NOT_DETECTED"
@@ -54,22 +91,7 @@ curations:
       concluded_license: "Apache-2.0"
 
     # Test Fixtures
-    - path: "lib/eex/test/fixtures/**/*"
-      reason: "NOT_DETECTED"
-      comment: "Apply default license to test fixtures"
-      detected_license: "NONE"
-      concluded_license: "Apache-2.0"
     - path: "lib/elixir/test/elixir/fixtures/**/*"
-      reason: "NOT_DETECTED"
-      comment: "Apply default license to test fixtures"
-      detected_license: "NONE"
-      concluded_license: "Apache-2.0"
-    - path: "lib/ex_unit/test/fixtures/**/*"
-      reason: "NOT_DETECTED"
-      comment: "Apply default license to test fixtures"
-      detected_license: "NONE"
-      concluded_license: "Apache-2.0"
-    - path: "lib/mix/test/fixtures/**/*"
       reason: "NOT_DETECTED"
       comment: "Apply default license to test fixtures"
       detected_license: "NONE"
@@ -89,57 +111,8 @@ curations:
         The guide mentions multiple licenses for users to choose from.
         It however is not licensed itself by the mentioned licenses.
       concluded_license: "Apache-2.0"
-    - path: ".gitignore"
-      reason: "INCORRECT"
-      comment: "Ignored by ScanCode"
-      detected_license: "NONE"
-      concluded_license: "Apache-2.0"
-    - path: ".gitattributes"
-      reason: "INCORRECT"
-      comment: "Ignored by ScanCode"
-      detected_license: "NONE"
-      concluded_license: "Apache-2.0"
     - path: "lib/elixir/scripts/windows_installer/.gitignore"
       reason: "INCORRECT"
       comment: "Ignored by ScanCode"
       detected_license: "NONE"
       concluded_license: "Apache-2.0"
-    - path: "CONTRIBUTING.md"
-      reason: "INCORRECT"
-      comment: "Wrongly identified TSL license"
-      detected_license: "Apache-2.0 OR NOASSERTION OR LicenseRef-scancode-tsl-2020"
-      concluded_license: "Apache-2.0"
-    - path: "OPEN_SOURCE_POLICY.md"
-      reason: "INCORRECT"
-      comment: "Wrongly identified NOASSERTION"
-      detected_license: "NOASSERTION"
-      concluded_license: "Apache-2.0"
-  
-  packages:
-    - id: "SpdxDocumentFile:The Elixir Team:elixir-lang:"
-      curations:
-        concluded_license: "Apache-2.0 AND LicenseRef-scancode-unicode"
-    - id: "SpdxDocumentFile:The Elixir Team:eex:"
-      curations:
-        concluded_license: "Apache-2.0"
-        is_metadata_only: true
-    - id: "SpdxDocumentFile:The Elixir Team:elixir:"
-      curations:
-        concluded_license: "Apache-2.0 AND LicenseRef-scancode-unicode"
-        is_metadata_only: true
-    - id: "SpdxDocumentFile:The Elixir Team:exunit:"
-      curations:
-        concluded_license: "Apache-2.0"
-        is_metadata_only: true
-    - id: "SpdxDocumentFile:The Elixir Team:iex:"
-      curations:
-        concluded_license: "Apache-2.0"
-        is_metadata_only: true
-    - id: "SpdxDocumentFile:The Elixir Team:logger:"
-      curations:
-        concluded_license: "Apache-2.0"
-        is_metadata_only: true
-    - id: "SpdxDocumentFile:The Elixir Team:mix:"
-      curations:
-        concluded_license: "Apache-2.0"
-        is_metadata_only: true

--- a/.ort/config/config.yml
+++ b/.ort/config/config.yml
@@ -3,6 +3,7 @@
 
 ort:
   enableRepositoryPackageCurations: true
+  enableRepositoryPackageConfigurations: true
 
   scanner:
     skipConcluded: false
@@ -11,4 +12,10 @@ ort:
   analyzer:
     allowDynamicVersions: true
     enabledPackageManagers: [SpdxDocumentFile]
-    skipExcluded: true
+
+  reporter:
+    reporters:
+      SpdxDocument:
+        options:
+          creationInfoOrganization: The Elixir Team
+          documentName: "Elixir Source SPDX Document"

--- a/.ort/package-configurations/eex.yml
+++ b/.ort/package-configurations/eex.yml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
+id: "SpdxDocumentFile:The Elixir Team:eex:"
+path_excludes:
+  - pattern: "lib/eex/test/**/*"
+    reason: "TEST_OF"
+    comment: "Tests"
+license_finding_curations:
+  # Test Fixtures
+  - path: "lib/eex/test/fixtures/**/*"
+    reason: "NOT_DETECTED"
+    comment: "Apply default license to test fixtures"
+    detected_license: "NONE"
+    concluded_license: "Apache-2.0"

--- a/.ort/package-configurations/elixir.yml
+++ b/.ort/package-configurations/elixir.yml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
+id: "SpdxDocumentFile:The Elixir Team:elixir:"
+path_excludes:
+  - pattern: "lib/elixir/pages/**/*"
+    reason: "DOCUMENTATION_OF"
+    comment: "Documentation"
+  - pattern: "lib/elixir/scripts/**/*"
+    reason: "BUILD_TOOL_OF"
+    comment: "Build Tool"
+  - pattern: "lib/elixir/test/**/*"
+    reason: "TEST_OF"
+    comment: "Tests"
+license_finding_curations:
+  # Logos
+  - path: "lib/elixir/pages/images/logo.png"
+    reason: "NOT_DETECTED"
+    comment: "Apply Trademark Policy to Elixir Logo"
+    detected_license: "NONE"
+    concluded_license: "LicenseRef-elixir-trademark-policy"
+  - path: "lib/elixir/scripts/windows_installer/assets/Elixir.ico"
+    reason: "NOT_DETECTED"
+    comment: "Apply Trademark Policy to Elixir Logo"
+    detected_license: "NONE"
+    concluded_license: "LicenseRef-elixir-trademark-policy"
+
+  # Documentation Images
+  - path: "lib/elixir/pages/images/**/*.png"
+    reason: "NOT_DETECTED"
+    comment: "Apply default license to all images"
+    detected_license: "NONE"
+    concluded_license: "Apache-2.0"
+
+  # Test Fixtures
+  - path: "lib/elixir/test/elixir/fixtures/**/*"
+    reason: "NOT_DETECTED"
+    comment: "Apply default license to test fixtures"
+    detected_license: "NONE"
+    concluded_license: "Apache-2.0"
+
+  # Unicode
+  - path: "lib/elixir/unicode/*.txt"
+    reason: "NOT_DETECTED"
+    comment: "Apply default license to unicode files"
+    detected_license: "NONE"
+    concluded_license: "LicenseRef-scancode-unicode"
+
+  # Wrongly Identified
+  - path: "lib/elixir/pages/references/library-guidelines.md"
+    reason: "INCORRECT"
+    comment: |
+      The guide mentions multiple licenses for users to choose from.
+      It however is not licensed itself by the mentioned licenses.
+    concluded_license: "Apache-2.0"
+  - path: "lib/elixir/scripts/windows_installer/.gitignore"
+    reason: "INCORRECT"
+    comment: "Ignored by ScanCode"
+    detected_license: "NONE"
+    concluded_license: "Apache-2.0"

--- a/.ort/package-configurations/ex_unit.yml
+++ b/.ort/package-configurations/ex_unit.yml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
+id: "SpdxDocumentFile:The Elixir Team:exunit:"
+path_excludes:
+  - pattern: "lib/ex_unit/examples/**/*"
+    reason: "EXAMPLE_OF"
+    comment: "Example"
+  - pattern: "lib/ex_unit/test/**/*"
+    reason: "TEST_OF"
+    comment: "Tests"
+license_finding_curations:
+  # Test Fixtures
+  - path: "lib/ex_unit/test/fixtures/**/*"
+    reason: "NOT_DETECTED"
+    comment: "Apply default license to test fixtures"
+    detected_license: "NONE"
+    concluded_license: "Apache-2.0"

--- a/.ort/package-configurations/logger.yml
+++ b/.ort/package-configurations/logger.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
+id: "SpdxDocumentFile:The Elixir Team:logger:"
+path_excludes:
+  - pattern: "lib/logger/test/**/*"
+    reason: "TEST_OF"
+    comment: "Tests"

--- a/.ort/package-configurations/mix.yml
+++ b/.ort/package-configurations/mix.yml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
+id: "SpdxDocumentFile:The Elixir Team:mix:"
+path_excludes:
+  - pattern: "lib/mix/test/**/*"
+    reason: "TEST_OF"
+    comment: "Tests"
+license_finding_curations:
+  # Test Fixtures
+  - path: "lib/mix/test/fixtures/**/*"
+    reason: "NOT_DETECTED"
+    comment: "Apply default license to test fixtures"
+    detected_license: "NONE"
+    concluded_license: "Apache-2.0"

--- a/lib/iex/test/iex/config_test.exs
+++ b/lib/iex/test/iex/config_test.exs
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule IEx.ConfigTest do


### PR DESCRIPTION
## Changes

* Update ORT to 61.... (TBD once ORT PR is merged)
* Adds Package Configurations (required by Update to get parity to before)

## Fixes

* Adds Header to `lib/iex/test/iex/config_test.exs`, was missing
* Makes sure CI *actually* fails if there's a missing copyright header
* Makes sure files are attributed to the correct package in the resulting SBoM

## TODO

* [ ] Refer to ORT release containing fix https://github.com/oss-review-toolkit/ort/pull/10502