### PR TITLE
Fix docs for Counter example

### DIFF
--- a/lib/elixir/pages/anti-patterns/process-anti-patterns.md
+++ b/lib/elixir/pages/anti-patterns/process-anti-patterns.md
@@ -308,8 +308,12 @@ iex> Counter.start_link(initial_value: 15, name: :other_counter)
 iex> Counter.get(:other_counter)
 15
 iex> Counter.bump(:other_counter, -3)
-12
+15
 iex> Counter.bump(Counter, 7)
+0
+iex> Counter.get(:other_counter)
+12
+iex> Counter.get()
 7
 ```
 
@@ -346,6 +350,8 @@ iex> Counter.get(Counter)
 iex> Counter.get(:other_counter)
 15
 iex> Counter.bump(Counter, 7)
+0
+iex> Counter.get(Counter)
 7
 iex> Supervisor.terminate_child(App.Supervisor, Counter)
 iex> Supervisor.count_children(App.Supervisor) # Only one active child


### PR DESCRIPTION
The documentation in the "process anti patterns" section shows an example of a Counter which uses a GenServer in its implementation. 
The bump handler replies with the current state before any bump operation has been applied to it however the iex snippet shows the new value being returned.

I chose to fix the iex snippets rather than editing the bump handler because in the docs for the [Supervisor](https://hexdocs.pm/elixir/Supervisor.html), we have a very similar example which does return the "old" value of the counter and I thought it best to keep the docs consistent.