### PR TITLE
Return error on invalid unicode sequences

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -1016,7 +1016,13 @@ build_bin_string({bin_string, Location, Args}, ExtraMeta) ->
   {'<<>>', Meta, string_parts(Args)}.
 
 build_list_string({list_string, _Location, [H]} = Token, ExtraMeta) when is_binary(H) ->
-  handle_literal(elixir_utils:characters_to_list(H), Token, ExtraMeta);
+  try
+    List = elixir_utils:characters_to_list(H),
+    handle_literal(List, Token, ExtraMeta)
+  catch
+    error:#{'__struct__' := 'Elixir.UnicodeConversionError', message := Message} ->
+      return_error(?location(Token), elixir_utils:characters_to_list(Message), "'")
+  end;
 build_list_string({list_string, Location, Args}, ExtraMeta) ->
   Meta = meta_from_location(Location),
   MetaWithExtra =


### PR DESCRIPTION
I revisited https://github.com/elixir-lang/elixir/pull/14589 and attempted to make the tokenizer and parser API more consistent. `Code.string_to_quoted` should not raise for valid string input. If the string has parsing errors it should always return an error tuple.

I collected all the cases where invalid UTF byte sequence may be used
```
cases = [
  # binstring
  "\"\\xFF\"",
  "\"\\xFF\#{some()}\"",
  # charlist
  "'\\xFF'",
  "'\\xFF\#{some()}'",
  # bin heredoc
  "\"\"\"\n\\xFF\n\"\"\"",
  "\"\"\"\n\\xFF\#{some()}\n\"\"\"",
  # list heredoc
  "'''\n\\xFF\n'''",
  "'''\n\\xFF\#{some()}\n'''",
  # quoted atom
  ":\"\\xFF\"",
  ":'\\xFF'",
  ":\"\\xFF\#{some()}\"",
  ":'\\xFF\#{some()}'",
  # quoted keyword identifier
  "[\"\\xFF\": 1]",
  "['\\xFF': 1]",
  "[\"\\xFF\#{some()}\": 1]",
  "['\\xFF\#{some()}': 1]",
  # quoted dot call
  "Foo.\"\\xFF\"",
  "Foo.'\\xFF'",
  "Foo.\"\\xFF\#{some()}\"",
  "Foo.'\\xFF\#{some()}'",
  # sigil
  "~s\"\\xFF\"",
  "~s'\\xFF'",
  "~s\"\\xFF\#{some()}\"",
  "~s'\\xFF\#{some()}'",
  "~S\"\\xFF\"",
  "~S'\\xFF'",
  "~S\"\\xFF\#{some()}\"",
  "~S'\\xFF\#{some()}'",
]
```
Before this PR the tokenizer used to raise on quoted atom/kw/dot call. The parser used to raise on list string and list heredoc.

Note that invalid byte sequences are still allowed in:
- bin string (AST node and token has raw binary)
- bin heredoc (AST node and token has raw binary)
- sigil (AST node and token has raw binary, may crash at runtime)
- anything with interpolation (AST has function calls with raw binary arg, will crash at runtime)