### PR TITLE
Added get_in/3 which allows for optional default values to be passed in

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2924,6 +2924,23 @@ defmodule Kernel do
   def get_in(data, [h]), do: Access.get(data, h)
   def get_in(data, [h | t]), do: get_in(Access.get(data, h), t)
 
+
+  @doc """
+  Gets a value from a nested structure with nil-safe handling. If the value does not exist or is nil, returns the default value.
+
+  ## Examples
+      iex> users = %{"john" => %{age: 27}, "meg" => %{age: 23, access_level: :admin}}
+      iex> get_in(users, ["john", :access_level], :none)
+      :none
+  """
+  @spec get_in(map, list, any) :: any
+  def get_in(map, keys, default) do
+    case get_in(map, keys) do
+      nil -> default
+      value -> value
+    end
+  end
+
   @doc """
   Puts a value in a nested structure.
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1002,6 +1002,16 @@ defmodule KernelTest do
       assert get_in(map, ["unknown", by_index(3)]) == nil
     end
 
+    test "get_in/3" do
+      users = %{"john" => %{age: 27}, "meg" => %{age: 23, access_level: :admin}}
+      assert get_in(users, ["john", :access_level], :none) == :none
+      assert get_in(users, ["meg", :access_level], :none) == :admin
+
+      map = %{"fruits" => ["banana", "apple", "orange"]}
+      assert get_in(map, ["fruits", by_index(0)], "strawberry") == "banana"
+      assert get_in(map, ["fruits", by_index(3)], "strawberry") == "strawberry"
+    end
+
     test "put_in/3" do
       users = %{"john" => %{age: 27}, "meg" => %{age: 23}}
 


### PR DESCRIPTION
Similar to `Map.get()` I have extended the `get_in` function to allow for a default value to be included as the last argument.

This will eliminate the need to `nil` check the return value when a default value can be used instead