### PR TITLE
Fix backport of workload identity & CI release scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: write
 
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Backported PRs:
* https://github.com/elixir-lang/elixir/pull/14604
* https://github.com/elixir-lang/elixir/pull/14627

The commits are based on the SBoM PR (#14241) which changed the actions.

Adding `attestations: write` permission fixes the issue. See
https://github.com/maennchen/elixir/actions/runs/17445512019/job/49539258297