### PR TITLE
Print intermediate results of dbg for pipes

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2893,7 +2893,7 @@ defmodule Macro do
   defp dbg_format_ast_to_debug({:pipe_end, code_ast, value}, options) do
     {formatted, value} = dbg_format_ast_to_debug({:pipe, code_ast, value}, options)
 
-    {[formatted | ?\n], value}
+    {[formatted, ?\n], value}
   end
 
   defp dbg_format_ast_to_debug({:case_argument, expr_ast, expr_value}, options) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -444,6 +444,28 @@ defmodule MacroTest do
       assert formatted =~ ~r/[^\n]\n\n$/
     end
 
+    test "pipeline on multiple lines that raises" do
+      {result, formatted} =
+        dbg_format_no_newline(
+          abc()
+          |> tl()
+          |> tl()
+          |> tl()
+          |> tl()
+        )
+
+      assert %ArgumentError{} = result
+
+      assert formatted =~ "macro_test.exs"
+
+      assert formatted =~ """
+             abc() #=> [:a, :b, :c]
+             |> tl() #=> [:b, :c]
+             |> tl() #=> [:c]
+             |> tl() #=> []
+             """
+    end
+
     test "simple boolean expressions" do
       {result, formatted} = dbg_format(:rand.uniform() < 0.0 and length([]) == 0)
       assert result == false


### PR DESCRIPTION
Print intermediate results when using dbg with pipes.
<img width="824" height="465" alt="Screenshot From 2025-07-31 00-35-07" src="https://github.com/user-attachments/assets/e44cdebe-81dc-4e00-9c8e-4ea368251539" />
