### PR TITLE
ex_unit: Add :capture_io tag

### DIFF
--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -39,29 +39,28 @@ end
 defmodule Kernel.CLITest do
   use ExUnit.Case, async: true
 
-  import ExUnit.CaptureIO
-
   defp run(argv) do
     {config, argv} = Kernel.CLI.parse_argv(Enum.map(argv, &String.to_charlist/1))
     assert Kernel.CLI.process_commands(config) == []
     Enum.map(argv, &IO.chardata_to_string/1)
   end
 
-  test "argv handling" do
-    assert capture_io(fn ->
-             assert run(["-e", "IO.puts :ok", "sample.exs", "-o", "1", "2"]) ==
-                      ["sample.exs", "-o", "1", "2"]
-           end) == "ok\n"
+  @tag :capture_io
+  test "argv handling", %{capture_io: io} do
+    assert run(["-e", "IO.puts :ok1", "sample.exs", "-o", "1", "2"]) ==
+             ["sample.exs", "-o", "1", "2"]
 
-    assert capture_io(fn ->
-             assert run(["-e", "IO.puts :ok", "--", "sample.exs", "-o", "1", "2"]) ==
-                      ["sample.exs", "-o", "1", "2"]
-           end) == "ok\n"
+    assert StringIO.flush(io) == "ok1\n"
 
-    assert capture_io(fn ->
-             assert run(["-e", "", "--", "sample.exs", "-o", "1", "2"]) ==
-                      ["sample.exs", "-o", "1", "2"]
-           end)
+    assert run(["-e", "IO.puts :ok2", "--", "sample.exs", "-o", "1", "2"]) ==
+             ["sample.exs", "-o", "1", "2"]
+
+    assert StringIO.flush(io) == "ok2\n"
+
+    assert run(["-e", "", "--", "sample.exs", "-o", "1", "2"]) ==
+             ["sample.exs", "-o", "1", "2"]
+
+    assert StringIO.flush(io) == ""
   end
 end
 

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -149,10 +149,21 @@ defmodule ExUnit do
       * `:time` - the duration in microseconds of the test's runtime
       * `:tags` - the test tags
       * `:logs` - the captured logs
+      * `:capture_io` - (since v1.20.0) the captured IO
       * `:parameters` - the test parameters
 
     """
-    defstruct [:name, :case, :module, :state, time: 0, tags: %{}, logs: "", parameters: %{}]
+    defstruct [
+      :name,
+      :case,
+      :module,
+      :state,
+      time: 0,
+      tags: %{},
+      logs: "",
+      capture_io: "",
+      parameters: %{}
+    ]
 
     # TODO: Remove the `:case` field on v2.0
     @type t :: %__MODULE__{

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -183,6 +183,8 @@ defmodule ExUnit.Case do
 
   The following tags customize how tests behave:
 
+    * `:capture_io` - (since v1.20.0) see the "IO Capture" section below
+
     * `:capture_log` - see the "Log Capture" section below
 
     * `:skip` - skips the test with the given reason
@@ -258,6 +260,34 @@ defmodule ExUnit.Case do
   Keep in mind that all tests are included by default, so unless they are
   excluded first, the `include` option has no effect.
 
+  ## IO Capture
+
+  ExUnit can optionally suppress printing of standard output messages generated
+  during a test. Messages generated while running a test are captured and
+  only if the test fails are they printed to aid with debugging.
+
+  The captured IO is available in the test context under `:capture_io`
+  key and can be read using `StringIO.flush/1`:
+
+      defmodule MyTest do
+        use ExUnit.Case, async: true
+
+        @tag :capture_io
+        test "with io", %{capture_io: io} do
+          IO.puts("Hello, World!")
+
+          assert StringIO.flush(io) == "Hello, World!\n"
+        end
+      end
+
+  As with other tags, `:capture_io` can also be set as `@moduletag` and
+  `@describetag`.
+
+  Since `setup_all` blocks don't belong to a specific test, standard output
+  messages generated in them (or between tests) are never captured.
+
+  See also `ExUnit.CaptureIO`.
+
   ## Log Capture
 
   ExUnit can optionally suppress printing of log messages that are generated
@@ -277,6 +307,8 @@ defmodule ExUnit.Case do
   messages as well, remove the console backend globally by setting:
 
       config :logger, :default_handler, false
+
+  See also `ExUnit.CaptureLog`.
 
   ## Tmp Dir
 

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -132,6 +132,7 @@ defmodule ExUnit.CLIFormatter do
       )
 
     print_failure(formatted, config)
+    print_capture_io(test.capture_io)
     print_logs(test.logs)
 
     test_counter = update_test_counter(config.test_counter, test)
@@ -518,5 +519,13 @@ defmodule ExUnit.CLIFormatter do
     indent = "\n     "
     output = String.replace(output, "\n", indent)
     IO.puts(["     The following output was logged:", indent | output])
+  end
+
+  defp print_capture_io(""), do: nil
+
+  defp print_capture_io(output) do
+    indent = "\n     "
+    output = String.replace(output, "\n", indent)
+    IO.puts(["     The following standard output was captured:", indent | output])
   end
 end

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -439,16 +439,19 @@ defmodule ExUnit.Runner do
       generate_test_seed(seed, test, rand_algorithm)
       context = context |> Map.merge(test.tags) |> Map.put(:test_pid, self())
       capture_log = Map.get(context, :capture_log, capture_log)
+      capture_io = Map.get(context, :capture_io, false)
 
       {time, test} =
         :timer.tc(
           maybe_capture_log(capture_log, test, fn ->
-            context = maybe_create_tmp_dir(context, test)
+            maybe_capture_io(capture_io, context, fn context ->
+              context = maybe_create_tmp_dir(context, test)
 
-            case exec_test_setup(test, context) do
-              {:ok, context} -> exec_test(test, context)
-              {:error, test} -> test
-            end
+              case exec_test_setup(test, context) do
+                {:ok, context} -> exec_test(test, context)
+                {:error, test} -> test
+              end
+            end)
           end)
         )
 
@@ -480,6 +483,32 @@ defmodule ExUnit.Runner do
         {test, logs} -> %{test | logs: logs}
       end
     end
+  end
+
+  defp maybe_capture_io(true, context, fun) do
+    {:ok, gl} = StringIO.open("")
+    Process.group_leader(self(), gl)
+    context = put_in(context.capture_io, gl)
+    test = fun.(context)
+    put_in(test.capture_io, StringIO.flush(gl))
+  end
+
+  defp maybe_capture_io(false, context, fun) do
+    fun.(context)
+  end
+
+  defp maybe_capture_io(other, _context, _fun) do
+    raise ArgumentError, """
+    invalid value for @tag :capture_io, expected one of:
+
+        @tag :capture_io
+        @tag capture_io: true
+        @tag capture_io: false
+
+    got:
+
+        @tag capture_io: #{inspect(other)}
+    """
   end
 
   defp receive_test_reply(test, test_pid, test_ref, timeout) do

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -350,6 +350,43 @@ defmodule ExUnitTest do
     assert output =~ "\n1 test, 1 failure (3 excluded)\n"
   end
 
+  test "io capturing" do
+    defmodule IOCapturingTest do
+      use ExUnit.Case
+
+      @tag :capture_io
+      test "one" do
+        # test successful, captured "one" isn't printed
+        IO.puts("one")
+        assert 1 == 1
+      end
+
+      @tag :capture_io
+      test "two" do
+        # test failed, captured "two" is printed
+        IO.puts("two")
+        assert 1 == 2
+      end
+
+      @tag :capture_io
+      test "three, four", %{capture_io: io} do
+        # io is flushed, captured "three" isn't printed
+        IO.puts("three")
+        assert StringIO.flush(io) == "three\n"
+
+        # test failed, captured "four" is printed
+        IO.puts("four")
+        assert 1 == 2
+      end
+    end
+
+    output = capture_io(&ExUnit.run/0)
+    refute output =~ "one\n"
+    assert output =~ "two\n"
+    refute output =~ "three\n"
+    assert output =~ "four\n"
+  end
+
   test "log capturing" do
     defmodule LogCapturingTest do
       use ExUnit.Case


### PR DESCRIPTION
Possible future work:

1. Allow `ExUnit.start(capture_io: true)` to mimic `capture_log: true`?

2. Add api to programmatically append to the StringIO _input_ buffer, right now it's only possible on creation:

   ```elixir
   {:ok, pid} = StringIO.open("3")
   "3" = IO.gets(pid, "1 + 2")
   ```

   The idea is something like this:   

   ```elixir
   {:ok, pid} = StringIO.open("")

   StringIO.buffer("1 + 2")
   "1 + 2" = IO.gets(pid, "> ")

   :eof = IO.gets(pid, "> ")

   StringIO.buffer("2 + 3")
   "2 + 3" = IO.gets(pid, "> ")
   ```

   And so we could replace the usage of:

   ```elixir
   capture_io(prompt, fn -> ... end)
   ```

   too.

   Maybe instead of calling it `StringIO.buffer` it could be called `StringIO.input_write` and `StringIO.input_puts` to mimic `IO.write` and `IO.puts`. Not sure if we'd need `.input_binwrite` too.

3. `@tag capture_io: :standard_error`?

   I think we could do this as long as the test is running in `async: false` which we'd know and then we can raise otherwise. This is as opposed to `capture_io(:standard_error, ...)` where ExUnit does _not_ know if it's sync or async.

   If we do this, do we want to capture both? I guess we could accept a list of devices and set it in context:

   ```elixir
   @tag capture_io: [:stdio, :standard_error]
   test "foo", %{capture_io: [stdio, stderr]}
   ```

   Not sure if `:stdio` is even semantically correct, my understanding is it's not stdio per se but the group leader. So yeah, it's probably a pass, and a reason to use `capture_io` in this case, but I thought I'd mention this for completeness.

4. Make the StringIO available to `@tag :capture_log` tests in context as `%{capture_log: io}`. This could be considered a breaking change since today the context is usually set as `%{capture_log: true}` or `%{capture_log: options}` but I can't think of a reason to read them back in a test.