### PR TITLE
Increase test coverage of IEx ls helper and handle edge case

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -1084,7 +1084,7 @@ defmodule IEx.Helpers do
         if File.exists?(path) do
           IO.puts(IEx.color(:eval_info, Path.absname(path)))
         else
-          IO.puts(IEx.color(:eval_error, "Not a directory #{path}"))
+          IO.puts(IEx.color(:eval_error, "No such file or directory #{path}"))
         end
 
       {:error, reason} ->

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -1081,7 +1081,11 @@ defmodule IEx.Helpers do
         IO.puts(IEx.color(:eval_error, "No such file or directory #{path}"))
 
       {:error, :enotdir} ->
-        IO.puts(IEx.color(:eval_info, Path.absname(path)))
+        if File.exists?(path) do
+          IO.puts(IEx.color(:eval_info, Path.absname(path)))
+        else
+          IO.puts(IEx.color(:eval_error, "Not a directory #{path}"))
+        end
 
       {:error, reason} ->
         IO.puts(IEx.color(:eval_error, :file.format_error(reason)))

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -1080,15 +1080,17 @@ defmodule IEx.Helpers do
       {:error, :enoent} ->
         IO.puts(IEx.color(:eval_error, "No such file or directory #{path}"))
 
-      {:error, :enotdir} ->
-        if File.exists?(path) do
-          IO.puts(IEx.color(:eval_info, Path.absname(path)))
-        else
-          IO.puts(IEx.color(:eval_error, "No such file or directory #{path}"))
-        end
-
       {:error, reason} ->
-        IO.puts(IEx.color(:eval_error, :file.format_error(reason)))
+        cond do
+          File.exists?(path) and not File.dir?(path) ->
+            IO.puts(IEx.color(:eval_info, Path.absname(path)))
+
+          reason == :enotdir ->
+            IO.puts(IEx.color(:eval_error, "No such file or directory #{path}"))
+
+          true ->
+            IO.puts(IEx.color(:eval_error, :file.format_error(reason)))
+        end
     end
 
     dont_display_result()

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1200,6 +1200,19 @@ defmodule IEx.HelpersTest do
     test "lists the given directory" do
       assert capture_io(fn -> ls("~") end) == capture_io(fn -> ls(System.user_home()) end)
     end
+
+    test "returns an existing file" do
+      File.cd!(iex_path(), fn ->
+        assert capture_io(fn -> ls("mix.exs") end) == Path.join(iex_path(), "mix.exs") <> "\n"
+      end)
+    end
+
+    test "prints an error if directory doesn't exist" do
+      File.cd!(iex_path(), fn ->
+        assert capture_io(fn -> ls("unknown_dir") end) ==
+                 "No such file or directory unknown_dir\n"
+      end)
+    end
   end
 
   describe "exports" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1213,6 +1213,15 @@ defmodule IEx.HelpersTest do
                  "No such file or directory unknown_dir\n"
       end)
     end
+
+    test "prints an error if part of the path is not a dir (enotdir)" do
+      File.cd!(iex_path(), fn ->
+        path = Path.join("mix.exs", "foo")
+
+        assert capture_io(fn -> ls(path) end) ==
+                 "Not a directory #{path}\n"
+      end)
+    end
   end
 
   describe "exports" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1219,7 +1219,7 @@ defmodule IEx.HelpersTest do
         path = Path.join("mix.exs", "foo")
 
         assert capture_io(fn -> ls(path) end) ==
-                 "Not a directory #{path}\n"
+                 "No such file or directory #{path}\n"
       end)
     end
   end


### PR DESCRIPTION
Probably not a very frequent case but it might be puzzling to `ls some_file/foo` and get back a non-existing path.
This makes it consistent with the shell `ls`:

![Screenshot 2025-07-05 at 15 53 27](https://github.com/user-attachments/assets/26c6baab-2568-4150-b42a-26212923524f)
