### PR TITLE
Correct grammar in structural sorting order section

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -231,7 +231,7 @@ defmodule Kernel do
 
   Finally, note there is an overall structural sorting order, called
   "Term Ordering", defined below. This order is provided for reference
-  purposes, it is not required by Elixir developers to know it by heart.
+  purposes, it is not required for Elixir developers to know it by heart.
 
   ### Term ordering
 


### PR DESCRIPTION
It is not required by the Elixir developer, but it is not required for them to know this by heart.

The former indicates that it is the Elixir developers who are not requiring this, the latter expresses that they do not need to know this by heart.