### PR TITLE
Fix link to type in Application docs

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -903,13 +903,13 @@ defmodule Application do
   @doc """
   Ensures the given `app` or `apps` and their child applications are started.
 
-  The second argument is either the `t:restart_type/1` (for consistency with
+  The second argument is either the `t:restart_type/0` (for consistency with
   `start/2`) or a keyword list.
 
   ## Options
 
     * `:type` - if the application should be started `:temporary` (default),
-      `:permanent`, or `:transient`. See `t:restart_type/1` for more information.
+      `:permanent`, or `:transient`. See `t:restart_type/0` for more information.
 
     * `:mode` - (since v1.15.0) if the applications should be started serially
       (`:serial`, default) or concurrently (`:concurrent`).


### PR DESCRIPTION
This is how it is rendered, and ExDoc is not emitting a warning about linking to an non-existent type

<img width="807" height="69" alt="image" src="https://github.com/user-attachments/assets/c7df848c-cf23-4314-88bb-3399fd9e5a0f" />
