### PR TITLE
Fix how UTF8 env is stored in .app file

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -192,7 +192,7 @@ defmodule Mix.Tasks.Compile.App do
       :application.load({:application, app, properties})
 
       Mix.Project.ensure_structure()
-      File.write!(target, [contents, ?.])
+      File.write!(target, IO.chardata_to_string([contents, ?.]))
       File.touch!(target, new_mtime)
 
       # If we just created the .app file, it will have touched

--- a/lib/mix/test/mix/tasks/compile.app_test.exs
+++ b/lib/mix/test/mix/tasks/compile.app_test.exs
@@ -110,7 +110,7 @@ defmodule Mix.Tasks.Compile.AppTest do
   test "uses custom application settings" do
     in_fixture("no_mixfile", fn ->
       Mix.Project.push(CustomProject)
-      env = [foo: [:one, "two", 3, 4], bar: [{} | %{foo: :bar}]]
+      env = [foo: [:one, "two", 3, 4, "฿"], bar: [{} | %{foo: :bar}]]
 
       Process.put(:application,
         maxT: :infinity,
@@ -132,7 +132,7 @@ defmodule Mix.Tasks.Compile.AppTest do
       assert properties[:applications] ==
                [:kernel, :stdlib, :elixir, :logger, :ex_unit, :example_app, :mix]
 
-      assert properties[:env] == [foo: [:one, "two", 3, 4], bar: [{} | %{foo: :bar}]]
+      assert properties[:env] == [foo: [:one, "two", 3, 4, "฿"], bar: [{} | %{foo: :bar}]]
 
       refute Keyword.has_key?(properties, :extra_applications)
     end)


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/14888

Regression introduced in https://github.com/elixir-lang/elixir/commit/a8000f211a46bc251bd9189bd3fd6eb718e9b678, since it tries to write chardata (as returned by `:io_lib.print`) as iodata (through `File.write`).


Without the fix:
<img width="1404" height="272" alt="Screenshot 2025-11-04 at 8 35 31" src="https://github.com/user-attachments/assets/5d3d8275-4179-42ac-9a59-16932d99b4dc" />
