### PR TITLE
chore: Add printable_limit and limit to IO.inspect doc examples

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -496,13 +496,13 @@ defmodule IO do
 
   Inspect truncates large inputs by default, to display large strings or maps use the limit options:
       "abc"
-      |> String.duplicate("abc", 9001)
+      |> String.duplicate(9001)
       |> IO.inspect(printable_limit: :infinity)
 
   Or for large maps:
 
-      1..500
-      |> Enum.reduce(%{}, & {&1, &1})
+      1..100
+      |> Enum.reduce(%{}, & {&1, &2})
       |> Enum.into(%{})
       |> IO.inspect(limit: :infinity)
 

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -502,7 +502,7 @@ defmodule IO do
   Or for large maps:
 
       1..100
-      |> Enum.reduce(%{}, & {&1, &2})
+      |> Enum.map(& {&1, &1})
       |> Enum.into(%{})
       |> IO.inspect(limit: :infinity)
 

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -467,32 +467,21 @@ defmodule IO do
 
   ## Examples
 
+  The following code:
+
       IO.inspect(<<0, 1, 2>>, width: 40)
 
   Prints:
 
       <<0, 1, 2>>
 
-  We can use the `:label` option to decorate the output:
+  You can use the `:label` option to decorate the output:
 
       IO.inspect(1..100, label: "a wonderful range")
 
   Prints:
 
       a wonderful range: 1..100
-
-  The `:label` option is especially useful with pipelines:
-
-      [1, 2, 3]
-      |> IO.inspect(label: "before")
-      |> Enum.map(&(&1 * 2))
-      |> IO.inspect(label: "after")
-      |> Enum.sum()
-
-  Prints:
-
-      before: [1, 2, 3]
-      after: [2, 4, 6]
 
   Inspect truncates large inputs by default. The `:printable_limit` controls
   the limit for strings and other string-like constructs (such as charlists):

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -494,6 +494,18 @@ defmodule IO do
       before: [1, 2, 3]
       after: [2, 4, 6]
 
+  Inspect truncates large inputs by default, to display large strings or maps use the limit options:
+      "abc"
+      |> String.duplicate("abc", 9001)
+      |> IO.inspect(printable_limit: :infinity)
+
+  Or for large maps:
+
+      1..500
+      |> Enum.reduce(%{}, & {&1, &1})
+      |> Enum.into(%{})
+      |> IO.inspect(limit: :infinity)
+
   """
   @spec inspect(item, inspect_opts) :: item when item: var
   def inspect(item, opts \\ []) do

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -494,13 +494,15 @@ defmodule IO do
       before: [1, 2, 3]
       after: [2, 4, 6]
 
-  Inspect truncates large inputs by default, to display large strings or maps use the limit options:
+  Inspect truncates large inputs by default. The `:printable_limit` controls
+  the limit for strings and other string-like constructs (such as charlists):
 
       "abc"
       |> String.duplicate(9001)
       |> IO.inspect(printable_limit: :infinity)
 
-  Or for large maps:
+  For containers such as lists, maps, and tuples, the number of entries
+  is managed by the `:limit` option:
 
       1..100
       |> Enum.map(& {&1, &1})

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -495,6 +495,7 @@ defmodule IO do
       after: [2, 4, 6]
 
   Inspect truncates large inputs by default, to display large strings or maps use the limit options:
+
       "abc"
       |> String.duplicate(9001)
       |> IO.inspect(printable_limit: :infinity)


### PR DESCRIPTION
I've noticed that often people forget about the :printable_limit and :limit options of IO.inspeact . Adding it to the doc example will make it easier for for people to see these options in editors and online documentation.