### PR TITLE
Drop :app_properties when rendering dependency in mix

### DIFF
--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -415,7 +415,7 @@ defmodule Mix.Dep do
       |> Kernel.++(if manager, do: [manager: manager], else: [])
       |> Kernel.++(if system_env != [], do: [system_env: system_env], else: [])
       |> Kernel.++(opts)
-      |> Keyword.drop([:dest, :build, :lock, :manager, :checkout])
+      |> Keyword.drop([:dest, :build, :lock, :manager, :checkout, :app_properties])
 
     info = if req, do: {app, req, opts}, else: {app, opts}
     "\n  > In #{Path.relative_to_cwd(from)}:\n    #{inspect(info)}\n"


### PR DESCRIPTION
This doesn't seem relevant to dep resolution and is quite spammy:

Before
<img width="1338" height="752" alt="Screenshot 2025-07-12 at 9 09 24" src="https://github.com/user-attachments/assets/b823b9c8-6f50-467e-b24c-a77f80abcb5e" />

After
<img width="1230" height="398" alt="Screenshot 2025-07-12 at 9 10 02" src="https://github.com/user-attachments/assets/5f5fcec6-d615-481e-b67f-1a0f62463bef" />
