### PR TITLE
Emit `{` token in map with correct column meta

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -652,7 +652,7 @@ map_args -> open_curly assoc_update ',' close_curly : build_map_update('$1', '$2
 map_args -> open_curly assoc_update ',' map_close : build_map_update('$1', '$2', element(2, '$4'), element(1, '$4')).
 map_args -> open_curly assoc_update_kw close_curly : build_map_update('$1', '$2', '$3', []).
 
-map -> map_op map_args : '$2'.
+map -> map_op map_args : update_map_meta('$1', '$2').
 map -> '%' map_base_expr map_args : {'%', meta_from_token('$1'), ['$2', '$3']}.
 map -> '%' map_base_expr eol map_args : {'%', meta_from_token('$1'), ['$2', '$4']}.
 
@@ -669,6 +669,13 @@ Erlang code.
 
 -compile({inline, meta_from_token/1, meta_from_location/1, is_eol/1}).
 -import(lists, [reverse/1, reverse/2]).
+
+update_map_meta(MapOp, {'%{}', Meta, Args}) ->
+  MapOpMeta = meta_from_token(MapOp),
+  FilteredMeta = [M || M <- Meta, 
+                   element(1, M) =/= line andalso 
+                   element(1, M) =/= column],
+  {'%{}', FilteredMeta ++ MapOpMeta, Args}.
 
 meta_from_token(Token) ->
   meta_from_location(?location(Token)).

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -655,7 +655,7 @@ tokenize([$%, $[ | Rest], Line, Column, Scope, Tokens) ->
   error(Reason, Rest, Scope, Tokens);
 
 tokenize([$%, ${ | T], Line, Column, Scope, Tokens) ->
-  Token = {'{', {Line, Column, nil}},
+  Token = {'{', {Line, Column + 1, nil}},
   handle_terminator(T, Line, Column + 2, Scope, Token, [{'%{}', {Line, Column, nil}} | Tokens]);
 
 tokenize([$% | T], Line, Column, Scope, Tokens) ->


### PR DESCRIPTION
@josevalim the fix in https://github.com/elixir-lang/elixir/commit/6a7511f9af5e94697cd14b647a695d9836eb53c4 is incomplete. Parser needs to be updated as well

Use `%{}` token meta in parser
Fixes https://github.com/elixir-lang/elixir/issues/14740