### PR TITLE
Perf optimizations and inferred intersections

### DIFF
--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -487,7 +487,7 @@ defmodule Module.Types.Apply do
                 {union(type, fun_from_non_overlapping_clauses(clauses)), fallback?, context}
 
               {{:infer, _, clauses}, context} when length(clauses) <= @max_clauses ->
-                {union(type, fun_from_overlapping_clauses(clauses)), fallback?, context}
+                {union(type, fun_from_inferred_clauses(clauses)), fallback?, context}
 
               {_, context} ->
                 {type, true, context}
@@ -705,7 +705,7 @@ defmodule Module.Types.Apply do
         result =
           case info do
             {:infer, _, clauses} when length(clauses) <= @max_clauses ->
-              fun_from_overlapping_clauses(clauses)
+              fun_from_inferred_clauses(clauses)
 
             _ ->
               dynamic(fun(arity))

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -138,7 +138,7 @@ defmodule Module.Types.Descr do
   Creates a function from overlapping function clauses.
   """
   def fun_from_inferred_clauses(args_clauses) do
-    if true do
+    if false do
       domain_clauses =
         Enum.reduce(args_clauses, [], fn {args, return}, acc ->
           domain = args |> Enum.map(&upper_bound/1) |> args_to_domain()
@@ -1479,73 +1479,71 @@ defmodule Module.Types.Descr do
   # Returns true if the intersection of the positives is a subtype of (t1,...,tn)->(not t).
   #
   # See [Castagna and Lanvin (2024)](https://arxiv.org/abs/2408.14345), Theorem 4.2.
-  def descr_size(:term), do: 1
+  # def descr_size(:term), do: 1
 
-  def descr_size(%{} = descr) do
-    Enum.reduce(descr, 0, fn {key, value}, acc ->
-      acc + descr_size(key, value)
-    end)
-  end
+  # def descr_size(%{} = descr) do
+  #   Enum.reduce(descr, 0, fn {key, value}, acc ->
+  #     acc + descr_size(key, value)
+  #   end)
+  # end
 
-  def descr_size(:tuple, dnf) do
-    Enum.sum(Enum.map(dnf, fn {tag, elems} -> length(elems) end))
-  end
+  # def descr_size(:tuple, dnf) do
+  #   Enum.sum(Enum.map(dnf, fn {tag, elems} -> length(elems) end))
+  # end
 
-  def descr_size(:fun, bdd), do: bdd_size(bdd)
+  # def descr_size(:fun, bdd), do: bdd_size(bdd)
 
-  def descr_size(:map, dnf) do
-    Enum.reduce(dnf, 0, fn {tag, pos, negs}, acc ->
-      acc + 1 + length(negs)
-    end)
-  end
+  # def descr_size(:map, dnf) do
+  #   Enum.reduce(dnf, 0, fn {tag, pos, negs}, acc ->
+  #     acc + 1 + length(negs)
+  #   end)
+  # end
 
-  def descr_size(:list, dnf) do
-    Enum.reduce(dnf, 0, fn {_, last, negs}, acc ->
-      acc + 1 + length(negs)
-    end)
-  end
+  # def descr_size(:list, dnf) do
+  #   Enum.reduce(dnf, 0, fn {_, last, negs}, acc ->
+  #     acc + 1 + length(negs)
+  #   end)
+  # end
 
-  def descr_size(_, _), do: 1
+  # def descr_size(_, _), do: 1
 
-  defp bdd_size({fun, l, r}) do
-    bdd_size(l) + bdd_size(r) + 1
-  end
+  # defp bdd_size({fun, l, r}) do
+  #   bdd_size(l) + bdd_size(r) + 1
+  # end
 
-  defp bdd_size(:fun_top), do: 1
-  defp bdd_size(:fun_bottom), do: 0
+  # defp bdd_size(:fun_top), do: 1
+  # defp bdd_size(:fun_bottom), do: 0
 
-  defp list_dnf_size(dnf) do
-    Enum.reduce(dnf, 0, fn {_, _, negs}, acc ->
-      1 + length(negs)
-    end)
-  end
+  # defp list_dnf_size(dnf) do
+  #   Enum.reduce(dnf, 0, fn {_, _, negs}, acc ->
+  #     1 + length(negs)
+  #   end)
+  # end
 
-  defp all_distinct_non_empty_domains?([{args, _ret}]) do
-    not empty?(args_to_domain(args))
-  end
+  # defp all_distinct_non_empty_domains?([{args, _ret}]) do
+  #   not empty?(args_to_domain(args))
+  # end
 
-  defp all_distinct_non_empty_domains?(positives) do
-    # For each two elements of positives, their domains are distinct
-    for {args1, _ret1} <- positives,
-        {args2, _ret2} <- positives,
-        args1 != args2,
-        reduce: true do
-      acc ->
-        # 1. check there are no empty args
-        dom1 = args_to_domain(args1)
-        dom2 = args_to_domain(args2)
-        if empty?(dom1) or empty?(dom2) do
-          IO.puts("We found that #{to_quoted_string(dom1)} or #{to_quoted_string(dom2)} is empty")
-          false
-        else
-          d = disjoint?(dom1, dom2)
-          if not d do
-            IO.puts("We found that #{to_quoted_string(dom1)} and #{to_quoted_string(dom2)} are not disjoint")
-          end
-          acc and d
-        end
-    end
-  end
+  # defp all_distinct_non_empty_domains?(positives) do
+  #   # For each two elements of positives, their domains are distinct
+  #   for {args1, _ret1} <- positives,
+  #       {args2, _ret2} <- positives,
+  #       args1 != args2,
+  #       reduce: true do
+  #     acc ->
+  #       # 1. check there are no empty args
+  #       dom1 = args_to_domain(args1)
+  #       dom2 = args_to_domain(args2)
+  #       if empty?(dom1) or empty?(dom2) do
+  #         false
+  #       else
+  #         d = disjoint?(dom1, dom2)
+  #         if not d do
+  #         end
+  #         acc and d
+  #       end
+  #   end
+  # end
 
   defp all_non_empty_domains?(positives) do
     Enum.all?(positives, fn {args, _ret} -> not empty?(args_to_domain(args)) end)
@@ -1556,42 +1554,18 @@ defmodule Module.Types.Descr do
     # In that case, checking subtyping of it with a single arrow is simply:
     # checking that the union of the domains of the positives is a supertype of the domain of the arrow
     # and that applying the input type of the arrow to the intersection gives sth that is a subtype of the return type of the arrow
-    IO.puts("Checking if all the positives have distinct non empty domains...")
     if all_non_empty_domains?(positives) and all_non_empty_domains?([{arguments, return}]) do
       return = negation(return)
-      IO.puts("They DO")
-      IO.puts("All distinct non empty domains")
-      IO.puts("The positives are:")
-      Enum.each(positives, fn {args, ret} ->
-        IO.puts("#{Enum.map(args, fn arg -> to_quoted_string(arg) end) |> Enum.join(", ")} -> #{to_quoted_string(ret)}")
-      end)
-      IO.puts("--------------------------------")
-      IO.puts("--------------------------------")
-      IO.puts("Checking if the single arrow")
-      IO.puts("#{Enum.map(arguments, fn arg -> to_quoted_string(arg) end) |> Enum.join(", ")} -> #{to_quoted_string(return)}")
-      IO.puts("is a supertype of the intersection of these #{length(positives)} positives")
-
       type_positives =
         Enum.map(positives, fn {args, ret} -> fun(args, ret) end) |> Enum.reduce(&intersection/2)
 
       {:ok, _dom, static_arrows} = fun_normalize(type_positives, length(arguments), :static)
       result = fun_apply_static(arguments, static_arrows, false)
 
-      IO.puts("We are done!")
-      IO.puts("After applying the intersection of positives")
-      IO.puts("to the arguments")
-      IO.puts("(#{Enum.map(arguments, fn arg -> to_quoted_string(arg) end) |> Enum.join(", ")})")
-      IO.puts("We get result:")
-      IO.puts("#{to_quoted_string(result)}")
-      IO.puts("And we are checking if it is a subtype of:")
-      IO.puts("#{to_quoted_string(return)}")
-
       r = subtype?(result, return)
       if r do
-        IO.puts("Thus, the single arrow IS a supertype.")
         r
       else
-        IO.puts("Thus, the single arrow IS NOT a supertype.")
         false
       end
 
@@ -1614,47 +1588,21 @@ defmodule Module.Types.Descr do
       # end
     else
       # Show the caller of this function
-      IO.puts("They DO NOT")
-      IO.puts("phi_starter")
       # IO.puts("Starting phi starter with arguments: #{inspect(arguments)}")
       # IO.puts("Starting phi starter with return: #{inspect(return)}")
       # IO.puts("Starting phi starter with positives: #{inspect(positives)}")
       # Total size of the descrs in arguments, return, and positives
-      total_size =
-        arguments
-        |> Enum.map(&descr_size/1)
-        |> Enum.sum()
-        |> Kernel.+(descr_size(return))
-        |> Kernel.+(
-          Enum.reduce(positives, 0, fn {args, ret}, acc ->
-            acc + Enum.sum(Enum.map(args, &descr_size/1)) + descr_size(ret)
-          end)
-        )
+      # total_size =
+      #   arguments
+      #   |> Enum.map(&descr_size/1)
+      #   |> Enum.sum()
+      #   |> Kernel.+(descr_size(return))
+      #   |> Kernel.+(
+      #     Enum.reduce(positives, 0, fn {args, ret}, acc ->
+      #       acc + Enum.sum(Enum.map(args, &descr_size/1)) + descr_size(ret)
+      #     end)
+      #   )
 
-      IO.puts("Total size: #{total_size}")
-      IO.puts("Size decomposition:")
-      IO.puts("How many arguments: #{length(arguments)}")
-      IO.puts("arguments: #{Enum.map(arguments, &descr_size/1) |> Enum.sum()}")
-      IO.puts("return: #{descr_size(return)}")
-      IO.puts("We are checking if this function:")
-
-      IO.puts(
-        "#{Enum.map(arguments, fn arg -> to_quoted_string(arg) end) |> Enum.join(", ")} -> #{to_quoted_string(return)}"
-      )
-
-      IO.puts(
-        "positives: #{Enum.reduce(positives, 0, fn {args, ret}, acc -> acc + Enum.sum(Enum.map(args, &descr_size/1)) + descr_size(ret) end)}"
-      )
-
-      # How many negatives there are
-      IO.puts("Is a supertype of the intersection of these #{length(positives)} positives:")
-      IO.puts("here are each of them:")
-
-      Enum.each(positives, fn {args, ret} ->
-        IO.puts(
-          "#{Enum.map(args, fn arg -> to_quoted_string(arg) end) |> Enum.join(", ")} -> #{to_quoted_string(ret)}\n"
-        )
-      end)
 
       # start_time = DateTime.utc_now()
 
@@ -1680,9 +1628,6 @@ defmodule Module.Types.Descr do
         {result, call_count} = phi(arguments, {false, return}, positives, 0)
         cache_size = map_size(Process.get(:phi_cache, %{}))
         # Recursive calls
-        IO.puts("phi recursive calls: #{call_count}")
-        # IO.puts("it took #{DateTime.diff(DateTime.utc_now(), start_time, :millisecond)}ms")
-        IO.puts("--------------------------------")
 
         result
       end

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -340,7 +340,7 @@ defmodule Module.Types.Expr do
             add_inferred(acc, args, body)
         end)
 
-      {fun_from_overlapping_clauses(acc), context}
+      {fun_from_inferred_clauses(acc), context}
     end
   end
 

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -461,7 +461,11 @@ defmodule Module.Types.Expr do
     {args_types, context} =
       Enum.map_reduce(args, context, &of_expr(&1, @pending, &1, stack, &2))
 
-    Apply.fun_apply(fun_type, args_types, call, stack, context)
+    if stack.mode == :traversal do
+      {dynamic(), context}
+    else
+      Apply.fun_apply(fun_type, args_types, call, stack, context)
+    end
   end
 
   def of_expr({{:., _, [callee, key_or_fun]}, meta, []} = call, expected, expr, stack, context)

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -674,6 +674,7 @@ defmodule Module.Types.DescrTest do
       assert subtype?(f, fun([none(), integer()], term()))
       assert subtype?(fun([none(), number()], atom()), f)
       assert subtype?(fun([tuple(), number()], atom()), f)
+
       # (none, float)->atom is not a subtype of (none, integer)->atom because float has an empty intersection with integer
       # it's only possible to find this out by doing the
       # intersection one by one.

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -675,7 +675,8 @@ defmodule Module.Types.DescrTest do
       assert subtype?(fun([none(), number()], atom()), f)
       assert subtype?(fun([tuple(), number()], atom()), f)
 
-      # (none, float)->atom is not a subtype of (none, integer)->atom because float has an empty intersection with integer
+      # (none, float -> atom) is not a subtype of (none, integer -> atom)
+      # because float has an empty intersection with integer.
       # it's only possible to find this out by doing the
       # intersection one by one.
       refute subtype?(fun([none(), float()], atom()), f)

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -767,54 +767,72 @@ defmodule Module.Types.DescrTest do
                intersection(fun([integer()], atom()), fun([float()], binary()))
     end
 
-    test "fun_from_overlapping_clauses" do
+    test "fun_from_inferred_clauses" do
       # No overlap
-      assert fun_from_overlapping_clauses([{[integer()], atom()}, {[float()], binary()}])
+      assert fun_from_inferred_clauses([{[integer()], atom()}, {[float()], binary()}])
              |> equal?(
-               fun_from_non_overlapping_clauses([{[integer()], atom()}, {[float()], binary()}])
+               intersection(
+                 fun_from_non_overlapping_clauses([{[integer()], atom()}, {[float()], binary()}]),
+                 fun([number()], dynamic())
+               )
              )
 
       # Subsets
-      assert fun_from_overlapping_clauses([{[integer()], atom()}, {[number()], binary()}])
+      assert fun_from_inferred_clauses([{[integer()], atom()}, {[number()], binary()}])
              |> equal?(
-               fun_from_non_overlapping_clauses([
-                 {[integer()], union(atom(), binary())},
-                 {[float()], binary()}
-               ])
+               intersection(
+                 fun_from_non_overlapping_clauses([
+                   {[integer()], union(atom(), binary())},
+                   {[float()], binary()}
+                 ]),
+                 fun([number()], dynamic())
+               )
              )
 
-      assert fun_from_overlapping_clauses([{[number()], binary()}, {[integer()], atom()}])
+      assert fun_from_inferred_clauses([{[number()], binary()}, {[integer()], atom()}])
              |> equal?(
-               fun_from_non_overlapping_clauses([
-                 {[integer()], union(atom(), binary())},
-                 {[float()], binary()}
-               ])
+               intersection(
+                 fun_from_non_overlapping_clauses([
+                   {[integer()], union(atom(), binary())},
+                   {[float()], binary()}
+                 ]),
+                 fun([number()], dynamic())
+               )
              )
 
       # Partial
-      assert fun_from_overlapping_clauses([
+      assert fun_from_inferred_clauses([
                {[union(integer(), pid())], atom()},
                {[union(float(), pid())], binary()}
              ])
              |> equal?(
-               fun_from_non_overlapping_clauses([
-                 {[integer()], atom()},
-                 {[float()], binary()},
-                 {[pid()], union(atom(), binary())}
-               ])
+               intersection(
+                 fun_from_non_overlapping_clauses([
+                   {[integer()], atom()},
+                   {[float()], binary()},
+                   {[pid()], union(atom(), binary())}
+                 ]),
+                 fun([union(number(), pid())], dynamic())
+               )
              )
 
       # Difference
-      assert fun_from_overlapping_clauses([
+      assert fun_from_inferred_clauses([
                {[integer(), union(pid(), atom())], atom()},
                {[number(), pid()], binary()}
              ])
              |> equal?(
-               fun_from_non_overlapping_clauses([
-                 {[float(), pid()], binary()},
-                 {[integer(), atom()], atom()},
-                 {[integer(), pid()], union(atom(), binary())}
-               ])
+               intersection(
+                 fun_from_non_overlapping_clauses([
+                   {[float(), pid()], binary()},
+                   {[integer(), atom()], atom()},
+                   {[integer(), pid()], union(atom(), binary())}
+                 ]),
+                 fun_from_non_overlapping_clauses([
+                   {[integer(), union(pid(), atom())], dynamic()},
+                   {[number(), pid()], dynamic()}
+                 ])
+               )
              )
     end
   end

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -674,6 +674,9 @@ defmodule Module.Types.DescrTest do
       assert subtype?(f, fun([none(), integer()], term()))
       assert subtype?(fun([none(), number()], atom()), f)
       assert subtype?(fun([tuple(), number()], atom()), f)
+      # (none, float)->atom is not a subtype of (none, integer)->atom because float has an empty intersection with integer
+      # it's only possible to find this out by doing the
+      # intersection one by one.
       refute subtype?(fun([none(), float()], atom()), f)
       refute subtype?(fun([pid(), float()], atom()), f)
       # A function with the wrong arity is refused

--- a/lib/elixir/test/elixir/module/types/integration_test.exs
+++ b/lib/elixir/test/elixir/module/types/integration_test.exs
@@ -180,8 +180,8 @@ defmodule Module.Types.IntegrationTest do
       assert return.(:captured, 0)
              |> equal?(
                fun_from_non_overlapping_clauses([
-                 {[dynamic(binary())], atom([:ok, :error])},
-                 {[dynamic(non_empty_list(term(), term()))], atom([:list])}
+                 {[binary()], dynamic(atom([:ok, :error]))},
+                 {[non_empty_list(term(), term())], dynamic(atom([:list]))}
                ])
              )
     end


### PR DESCRIPTION
- 1. Memoize `phi()`.
- 2. Fast path: if there are no `none()` in the arguments of an intersection, we can compute subtyping quicker using `fun_apply`
- 3. Remove duplicates in `tuple_difference` (reuses `tuple_union` logic).

2. and 3. are sufficient to make the `fun_from_inferred_clauses` work. 
1. will be necessary for large function intersections with empty arguments.

Also adds inferred intersection types, in `fun_from_inferred_clauses`.