### PR TITLE
Assert scope is not match/guard when using escaped regexes

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -1021,9 +1021,10 @@ defmodule Regex do
           {:ok, exported} = :re.compile(regex.source, [:export] ++ regex.opts)
 
           quote do
-            require Regex
             Regex.__import_pattern__(unquote(Macro.escape(exported)))
           end
+          # we now that the Regex module is defined at this stage, so this macro can be safely called
+          |> Macro.update_meta(&([required: true] ++ &1))
 
         # TODO: Remove this when we require Erlang/OTP 28.1+
         # OTP 28.0 works in degraded mode performance-wise, we need to recompile from the source
@@ -1049,7 +1050,7 @@ defmodule Regex do
   @doc false
   defmacro __import_pattern__(pattern) do
     if __CALLER__.context in [:match, :guard] do
-      raise ArgumentError, "escaped"
+      raise ArgumentError, "escaped Regex structs are not allowed in match or guards"
     end
 
     quote do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -167,14 +167,9 @@ defmodule MacroTest do
                [],
                [
                  __struct__: Regex,
-                 re_pattern: {
-                   :__block__,
-                   [],
-                   [
-                     {:__assert_assert_no_match_or_guard_scope__, _, _},
-                     {{:., [], [:re, :import]}, [], [{:{}, [], [:re_exported_pattern | _]}]}
-                   ]
-                 },
+                 re_pattern:
+                   {{:., [], [{:__aliases__, _, [:Regex]}, :__import_pattern__]},
+                    [required: true], [{:{}, [], [:re_exported_pattern | _]}]},
                  source: "foo",
                  opts: []
                ]

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -32,7 +32,7 @@ defmodule RegexTest do
   test "module attribute in match context" do
     assert_raise(
       ArgumentError,
-      ~r/invalid expression in match, an escaped Regex is not allowed in patterns such as function clauses/,
+      ~r/escaped Regex structs are not allowed in match or guards/,
       fn ->
         Code.eval_quoted(
           quote do


### PR DESCRIPTION
Following on https://github.com/elixir-lang/elixir/pull/14720, I've been thinking if we could/should improve the error message when trying to use regex module attributes in guards/match scope.
This PR explores the idea, but feel free to close if this is overthinking on my part.

Before (confusing: `:re.compile` mentioned but not in the code)
<img width="1066" height="324" alt="Screenshot 2025-09-20 at 10 15 31" src="https://github.com/user-attachments/assets/692e686c-a5a8-4138-b7d6-e198d54ae317" />

After
<img width="1766" height="214" alt="Screenshot 2025-09-20 at 10 16 06" src="https://github.com/user-attachments/assets/d3caeb10-7b7a-456d-a78f-aca7f097652d" />
