### PR TITLE
Correct docs for `Kernel.match?/2`

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3524,7 +3524,7 @@ defmodule Kernel do
   end
 
   @doc """
-  A convenience macro that checks if `expression` matches `pattern`.
+  A convenience macro that checks if the result of `expression` matches `pattern`.
 
   ## Examples
 


### PR DESCRIPTION
`Kernel.match?/2` is not an operator, therefore there is not such a thing as `left` and `right` sides.