### PR TITLE
Fix parallel option type in Mix.Compilers.Erlang.compile/6 spec

### DIFF
--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -13,7 +13,7 @@ defmodule Mix.Compilers.Erlang do
   @type compile_opts :: [
           all_warnings: boolean(),
           force: boolean(),
-          parallel: MapSet.t(Path.t()),
+          parallel: boolean() | MapSet.t(Path.t()),
           preload: (-> term()),
           verbose: boolean()
         ]


### PR DESCRIPTION
compile.yecc and compile.leex tasks call it with parallel: true