### PR TITLE
Improve docs on iex remote shell halt behaviour

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -323,6 +323,8 @@ defmodule IEx do
   Connecting an Elixir shell to a remote node without Elixir is
   **not** supported.
 
+  When remsh halts, the Elixir shell process exits with reason `:normal`.
+
   ## The .iex.exs file
 
   When starting, IEx looks for a configured path, then for a local `.iex.exs` file


### PR DESCRIPTION
[Relevant Elixir forum post](https://elixirforum.com/t/processes-linked-to-iex-are-not-killed-when-iex-exits/72188)

It will be helpful for users of iex remsh to understand that when the VM halts, the Elixir shell process exits normally, which implies that any remote processes that had been linked to the shell process remain running. This docs change intends to make that point in a minimal way.