### PR TITLE
Tighten secret scope in `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,14 +303,14 @@ jobs:
     needs: [build, sign]
     runs-on: ubuntu-22.04
     concurrency: builds-hex-pm
+    environment: release
+    # Only run if HEX_AWS_REGION is set (no failing job in forks)
+    if: "${{ vars.HEX_AWS_REGION }}"
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.HEX_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.HEX_AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.HEX_AWS_REGION }}
-      AWS_S3_BUCKET: ${{ secrets.HEX_AWS_S3_BUCKET }}
-      FASTLY_REPO_SERVICE_ID: ${{ secrets.HEX_FASTLY_REPO_SERVICE_ID }}
-      FASTLY_BUILDS_SERVICE_ID: ${{ secrets.HEX_FASTLY_BUILDS_SERVICE_ID }}
-      FASTLY_KEY: ${{ secrets.HEX_FASTLY_KEY }}
+      AWS_REGION: ${{ vars.HEX_AWS_REGION }}
+      AWS_S3_BUCKET: ${{ vars.HEX_AWS_S3_BUCKET }}
       OTP_GENERIC_VERSION: "25"
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -417,3 +417,7 @@ jobs:
           for key in $(cat purge_keys.txt); do
             purge "${key}"
           done
+        env:
+          FASTLY_REPO_SERVICE_ID: ${{ secrets.HEX_FASTLY_REPO_SERVICE_ID }}
+          FASTLY_BUILDS_SERVICE_ID: ${{ secrets.HEX_FASTLY_BUILDS_SERVICE_ID }}
+          FASTLY_KEY: ${{ secrets.HEX_FASTLY_KEY }}


### PR DESCRIPTION
## What changed

- **Introduced `environment: release`** to the `publish-to-hex` job so that only workflows explicitly targeting the release environment can read sensitive values.  
- **Added a safeguard** – `if: ${{ vars.HEX_AWS_REGION }}` – to skip the job in forks that don’t define release variables.  
- **Converted non-secret AWS settings to environment variables**  
  - `${{ vars.HEX_AWS_REGION }}`  
  - `${{ vars.HEX_AWS_S3_BUCKET }}`  
  These are configuration values, not credentials, so variables are a better fit and remain visible only to jobs using the `release` environment.  
- **Scoped Fastly secrets to the purge step** instead of the whole job, keeping tokens out of steps that don’t need them.

## Why it matters

Placing secrets in an environment and scoping them to the minimum surface area:

* prevents forks and unrelated jobs from accessing production credentials;  
* limits accidental leakage in logs;  
* follows the principle of least privilege, reducing the blast radius if any single step is compromised.

## TODO for Maintainers

| Item | New home |
| --- | --- |
| `HEX_AWS_REGION`, `HEX_AWS_S3_BUCKET` | **Environment → release → Variables** |
| `HEX_AWS_ACCESS_KEY_ID`<br>`HEX_AWS_SECRET_ACCESS_KEY`<br>`HEX_FASTLY_REPO_SERVICE_ID`<br>`HEX_FASTLY_BUILDS_SERVICE_ID`<br>`HEX_FASTLY_KEY` | **Environment → release → Secrets** |

Once the moves are complete, new release builds will run with the tighter permissions automatically.

