### PR TITLE
doc: mention receive/1 and ExUnit.Assertions.assert_receive/4 removes messages

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -2356,7 +2356,7 @@ defmodule Kernel.SpecialForms do
 
   @doc """
   Checks if there is a message matching any of the given clauses in the current
-  process mailbox.
+  process mailbox. The first matching message is consumed and no longer available.
 
   If there is no matching message, the current process waits until a matching
   message arrives or until after a given timeout value.

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -459,8 +459,10 @@ defmodule ExUnit.Assertions do
   The default timeout duration is determined by the `assert_receive_timeout` option,
   which can be set using `ExUnit.configure/1`. This option defaults to 100 milliseconds.
 
-  The `pattern` argument must be a match pattern. Flunks with `failure_message`
-  if a message matching `pattern` is not received.
+  The `pattern` argument must be a match pattern.
+
+  Flunks with `failure_message` if a message matching `pattern` is not received.
+  If a message matches, it is also removed from the process mailbox.
 
   ## Examples
 
@@ -487,8 +489,10 @@ defmodule ExUnit.Assertions do
   Asserts that a message matching `pattern` was received and is in the
   current process' mailbox.
 
-  The `pattern` argument must be a match pattern. Flunks with `failure_message`
-  if a message matching `pattern` was not received.
+  The `pattern` argument must be a match pattern.
+
+  Flunks with `failure_message` if a message matching `pattern` was not received.
+  If a message matches, it is also removed from the process mailbox.
 
   Timeout is set to `0`, so there is no waiting time.
 


### PR DESCRIPTION
These macros are missing an explicit mention of the fact that they remove the first match, which is an important piece of behavior in the documentation.

This behavior detail is often learned indirectly for `receive/1`, since most explanations also mention that a matching message is removed from the mailbox. Still, making it explicit in the docs avoids ambiguity.

For `assert_receive/2` and `assert_received/2`, the removal is a hidden side effect that may not be noticed, since the focus is on assertion semantics. Calling it out in the docs prevents confusion and makes the behavior clearer.