### PR TITLE
Fix trailing token crash

### DIFF
--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -1332,7 +1332,7 @@ defmodule Code.Fragment do
   defp drop_tokens([{:do, _} | tokens], counter), do: drop_tokens(tokens, counter + 1)
 
   defp drop_tokens([_ | tokens], counter), do: drop_tokens(tokens, counter)
-  defp drop_tokens([], 0), do: []
+  defp drop_tokens([], _counter), do: []
 
   defp maybe_missing_stab?([{:after, _} | _], _stab_choice?), do: true
   defp maybe_missing_stab?([{:do, _} | _], _stab_choice?), do: true


### PR DESCRIPTION
I noticed this crash in the logs. I'm not sure what input produced that error.

```
an exception was raised:
    ** (FunctionClauseError) no function clause matching in Code.Fragment.drop_tokens_2
        (elixir 1.18.3) <REDACTED: user-file-path>:1209: Code.Fragment.drop_tokens([], 2)
        (elixir 1.18.3) <REDACTED: user-file-path>:1184: Code.Fragment.container_cursor_to_quoted_2
```