### PR TITLE
Clean up unreachable clause of Types.Descr.atom_only? helper

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -972,7 +972,6 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp atom_only?(:term), do: false
   defp atom_only?(descr), do: empty?(Map.delete(descr, :atom))
   defp atom_new(as) when is_list(as), do: {:union, :sets.from_list(as, version: 2)}
 


### PR DESCRIPTION
it's being always called with a map