### PR TITLE
ExUnit: Raise explaining what failed on invalid tags

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -940,9 +940,19 @@ defmodule ExUnit.Case do
 
   defp normalize_tags(tags) do
     Enum.reduce(Enum.reverse(tags), %{}, fn
-      {key, value}, acc -> Map.put(acc, key, value)
-      tag, acc when is_atom(tag) -> Map.put(acc, tag, true)
-      tag, acc when is_list(tag) -> Enum.into(tag, acc)
+      {key, value}, acc ->
+        Map.put(acc, key, value)
+
+      tag, acc when is_atom(tag) ->
+        Map.put(acc, tag, true)
+
+      tag, acc ->
+        if Keyword.keyword?(tag) do
+          Enum.into(tag, acc)
+        else
+          raise "an invalid value for a tag was used; " <>
+                  "expected an atom or a keyword list, got: #{inspect(tag)}"
+        end
     end)
   end
 end

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -950,8 +950,8 @@ defmodule ExUnit.Case do
         if Keyword.keyword?(tag) do
           Enum.into(tag, acc)
         else
-          raise "an invalid value for a tag was used; " <>
-                  "expected an atom or a keyword list, got: #{inspect(tag)}"
+          raise "an invalid value for a tag was used. " <>
+                  "Expected an atom or a keyword list, got: #{inspect(tag)}"
         end
     end)
   end


### PR DESCRIPTION
Errors were a bit cryptic when running `mix test`.

`@tag "a"` before:

```
== Compilation error in file test/ex_unit_tag_error_test.exs ==
** (FunctionClauseError) no function clause matching in anonymous fn/2 in ExUnit.Case.normalize_tags/1

    The following arguments were given to anonymous fn/2 in ExUnit.Case.normalize_tags/1:

        # 1
        "a"

        # 2
        %{}

    (ex_unit 1.18.4) lib/ex_unit/case.ex:896: anonymous fn/2 in ExUnit.Case.normalize_tags/1
    (elixir 1.18.4) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ex_unit 1.18.4) lib/ex_unit/case.ex:669: ExUnit.Case.register_test/6
    test/ex_unit_tag_error_test.exs:7: (module)
    (elixir 1.18.4) lib/kernel/parallel_compiler.ex:542: Kernel.ParallelCompiler.require_file/2
    (elixir 1.18.4) lib/kernel/parallel_compiler.ex:425: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/8
```


`@tag "a"` now:

```
== Compilation error in file test/ex_unit_tag_error_test.exs ==
** (RuntimeError) an invalid value for a tag was used; expected an atom or a keyword list, got: "a"
    (ex_unit 1.20.0-dev) lib/ex_unit/case.ex:953: anonymous fn/2 in ExUnit.Case.normalize_tags/1
    (elixir 1.20.0-dev) lib/enum.ex:2580: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ex_unit 1.20.0-dev) lib/ex_unit/case.ex:715: ExUnit.Case.register_test/6
    test/ex_unit_tag_error_test.exs:7: (module)
    (elixir 1.20.0-dev) lib/kernel/parallel_compiler.ex:599: Kernel.ParallelCompiler.require_file/2
    (elixir 1.20.0-dev) lib/kernel/parallel_compiler.ex:482: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/8
```

`@tag [:foo, :bar]` before:

```
== Compilation error in file test/ex_unit_tag_error_test.exs ==
** (ArgumentError) argument error
    (stdlib 6.2) :maps.from_list([:foo, :bar])
    (elixir 1.18.4) lib/enum.ex:1543: Enum.into_map/1
    (elixir 1.18.4) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ex_unit 1.18.4) lib/ex_unit/case.ex:669: ExUnit.Case.register_test/6
    test/ex_unit_tag_error_test.exs:7: (module)
    (elixir 1.18.4) lib/kernel/parallel_compiler.ex:542: Kernel.ParallelCompiler.require_file/2
    (elixir 1.18.4) lib/kernel/parallel_compiler.ex:425: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/8

```

`@tag [:foo, :bar]` now:

```
== Compilation error in file test/ex_unit_tag_error_test.exs ==
** (RuntimeError) an invalid value for a tag was used; expected an atom or a keyword list, got: [:foo, :bar]
    (ex_unit 1.20.0-dev) lib/ex_unit/case.ex:953: anonymous fn/2 in ExUnit.Case.normalize_tags/1
    (elixir 1.20.0-dev) lib/enum.ex:2580: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ex_unit 1.20.0-dev) lib/ex_unit/case.ex:715: ExUnit.Case.register_test/6
    test/ex_unit_tag_error_test.exs:7: (module)
    (elixir 1.20.0-dev) lib/kernel/parallel_compiler.ex:599: Kernel.ParallelCompiler.require_file/2
    (elixir 1.20.0-dev) lib/kernel/parallel_compiler.ex:482: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/8


```