### PR TITLE
Fix Macro.escape/1 bug when :quote tuples is in the tail of a list

### DIFF
--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -199,7 +199,11 @@ do_escape([], _) ->
   [];
 
 do_escape([H | T], #elixir_quote{unquote=false} = Q) ->
-  do_quote_simple_list(T, do_escape(H, Q), Q);
+  case is_list(T) of
+    true -> [do_escape(H, Q) | do_escape(T, Q)];
+    % improper list
+    false -> [{'|', [], [do_escape(H, Q), do_escape(T, Q)]}]
+  end;
 
 do_escape([H | T], Q) ->
   %% The improper case is inefficient, but improper lists are rare.

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -149,6 +149,9 @@ defmodule MacroTest do
     test "escapes the content of :quote tuples" do
       assert Macro.escape({:quote, [%{}], [{}]}) ==
                {:{}, [], [:quote, [{:%{}, [], []}], [{:{}, [], []}]]}
+
+      assert Macro.escape([:foo, {:quote, [%{}], [{}]}]) ==
+               [:foo, {:{}, [], [:quote, [{:%{}, [], []}], [{:{}, [], []}]]}]
     end
 
     test "escape container when a reference cannot be escaped" do


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/14771