### PR TITLE
Correct builds.hex.pm Publish Condition in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,8 +304,6 @@ jobs:
     runs-on: ubuntu-22.04
     concurrency: builds-hex-pm
     environment: release
-    # Only run if HEX_AWS_REGION is set (no failing job in forks)
-    if: "${{ vars.HEX_AWS_REGION }}"
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.HEX_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.HEX_AWS_SECRET_ACCESS_KEY }}
@@ -313,6 +311,12 @@ jobs:
       AWS_S3_BUCKET: ${{ vars.HEX_AWS_S3_BUCKET }}
       OTP_GENERIC_VERSION: "25"
     steps:
+      - name: "Check if variables are set up"
+        if: "${{ ! vars.HEX_AWS_REGION }}"
+        run: |
+          echo "Required variables for uploading to hex.pm are not set up, skipping..."
+          exit 1
+
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           pattern: "{sign-*-elixir-otp-*,Docs}"


### PR DESCRIPTION
Follow up to https://github.com/elixir-lang/elixir/pull/14627#issuecomment-3292707930

Apparently, GitHub evaluates job conditions before taking the environment into account. This leaves me with 3 options (and a lot more not great ones):
* Move the condition to each step instead of the job
* Extract the steps into a shared workflow and call that one conditionally (something like `.github/workflows/publish_builds_hex_pm/action.yml`)
* Just make it fail if the variables are not present **<= chose this one**