### PR TITLE
Improve DevEx when failing Mix commands receive no arguments

### DIFF
--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -315,7 +315,10 @@ defmodule Mix.Local.Installer do
           nil
       end
     else
-      Mix.raise("No argument was given to uninstall command")
+      Mix.raise(
+        "No argument was given to uninstall command. " <>
+          " Use \"mix archive.uninstall PATH\" or run \"mix help archive.uninstall\" for more information"
+      )
     end
   end
 

--- a/lib/mix/lib/mix/tasks/cmd.ex
+++ b/lib/mix/lib/mix/tasks/cmd.ex
@@ -100,7 +100,7 @@ defmodule Mix.Tasks.Cmd do
     {opts, args} = OptionParser.parse_head!(args, strict: @switches)
 
     if args == [] do
-      Mix.raise("Expected at least one argument in mix cmd")
+      Mix.raise("No argument was given to mix cmd. Run \"mix help cmd\" for more information")
     end
 
     apps =

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -154,7 +154,8 @@ defmodule Mix.Tasks.Escript.Build do
     if !main do
       error_message =
         "Could not generate escript, please set :main_module " <>
-          "in your project configuration (under :escript option) to a module that implements main/1"
+          "in your project configuration (under :escript option) to a module that implements main/1. " <>
+          "Run \"mix help escript.build\" for more information"
 
       Mix.raise(error_message)
     end

--- a/lib/mix/lib/mix/tasks/eval.ex
+++ b/lib/mix/lib/mix/tasks/eval.ex
@@ -97,7 +97,10 @@ defmodule Mix.Tasks.Eval do
         end
 
       _ ->
-        Mix.raise("\"mix eval\" expects a single string to evaluate as argument")
+        Mix.raise(
+          "\"mix eval\" expects a single string to evaluate as argument. " <>
+            "Run \"mix help eval\" for more information"
+        )
     end
   end
 end

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -64,7 +64,10 @@ defmodule Mix.Tasks.New do
 
     case argv do
       [] ->
-        Mix.raise("Expected PATH to be given, please use \"mix new PATH\"")
+        Mix.raise(
+          "Expected PATH to be given. " <>
+            "Use \"mix new PATH\" or run \"mix help new\" for more information"
+        )
 
       [path | _] ->
         app = opts[:app] || Path.basename(Path.expand(path))

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -470,7 +470,9 @@ defmodule Mix.Tasks.Xref do
         )
 
       _ ->
-        Mix.raise("xref doesn't support this command. For more information run \"mix help xref\"")
+        Mix.raise(
+          "No argument was given to xref command. Run \"mix help xref\" for more information"
+        )
     end
   end
 

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -223,9 +223,11 @@ defmodule Mix.Tasks.NewTest do
     end)
 
     in_tmp("new without a specified path", fn ->
-      assert_raise Mix.Error, "Expected PATH to be given, please use \"mix new PATH\"", fn ->
-        Mix.Tasks.New.run([])
-      end
+      assert_raise Mix.Error,
+                   "Expected PATH to be given. Use \"mix new PATH\" or run \"mix help new\" for more information",
+                   fn ->
+                     Mix.Tasks.New.run([])
+                   end
     end)
   end
 

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -177,7 +177,8 @@ defmodule Mix.Tasks.XrefTest do
 
     test "no argument gives error" do
       in_fixture("no_mixfile", fn ->
-        message = "xref doesn't support this command. For more information run \"mix help xref\""
+        message =
+          "No argument was given to xref command. Run \"mix help xref\" for more information"
 
         assert_raise Mix.Error, message, fn ->
           assert Mix.Task.run("xref", ["callers"]) == :error


### PR DESCRIPTION
Some mix commands fail when no argument is given.

Before this PR:

```
$ mix archive.uninstall
** (Mix) No argument was given to uninstall command

$ mix cmd
** (Mix) Expected at least one argument in mix cmd

$ mix escript.build
** (Mix) Could not generate escript, please set :main_module in your project configuration (under :escript option) to a module that implements main/1

$ mix escript.install
** (Mix) Could not generate escript, please set :main_module in your project configuration (under :escript option) to a module that implements main/1

$ mix escript.uninstall
** (Mix) No argument was given to uninstall command

$ mix eval
** (Mix) "mix eval" expects a single string to evaluate as argument

$ mix new
** (Mix) Expected PATH to be given, please use "mix new PATH"

$ mix xref
** (Mix) xref doesn't support this command. For more information run "mix help xref"
```

With this PR:

```
$ mix archive.uninstall
** (Mix) No argument was given to uninstall command.  Use "mix archive.uninstall PATH" or run "mix help archive.uninstall" for more information

$ mix cmd
** (Mix) No argument was given to mix cmd. Run "mix help cmd" for more information

$ mix escript.build
** (Mix) Could not generate escript, please set :main_module in your project configuration (under :escript option) to a module that implements main/1. Run "mix help escript.build" for more information

$ mix escript.install
** (Mix) Could not generate escript, please set :main_module in your project configuration (under :escript option) to a module that implements main/1. Run "mix help escript.build" for more information

$ mix escript.uninstall
** (Mix) No argument was given to uninstall command.  Use "mix archive.uninstall PATH" or run "mix help archive.uninstall" for more information

$ mix eval
** (Mix) "mix eval" expects a single string to evaluate as argument. Run "mix help eval" for more information

$ mix new
** (Mix) Expected PATH to be given. Use "mix new PATH" or run "mix help new" for more information

$ mix xref
** (Mix) No argument was given to xref command. Run "mix help xref" for more information
```

Screenshot:
<img width="3266" height="832" alt="image" src="https://github.com/user-attachments/assets/ca536ce3-88bf-4ed4-bf8b-4899e63a6e9c" />
