### PR TITLE
Escape quotes and control chars in DOT

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -496,7 +496,7 @@ defmodule Mix.Utils do
   defp escape_dot_string(<<?", rest::binary>>, acc) do
     escape_dot_string(rest, <<acc::binary, ?\\, ?">>)
   end
-  
+
   defp escape_dot_string(<<?\\>>, acc) do
     <<acc::binary, ?\\, ?\\, ?">>
   end
@@ -504,7 +504,7 @@ defmodule Mix.Utils do
   defp escape_dot_string(<<char, rest::binary>>, acc) do
     escape_dot_string(rest, <<acc::binary, char>>)
   end
-  
+
   defp escape_dot_string(<<>>, acc) do
     <<acc::binary, ?">>
   end

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -481,7 +481,28 @@ defmodule Mix.Utils do
     ["  ", parent, quoted(name), edge_info, ?\n]
   end
 
-  defp quoted(data), do: [?", to_string(data), ?"]
+  defp quoted(data) do
+    escaped_data =
+      data
+      |> to_string()
+      # escape \
+      |> String.replace("\\", "\\\\")
+      # escape " (required in DOT quoted strings)
+      |> String.replace("\"", "\\\"")
+      # escape other special characters
+      |> String.replace("\0", "\\0")
+      |> String.replace("\a", "\\a")
+      |> String.replace("\b", "\\b")
+      |> String.replace("\d", "\\d")
+      |> String.replace("\e", "\\e")
+      |> String.replace("\f", "\\f")
+      |> String.replace("\n", "\\n")
+      |> String.replace("\r", "\\r")
+      |> String.replace("\t", "\\t")
+      |> String.replace("\v", "\\v")
+
+    [?", escaped_data, ?"]
+  end
 
   @doc false
   @deprecated "Use Macro.underscore/1 instead"

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -497,12 +497,12 @@ defmodule Mix.Utils do
     escape_dot_string(rest, <<acc::binary, ?\\, ?">>)
   end
   
-  defp escape_dot_string(<<char, rest::binary>>, acc) do
-    escape_dot_string(rest, <<acc::binary, char>>)
-  end
-  
   defp escape_dot_string(<<?\\>>, acc) do
     <<acc::binary, ?\\, ?\\, ?">>
+  end
+
+  defp escape_dot_string(<<char, rest::binary>>, acc) do
+    escape_dot_string(rest, <<acc::binary, char>>)
   end
   
   defp escape_dot_string(<<>>, acc) do

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -229,20 +229,6 @@ defmodule Mix.UtilsTest do
   end
 
   describe "write_dot_graph!/4" do
-    test "escapes quotes" do
-      in_tmp("dot_quotes", fn ->
-        callback = fn node -> {{node, nil}, []} end
-
-        Mix.Utils.write_dot_graph!("graph.dot", "graph", ["foo \"bar\""], callback, [])
-
-        assert File.read!("graph.dot") == """
-               digraph "graph" {
-                 "foo \\"bar\\""
-               }
-               """
-      end)
-    end
-
     test "preserves newlines and other control characters" do
       in_tmp("dot_newlines", fn ->
         callback = fn node -> {{node, nil}, []} end
@@ -254,20 +240,6 @@ defmodule Mix.UtilsTest do
                  "foo 
                bar\r
                baz"
-               }
-               """
-      end)
-    end
-
-    test "handles backslashes correctly" do
-      in_tmp("dot_backslashes", fn ->
-        callback = fn node -> {{node, nil}, []} end
-
-        Mix.Utils.write_dot_graph!("graph.dot", "graph", ["foo\\bar"], callback, [])
-
-        assert File.read!("graph.dot") == """
-               digraph "graph" {
-                 "foo\\bar"
                }
                """
       end)

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -243,21 +243,23 @@ defmodule Mix.UtilsTest do
       end)
     end
 
-    test "escapes newlines" do
-      in_tmp("dot_quotes", fn ->
+    test "preserves newlines and other control characters" do
+      in_tmp("dot_newlines", fn ->
         callback = fn node -> {{node, nil}, []} end
 
         Mix.Utils.write_dot_graph!("graph.dot", "graph", ["foo \nbar\r\nbaz"], callback, [])
 
         assert File.read!("graph.dot") == """
                digraph "graph" {
-                 "foo \\nbar\\r\\nbaz"
+                 "foo 
+               bar\r
+               baz"
                }
                """
       end)
     end
 
-    test "escapes backslashes" do
+    test "handles backslashes correctly" do
       in_tmp("dot_backslashes", fn ->
         callback = fn node -> {{node, nil}, []} end
 
@@ -265,21 +267,81 @@ defmodule Mix.UtilsTest do
 
         assert File.read!("graph.dot") == """
                digraph "graph" {
-                 "foo\\\\bar"
+                 "foo\\bar"
                }
                """
       end)
     end
 
-    test "escapes control characters" do
-      in_tmp("dot_tabs", fn ->
+    test "quote and backslash combinations" do
+      in_tmp("dot_complex", fn ->
         callback = fn node -> {{node, nil}, []} end
 
-        Mix.Utils.write_dot_graph!("graph.dot", "graph", ["foo\v\t\f\e\d\b\a\0bar"], callback, [])
+        test_cases = [
+          # "fo"o" -> "fo\"o"
+          {"fo\"o", "fo\\\"o"},
+          # "fo\"o" -> "fo\\\"o"
+          {"fo\\\"o", "fo\\\\\"o"},
+          # "fo\o" -> "fo\o"
+          {"fo\\o", "fo\\o"},
+          # "fo\\o" -> "fo\\o"
+          {"fo\\\\o", "fo\\\\o"},
+          # "fo\\\o" -> "fo\\\o"
+          {"fo\\\\\\o", "fo\\\\\\o"}
+        ]
+
+        Enum.each(test_cases, fn {input, expected} ->
+          Mix.Utils.write_dot_graph!("graph.dot", "graph", [input], callback, [])
+          content = File.read!("graph.dot")
+          assert content == "digraph \"graph\" {\n  \"#{expected}\"\n}\n"
+        end)
+      end)
+    end
+
+    test "escapes backslash at end of string" do
+      in_tmp("dot_end_backslash", fn ->
+        callback = fn node -> {{node, nil}, []} end
+
+        test_cases = [
+          # "fo\" -> "fo\\" (add backslash)
+          {"fo\\", "fo\\\\"},
+          # "fo\\" -> "fo\\" (already valid)
+          {"fo\\\\", "fo\\\\"},
+          # "fo\\\" -> "fo\\\\" (add backslash)
+          {"fo\\\\\\", "fo\\\\\\\\"}
+        ]
+
+        Enum.each(test_cases, fn {input, expected} ->
+          Mix.Utils.write_dot_graph!("graph.dot", "graph", [input], callback, [])
+          content = File.read!("graph.dot")
+          assert content == "digraph \"graph\" {\n  \"#{expected}\"\n}\n"
+        end)
+      end)
+    end
+
+    test "handles empty strings" do
+      in_tmp("dot_empty", fn ->
+        callback = fn node -> {{node, nil}, []} end
+
+        Mix.Utils.write_dot_graph!("graph.dot", "graph", [""], callback, [])
 
         assert File.read!("graph.dot") == """
                digraph "graph" {
-                 "foo\\v\\t\\f\\e\\d\\b\\a\\0bar"
+                 ""
+               }
+               """
+      end)
+    end
+
+    test "handles edge labels with escaping" do
+      in_tmp("dot_edge_labels", fn ->
+        callback = fn node -> {{node, "edge \"label\""}, []} end
+
+        Mix.Utils.write_dot_graph!("graph.dot", "graph", ["node"], callback, [])
+
+        assert File.read!("graph.dot") == """
+               digraph "graph" {
+                 "node" [label="edge \\"label\\""]
                }
                """
       end)

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -228,6 +228,64 @@ defmodule Mix.UtilsTest do
     end
   end
 
+  describe "write_dot_graph!/4" do
+    test "escapes quotes" do
+      in_tmp("dot_quotes", fn ->
+        callback = fn node -> {{node, nil}, []} end
+
+        Mix.Utils.write_dot_graph!("graph.dot", "graph", ["foo \"bar\""], callback, [])
+
+        assert File.read!("graph.dot") == """
+               digraph "graph" {
+                 "foo \\"bar\\""
+               }
+               """
+      end)
+    end
+
+    test "escapes newlines" do
+      in_tmp("dot_quotes", fn ->
+        callback = fn node -> {{node, nil}, []} end
+
+        Mix.Utils.write_dot_graph!("graph.dot", "graph", ["foo \nbar\r\nbaz"], callback, [])
+
+        assert File.read!("graph.dot") == """
+               digraph "graph" {
+                 "foo \\nbar\\r\\nbaz"
+               }
+               """
+      end)
+    end
+
+    test "escapes backslashes" do
+      in_tmp("dot_backslashes", fn ->
+        callback = fn node -> {{node, nil}, []} end
+
+        Mix.Utils.write_dot_graph!("graph.dot", "graph", ["foo\\bar"], callback, [])
+
+        assert File.read!("graph.dot") == """
+               digraph "graph" {
+                 "foo\\\\bar"
+               }
+               """
+      end)
+    end
+
+    test "escapes control characters" do
+      in_tmp("dot_tabs", fn ->
+        callback = fn node -> {{node, nil}, []} end
+
+        Mix.Utils.write_dot_graph!("graph.dot", "graph", ["foo\v\t\f\e\d\b\a\0bar"], callback, [])
+
+        assert File.read!("graph.dot") == """
+               digraph "graph" {
+                 "foo\\v\\t\\f\\e\\d\\b\\a\\0bar"
+               }
+               """
+      end)
+    end
+  end
+
   defp assert_ebin_symlinked_or_copied(result) do
     case result do
       {:ok, paths} ->


### PR DESCRIPTION
DOT syntax requires escaping quotes in quoted string Other control characters are not strictly required to be escaped but a DOT graph containing them will most likely not be parsed by other tools See reference DOT syntax https://graphviz.org/doc/info/lang.html