### PR TITLE
Fix ex_unit formatter crash when find_diff returns nil

### DIFF
--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -513,10 +513,15 @@ defmodule ExUnit.Formatter do
 
   defp format_diff(left, right, context, formatter) do
     if has_value?(left) and has_value?(right) do
-      {result, env} = find_diff(left, right, context)
-      result = if formatter.(:diff_enabled?, false), do: result
-      hints = Enum.map(env.hints, &{:hint, format_hint(&1)})
-      {result, hints}
+      case find_diff(left, right, context) do
+        {result, env} ->
+          result = if formatter.(:diff_enabled?, false), do: result
+          hints = Enum.map(env.hints, &{:hint, format_hint(&1)})
+          {result, hints}
+
+        nil ->
+          {nil, []}
+      end
     else
       {nil, []}
     end


### PR DESCRIPTION
Tentative fix for https://github.com/elixir-lang/elixir/issues/14938. I haven't checked why the diff is nil