### PR TITLE
Handle filesystem errors in iex helpers

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -1035,6 +1035,9 @@ defmodule IEx.Helpers do
 
       {:error, :enoent} ->
         IO.puts(IEx.color(:eval_error, "No directory #{directory}"))
+
+      {:error, reason} ->
+        IO.puts(IEx.color(:eval_error, :file.format_error(reason)))
     end
 
     dont_display_result()
@@ -1079,6 +1082,9 @@ defmodule IEx.Helpers do
 
       {:error, :enotdir} ->
         IO.puts(IEx.color(:eval_info, Path.absname(path)))
+
+      {:error, reason} ->
+        IO.puts(IEx.color(:eval_error, :file.format_error(reason)))
     end
 
     dont_display_result()


### PR DESCRIPTION
`File.cd` and `File.ls` can return any posix error code