### PR TITLE
Use thin-space (U+2009) as a numeric separator in regular English language

### DIFF
--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.Profile.Fprof do
     * OWN - time spent in the function, excluding the time of called functions
 
   The first row (Total) is the sum of all functions executed in all profiled
-  processes. For the given output, we had a total of 200279 function calls and spent
+  processes. For the given output, we had a total of 200 279 function calls and spent
   about 2 seconds running the code.
 
   More detailed information is returned if you provide the `--callers` and

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -191,7 +191,7 @@ defmodule Mix.Tasks.Test do
     * `--repeat-until-failure` *(since v1.17.0)* - sets the number of repetitions for running
       the suite until it fails. This is useful for debugging flaky tests within the same instance
       of the Erlang VM. For example, `--repeat-until-failure 10000` repeats the test suite
-      up to 10000 times until the first failure. This can be combined with `--max-failures 1`
+      up to 10 000 times until the first failure. This can be combined with `--max-failures 1`
       to immediately stop if one test fails. However, if there is any leftover global state
       after running the tests, re-running the suite may trigger unrelated failures.
 


### PR DESCRIPTION
Related PR: https://github.com/elixir-lang/elixir/pull/14635