### PR TITLE
Fix dialyzer warning on IO.inspect :label

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -511,7 +511,8 @@ defmodule IO do
   """
   @spec inspect(device, item, inspect_opts) :: item when item: var
   def inspect(device, item, opts) when is_device(device) and is_list(opts) do
-    label = if label = opts[:label], do: [to_chardata(label), ": "], else: []
+    {label, opts} = Keyword.pop(opts, :label)
+    label = if label, do: [to_chardata(label), ": "], else: []
     opts = Inspect.Opts.new(opts)
     doc = Inspect.Algebra.group(Inspect.Algebra.to_doc(item, opts))
     chardata = Inspect.Algebra.format(doc, opts.width)


### PR DESCRIPTION
Addresses this comment: https://github.com/elixir-lang/elixir/issues/14837#issuecomment-3452772021

To be backported.

I couldn't manage to write a failing test here for some reason.
Confirmed the bug & fix in a separate project but it doesn't work when added to a test fixture module:

```elixir
  def inspect_label(slug) do
    IO.inspect(slug, label: "# Slug")
  end
```