### PR TITLE
Fix preloading modules in `mix test --slowest-modules=N`

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -610,7 +610,14 @@ defmodule Mix.Tasks.Test do
     # before requiring test_helper.exs so that the configuration is
     # available in test_helper.exs
     Mix.shell().print_app()
-    app_start_args = if opts[:slowest], do: ["--preload-modules" | args], else: args
+
+    app_start_args =
+      if opts[:slowest] || opts[:slowest_modules] do
+        ["--preload-modules" | args]
+      else
+        args
+      end
+
     Mix.Task.run("app.start", app_start_args)
 
     # The test helper may change the Mix.shell(), so revert it whenever we raise and after suite


### PR DESCRIPTION
Before this patch, I have seen the following with some extra debugging
statements and modules with `@on_load` that makes them slow to load:

    $ mix test --slowest-modules=5
    [lib/mix/tasks/test.ex:614: Mix.Tasks.Test.do_run/3]
    app_start_args #=> ["--slowest-modules=5"]

    [lib/mix/tasks/app.config.ex:43: Mix.Tasks.App.Config.run/1]
    opts[:preload_modules] #=> nil

    Running ExUnit with seed: 829176, max_cases: 1

    Mod1Test [test/mod1_test.exs]
      * test mod1 [L#4]Mod1.__on_load__/0...
    Mod1.__on_load__/0 ok
      * test mod1 (5004.1ms) [L#4]

    Mod2Test [test/mod2_test.exs]
      * test mod2 [L#4]Mod2.__on_load__/0...
    Mod2.__on_load__/0 ok
      * test mod2 (5005.7ms) [L#4]

    Finished in 10.0 seconds (10.0s async, 0.00s sync)

    Top 5 slowest (10.0s), 99.9% of total time:

    Mod2Test (5005.7ms)
     [test/mod2_test.exs]
    Mod1Test (5004.1ms)
     [test/mod1_test.exs]

    2 tests, 0 failures

Additionally passing `--preload-modules` fixed the issue.

With this patch, preloading is correctly set.
