### PR TITLE
Update commands for building docs in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,17 +177,19 @@ affecting **all external contributors**:
 ## Building documentation
 
 Building the documentation requires that [ExDoc](https://github.com/elixir-lang/ex_doc)
-is installed and built alongside Elixir:
+is installed and built alongside Elixir.
+
+After cloning and compiling Elixir, run:
 
 ```sh
-# After cloning and compiling Elixir, in its parent directory:
-git clone https://github.com/elixir-lang/ex_doc.git
-cd ex_doc && ../elixir/bin/elixir ../elixir/bin/mix do deps.get + compile
-```
+elixir_dir=$(pwd)
+cd .. && git clone https://github.com/elixir-lang/ex_doc.git
+cd ex_doc && "${elixir_dir}/bin/elixir" "${elixir_dir}/bin/mix" do deps.get + compile
 
-Now go back to Elixir's root directory and generate HTML and EPUB documents:
+# Now we will go back to Elixir's root directory,
+cd "${elixir_dir}"
 
-```sh
+# and generate HTML and EPUB documents:
 make docs
 ```
 


### PR DESCRIPTION
- `$DOCS_FORMAT` is no longer supported in Makefile
- By default HTML and EPUB doc formats are created

Also fix instructions for  building docs from release sources
The following instructions do not work because the source code version
of the release create a folder with the version in it.

```console
❯ unzip -l v1.19.3.zip
Archive:  v1.19.3.zip
https://github.com/elixir-lang/elixir/commit/427d21e410d1846c232d0a0b0e87cce629884dfa
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  11-13-2025 11:33   elixir-1.19.3/
      502  11-13-2025 11:33   elixir-1.19.3/.formatter.exs
...
```

So the instructions do not work because it expects a folder named `elixir/`.

Instructions have been updated to work from the Git repo as well as from the
downloaded release source files.