### PR TITLE
Fix shebang

### DIFF
--- a/lib/elixir/scripts/cover.exs
+++ b/lib/elixir/scripts/cover.exs
@@ -1,4 +1,4 @@
-#!bin/elixir
+#!/bin/elixir
 
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2021 The Elixir Team


### PR DESCRIPTION
Unfortunately a small typo slipped in PR #14343. it was unnoticed because if you run `bin/elixir ./lib/elixir/scripts/cover.exs` sheband won't be used at all.