### PR TITLE
Fix expand crash on invalid multialias root

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -573,18 +573,24 @@ escape_map(Map) -> {'%{}', [], lists:sort(maps:to_list(Map))}.
 expand_multi_alias_call(Kind, Meta, Base, Refs, Opts, S, E) ->
   {BaseRef, SB, EB} = expand_without_aliases_report(Base, S, E),
 
-  Fun = fun
-    ({'__aliases__', _, Ref}, SR, ER) ->
-      expand({Kind, Meta, [elixir_aliases:concat([BaseRef | Ref]), Opts]}, SR, ER);
+  case is_atom(BaseRef) of
+    true ->
+      Fun = fun
+        ({'__aliases__', _, Ref}, SR, ER) ->
+          expand({Kind, Meta, [elixir_aliases:concat([BaseRef | Ref]), Opts]}, SR, ER);
 
-    (Ref, SR, ER) when is_atom(Ref) ->
-      expand({Kind, Meta, [elixir_aliases:concat([BaseRef, Ref]), Opts]}, SR, ER);
+        (Ref, SR, ER) when is_atom(Ref) ->
+          expand({Kind, Meta, [elixir_aliases:concat([BaseRef, Ref]), Opts]}, SR, ER);
 
-    (Other, _SR, _ER) ->
-      file_error(Meta, E, ?MODULE, {expected_compile_time_module, Kind, Other})
-  end,
+        (Other, _SR, _ER) ->
+          file_error(Meta, E, ?MODULE, {expected_compile_time_module, Kind, Other})
+      end,
 
-  mapfold(Fun, SB, EB, Refs).
+      mapfold(Fun, SB, EB, Refs);
+
+    false ->
+      file_error(Meta, E, ?MODULE, {invalid_alias, Base})
+  end.
 
 resolve_super(Meta, Arity, E) ->
   Module = assert_module_scope(Meta, super, E),

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -118,6 +118,12 @@ defmodule Kernel.ExpansionTest do
       end)
     end
 
+    test "raises on multi-alias with non-atom base" do
+      assert_compile_error(~r"invalid alias: \"foo\"", fn ->
+        expand(quote(do: alias(foo.{Bar, Baz})))
+      end)
+    end
+
     test "invalid options" do
       assert_compile_error(~r"unsupported option :ops given to alias", fn ->
         expand(quote(do: alias(Foo, ops: 1)))


### PR DESCRIPTION
I noticed this code crashes
```
iex(1)> defmodule A do
...(1)> @asd Foo
...(1)> alias @asd.{Bar}
...(1)> end
** (FunctionClauseError) no function clause matching in :elixir_aliases.do_concat/2    
    
    The following arguments were given to :elixir_aliases.do_concat/2:
    
        # 1
        [
          {{:., [line: 3], [Module, :__get_attribute__]}, [line: 3], [A, :asd, 3, true]},
          :Bar
        ]
    
        # 2
        "Elixir"
    
    (elixir 1.18.4) src/elixir_aliases.erl:183: :elixir_aliases.do_concat/2
    (elixir 1.18.4) src/elixir_aliases.erl:171: :elixir_aliases.concat/1
    (elixir 1.18.4) src/elixir_expand.erl:575: anonymous fn/8 in :elixir_expand.expand_multi_alias_call/7
    (elixir 1.18.4) src/elixir_expand.erl:701: :elixir_expand.mapfold/5
    (elixir 1.18.4) src/elixir_expand.erl:625: :elixir_expand.expand_block/5
    (elixir 1.18.4) src/elixir_expand.erl:48: :elixir_expand.expand/3
    (elixir 1.18.4) src/elixir_expand.erl:13: :elixir_expand.expand/3
    iex:1: (file)
```
Compare to:

```
iex(1)> defmodule A do
...(1)> @asd Foo
...(1)> alias @asd.Bar
...(1)> end
error: invalid alias: "@asd.Bar". If you wanted to define an alias, an alias must expand to an atom at compile time but it did not, you may use Module.concat/2 to build it at runtime. If instead you wanted to invoke a function or access a field, wrap the function or field name in double quotes
└─ iex:3: A (module)

** (CompileError) iex: cannot compile module A (errors have been logged)
    (elixir 1.18.4) src/elixir_expand.erl:71: :elixir_expand.expand/3
    (elixir 1.18.4) src/elixir_expand.erl:625: :elixir_expand.expand_block/5
    (elixir 1.18.4) src/elixir_expand.erl:48: :elixir_expand.expand/3
    (elixir 1.18.4) src/elixir_expand.erl:13: :elixir_expand.expand/3
    (elixir 1.18.4) src/elixir_expand.erl:634: :elixir_expand.expand_block/5
    (elixir 1.18.4) src/elixir_expand.erl:48: :elixir_expand.expand/3
    iex:1: (file)
```