### PR TITLE
Fix EEx.compile_string passing invalid options to tokenize

### DIFF
--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -236,7 +236,9 @@ defmodule EEx do
   """
   @spec compile_string(String.t(), [compile_opt]) :: Macro.t()
   def compile_string(source, options \\ []) when is_binary(source) and is_list(options) do
-    case tokenize(source, options) do
+    tokenize_opts = Keyword.take(options, [:file, :line, :column, :indentation, :trim])
+
+    case tokenize(source, tokenize_opts) do
       {:ok, tokens} ->
         EEx.Compiler.compile(tokens, source, options)
 


### PR DESCRIPTION
EEx.compile_string/2 was passing all options to tokenize/2, but tokenize/2 only accepts tokenize_opt (:file, :line, :column, :indentation, :trim). This caused dialyzer to correctly flag calls with :engine or :parser_options as type errors in Elixir 1.19+.

The fix filters options before passing to tokenize/2, keeping only the valid tokenize_opt keys, while still passing the full options list to EEx.Compiler.compile/3 which needs :engine, :parser_options, and custom engine options.

Fixes #14834