### PR TITLE
Use "some_function" instead of "sum_fun" in warnings

### DIFF
--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -852,12 +852,12 @@ defmodule Module.Types.Expr do
           you may optionally convert the struct update into a map update. For \
           example, instead of:
 
-              user = some_fun()
+              user = some_function()
               %User{user | name: "John Doe"}
 
           it is enough to write:
 
-              %User{} = user = some_fun()
+              %User{} = user = some_function()
               %{user | name: "John Doe"}
           """
         ])

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -448,17 +448,17 @@ defmodule Task do
   the code before async/await has the same properties after you
   add the async call. For example, imagine you have this:
 
-      x = heavy_fun()
-      y = some_fun()
+      x = heavy_function()
+      y = some_function()
       x + y
 
-  Now you want to make the `heavy_fun()` async:
+  Now you want to make the `heavy_function()` async:
 
-      x = Task.async(&heavy_fun/0)
-      y = some_fun()
+      x = Task.async(&heavy_function/0)
+      y = some_function()
       Task.await(x) + y
 
-  As before, if `heavy_fun/0` fails, the whole computation will
+  As before, if `heavy_function/0` fails, the whole computation will
   fail, including the caller process. If you don't want the task
   to fail then you must change the `heavy_fun/0` code in the
   same way you would achieve it if you didn't have the async call.

--- a/lib/elixir/pages/getting-started/debugging.md
+++ b/lib/elixir/pages/getting-started/debugging.md
@@ -50,13 +50,13 @@ after: [2, 4, 6]
 It is also very common to use `IO.inspect/2` with `binding/0`, which returns all variable names and their values:
 
 ```elixir
-def some_fun(a, b, c) do
+def some_function(a, b, c) do
   IO.inspect(binding())
   ...
 end
 ```
 
-When `some_fun/3` is invoked with `:foo`, `"bar"`, `:baz` it prints:
+When `some_function/3` is invoked with `:foo`, `"bar"`, `:baz` it prints:
 
 ```elixir
 [a: :foo, b: "bar", c: :baz]

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -1051,12 +1051,12 @@ defmodule Module.Types.ExprTest do
 
              hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:
 
-                 user = some_fun()
+                 user = some_function()
                  %User{user | name: "John Doe"}
 
              it is enough to write:
 
-                 %User{} = user = some_fun()
+                 %User{} = user = some_function()
                  %{user | name: "John Doe"}
              """
 


### PR DESCRIPTION
Elixir v1.19 introduces a warning related to structs,

     hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

         user = some_fun()
         %User{user | name: "John Doe"}

     it is enough to write:

         %User{} = user = some_fun()
         %{user | name: "John Doe"}

Since this could be seen by new-comers to the language, offering a better user experience by avoiding abbreviations. Favoring the usage of "some_function" instead of "some_fun"