### PR TITLE
Correct SPDX-FileCopyrightText

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
 
 name: CI
 


### PR DESCRIPTION
This file was originally created on 2020-06-26,
therefore the copyright belonged to Plataformatec at the time.