### PR TITLE
feat(logger): Logger.log includes process_label in metadata if available

### DIFF
--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -6,7 +6,7 @@ defmodule LoggerTest do
   use Logger.Case
   require Logger
 
-  @moduletag formatter: [metadata: [:application, :module]]
+  @moduletag formatter: [metadata: [:application, :module, :process_label]]
 
   setup tags do
     :logger.update_handler_config(:default, :formatter, Logger.default_formatter(tags.formatter))
@@ -531,6 +531,14 @@ defmodule LoggerTest do
            end) =~ msg("application=sample_app module=LoggerTest.SampleApp [info] hello")
   after
     Logger.configure(compile_time_application: nil)
+  end
+
+  test "sets process_label in metadata if available" do
+    Process.set_label(SampleProcess)
+
+    assert capture_log(fn ->
+             assert Logger.bare_log(:info, "ok") == :ok
+           end) =~ msg("process_label=SampleProcess [info] ok")
   end
 
   @tag formatter: [truncate: 4]


### PR DESCRIPTION
Hi there :wave: 

It seems `Logger` documentation currently states that `:process_label` metadata key is among those that

> may be added automatically by Logger whenever possible

https://hexdocs.pm/logger/1.19.1/Logger.html#module-metadata.

However, per current implementation I only see the Logger Translator using it in a few instances (Task and GenServer terminate reports and proc lib crash) to include it in the translated string message, not included in the log event metadata.

Shouldn't `Logger` include whenever a `Logger.error` or whatever log function is called anywhere if the logging process has the label set?

