### PR TITLE
Optimize Access.filter to eliminate intermediate list creation

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -891,7 +891,7 @@ defmodule Access do
   end
 
   defp filter(:get, data, func, next) when is_list(data) do
-    data |> Enum.filter(func) |> Enum.map(next)
+    for elem <- data, func.(elem), do: next.(elem)
   end
 
   defp filter(:get_and_update, data, func, next) when is_list(data) do


### PR DESCRIPTION
This PR replaces the `Enum.filter |> Enum.map` chain in `Access.filter` with a more efficient `for` comprehension that eliminates unnecessary intermediate list creation, which (I believe) should be a somewhat meaningful improvement for large lists.

The tests for the module pass locally:

```sh
$> bin/elixir lib/elixir/test/elixir/access_test.exs
Running ExUnit with seed: 375552, max_cases: 20
Excluding tags: [:re_import, {:windows, true}, {:distributed, true}]

...............................................................................................
Finished in 0.1 seconds (0.09s on load, 0.01s async, 0.00s sync)
54 doctests, 41 tests, 0 failures
```