### PR TITLE
Fix exunit format_message crash when message is not a string

### DIFF
--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -622,7 +622,12 @@ defmodule ExUnit.Formatter do
   end
 
   defp format_message(value, formatter) do
-    value = pad_multiline(value, 5)
+    value =
+      case value do
+        binary when is_binary(binary) -> binary
+        other -> inspect(other)
+      end
+      |> pad_multiline(5)
 
     if String.contains?(value, IO.ANSI.reset()) do
       value


### PR DESCRIPTION
I noticed this crash in the logs. I'm not sure if a struct is supposed to be in `message`. The `ExUnit.AssertionError` struct typespec has type `any`
```
an exception was raised:
    ** (FunctionClauseError) no function clause matching in ExUnit.Formatter.pad_multiline_2
USER_PATH_ex_unit_formatter.ex:735: ExUnit.Formatter.pad_multiline(#Ecto.Changeset<action: nil, changes: %{foo_id: 123}, errors: [prefered_locale: {"can't be blank", [validation: :required]}], data: #Foo.Domain<>, valid?: false, ...>, 5)
USER_PATH_ex_unit_formatter.ex:616: ExUnit.Formatter.format_message_2
USER_PATH_ex_unit_formatter.ex:377: ExUnit.Formatter.format_exception_6
USER_PATH_ex_unit_formatter.ex:278: anonymous fn_7 in ExUnit.Formatter.format_test_failure_5
        (elixir 1.18.2) <REDACTED: user-file-path>:1815: anonymous fn_2 in Enum.map_join_3
        (elixir 1.18.2) <REDACTED: user-file-path>:4493: Enum.map_intersperse_list_3
        (elixir 1.18.2) <REDACTED: user-file-path>:1815: Enum.map_join_3
USER_PATH_ex_unit_formatter.ex:277: ExUnit.Formatter.format_test_failure_5
```