### PR TITLE
Tighten up Markdownlint rule: Trailing punctuation in heading

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -30,8 +30,12 @@
       // Duplication is allowed for headings with different parents.
       "siblings_only": true
     },
-    // Some headers finish with ! because it refers to a function name
-    "MD026": false,
+    // Trailing punctuation in heading.
+    // Some headers finish with ! because it refers to a function name. Therefore we remove ! from
+    // the default values.
+    "MD026": {
+      "punctuation": ".,;:。，；：！"
+    },
     // Allow empty line between block quotes. Used by contiguous admonition blocks.
     "MD028": false,
     // Allowed HTML inline elements.


### PR DESCRIPTION
Rule MD026 "Trailing punctuation in heading" is enforced, we simply remove `!` from the list of forbidden characters.

Source: https://github.com/DavidAnson/markdownlint/blob/main/doc/md026.md