### PR TITLE
Fix unregister_name signature for PartitionSupervisor

### DIFF
--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -546,7 +546,7 @@ defmodule PartitionSupervisor do
   end
 
   @doc false
-  def unregister_name(_, _) do
+  def unregister_name(_) do
     raise "{:via, PartitionSupervisor, _} cannot be given on unregistration"
   end
 end


### PR DESCRIPTION
unregister_name takes just a name parameter