### PR TITLE
Fix grammar in `mix run --no-start` documentation

### DIFF
--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Run do
 
       $ mix run --no-halt
 
-  The `--no-start` option can also be given and the current application,
+  The `--no-start` option can also be given and neither the current application
   nor its dependencies will be started. Alternatively, you may use
   `mix eval` to evaluate a single expression without starting the current
   application.


### PR DESCRIPTION
I'm brand new to Elixir and just noticed a minor grammar error while reading the `mix run --no-start` documentation. 

This PR makes the following simple change:

CURRENT:
`The --no-start option can also be given and the current application, nor its dependencies will be started.`

PROPOSED:
`The --no-start option can also be given and neither the current application nor its dependencies will be started.`