### PR TITLE
Add local_for_callback option to Macro.Env.expand_import

### DIFF
--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -96,7 +96,8 @@ defmodule Macro.Env do
         ]
 
   @type expand_import_opts :: [
-          allow_locals: boolean() | (Macro.metadata(), atom(), arity(), [atom()], t() -> any()),
+          allow_locals:
+            boolean() | (Macro.metadata(), atom(), arity(), t() -> function() | false),
           check_deprecations: boolean(),
           trace: boolean()
         ]
@@ -563,9 +564,7 @@ defmodule Macro.Env do
       - When `true`, uses a default resolver that looks for public macros in
         the current module
       - When a function, uses the function as a custom local resolver. The function
-        must have the signature: `(meta, name, arity, kinds, env) -> function() | false`
-        where `kinds` is a list of atoms indicating the types of symbols being
-        searched (e.g., `[:defmacro, :defmacrop]`)
+        must have the signature: `(meta, name, arity, env) -> function() | false`
 
     * `:check_deprecations` - when set to `false`, does not check for deprecations
       when expanding macros
@@ -592,7 +591,7 @@ defmodule Macro.Env do
         # When allow_locals is a callback, we don't need to pass module macros as extra
         # because the callback will handle local macro resolution
         extra =
-          if is_function(allow_locals, 5) do
+          if is_function(allow_locals, 4) do
             []
           else
             case allow_locals and function_exported?(module, :__info__, 1) do

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -601,7 +601,15 @@ defmodule Macro.Env do
             end
           end
 
-        case :elixir_dispatch.expand_import(meta, name, arity, env, extra, local_for_callback || allow_locals, trace) do
+        case :elixir_dispatch.expand_import(
+               meta,
+               name,
+               arity,
+               env,
+               extra,
+               local_for_callback || allow_locals,
+               trace
+             ) do
           {:macro, receiver, expander} ->
             {:macro, receiver, wrap_expansion(receiver, expander, meta, name, arity, env, opts)}
 

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -601,15 +601,7 @@ defmodule Macro.Env do
             end
           end
 
-        case :elixir_dispatch.expand_import(
-               meta,
-               name,
-               arity,
-               env,
-               extra,
-               allow_locals,
-               trace
-             ) do
+        case :elixir_dispatch.expand_import(meta, name, arity, env, extra, allow_locals, trace) do
           {:macro, receiver, expander} ->
             {:macro, receiver, wrap_expansion(receiver, expander, meta, name, arity, env, opts)}
 

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -8,7 +8,7 @@
 -module(elixir_dispatch).
 -export([dispatch_import/6, dispatch_require/7,
   require_function/5, import_function/4,
-  expand_import/7, expand_require/6, check_deprecated/6,
+  expand_import/6, expand_require/6, check_deprecated/6,
   default_functions/0, default_macros/0, default_requires/0,
   find_import/4, find_imports/3, format_error/1]).
 -include("elixir.hrl").
@@ -29,7 +29,7 @@ default_requires() ->
 find_import(Meta, Name, Arity, E) ->
   Tuple = {Name, Arity},
 
-  case find_import_by_name_arity(Meta, Tuple, [], E) of
+  case find_import_by_name_arity(Meta, Tuple, E) of
     {function, Receiver} ->
       elixir_env:trace({imported_function, Meta, Receiver, Name, Arity}, E),
       Receiver;
@@ -56,7 +56,7 @@ find_imports(Meta, Name, E) ->
 
 import_function(Meta, Name, Arity, E) ->
   Tuple = {Name, Arity},
-  case find_import_by_name_arity(Meta, Tuple, [], E) of
+  case find_import_by_name_arity(Meta, Tuple, E) of
     {function, Receiver} ->
       elixir_env:trace({imported_function, Meta, Receiver, Name, Arity}, E),
       elixir_import:record(Tuple, Receiver, ?key(E, module), ?key(E, function)),
@@ -115,7 +115,7 @@ dispatch_import(Meta, Name, Args, S, E, Callback) ->
       _ -> false
     end,
 
-  case expand_import(Meta, Name, Arity, E, [], AllowLocals, true) of
+  case expand_import(Meta, Name, Arity, E, AllowLocals, true) of
     {macro, Receiver, Expander} ->
       check_deprecated(macro, Meta, Receiver, Name, Arity, E),
       Caller = {?line(Meta), S, E},
@@ -159,10 +159,10 @@ dispatch_require(_Meta, Receiver, Name, _Args, _S, _E, Callback) ->
 
 %% Macros expansion
 
-expand_import(Meta, Name, Arity, E, Extra, AllowLocals, Trace) ->
+expand_import(Meta, Name, Arity, E, AllowLocals, Trace) ->
   Tuple = {Name, Arity},
   Module = ?key(E, module),
-  Dispatch = find_import_by_name_arity(Meta, Tuple, Extra, E),
+  Dispatch = find_import_by_name_arity(Meta, Tuple, E),
 
   case Dispatch of
     {ambiguous, Ambiguous} ->
@@ -303,13 +303,13 @@ find_imports_by_name(Name, [{ImportName, _} | Imports], Acc, Mod, Meta, E) when 
 find_imports_by_name(_Name, _Imports, Acc, _Mod, _Meta, _E) ->
   Acc.
 
-find_import_by_name_arity(Meta, {_Name, Arity} = Tuple, Extra, E) ->
+find_import_by_name_arity(Meta, {_Name, Arity} = Tuple, E) ->
   case is_import(Meta, Arity) of
     {import, _} = Import ->
       Import;
     false ->
       Funs = ?key(E, functions),
-      Macs = Extra ++ ?key(E, macros),
+      Macs = ?key(E, macros),
       FunMatch = find_import_by_name_arity(Tuple, Funs),
       MacMatch = find_import_by_name_arity(Tuple, Macs),
 

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -175,9 +175,9 @@ expand_import(Meta, Name, Arity, E, Extra, AllowLocals, Trace) ->
       Local = case AllowLocals of
         false -> false;
         true  -> elixir_def:local_for(Meta, Name, Arity, [defmacro, defmacrop], E);
-        Fun when is_function(Fun, 5) ->
+        Fun when is_function(Fun, 4) ->
           %% If we have a custom local resolver, use it.
-          Fun(Meta, Name, Arity, [defmacro, defmacrop], E)
+          Fun(Meta, Name, Arity, E)
       end,
 
       case Dispatch of

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -8,7 +8,7 @@
 -module(elixir_dispatch).
 -export([dispatch_import/6, dispatch_require/7,
   require_function/5, import_function/4,
-  expand_import/8, expand_require/6, check_deprecated/6,
+  expand_import/7, expand_require/6, check_deprecated/6,
   default_functions/0, default_macros/0, default_requires/0,
   find_import/4, find_imports/3, format_error/1]).
 -include("elixir.hrl").
@@ -115,8 +115,7 @@ dispatch_import(Meta, Name, Args, S, E, Callback) ->
       _ -> false
     end,
 
-  DefaultLocalForCallback = fun(M, N, A, K, Env) -> elixir_def:local_for(M, N, A, K, Env) end,
-  case expand_import(Meta, Name, Arity, E, [], AllowLocals, true, DefaultLocalForCallback) of
+  case expand_import(Meta, Name, Arity, E, [], AllowLocals, true) of
     {macro, Receiver, Expander} ->
       check_deprecated(macro, Meta, Receiver, Name, Arity, E),
       Caller = {?line(Meta), S, E},
@@ -160,7 +159,7 @@ dispatch_require(_Meta, Receiver, Name, _Args, _S, _E, Callback) ->
 
 %% Macros expansion
 
-expand_import(Meta, Name, Arity, E, Extra, AllowLocals, Trace, LocalForCallback) ->
+expand_import(Meta, Name, Arity, E, Extra, AllowLocals, Trace) ->
   Tuple = {Name, Arity},
   Module = ?key(E, module),
   Dispatch = find_import_by_name_arity(Meta, Tuple, Extra, E),
@@ -173,7 +172,13 @@ expand_import(Meta, Name, Arity, E, Extra, AllowLocals, Trace, LocalForCallback)
       do_expand_import(Dispatch, Meta, Name, Arity, Module, E, Trace);
 
     _ ->
-      Local = AllowLocals andalso LocalForCallback(Meta, Name, Arity, [defmacro, defmacrop], E),
+      Local = case AllowLocals of
+        false -> false;
+        true  -> elixir_def:local_for(Meta, Name, Arity, [defmacro, defmacrop], E);
+        Fun when is_function(Fun, 5) ->
+          %% If we have a custom local resolver, use it.
+          Fun(Meta, Name, Arity, [defmacro, defmacrop], E)
+      end,
 
       case Dispatch of
         %% There is a local and an import. This is a conflict unless
@@ -250,22 +255,14 @@ expander_macro_named(Meta, Receiver, Name, Arity, E) ->
   fun(Args, Caller) -> expand_macro_fun(Meta, Fun, Receiver, Name, Args, Caller, E) end.
 
 expand_macro_fun(Meta, Fun, Receiver, Name, Args, Caller, E) ->
-  %% Check if Fun is actually a function, as it might be a fake value for local macros
-  %% when using custom local_for_callback
-  case is_function(Fun) of
-    true ->
-      try
-        apply(Fun, [Caller | Args])
-      catch
-        Kind:Reason:Stacktrace ->
-          Arity = length(Args),
-          MFA  = {Receiver, elixir_utils:macro_name(Name), Arity+1},
-          Info = [{Receiver, Name, Arity, [{file, "expanding macro"}]}, caller(?line(Meta), E)],
-          erlang:raise(Kind, Reason, prune_stacktrace(Stacktrace, MFA, Info, {ok, Caller}))
-      end;
-    false ->
-      %% Return a fake value and omit expansion when Fun is not a function
-      ok
+  try
+    apply(Fun, [Caller | Args])
+  catch
+    Kind:Reason:Stacktrace ->
+      Arity = length(Args),
+      MFA  = {Receiver, elixir_utils:macro_name(Name), Arity+1},
+      Info = [{Receiver, Name, Arity, [{file, "expanding macro"}]}, caller(?line(Meta), E)],
+      erlang:raise(Kind, Reason, prune_stacktrace(Stacktrace, MFA, Info, {ok, Caller}))
   end.
 
 expand_quoted(Meta, Receiver, Name, Arity, Quoted, S, E) ->


### PR DESCRIPTION
This PR adds a new option `:local_for_callback` to `Macro.Env.expand_import` in order to allow hooking into local macro resolution and providing a custom resolver.

Rationale:
In ElixirSense minicompiler I need to resolve local macros using the metadata extracted from the AST. The current mechanism relying on `:elixir_def.local_for` is not going to work correctly when there is no real compilation in process. The current hacky code using `extra` filled with `__info__(:macros)` only returns public macros and with that only those already compiled and loadable. The result is improper tracking of references in traversed code.

Example code using the new option:
```elixir
case Macro.Env.expand_import(env, meta, fun, arity,
  trace: true,
  allow_locals: allow_locals,
  check_deprecations: false,
  local_for_callback: fn meta, name, arity, kinds, e ->
    # a custom local resolver that uses mods_funs_to_positions def dictionary
    case state.mods_funs_to_positions[{e.module, name, arity}] do
      nil ->
        # no info found - treat as reference to a not existing local
        false

      %ModFunInfo{} = info ->
        category = ModFunInfo.get_category(info)
        definition_line = info.positions |> List.first() |> elem(0)
        usage_line = meta |> Keyword.get(:line)

        if ModFunInfo.get_def_kind(info) in kinds and
            (category != :macro or usage_line >= definition_line) do
          # found a local function or macro that is visible in the context
          if macro_exported?(e.module, name, arity) do
            # public macro found - return the expander
            proper_name = :"MACRO-#{name}"
            proper_arity = arity + 1
            Function.capture(e.module, proper_name, proper_arity)
          else
            # return a fake macro expander
            true
          end
        else
          # local not found - return false
          false
        end
    end
  end
) do
  {:macro, module, callback} ->
    expand_macro(meta, module, fun, args, callback, state, env)
  _ ->
    # omitted
end
```

The PR is based on the current code used in ElixirSense. I'm opening it as a draft. If there is will to merge this I'll work on tests.

Related PR hooking into `define_import`:
https://github.com/elixir-lang/elixir/pull/13628
