### PR TITLE
make errors when piping in expressions safer

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -101,7 +101,7 @@ defmodule IEx.Evaluator do
         forms =
           if adjusted_op != nil do
             quote do
-              if Process.get(:iex_error?) == true do
+              if Process.get(:iex_error) do
                 reraise RuntimeError.exception(
                           "skipping evaluation of expression because pipeline has failed"
                         ),
@@ -311,11 +311,17 @@ defmodule IEx.Evaluator do
     put_history(state)
     put_whereami(state)
     result = eval_and_inspect(forms, counter, state)
-    Process.delete(:iex_error?)
+
+    if Process.get(:iex_error) == :force do
+      Process.put(:iex_error, true)
+    else
+      Process.delete(:iex_error)
+    end
+
     {:ok, result}
   catch
     kind, error ->
-      Process.put(:iex_error?, true)
+      Process.put(:iex_error, true)
       print_error(kind, error, __STACKTRACE__)
       {:error, state}
   after

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -101,14 +101,8 @@ defmodule IEx.Evaluator do
         forms =
           if adjusted_op != nil do
             quote do
-              if Process.get(:iex_error, false) do
-                reraise RuntimeError.exception(
-                          "skipping evaluation of expression because pipeline has failed"
-                        ),
-                        []
-              else
-                unquote(forms)
-              end
+              IEx.Evaluator.assert_no_error!()
+              unquote(forms)
             end
           else
             forms
@@ -150,6 +144,18 @@ defmodule IEx.Evaluator do
   end
 
   defp adjust_operator(tokens, _line, _column, _file, _opts, _last_op), do: {:ok, tokens, nil}
+
+  @doc """
+  Raises an error if the last iex result was itself an error
+  """
+  def assert_no_error!() do
+    if Process.get(:iex_error, false) do
+      reraise RuntimeError.exception(
+                "skipping evaluation of expression because pipeline has failed"
+              ),
+              []
+    end
+  end
 
   @doc """
   Gets a value out of the binding, using the provided

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -101,7 +101,7 @@ defmodule IEx.Evaluator do
         forms =
           if adjusted_op != nil do
             quote do
-              if Process.get(:iex_error) do
+              if Process.get(:iex_error, false) do
                 reraise RuntimeError.exception(
                           "skipping evaluation of expression because pipeline has failed"
                         ),

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -99,22 +99,9 @@ defmodule IEx.Evaluator do
           end
 
         forms =
-          if adjusted_op do
+          if adjusted_op != nil and Process.get(:iex_error) != nil do
             quote do
-              case Process.get(:iex_error) do
-                {_kind, _error, _stacktrace} ->
-                  IO.write(:stdio, [
-                    "Skippping evaluation of:\n\n",
-                    unquote(input),
-                    "\n\n",
-                    "For safety, you cannot begin an expression with `#{unquote(adjusted_op)}` when the last expression was an error.\n"
-                  ])
-
-                  IEx.dont_display_result()
-
-                _ ->
-                  unquote(forms)
-              end
+             reraise RuntimeError.exception("skipping evaluation of expression because pipeline has failed"), []
             end
           else
             forms

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -150,10 +150,8 @@ defmodule IEx.Evaluator do
   """
   def assert_no_error!() do
     if Process.get(:iex_error, false) do
-      reraise RuntimeError.exception(
-                "skipping evaluation of expression because pipeline has failed"
-              ),
-              []
+      message = "skipping evaluation of expression because pipeline has failed"
+      reraise RuntimeError.exception(message), []
     end
   end
 
@@ -321,9 +319,7 @@ defmodule IEx.Evaluator do
     put_history(state)
     put_whereami(state)
     result = eval_and_inspect(forms, counter, state)
-
     Process.delete(:iex_error)
-
     {:ok, result}
   catch
     kind, error ->

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -150,14 +150,7 @@ defmodule IEx.Server do
         end
 
       {:io_reply, ^input, {:error, kind, error, stacktrace}} ->
-        send(
-          evaluator,
-          {:eval, self(),
-           quote do
-             Process.put(:iex_error, :force)
-             IEx.dont_display_result()
-           end, 0}
-        )
+        send(evaluator, {:reader_errored, self()})
 
         banner = Exception.format_banner(kind, error, stacktrace)
 

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -150,6 +150,15 @@ defmodule IEx.Server do
         end
 
       {:io_reply, ^input, {:error, kind, error, stacktrace}} ->
+        send(
+          evaluator,
+          {:eval, self(),
+           quote do
+             Process.put(:iex_error, :force)
+             IEx.dont_display_result()
+           end, 0}
+        )
+
         banner = Exception.format_banner(kind, error, stacktrace)
 
         banner =


### PR DESCRIPTION
For example:

If you pasted this into an iex shell, you might have a very very bad day.

```elixir
MyApp.Accounts.User
|> Ecto.Query.where(user], user.id == 1) # note the missing open bracket
|> MyApp.Repo.delete_all()
```

---

This is still rough, things I'm not sure about:

1. I'm not sure how we feel about the method of just rewriting the evaluated code to check for this condition.
2. I'm trying to display the operator, but it's using the tokenized representation of it and I couldn't find a mapper for that. I can just not display the operator, or I can write a mapping function myself.
3. I should probably colorize and indent the message properly, but wanted to validate the approach before pushing further.

---

In practice it looks like this:

```elixir
Interactive Elixir (1.20.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> 1
1
iex(2)> |> Kernel.+-(1)
** (ArgumentError) cannot pipe v(-1) into Kernel.+() - 1, the :- operator can only take one argument
    (elixir 1.20.0-dev) lib/macro.ex:341: Macro.pipe/3
    (stdlib 7.0.2) lists.erl:2466: :lists.foldl/3
    (elixir 1.20.0-dev) expanding macro: Kernel.|>/2
    iex:2: (file)
iex(2)> |> Kernel.+(1)
Skippping evaluation of:

|> Kernel.+(1)

For safety, you cannot begin an expression with `arrow_op` when the last expression was an error.
iex(3)>
```
https://github.com/user-attachments/assets/0a9a7d3c-4555-4dc4-ad68-b2fb65a1020c


