### PR TITLE
Update .gitnore rules for generated .zip files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@
 /lib/elixir/test/ebin/
 /man/elixir.1
 /man/iex.1
-/Docs-v*.zip
-/Precompiled-v*.zip
+/Docs.zip
+/Precompiled.zip
 /.eunit
 .elixir.plt
 erl_crash.dump


### PR DESCRIPTION
`make Docs.zip` and `make Precompiled.zip` generates names with those files names.

The `v-*` format has been deprecated.