### PR TITLE
Add missing erlang compiler options

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.Compile.Erlang do
 
   @recursive true
   @manifest "compile.erlang"
-  @switches [force: :boolean, all_warnings: :boolean]
+  @switches [force: :boolean, verbose: :boolean, all_warnings: :boolean]
 
   @moduledoc """
   Compiles Erlang source files.
@@ -23,6 +23,7 @@ defmodule Mix.Tasks.Compile.Erlang do
     * `--all-warnings` (`--no-all-warnings`) - prints all warnings, including previous compilations
       (default is true except on errors)
     * `--force` - forces compilation regardless of modification times
+    * `--verbose` - prints verbose output
 
   ## Configuration
 

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -30,6 +30,7 @@ defmodule Mix.Tasks.Compile.Leex do
     * `--all-warnings` (`--no-all-warnings`) - prints all warnings, including previous compilations
       (default is true except on errors)
     * `--force` - forces compilation regardless of modification times
+    * `--verbose` - prints verbose output
 
   ## Configuration
 

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.Compile.Yecc do
 
   @recursive true
   @manifest "compile.yecc"
-  @switches [force: :boolean, all_warnings: :boolean]
+  @switches [force: :boolean, verbose: :boolean, all_warnings: :boolean]
 
   # These options can't be controlled with :yecc_options.
   @forced_opts [report: true, return: true]
@@ -30,6 +30,7 @@ defmodule Mix.Tasks.Compile.Yecc do
     * `--all-warnings` (`--no-all-warnings`) - prints all warnings, including previous compilations
       (default is true except on errors)
     * `--force` - forces compilation regardless of modification times
+    * `--verbose` - prints verbose output
 
   ## Configuration
 


### PR DESCRIPTION
Document options on leex and yecc compilers

I noticed that `--verbose` was already exposed on leex so probably also worht exposing on yecc and erlang