### PR TITLE
Fix filtering documentation

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -437,6 +437,7 @@ defmodule Logger do
         def filter(log_event, _opts) do
           case log_event do
             %{msg: {:string, msg}} ->
+              # msg may be a charlist or a binary
               if to_string(msg) =~ "password" do
                 :stop
               else


### PR DESCRIPTION
The filtering documentation implied that the msg attribute of the logger event map could be a binary, but according to the erlang types (https://www.erlang.org/doc/apps/kernel/logger.html#t:log_event/0) it can't be a binary.

This change updates the docs with an example that comports with the actual typing.