### PR TITLE
Rephrase docs when mentioning out-of-memory errors

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -483,8 +483,8 @@ defmodule DynamicSupervisor do
   Returns a list with information about all children.
 
   Note that calling this function when supervising a large number
-  of children under low memory conditions can cause an out of memory
-  exception.
+  of children under low memory conditions can bring the system down due to an
+  out of memory error.
 
   This function returns a list of tuples containing:
 

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -1111,7 +1111,8 @@ defmodule Supervisor do
   Returns a list with information about all children of the given supervisor.
 
   Note that calling this function when supervising a large number of children
-  under low memory conditions can cause an out of memory exception.
+  under low memory conditions can bring the system down due to an out of memory
+  error.
 
   This function returns a list of `{id, child, type, modules}` tuples, where:
 

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -502,8 +502,8 @@ defmodule Task.Supervisor do
   Returns all children PIDs except those that are restarting.
 
   Note that calling this function when supervising a large number
-  of children under low memory conditions can cause an out of memory
-  exception.
+  of children under low memory conditions can bring the system down due to an
+  out of memory error.
   """
   @spec children(Supervisor.supervisor()) :: [pid]
   def children(supervisor) do


### PR DESCRIPTION
Avoid using the term exception as it could be confusing for the user and mislead him thinking it could be an Elixir `t:Exception.t/0`.