### PR TITLE
Optimize for comprehensions into: MapSet

### DIFF
--- a/lib/elixir/src/elixir_erl_for.erl
+++ b/lib/elixir/src/elixir_erl_for.erl
@@ -162,9 +162,16 @@ build_into(Ann, Clauses, Expr, {map, _, []}, Uniq, S) ->
   {ReduceExpr, SR} = build_inline_each(Ann, Clauses, Expr, {nil, Ann}, Uniq, S),
   {?remote(Ann, maps, from_list, [ReduceExpr]), SR};
 build_into(Ann, Clauses, Expr, ?empty_map_set_pattern = _Into, Uniq, S) ->
-  InnerFun = fun(InnerExpr, InnerAcc) -> {cons, Ann, InnerExpr, InnerAcc} end,
+  InnerFun = fun(InnerExpr, InnerAcc) ->
+    % [{Expr, []} | Acc]
+    {cons, Ann, {tuple, Ann, [InnerExpr, {nil, Ann}]}, InnerAcc}
+  end,
   {ReduceExpr, SR} = build_reduce(Ann, Clauses, InnerFun, Expr, {nil, Ann}, Uniq, S),
-  {?remote(Ann, 'Elixir.MapSet', new, [ReduceExpr]), SR};
+  MapSetExpr = {map, Ann, [
+    {map_field_assoc, Ann, {atom, Ann, '__struct__'}, {atom, Ann, 'Elixir.MapSet'}},
+    {map_field_assoc, Ann, {atom, Ann, map}, ?remote(Ann, maps, from_list, [ReduceExpr])}
+  ]},
+  {MapSetExpr, SR};
 build_into(Ann, Clauses, Expr, Into, Uniq, S) ->
   {Fun, SF}    = build_var(Ann, S),
   {Acc, SA}    = build_var(Ann, SF),

--- a/lib/elixir/src/elixir_erl_for.erl
+++ b/lib/elixir/src/elixir_erl_for.erl
@@ -162,16 +162,9 @@ build_into(Ann, Clauses, Expr, {map, _, []}, Uniq, S) ->
   {ReduceExpr, SR} = build_inline_each(Ann, Clauses, Expr, {nil, Ann}, Uniq, S),
   {?remote(Ann, maps, from_list, [ReduceExpr]), SR};
 build_into(Ann, Clauses, Expr, ?empty_map_set_pattern = _Into, Uniq, S) ->
-  InnerFun = fun(InnerExpr, InnerAcc) ->
-    % [{Expr, []} | Acc]
-    {cons, Ann, {tuple, Ann, [InnerExpr, {nil, Ann}]}, InnerAcc}
-  end,
+  InnerFun = fun(InnerExpr, InnerAcc) -> {cons, Ann, InnerExpr, InnerAcc} end,
   {ReduceExpr, SR} = build_reduce(Ann, Clauses, InnerFun, Expr, {nil, Ann}, Uniq, S),
-  MapSetExpr = {map, Ann, [
-    {map_field_assoc, Ann, {atom, Ann, '__struct__'}, {atom, Ann, 'Elixir.MapSet'}},
-    {map_field_assoc, Ann, {atom, Ann, map}, ?remote(Ann, maps, from_list, [ReduceExpr])}
-  ]},
-  {MapSetExpr, SR};
+  {?remote(Ann, 'Elixir.MapSet', new, [ReduceExpr]), SR};
 build_into(Ann, Clauses, Expr, Into, Uniq, S) ->
   {Fun, SF}    = build_var(Ann, S),
   {Acc, SA}    = build_var(Ann, SF),


### PR DESCRIPTION
Follow-up for https://github.com/elixir-lang/elixir/pull/14774.

Fixes the discrepancy found in the previous benchmark: https://github.com/sabiwara/elixir_benches/commit/cd1c9a30adb9e6521bffc5d502accbacccfcb76d.

Before
<img width="2198" height="682" alt="Screenshot 2025-09-29 at 15 38 13" src="https://github.com/user-attachments/assets/d77349df-8699-4460-8c50-0187009223d1" />

After
<img width="2228" height="370" alt="Screenshot 2025-09-29 at 15 41 53" src="https://github.com/user-attachments/assets/41959f5a-7915-4365-b5f2-13e22167374a" />

Note: this is basically the same as building a list, but we don't need the `lists:reverse` step and replace it with `MapSet.new/1`.