### PR TITLE
Validate type of :deps_paths option for formatter_for_file/2

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -518,6 +518,12 @@ defmodule Mix.Tasks.Format do
   defp eval_deps_opts(deps, opts) do
     deps_paths = opts[:deps_paths] || Mix.Project.deps_paths()
 
+    if not is_map(deps_paths) do
+      Mix.raise(
+        "Expected :deps_paths to return a map of dependency paths, got: #{inspect(deps_paths)}"
+      )
+    end
+
     for dep <- deps,
         dep_path = assert_valid_dep_and_fetch_path(dep, deps_paths),
         dep_dot_formatter = Path.join(dep_path, ".formatter.exs"),


### PR DESCRIPTION
I ran into an issue caused by a typo when passing `:deps_paths`:

```elixir
Mix.Tasks.Format.formatter_for_file(file_path, deps_paths: Mix.Project.deps_path())
# Should have been:
Mix.Tasks.Format.formatter_for_file(file_path, deps_paths: Mix.Project.deps_paths())
```

Notice the missing "s". The result was a message about missing dependencies, and in combination with the subtle typo, it took some time to figure out what was going wrong here. The additional check should make this kind of issue much clearer.