### PR TITLE
Use new OTP28.1 :re.import for regexes

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -6657,7 +6657,16 @@ defmodule Kernel do
       # TODO: Remove this when we require Erlang/OTP 28.1+
       is_binary(binary_or_tuple) and Code.ensure_loaded?(:re) and
           function_exported?(:re, :import, 1) ->
-        Macro.escape(Regex.compile_export!(binary_or_tuple, bin_opts))
+        %{re_pattern: exported_pattern, source: source, opts: opts} =
+          Regex.compile_export!(binary_or_tuple, bin_opts)
+
+        quote do
+          %Regex{
+            re_pattern: :re.import(unquote(Macro.escape(exported_pattern))),
+            source: unquote(source),
+            opts: unquote(opts)
+          }
+        end
 
       true ->
         quote(do: Regex.compile!(unquote(binary_or_tuple), unquote(bin_opts)))


### PR DESCRIPTION
This is a PoC to integrate https://github.com/erlang/otp/pull/9976.

I'm not sure about introducing a separate `compile_export` function or always do it in `compile`, but given there is a small perf cost for using an exported pattern over a ref one, it might be good to distinguish?

If we agree with the approach, will add proper docs.