### PR TITLE
Add missing :generated to Macro.escape_opts/0 type

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -199,7 +199,8 @@ defmodule Macro do
 
   @type escape_opts :: [
           unquote: boolean(),
-          prune_metadata: boolean()
+          prune_metadata: boolean(),
+          generated: boolean()
         ]
 
   @type inspect_atom_opts :: [


### PR DESCRIPTION
Addresses https://github.com/elixir-lang/elixir/pull/14755#discussion_r2336033647

Will backport too