### PR TITLE
docs(logger): :process_label is not really ever included in the metadata as of now

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -126,10 +126,6 @@ defmodule Logger do
 
     * `:registered_name` - the process registered name as an atom
 
-    * `:process_label` - (available from Erlang/OTP 27+) an arbitrary term
-      which can be added to a process with `Process.set_label/1` for
-      debugging purposes
-
     * `:domain` - a list of domains for the logged message. For example,
       all Elixir reports default to `[:elixir]`. Erlang reports may start
       with `[:otp]` or `[:sasl]`


### PR DESCRIPTION
address https://github.com/elixir-lang/elixir/pull/14879#issuecomment-3468796662.

This documentation is present since elixir 1.17+.

Not sure if just fine to update `main` or any other updates needed against other branches.