### PR TITLE
use simpler words in mix-and-otp guides

### DIFF
--- a/lib/elixir/pages/mix-and-otp/erlang-term-storage.md
+++ b/lib/elixir/pages/mix-and-otp/erlang-term-storage.md
@@ -166,7 +166,7 @@ may be failing on this line:
 
 How can this line fail if we just created the bucket in the previous line?
 
-The reason those failures are happening is because, for didactic purposes, we have made two mistakes:
+The reason those failures are happening is because, for educational purposes, we have made two mistakes:
 
   1. We are prematurely optimizing (by adding this cache layer)
   2. We are using `cast/2` (while we should be using `call/2`)

--- a/lib/elixir/pages/mix-and-otp/genservers.md
+++ b/lib/elixir/pages/mix-and-otp/genservers.md
@@ -319,7 +319,7 @@ So far we have used three callbacks: `handle_call/3`, `handle_cast/2` and `handl
 
 1. `handle_call/3` must be used for synchronous requests. This should be the default choice as waiting for the server reply is a useful back-pressure mechanism.
 
-2. `handle_cast/2` must be used for asynchronous requests, when you don't care about a reply. A cast does not guarantee the server has received the message and, for this reason, should be used sparingly. For example, the `create/2` function we have defined in this chapter should have used `call/2`. We have used `cast/2` for didactic purposes.
+2. `handle_cast/2` must be used for asynchronous requests, when you don't care about a reply. A cast does not guarantee the server has received the message and, for this reason, should be used sparingly. For example, the `create/2` function we have defined in this chapter should have used `call/2`. We have used `cast/2` for educational purposes.
 
 3. `handle_info/2` must be used for all other messages a server may receive that are not sent via `GenServer.call/2` or `GenServer.cast/2`, including regular messages sent with `send/2`. The monitoring `:DOWN` messages are an example of this.
 


### PR DESCRIPTION
"didactic" is a word that even many native English speakers do not understand. "educational purposes" is much easier to understand.