### PR TITLE
Fix typo on task-and-gen-tcp.md

### DIFF
--- a/lib/elixir/pages/mix-and-otp/task-and-gen-tcp.md
+++ b/lib/elixir/pages/mix-and-otp/task-and-gen-tcp.md
@@ -122,7 +122,7 @@ For now, there is a more important bug we need to fix: what happens if our TCP a
 
 ## Tasks
 
-Whenever you have an existing function and you simply want to execute it when your application starts, the `Task` module is exactly you need. For example, it has a `Task.start_link/1` function that receives an anonymous function and executes it inside a new process that will be part of a supervision tree.
+Whenever you have an existing function and you simply want to execute it when your application starts, the `Task` module is exactly what you need. For example, it has a `Task.start_link/1` function that receives an anonymous function and executes it inside a new process that will be part of a supervision tree.
 
 Let's give it a try. Open up `lib/kv.ex` and let's add a new child:
 


### PR DESCRIPTION
missing "what"
<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/1d9dd4b7-fca9-4576-b406-68f6c64e01de" />
