### PR TITLE
Add .tool-versions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 .elixir.plt
 erl_crash.dump
 /cover/
+.tool-versions


### PR DESCRIPTION
I know this could be opinionated, but I think that is the most common way to build Elixir with different OTP versions.