### PR TITLE
Add ETS to the Erlang Term Storage section of erlang libs

### DIFF
--- a/lib/elixir/pages/getting-started/erlang-libraries.md
+++ b/lib/elixir/pages/getting-started/erlang-libraries.md
@@ -85,7 +85,7 @@ iex> :digraph.get_short_path(digraph, v0, v2)
 Note that the functions in `:digraph` alter the graph structure in-place, this
 is possible because they are implemented as ETS tables, explained next.
 
-## Erlang Term Storage
+## Erlang Term Storage (ETS)
 
 The modules [`:ets`](`:ets`) and [`:dets`](`:dets`) handle storage of large data structures in memory or on disk respectively.
 


### PR DESCRIPTION
This will ensure that it appears in the short search results on ExDoc instead of having to navigate through to the search results.