### PR TITLE
Improve Enum.min_max/1,2,3 specs and docs

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2187,19 +2187,18 @@ defmodule Enum do
       nil
 
   """
-  @spec min_max(t, (element, element -> boolean) | module()) ::
+  @spec min_max(t) :: {element, element}
+  @spec min_max(t, (element, element -> boolean) | module()) :: {element, element}
+  @spec min_max(t, (-> empty_result)) :: {element, element} | empty_result when empty_result: any
+  @spec min_max(t, (element, element -> boolean) | module(), (-> empty_result)) ::
           {element, element} | empty_result
-        when empty_result: any
-  @spec min_max(
-          t,
-          (element, element -> boolean) | module(),
-          (-> empty_result)
-        ) :: {element, element} | empty_result
         when empty_result: any
 
   def min_max(enumerable) do
     min_max(enumerable, fn -> raise Enum.EmptyError end)
   end
+
+  def min_max(enumerable, sorter_or_empty_fallback)
 
   def min_max(first..last//step = range, empty_fallback)
       when is_function(empty_fallback, 0) do

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2187,18 +2187,13 @@ defmodule Enum do
       nil
 
   """
-  @spec min_max(t) :: {element, element}
   @spec min_max(t, (element, element -> boolean) | module()) :: {element, element}
   @spec min_max(t, (-> empty_result)) :: {element, element} | empty_result when empty_result: any
   @spec min_max(t, (element, element -> boolean) | module(), (-> empty_result)) ::
           {element, element} | empty_result
         when empty_result: any
 
-  def min_max(enumerable) do
-    min_max(enumerable, fn -> raise Enum.EmptyError end)
-  end
-
-  def min_max(enumerable, sorter_or_empty_fallback)
+  def min_max(enumerable, sorter_or_empty_fallback \\ fn -> raise Enum.EmptyError end)
 
   def min_max(first..last//step = range, empty_fallback)
       when is_function(empty_fallback, 0) do


### PR DESCRIPTION
- Add min_max/1 spec for confirming quickly that it returns a tuple
- Add back min_max/2 spec for the empty_result fallback clause, as a separate spec with non overlapping domain
- Add min_max/2 empty head so that the doc shows 2nd arg as sorter_or_empty_fallback and not just empty_fallback from the first clause

(min_max/3 spec didn't change, was only re-formatted for compactness)