### PR TITLE
Add __escape__/1 and use it to fix Regex escaping in OTP28.1 

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -6648,22 +6648,13 @@ defmodule Kernel do
   defp compile_regex(binary_or_tuple, options) do
     bin_opts = :binary.list_to_bin(options)
 
-    # TODO: Remove this when we require Erlang/OTP 28.1+
-    case is_binary(binary_or_tuple) and compile_time_regexes_supported?() do
+    case is_binary(binary_or_tuple) do
       true ->
         Macro.escape(Regex.compile!(binary_or_tuple, bin_opts))
 
       false ->
         quote(do: Regex.compile!(unquote(binary_or_tuple), unquote(bin_opts)))
     end
-  end
-
-  defp compile_time_regexes_supported? do
-    # OTP 28.0 introduced refs in patterns, which can't be used in AST anymore
-    # OTP 28.1 introduced :re.import/1 which allows us to fix this in Macro.escape
-    :erlang.system_info(:otp_release) < [?2, ?8] or
-      (Code.ensure_loaded?(:re) and
-         function_exported?(:re, :import, 1))
   end
 
   @doc ~S"""

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3813,13 +3813,6 @@ defmodule Kernel do
           {_, doc} when doc_attr? ->
             do_at_escape(name, doc)
 
-          %{__struct__: Regex, source: source, opts: opts} = regex ->
-            # TODO: Automatically deal with exported regexes
-            case :erlang.system_info(:otp_release) < [?2, ?8] do
-              true -> do_at_escape(name, regex)
-              false -> quote(do: Regex.compile!(unquote(source), unquote(opts)))
-            end
-
           value ->
             do_at_escape(name, value)
         end

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -6646,14 +6646,24 @@ defmodule Kernel do
   end
 
   defp compile_regex(binary_or_tuple, options) do
-    # TODO: Remove this when we require Erlang/OTP 28+
-    case is_binary(binary_or_tuple) and :erlang.system_info(:otp_release) < [?2, ?8] do
+    bin_opts = :binary.list_to_bin(options)
+
+    # TODO: Remove this when we require Erlang/OTP 28.1+
+    case is_binary(binary_or_tuple) and compile_time_regexes_supported?() do
       true ->
-        Macro.escape(Regex.compile!(binary_or_tuple, :binary.list_to_bin(options)))
+        Macro.escape(Regex.compile!(binary_or_tuple, bin_opts))
 
       false ->
-        quote(do: Regex.compile!(unquote(binary_or_tuple), unquote(:binary.list_to_bin(options))))
+        quote(do: Regex.compile!(unquote(binary_or_tuple), unquote(bin_opts)))
     end
+  end
+
+  defp compile_time_regexes_supported? do
+    # OTP 28.0 introduced refs in patterns, which can't be used in AST anymore
+    # OTP 28.1 introduced :re.import/1 which allows us to fix this in Macro.escape
+    :erlang.system_info(:otp_release) < [?2, ?8] or
+      (Code.ensure_loaded?(:re) and
+         function_exported?(:re, :import, 1))
   end
 
   @doc ~S"""

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -853,7 +853,7 @@ defmodule Macro do
   However, you may have values at compile-time which cannot be escaped, such as
   `reference`s and `pid`s, since the process or memory address they point to will
   no longer exist once compilation completes. Attempting to escape said values will
-  raise. This is a common issue when working with NIFs.
+  raise an exception. This is a common issue when working with NIFs.
 
   Luckily, Elixir v1.19 introduces a mechanism that allows those values to be escaped,
   as long as they are encapsulated by a struct within a module that defines the

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -846,16 +846,16 @@ defmodule Macro do
 
   ## Dealing with references and other runtime values
 
-  Macros work at compile-time and therefore `Macro.escape/1` can only escape
-  values that are valid during compilation, such as numbers, atoms, tuples, binaries,
+  Macros work at compile-time and therefore `Macro.escape/1` can only escape values
+  that are valid during compilation, such as numbers, atoms, tuples, maps, binaries,
   etc.
 
   However, you may have values at compile-time which cannot be escaped, such as
   `reference`s and `pid`s, since the process or memory address they point to will
   no longer exist once compilation completes. Attempting to escape said values will
-  load to errors. This is a common issue when working with NIFs.
+  raise. This is a common issue when working with NIFs.
 
-  Luckily, Elixir v1.19 introduces a mechanism that allow those values to be escaped,
+  Luckily, Elixir v1.19 introduces a mechanism that allows those values to be escaped,
   as long as they are encapsulated by a struct within a module that defines the
   `__escape__/1` function. This is possible as long as the reference has a natural
   text or binary representation that can be serialized during compilation.

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -844,13 +844,21 @@ defmodule Macro do
   bound), while `quote/2` produces syntax trees for
   expressions.
 
-  ## Customizing struct escapes
+  ## Dealing with references and other runtime values
 
-  By default, structs are escaped to generate the AST for their internal representation.
+  Macros work at compile-time and therefore `Macro.escape/1` can only escape
+  values that are valid during compilation, such as numbers, atoms, tuples, binaries,
+  etc.
 
-  This approach does not work if the internal representation contains references (like
-  `Regex` structs), because references can't be escaped.
-  This is a common issue when working with NIFs.
+  However, you may have values at compile-time which cannot be escaped, such as
+  `reference`s and `pid`s, since the process or memory address they point to will
+  no longer exist once compilation completes. Attempting to escape said values will
+  load to errors. This is a common issue when working with NIFs.
+
+  Luckily, Elixir v1.19 introduces a mechanism that allow those values to be escaped,
+  as long as they are encapsulated by a struct within a module that defines the
+  `__escape__/1` function. This is possible as long as the reference has a natural
+  text or binary representation that can be serialized during compilation.
 
   Let's imagine we have the following struct:
 
@@ -893,6 +901,8 @@ defmodule Macro do
 
       def my_struct, do: WrapperStruct.load_from_binary(<<...>>)
 
+  When implementing `__escape__/1`, you must ensure that the quoted expression
+  will evaluate to a struct that represents the one given as argument.
   """
   @spec escape(term, escape_opts) :: t()
   def escape(expr, opts \\ []) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -141,10 +141,26 @@ defmodule MacroTest do
       assert Macro.escape({:quote, [], [[do: :foo]]}) == {:{}, [], [:quote, [], [[do: :foo]]]}
     end
 
-    test "inspects container when a reference cannot be escaped" do
+    @tag skip: System.otp_release() < "28" or function_exported?(:re, :import, 1)
+    test "escape container when a reference cannot be escaped" do
       assert_raise ArgumentError, ~r"~r/foo/ contains a reference", fn ->
         Macro.escape(%{~r/foo/ | re_pattern: {:re_pattern, 0, 0, 0, make_ref()}})
       end
+    end
+
+    @tag skip: not function_exported?(:re, :import, 1)
+    test "escape regex will remove references and replace it by a call to :re.import/1" do
+      assert {
+               :%{},
+               [],
+               [
+                 __struct__: Regex,
+                 re_pattern:
+                   {{:., [], [:re, :import]}, [], [{:{}, [], [:re_exported_pattern | _]}]},
+                 source: "foo",
+                 opts: []
+               ]
+             } = Macro.escape(%{~r/foo/ | re_pattern: {:re_pattern, 0, 0, 0, make_ref()}})
     end
   end
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -141,10 +141,9 @@ defmodule MacroTest do
       assert Macro.escape({:quote, [], [[do: :foo]]}) == {:{}, [], [:quote, [], [[do: :foo]]]}
     end
 
-    @tag skip: System.otp_release() < "28" or function_exported?(:re, :import, 1)
     test "escape container when a reference cannot be escaped" do
-      assert_raise ArgumentError, ~r"~r/foo/ contains a reference", fn ->
-        Macro.escape(%{~r/foo/ | re_pattern: {:re_pattern, 0, 0, 0, make_ref()}})
+      assert_raise ArgumentError, ~r"contains a reference", fn ->
+        Macro.escape(%{re_pattern: {:re_pattern, 0, 0, 0, make_ref()}})
       end
     end
 
@@ -160,7 +159,7 @@ defmodule MacroTest do
                  source: "foo",
                  opts: []
                ]
-             } = Macro.escape(%{~r/foo/ | re_pattern: {:re_pattern, 0, 0, 0, make_ref()}})
+             } = Macro.escape(~r/foo/)
     end
   end
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -147,7 +147,7 @@ defmodule MacroTest do
       end
     end
 
-    @tag skip: not function_exported?(:re, :import, 1)
+    @tag :re_import
     test "escape regex will remove references and replace it by a call to :re.import/1" do
       assert {
                :%{},

--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -132,11 +132,20 @@ cover_exclude =
     []
   end
 
+# OTP 28.1+
+re_import_exclude =
+  if Code.ensure_loaded?(:re) and function_exported?(:re, :import, 1) do
+    []
+  else
+    [:re_import]
+  end
+
 ExUnit.start(
   trace: !!System.get_env("TRACE"),
   exclude:
     epmd_exclude ++
-      os_exclude ++ line_exclude ++ distributed_exclude ++ source_exclude ++ cover_exclude,
+      os_exclude ++
+      line_exclude ++ distributed_exclude ++ source_exclude ++ cover_exclude ++ re_import_exclude,
   include: line_include,
   assert_receive_timeout: String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT", "300"))
 )


### PR DESCRIPTION
Take 2 for https://github.com/elixir-lang/elixir/pull/14719.

Leverages `:re.import` added in https://github.com/erlang/otp/pull/9976.

Here I went for `Macro.escape` rather than `:elixir_expand`, because `:elixir_expand` is harder to work with since we're already in AST land and the AST for a struct is hard to pattern-match on.

This works since `Macro.escape` is used in `~r`, and also fixes the escaping issue discussed previously. But this is violating the assumption that escape emits AST for a literal, which is probably a no-go.

Will work on supporting the `:export` option separately since this is not strictly needed for this.