### PR TITLE
documentation: add command needed for `:observer.start()` to be successful when running within `iex -S mix`

### DIFF
--- a/lib/elixir/pages/mix-and-otp/dynamic-supervisor.md
+++ b/lib/elixir/pages/mix-and-otp/dynamic-supervisor.md
@@ -202,10 +202,10 @@ iex> :observer.start()
 
 > #### Missing dependencies {: .warning}
 >
-> When running `iex` inside a project with `iex -S mix`, `observer` won't be available as a dependency. To do so, you will need to call the following functions before `:observer.start()`:
+> When running `iex` inside a project with `iex -S mix`, `observer` won't be available as a dependency. To do so, you will need to call the following functions:
 >
 > ```elixir
-> iex> Mix.ensure_application!(:observer);
+> iex> Mix.ensure_application!(:observer)
 > iex> :observer.start()
 > ```
 >


### PR DESCRIPTION
This adds the missing command required to start observer within an iex shell started with `-S mix`.

The documentation [currently states](https://hexdocs.pm/elixir/1.19.2/dynamic-supervisor.html#observer):

> [...] When running `iex` inside a project with `iex -S mix`, `observer` won't be available as a dependency. To do so, you will need to call the following functions before: [...]

but then it never tells you the correct command.

(This was the reason I created Issue #14882, since I thought it was a bug and I have followed the documentation to the letter.)