### PR TITLE
Clarify Scope of Open Source Policy

### DIFF
--- a/OPEN_SOURCE_POLICY.md
+++ b/OPEN_SOURCE_POLICY.md
@@ -19,9 +19,8 @@ ensuring that Elixir remains a trusted and innovative open source project.
 
 ## 2. Scope
 
-This policy applies to the Elixir Programming Language, located at
-<https://github.com/elixir-lang/elixir>, and the rest of the projects under the
-Elixir Programming Organization, which is located at <https://github.com/elixir-lang/>.
+This policy applies to the Elixir Programming language and all other projects under the
+Elixir Organization, which is located at <https://github.com/elixir-lang/>.
 It covers every file, and contribution made, including documentation and any
 associated assets.
 


### PR DESCRIPTION
Update `OPEN_SOURCE_POLICY.md` to clarify that the policy applies to all projects under the Elixir organization, and not for any  project written in the Elixir programming language.

This change helps to avoid ambiguity around what contributions are covered by the policy and ensures that contributors understand which guidelines apply to their work.