### PR TITLE
File.cp_r reports non-existing dest dir properly

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1224,7 +1224,13 @@ defmodule File do
   defp do_cp_r(src, dest, on_conflict, dereference?, acc) when is_list(acc) do
     case :elixir_utils.read_link_type(src) do
       {:ok, :regular} ->
-        do_cp_file(src, dest, on_conflict, acc)
+        case do_cp_file(src, dest, on_conflict, acc) do
+          # we don't have a way to make a distinction between a non-existing src
+          # or dest being a non-existing dir in the case of :enoent,
+          # but we already know that src exists here.
+          {:error, :enoent, _} -> {:error, :enoent, dest}
+          other -> other
+        end
 
       {:ok, :symlink} ->
         case :file.read_link(src) do

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -787,6 +787,18 @@ defmodule FileTest do
       end
     end
 
+    test "cp_r! with file src and dest unknown" do
+      src = fixture_path("cp_r/a/1.txt")
+      dest = tmp_path("tmp/unknown/")
+
+      message =
+        "could not copy recursively from #{inspect(src)} to #{inspect(dest)}. #{dest}: no such file or directory"
+
+      assert_raise File.CopyError, message, fn ->
+        File.cp_r!(src, dest)
+      end
+    end
+
     test "cp preserves mode" do
       File.mkdir_p!(tmp_path("tmp"))
       src = fixture_path("cp_mode")


### PR DESCRIPTION
Tentative fix for https://github.com/elixir-lang/elixir/issues/14924

I don't like it too much, because we could still have a race condition and the src file could have been removed in between the two calls - but the current code works with two successive calls anyway so it's probably acceptable.

The core issue is that `:file.copy`, called in `do_cp_file`, would return `{:error, :enoent}` in both those cases without allowing us to distinguish:
- `:file.copy(non_existing_file, existing_dir)`
- `:file.copy(existing_file, non_existing_dir)`