### PR TITLE
Optimize Enum.into/2 and Enum.into/3

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1496,6 +1496,14 @@ defmodule Enum do
     to_list(enumerable)
   end
 
+  def into(enumerable, collectable) when is_struct(collectable, MapSet) do
+    if MapSet.size(collectable) == 0 do
+      MapSet.new(enumerable)
+    else
+      MapSet.new(enumerable) |> MapSet.union(collectable)
+    end
+  end
+
   def into(%_{} = enumerable, collectable) do
     into_protocol(enumerable, collectable)
   end

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1580,6 +1580,14 @@ defmodule Enum do
     map(enumerable, transform)
   end
 
+  def into(enumerable, collectable, transform) when is_struct(collectable, MapSet) do
+    if MapSet.size(collectable) == 0 do
+      MapSet.new(enumerable, transform)
+    else
+      MapSet.new(enumerable, transform) |> MapSet.union(collectable)
+    end
+  end
+
   def into(enumerable, %_{} = collectable, transform) do
     into_protocol(enumerable, collectable, transform)
   end

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1572,10 +1572,6 @@ defmodule Enum do
     map(enumerable, transform)
   end
 
-  def into(%_{} = enumerable, collectable, transform) do
-    into_protocol(enumerable, collectable, transform)
-  end
-
   def into(enumerable, %_{} = collectable, transform) do
     into_protocol(enumerable, collectable, transform)
   end

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -455,6 +455,10 @@ defmodule EnumTest do
     assert Enum.into(%{a: 1, b: 2}, []) |> Enum.sort() == [a: 1, b: 2]
     assert Enum.into(1..3, []) == [1, 2, 3]
     assert Enum.into(["H", "i"], "") == "Hi"
+
+    assert Enum.into([a: 1, b: 2], MapSet.new()) == MapSet.new(a: 1, b: 2)
+    assert Enum.into(%{a: 1, b: 2}, MapSet.new()) == MapSet.new(a: 1, b: 2)
+    assert Enum.into([a: 1, b: 2], MapSet.new(a: 1, c: 3)) == MapSet.new(a: 1, b: 2, c: 3)
   end
 
   test "into/2 exceptions" do
@@ -2039,6 +2043,7 @@ defmodule EnumTest.Range do
 
   test "into/2" do
     assert Enum.into(1..5, []) == [1, 2, 3, 4, 5]
+    assert Enum.into(1..5, MapSet.new()) == MapSet.new([1, 2, 3, 4, 5])
   end
 
   test "into/3" do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -479,6 +479,9 @@ defmodule EnumTest do
     assert Enum.into([1, 2, 3], [], fn x -> x * 2 end) == [2, 4, 6]
     assert Enum.into([1, 2, 3], "numbers: ", &to_string/1) == "numbers: 123"
 
+    assert Enum.into([1, 2, 3], MapSet.new(), &(&1 * 2)) == MapSet.new([2, 4, 6])
+    assert Enum.into([1, 2, 3], MapSet.new([0, 2]), &(&1 * 2)) == MapSet.new([0, 2, 4, 6])
+
     assert_raise MatchError, fn ->
       Enum.into([2, 3], %{a: 1}, & &1)
     end
@@ -2049,6 +2052,7 @@ defmodule EnumTest.Range do
   test "into/3" do
     assert Enum.into(1..5, [], fn x -> x * 2 end) == [2, 4, 6, 8, 10]
     assert Enum.into(1..3, "numbers: ", &to_string/1) == "numbers: 123"
+    assert Enum.into(1..3, MapSet.new(), &(&1 * 2)) == MapSet.new([2, 4, 6])
   end
 
   test "join/2" do


### PR DESCRIPTION
I tested several scenarios and noticed that the memory usage could easily go down by a 3~6x factor:
https://github.com/sabiwara/elixir_benches/commit/db829b8ab0dcd4f2b2e888985b53f9083cfffb16

See individual commits.
For `Enum.into(struct, map, fun)` (first commit), I actually just had to remove a specialized clause that doesn't feel needed, was probably just copy-pasted from into/2.

Optimizing `MapSet` as a collectable feels legit, given it is a core data structure - in the same way that we have some optimizations for ranges as enumerables. Especially given the factors involved.

As a follow-up, I also plan to optimize `into: MapSet.new()` in comprehensions.
Given how wasteful it is right now (see bench above), it kind of defeats the purpose of trying to merge steps in one pass vs a regular pipeline, but I think we want to encourage comprehensions in such cases.