### PR TITLE
Fix dialyzer opaqueness warnings on module attrs in OTP28

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3858,17 +3858,14 @@ defmodule Kernel do
 
   defp do_at_escape(name, value) do
     try do
-      :elixir_quote.escape(value, :none, false)
+      # mark module attrs as shallow-generated since the ast for their representation
+      # might contain opaque terms
+      Macro.escape(value, generated: true)
     rescue
       ex in [ArgumentError] ->
         raise ArgumentError,
               "cannot inject attribute @#{name} into function/macro because " <>
                 Exception.message(ex)
-    else
-      # mark module attrs as shallow-generated since the ast for their representation
-      # might contain opaque terms
-      {caller, meta, args} when is_list(meta) -> {caller, [generated: true] ++ meta, args}
-      ast -> ast
     end
   end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3864,6 +3864,11 @@ defmodule Kernel do
         raise ArgumentError,
               "cannot inject attribute @#{name} into function/macro because " <>
                 Exception.message(ex)
+    else
+      # mark module attrs as shallow-generated since the ast for their representation
+      # might contain opaque terms
+      {caller, meta, args} when is_list(meta) -> {caller, [generated: true] ++ meta, args}
+      ast -> ast
     end
   end
 

--- a/lib/elixir/test/elixir/fixtures/dialyzer/opaqueness.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/opaqueness.ex
@@ -4,9 +4,14 @@ defmodule Dialyzer.Opaqueness do
     set
   end
 
-  def foo() do
+  def inlined do
     # inlining of literals should not violate opaqueness check
     bar(MapSet.new([1, 2, 3]))
+  end
+
+  @my_set MapSet.new([1, 2, 3])
+  def module_attr do
+    bar(@my_set)
   end
 
   # Task.Supervisor returns a Task.t() containing an opaque Task.ref()

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -84,6 +84,11 @@ defmodule MacroTest do
       assert Macro.escape(contents, unquote: true) == {:x, [], MacroTest}
     end
 
+    test "with generated" do
+      assert Macro.escape(%{a: {}}, generated: true) ==
+               {:%{}, [generated: true], [a: {:{}, [], []}]}
+    end
+
     defp eval_escaped(contents) do
       {eval, []} = Code.eval_quoted(Macro.escape(contents, unquote: true))
       eval


### PR DESCRIPTION
Marks module attributes as generated in case they contain opaque terms

Close https://github.com/elixir-lang/elixir/issues/14750

To be backported to 1.19