### PR TITLE
add warnings_as_errors to protocol switches list

### DIFF
--- a/lib/mix/lib/mix/compilers/protocol.ex
+++ b/lib/mix/lib/mix/compilers/protocol.ex
@@ -9,7 +9,7 @@ defmodule Mix.Compilers.Protocol do
 
   ## Umbrella handling
 
-  @switches [force: :boolean, verbose: :boolean, consolidate_protocols: :boolean]
+  @switches [force: :boolean, verbose: :boolean, consolidate_protocols: :boolean, warnings_as_errors: :boolean]
 
   def umbrella(args, res) do
     config = Mix.Project.config()


### PR DESCRIPTION
Working on fixing broken flags like `warnings_as_errors` and `force` for umbrella apps on elixir >= 1.19