### PR TITLE
Restore warnings in assert/1 by not marking expressions as generated

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -177,13 +177,16 @@ defmodule ExUnit.Assertions do
       {args, value} = extract_args(assertion, __CALLER__)
 
       quote generated: true do
-        if value = unquote(value) do
-          value
-        else
-          raise ExUnit.AssertionError,
-            args: unquote(args),
-            expr: unquote(escape_quoted(:assert, [], assertion)),
-            message: "Expected truthy, got #{inspect(value)}"
+        # not using `if` here because we don't want :generated to be propagated and suppress warnings
+        case unquote(value) do
+          falsy when falsy in [false, nil] ->
+            raise ExUnit.AssertionError,
+              args: unquote(args),
+              expr: unquote(escape_quoted(:assert, [], assertion)),
+              message: "Expected truthy, got #{inspect(falsy)}"
+
+          truthy ->
+            truthy
         end
       end
     end
@@ -238,13 +241,16 @@ defmodule ExUnit.Assertions do
       {args, value} = extract_args(assertion, __CALLER__)
 
       quote generated: true do
-        if value = unquote(value) do
-          raise ExUnit.AssertionError,
-            args: unquote(args),
-            expr: unquote(escape_quoted(:refute, [], assertion)),
-            message: "Expected false or nil, got #{inspect(value)}"
-        else
-          value
+        # not using `if` here because we don't want :generated to be propagated and suppress warnings
+        case unquote(value) do
+          falsy when falsy in [false, nil] ->
+            falsy
+
+          truthy ->
+            raise ExUnit.AssertionError,
+              args: unquote(args),
+              expr: unquote(escape_quoted(:refute, [], assertion)),
+              message: "Expected false or nil, got #{inspect(truthy)}"
         end
       end
     end


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/14676

I think the ideal fix would be to improve macro expansion to never propagate `generated: true` to `unquotes`... but that might be tricky and maybe introduce other false positives?

<img width="1522" height="208" alt="Screenshot 2025-07-29 at 8 26 06" src="https://github.com/user-attachments/assets/fc8c69f8-ae9c-49ea-a868-c4bd85ce0e51" />
