### PR TITLE
Rewrite maps, tuples, lists as BDDs. Performance improvements.

### DIFF
--- a/lib/elixir/lib/module/parallel_checker.ex
+++ b/lib/elixir/lib/module/parallel_checker.ex
@@ -423,7 +423,7 @@ defmodule Module.ParallelChecker do
       mode =
         with {^module, binary, _filename} <- object_code,
              {:ok, {^module, [{~c"ExCk", chunk}]}} <- :beam_lib.chunks(binary, [~c"ExCk"]),
-             {:elixir_checker_v2, contents} <- :erlang.binary_to_term(chunk) do
+             {:elixir_checker_v3, contents} <- :erlang.binary_to_term(chunk) do
           # The chunk has more information, so that's our preference
           cache_chunk(table, module, contents)
         else

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -2493,12 +2493,14 @@ defmodule Module.Types.Descr do
 
   def map_union(map_literal(tag1, fields1), map_literal(tag2, fields2)) do
     case maybe_optimize_map_union({tag1, fields1, []}, {tag2, fields2, []}) do
-      {tag, fields, []} -> map_literal(tag, fields)
-      nil -> 
+      {tag, fields, []} ->
+        map_literal(tag, fields)
+
+      nil ->
         case {{tag1, fields1}, {tag2, fields2}} do
           {r, l} when l < r -> {l, :bdd_top, {r, :bdd_top, :bdd_bot}}
           {l, r} -> {l, :bdd_top, {r, :bdd_top, :bdd_bot}}
-      end
+        end
     end
   end
 

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -2265,7 +2265,7 @@ defmodule Module.Types.Descr do
 
   # Case 3: when a list with negations is united with one of its negations
   defp add_to_list_normalize([{t, l, n} = cur | rest], list, last, []) do
-    case pop_elem({list, last}, n) do
+    case pop_elem(n, {list, last}, []) do
       {true, n1} -> [{t, l, n1} | rest]
       {false, _} -> [cur | add_to_list_normalize(rest, list, last, n)]
     end
@@ -2273,13 +2273,9 @@ defmodule Module.Types.Descr do
 
   defp add_to_list_normalize(rest, list, last, negs), do: [{list, last, negs} | rest]
 
-  defp pop_elem(elem, list) do
-    case :lists.delete(elem, list) do
-      ^list -> {false, list}
-      new_list -> {true, new_list}
-    end
-  end
-
+  defp pop_elem([key | t], key, acc), do: {true, :lists.reverse(acc, t)}
+  defp pop_elem([h | t], key, acc), do: pop_elem(t, key, [h | acc])
+  defp pop_elem([], _key, acc), do: {false, :lists.reverse(acc)}
   ## Dynamic
   #
   # A type with a dynamic component is a gradual type; without, it is a static

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -3547,7 +3547,7 @@ defmodule Module.Types.Descr do
     end)
   end
 
-  # Use heuristics to normalize a map dnf for pretty printing.
+  # Use heuristics to normalize a map bdd for pretty printing.
   defp map_normalize(bdd) do
     map_bdd_get(bdd)
     |> Enum.map(fn {tag, fields, negs} ->

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -1421,7 +1421,7 @@ defmodule Module.Types.Descr do
         acc
 
       :bdd_top ->
-        if fun_empty?(pos, neg), do: acc, else: [{pos, neg} | acc]
+        if fun_line_empty?(pos, neg), do: acc, else: [{pos, neg} | acc]
 
       {fun, left, right} ->
         fun_bdd_to_dnf(fun_bdd_to_dnf(acc, [fun | pos], neg, left), pos, [fun | neg], right)
@@ -1448,7 +1448,7 @@ defmodule Module.Types.Descr do
         true
 
       :bdd_top ->
-        fun_empty?(pos, neg)
+        fun_line_empty?(pos, neg)
 
       {fun, left, right} ->
         fun_bdd_empty?([fun | pos], neg, left) and fun_bdd_empty?(pos, [fun | neg], right)
@@ -1468,9 +1468,9 @@ defmodule Module.Types.Descr do
   # - `{[fun(integer() -> atom())], [fun(none() -> term())]}` is empty
   # - `{[], _}` (representing the top function type fun()) is never empty
   #
-  defp fun_empty?([], _), do: false
+  defp fun_line_empty?([], _), do: false
 
-  defp fun_empty?(positives, negatives) do
+  defp fun_line_empty?(positives, negatives) do
     case fetch_arity_and_domain(positives) do
       # If there are functions with different arities in positives, then the function type is empty
       {:empty, _} ->

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -73,8 +73,8 @@ defmodule Module.Types.Descr do
   @term_or_dynamic_optional Map.put(@term, :dynamic, %{optional: 1})
   @not_atom_or_optional Map.delete(@term_or_optional, :atom)
 
-  @empty_intersection [0, [], :bdd_bot]
-  @empty_difference [0, [], :bdd_bot]
+  @empty_intersection [0, :bdd_bot]
+  @empty_difference [0, :bdd_bot]
 
   defguard is_descr(descr) when is_map(descr) or descr == :term
 

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -1440,7 +1440,20 @@ defmodule Module.Types.Descr do
   # - `fun(1) and not fun(1)` is empty
   # - `fun(integer() -> atom()) and not fun(none() -> term())` is empty
   # - `fun(integer() -> atom()) and not fun(atom() -> integer())` is not empty
-  defp fun_empty?(bdd), do: fun_bdd_to_dnf(bdd) == []
+  defp fun_empty?(bdd), do: fun_bdd_empty?([], [], bdd)
+
+  defp fun_bdd_empty?(pos, neg, bdd) do
+    case bdd do
+      :bdd_bot ->
+        true
+
+      :bdd_top ->
+        fun_empty?(pos, neg)
+
+      {fun, left, right} ->
+        fun_bdd_empty?([fun | pos], neg, left) and fun_bdd_empty?(pos, [fun | neg], right)
+    end
+  end
 
   # Checks if a function type represented by positive and negative function literals is empty.
 

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -754,24 +754,12 @@ defmodule Module.Types.Descr do
   def disjoint?(%{dynamic: :term}, other), do: empty?(remove_optional(other))
   def disjoint?(other, %{dynamic: :term}), do: empty?(remove_optional(other))
 
+  # Two gradual types are disjoint if their upper bounds are disjoint.
   def disjoint?(left, right) do
-    left = unfold(left)
-    right = unfold(right)
-    is_gradual_left = gradual?(left)
-    is_gradual_right = gradual?(right)
+    left_upper = unfold(left) |> Map.get(:dynamic, left)
+    right_upper = unfold(right) |> Map.get(:dynamic, right)
 
-    cond do
-      is_gradual_left and not is_gradual_right ->
-        right_with_dynamic = Map.put(right, :dynamic, right)
-        not non_disjoint_intersection?(left, right_with_dynamic)
-
-      is_gradual_right and not is_gradual_left ->
-        left_with_dynamic = Map.put(left, :dynamic, left)
-        not non_disjoint_intersection?(left_with_dynamic, right)
-
-      true ->
-        not non_disjoint_intersection?(left, right)
-    end
+    not non_disjoint_intersection?(left_upper, right_upper)
   end
 
   @doc """

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -2038,11 +2038,8 @@ defmodule Module.Types.Descr do
   # 3. Base case: adds bdd2 type to negations of bdd1 type
   # The result may be larger than the initial bdd1, which is maintained in the accumulator.
   defp list_difference(list_literal(list1, last1) = bdd1, list_literal(list2, last2) = bdd2) do
-    list = intersection(list1, list2)
-    last = intersection(last1, last2)
-
     cond do
-      empty?(list) or empty?(last) -> list_literal(list1, last1)
+      disjoint?(list1, list2) or disjoint?(last1, last2) -> list_literal(list1, last1)
       subtype?(list1, list2) and subtype?(last1, last2) -> :bdd_bot
       equal?(list1, list2) -> list_literal(list1, difference(last1, last2))
       true -> bdd_difference(bdd1, bdd2)
@@ -4171,13 +4168,11 @@ defmodule Module.Types.Descr do
         end
 
       {{next_tag, next_elements} = next_tuple, left, right} ->
+        # If an intersection of tuples is empty, the line is empty and we skip it.
         acc =
           case tuple_literal_intersection(tag, elements, next_tag, next_elements) do
-            :empty ->
-              acc
-
-            new_tuple ->
-              tuple_bdd_get(acc, new_tuple, negs, left, transform, compose)
+            :empty -> acc
+            new_tuple -> tuple_bdd_get(acc, new_tuple, negs, left, transform, compose)
           end
 
         tuple_bdd_get(acc, tuple, [next_tuple | negs], right, transform, compose)

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -2494,7 +2494,11 @@ defmodule Module.Types.Descr do
   def map_union(map_literal(tag1, fields1), map_literal(tag2, fields2)) do
     case maybe_optimize_map_union({tag1, fields1, []}, {tag2, fields2, []}) do
       {tag, fields, []} -> map_literal(tag, fields)
-      nil -> {{tag1, fields1}, :bdd_top, {{tag2, fields2}, :bdd_top, :bdd_bot}}
+      nil -> 
+        case {{tag1, fields1}, {tag2, fields2}} do
+          {r, l} when l < r -> {l, :bdd_top, {r, :bdd_top, :bdd_bot}}
+          {l, r} -> {l, :bdd_top, {r, :bdd_top, :bdd_bot}}
+      end
     end
   end
 

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -662,7 +662,7 @@ checker_chunk(Map, Def, ChunkOpts) ->
     end
   },
 
-  [{<<"ExCk">>, term_to_binary({elixir_checker_v2, Contents}, ChunkOpts)}].
+  [{<<"ExCk">>, term_to_binary({elixir_checker_v3, Contents}, ChunkOpts)}].
 
 prepend_behaviour_info(true, Def) -> [{{behaviour_info, 1}, []} | Def];
 prepend_behaviour_info(false, Def) -> Def.

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -587,7 +587,7 @@ defmodule Module.Types.DescrTest do
     test "list" do
       # Basic list type differences
       assert difference(list(term()), empty_list()) == non_empty_list(term())
-      assert difference(list(integer()), list(term())) == none()
+      assert difference(list(integer()), list(term())) |> empty?()
 
       assert difference(list(integer()), list(float()))
              |> equal?(non_empty_list(integer()))
@@ -609,7 +609,7 @@ defmodule Module.Types.DescrTest do
       refute difference(list(union(atom(), binary())), list(atom())) == list(binary())
 
       # Tests for list with last element
-      assert difference(list(integer(), atom()), list(number(), term())) == none()
+      assert difference(list(integer(), atom()), list(number(), term())) |> empty?()
 
       assert difference(
                list(atom(), term()),
@@ -657,8 +657,8 @@ defmodule Module.Types.DescrTest do
              )
 
       # Difference with proper list
-      assert difference(list(integer(), atom()), list(integer())) ==
-               non_empty_list(integer(), atom())
+      assert difference(list(integer(), atom()), list(integer()))
+             |> equal?(non_empty_list(integer(), atom()))
     end
 
     test "fun" do

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -135,6 +135,18 @@ defmodule Module.Types.DescrTest do
       # Test union of open map and map with domain key
       assert union(open_map(), open_map([{domain_key(:integer), atom()}]))
              |> equal?(open_map())
+
+      # Ensure no duplicate, no matter the order
+      assert union(
+               open_map(a: integer()),
+               open_map(a: number(), b: binary())
+             )
+             |> union(open_map(a: integer())) ==
+               union(
+                 open_map(a: number(), b: binary()),
+                 open_map(a: integer())
+               )
+               |> union(open_map(a: integer()))
     end
 
     test "list" do

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -2375,7 +2375,7 @@ defmodule Module.Types.DescrTest do
              )
              |> union(difference(open_map(x: atom()), open_map(x: boolean())))
              |> to_quoted_string() ==
-               "%{..., a: integer(), b: atom(), c: boolean()} or\n  (%{..., x: atom() and not boolean()} and not %{..., a: integer(), b: atom(), c: boolean()})"
+               "%{..., x: atom() and not boolean()} or\n  (%{..., a: integer(), b: atom(), c: boolean()} and not %{..., x: atom() and not boolean()})"
 
       assert closed_map(a: number(), b: atom(), c: pid())
              |> difference(closed_map(a: integer(), b: atom(), c: pid()))

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -964,24 +964,18 @@ defmodule Module.Types.DescrTest do
       # Subsets
       assert fun_from_inferred_clauses([{[integer()], atom()}, {[number()], binary()}])
              |> equal?(
-               intersection(
-                 fun_from_non_overlapping_clauses([
-                   {[integer()], union(atom(), binary())},
-                   {[float()], binary()}
-                 ]),
-                 fun([number()], dynamic())
-               )
+               fun_from_non_overlapping_clauses([
+                 {[integer()], dynamic(union(atom(), binary()))},
+                 {[number()], dynamic(union(atom(), binary()))}
+               ])
              )
 
       assert fun_from_inferred_clauses([{[number()], binary()}, {[integer()], atom()}])
              |> equal?(
-               intersection(
-                 fun_from_non_overlapping_clauses([
-                   {[integer()], union(atom(), binary())},
-                   {[float()], binary()}
-                 ]),
-                 fun([number()], dynamic())
-               )
+               fun_from_non_overlapping_clauses([
+                 {[integer()], dynamic(union(atom(), binary()))},
+                 {[number()], dynamic(union(atom(), binary()))}
+               ])
              )
 
       # Partial
@@ -990,14 +984,10 @@ defmodule Module.Types.DescrTest do
                {[union(float(), pid())], binary()}
              ])
              |> equal?(
-               intersection(
-                 fun_from_non_overlapping_clauses([
-                   {[integer()], atom()},
-                   {[float()], binary()},
-                   {[pid()], union(atom(), binary())}
-                 ]),
-                 fun([union(number(), pid())], dynamic())
-               )
+               fun_from_non_overlapping_clauses([
+                 {[union(integer(), pid())], dynamic(union(atom(), binary()))},
+                 {[union(float(), pid())], dynamic(union(atom(), binary()))}
+               ])
              )
 
       # Difference
@@ -1006,17 +996,10 @@ defmodule Module.Types.DescrTest do
                {[number(), pid()], binary()}
              ])
              |> equal?(
-               intersection(
-                 fun_from_non_overlapping_clauses([
-                   {[float(), pid()], binary()},
-                   {[integer(), atom()], atom()},
-                   {[integer(), pid()], union(atom(), binary())}
-                 ]),
-                 fun_from_non_overlapping_clauses([
-                   {[integer(), union(pid(), atom())], dynamic()},
-                   {[number(), pid()], dynamic()}
-                 ])
-               )
+               fun_from_non_overlapping_clauses([
+                 {[integer(), union(pid(), atom())], dynamic(union(atom(), binary()))},
+                 {[number(), pid()], dynamic(union(atom(), binary()))}
+               ])
              )
     end
   end

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -291,6 +291,37 @@ defmodule Module.Types.ExprTest do
                  (term() -> dynamic({:ok, term()}))
              """
     end
+
+    test "works when there are multiple clauses with lists and maps" do
+      type =
+        typecheck!(fn
+          [:oban, :job, _event], _measure, _meta, _opts ->
+            :ok
+
+          [:oban, :notifier, :switch], _measure, %{status: _status}, _opts ->
+            :ok
+
+          [:oban, :peer, :election, :stop], _measure, _meta, _opts ->
+            :ok
+
+          [:oban, :plugin, :exception], _measure, _meta, _opts ->
+            :ok
+
+          [:oban, :plugin, :stop], _measure, _meta, _opts ->
+            :ok
+
+          [:oban, :queue, :shutdown], _measure, %{orphaned: [_ | _]}, _opts ->
+            :ok
+
+          [:oban, :stager, :switch], _measure, %{mode: _mode}, _opts ->
+            :ok
+
+          _event, _measure, _meta, _opts ->
+            :ok
+        end)
+
+      assert subtype?(type, fun([term(), term(), term(), term()], atom([:ok])))
+    end
   end
 
   describe "remotes" do
@@ -2030,37 +2061,6 @@ defmodule Module.Types.ExprTest do
                  x
                )
              ) == dynamic(integer())
-    end
-
-    test "typecheck! must finish fast for large pattern match" do
-      type =
-        typecheck!(fn
-          [:oban, :job, _event], _measure, _meta, _opts ->
-            :ok
-
-          [:oban, :notifier, :switch], _measure, %{status: _status}, _opts ->
-            :ok
-
-          [:oban, :peer, :election, :stop], _measure, _meta, _opts ->
-            :ok
-
-          [:oban, :plugin, :exception], _measure, _meta, _opts ->
-            :ok
-
-          [:oban, :plugin, :stop], _measure, _meta, _opts ->
-            :ok
-
-          [:oban, :queue, :shutdown], _measure, %{orphaned: [_ | _]}, _opts ->
-            :ok
-
-          [:oban, :stager, :switch], _measure, %{mode: _mode}, _opts ->
-            :ok
-
-          _event, _measure, _meta, _opts ->
-            :ok
-        end)
-
-      assert subtype?(type, fun([term(), term(), term(), term()], atom([:ok])))
     end
   end
 

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -2031,6 +2031,30 @@ defmodule Module.Types.ExprTest do
                )
              ) == dynamic(integer())
     end
+
+    # test "regressions – duplicate-key list pattern" do
+    #   assert typecheck!(
+    #            # HEAD PATTERN LIST
+    #            [
+    #              # first tuple
+    #              [
+    #                {key, _}
+    #                # second tuple + rest
+    #                | [{key, _} | _] = rest
+    #              ]
+    #            ],
+    #            # BODY – we just return the tail we captured
+    #            rest
+    #          ) ==
+    #            dynamic(
+    #              non_empty_list(
+    #                # every element is {term, term}
+    #                tuple([term(), term()]),
+    #                # the tail can be anything
+    #                term()
+    #              )
+    #            )
+    # end
   end
 
   describe "info" do

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -2055,6 +2055,25 @@ defmodule Module.Types.ExprTest do
     #              )
     #            )
     # end
+
+    test "Oban.Telemetry pattern matching does not time-out" do
+      assert typecheck!(fn
+               [:oban, :job, _event], _measure, _meta, _opts -> :ok
+               #  [:oban, :notifier, :switch], _measure, %{status: _status}, _opts -> :ok
+               [:oban, :peer, :election, :stop], _measure, _meta, _opts -> :ok
+               [:oban, :plugin, :exception], _measure, _meta, _opts -> :ok
+               [:oban, :plugin, :stop], _measure, _meta, _opts -> :ok
+               #  [:oban, :queue, :shutdown], _measure, %{orphaned: [_ | _]}, _opts -> :ok
+               #  [:oban, :stager, :switch], _measure, %{mode: _mode}, _opts -> :ok
+               _event, _measure, _meta, _opts -> :ok
+             end)
+             |> equal?(
+               fun(
+                 [term(), term(), term(), term()],
+                 dynamic(atom([:ok]))
+               )
+             )
+    end
   end
 
   describe "info" do

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -2033,19 +2033,26 @@ defmodule Module.Types.ExprTest do
     end
 
     # test "regressions – duplicate-key list pattern" do
-    #   assert typecheck!(
-    #            # HEAD PATTERN LIST
-    #            [
-    #              # first tuple
-    #              [
-    #                {key, _}
-    #                # second tuple + rest
-    #                | [{key, _} | _] = rest
-    #              ]
-    #            ],
-    #            # BODY – we just return the tail we captured
-    #            rest
-    #          ) ==
+    #   x =
+    #     typecheck!(
+    #       # HEAD PATTERN LIST
+    #       [
+    #         # first tuple
+    #         [
+    #           {key, _}
+    #           # second tuple + rest
+    #           | [{key, _} | _] = rest
+    #         ]
+    #       ],
+    #       # BODY – we just return the tail we captured
+    #       rest
+    #     )
+
+    #   IO.puts("x: #{to_quoted_string(x)}")
+    #   IO.puts("x: #{inspect(x)}")
+
+    #   assert x
+    #          |> equal?(
     #            dynamic(
     #              non_empty_list(
     #                # every element is {term, term}
@@ -2054,6 +2061,7 @@ defmodule Module.Types.ExprTest do
     #                term()
     #              )
     #            )
+    #          )
     # end
 
     test "typecheck! must finish fast for large pattern match" do

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -2032,38 +2032,6 @@ defmodule Module.Types.ExprTest do
              ) == dynamic(integer())
     end
 
-    # test "regressions – duplicate-key list pattern" do
-    #   x =
-    #     typecheck!(
-    #       # HEAD PATTERN LIST
-    #       [
-    #         # first tuple
-    #         [
-    #           {key, _}
-    #           # second tuple + rest
-    #           | [{key, _} | _] = rest
-    #         ]
-    #       ],
-    #       # BODY – we just return the tail we captured
-    #       rest
-    #     )
-
-    #   IO.puts("x: #{to_quoted_string(x)}")
-    #   IO.puts("x: #{inspect(x)}")
-
-    #   assert x
-    #          |> equal?(
-    #            dynamic(
-    #              non_empty_list(
-    #                # every element is {term, term}
-    #                tuple([term(), term()]),
-    #                # the tail can be anything
-    #                term()
-    #              )
-    #            )
-    #          )
-    # end
-
     test "typecheck! must finish fast for large pattern match" do
       type =
         typecheck!(fn

--- a/lib/elixir/test/elixir/module/types/integration_test.exs
+++ b/lib/elixir/test/elixir/module/types/integration_test.exs
@@ -1538,7 +1538,7 @@ defmodule Module.Types.IntegrationTest do
 
   defp read_chunk(binary) do
     assert {:ok, {_module, [{~c"ExCk", chunk}]}} = :beam_lib.chunks(binary, [~c"ExCk"])
-    assert {:elixir_checker_v2, map} = :erlang.binary_to_term(chunk)
+    assert {:elixir_checker_v3, map} = :erlang.binary_to_term(chunk)
     map
   end
 

--- a/lib/elixir/test/elixir/protocol/consolidation_test.exs
+++ b/lib/elixir/test/elixir/protocol/consolidation_test.exs
@@ -165,7 +165,7 @@ defmodule Protocol.ConsolidationTest do
 
     defp exports(binary) do
       {:ok, {_, [{~c"ExCk", check_bin}]}} = :beam_lib.chunks(binary, [~c"ExCk"])
-      assert {:elixir_checker_v2, contents} = :erlang.binary_to_term(check_bin)
+      assert {:elixir_checker_v3, contents} = :erlang.binary_to_term(check_bin)
       Map.new(contents.exports)
     end
 


### PR DESCRIPTION
Changing the representation of maps, tuples to instead use trees (binary decision diagrams).

As we use more and more the difference operator in the type system (e.g. to compute `fun_from_inferred_clauses(args_clauses)` for inferred function types from patterns), the "DNF" representation started running into pathological cases and hog out time during emptiness checks, and printing.

The BDD is now used for set operations and subtyping, and translated (using previous logic and simplications) to DNF for printing and type operations like map fetch.

The BDD representation is common to maps, tuples, lists and functions. Some functions are generic (called bdd_difference, bdd_intersection, ...). 

We also changes some algorithms:
- `tuple_eliminate_negation` was not generating disjoint tuples. It now does, which greatly improves performance and printing quality.
-`tuple_empty?` now uses the same logic, this improves performances.
- `pivot_overlapping_clauses` algorithm was not generating disjoint tuples. It now does.
- The computation of subtyping for functions and function application is too slow for large arrow intersections (>30). This adds a special case `apply_disjoint`, when the functions are disjoint and non-empty (as produced by fun_from_inferred_clauses, for instance), which is much faster.