### PR TITLE
Write ascii printable charlists as such in .app file

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -214,7 +214,11 @@ defmodule Mix.Tasks.Compile.App do
   end
 
   defp to_erl_term(list) when is_list(list) do
-    [?[, to_erl_head(list), ?]]
+    if List.ascii_printable?(list) do
+      :io_lib.print(list)
+    else
+      [?[, to_erl_head(list), ?]]
+    end
   end
 
   defp to_erl_term(map) when is_map(map) do


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/14905

This was introduced in https://github.com/elixir-lang/elixir/commit/a8000f211a46bc251bd9189bd3fd6eb718e9b678.

To be backported.

I don't think we have tests for the raw file output, only the parsed result, but I checked manually the before/after:

Before:

```erlang
..., {description,[112,108,97,121,103,114,111,117,110,100]},{registered,[]},{vsn,[48,46,49,46,48]},{mod,{'Elixir.Playground.Application',[]}}]}.
```

After

```erlang
...,{description,"playground"},{registered,[]},{vsn,"0.1.0"},{mod,{'Elixir.Playground.Application',[]}}]}.
```