### PR TITLE
Shallow-validate the return of __escape__/1

### DIFF
--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -177,7 +177,12 @@ do_escape(Map, Q) when is_map(Map) ->
     true ?= is_atom(Module),
     {module, Module} ?= code:ensure_loaded(Module),
     true ?= erlang:function_exported(Module, '__escape__', 1),
-    Module:'__escape__'(Map)
+    Expr = Module:'__escape__'(Map),
+    case shallow_valid_ast(Expr) of
+      true -> Expr;
+      false -> argument_error(
+        <<('Elixir.Kernel':inspect(Module))/binary, ".__escape__/1 returned invalid AST: ", ('Elixir.Kernel':inspect(Expr))/binary>>)
+    end
   else
     _ ->
       TT = [escape_map_key_value(K, V, Map, Q) || {K, V} <- lists:sort(maps:to_list(Map))],

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -161,6 +161,26 @@ defmodule MacroTest do
                ]
              } = Macro.escape(~r/foo/)
     end
+
+    defmodule EscapedStruct do
+      defstruct [:ast, :ref]
+
+      def __escape__(%{ast: ast}), do: ast
+    end
+
+    test "escape struct with custom __escape__ (valid AST)" do
+      struct = %EscapedStruct{ast: {:valid_ast, [], []}, ref: make_ref()}
+
+      assert {:valid_ast, [], []} = Macro.escape(struct)
+    end
+
+    test "escape struct with custom __escape__ (shallow invalid AST)" do
+      struct = %EscapedStruct{ast: %{invalid: :ast}, ref: make_ref()}
+
+      assert_raise ArgumentError,
+                   "MacroTest.EscapedStruct.__escape__/1 returned invalid AST: %{invalid: :ast}",
+                   fn -> Macro.escape(struct) end
+    end
   end
 
   describe "expand_once/2" do


### PR DESCRIPTION
Small improvement following https://github.com/elixir-lang/elixir/pull/14720.

Applying the same shallow-validation we use for `unquote` to fail early and provide better feedback if `Macro.escape` returns obviously broken AST (e.g. forgot to use `quote`).

Will backport.