### PR TITLE
CI: Move POSIX compliance action to its own file

### DIFF
--- a/.github/workflows/ci-posix-compliance.yml
+++ b/.github/workflows/ci-posix-compliance.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+# SPDX-FileCopyrightText: 2012 Plataformatec
+
+name: CI
+
+on:
+  workflow_dispatch:
+
+  push:
+    paths:
+      - ".github/workflows/ci-posix-compliance.yml"
+      - "bin/elixir"
+      - "bin/elixirc"
+      - "bin/iex"
+
+  pull_request:
+    paths:
+      - ".github/workflows/ci-posix-compliance.yml"
+      - "bin/elixir"
+      - "bin/elixirc"
+      - "bin/iex"
+
+env:
+  LANG: C.UTF-8
+
+permissions:
+  contents: read
+
+jobs:
+  check_posix_compliance:
+    name: Check POSIX compliance
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Install ShellCheck
+        run: |
+          sudo apt update
+          sudo apt install -y shellcheck
+      - name: Run ShellCheck on bin/ dir
+        run: |
+          shellcheck -e SC2039,2086 bin/elixir && echo "bin/elixir is POSIX compliant"
+          shellcheck bin/elixirc && echo "bin/elixirc is POSIX compliant"
+          shellcheck bin/iex && echo "bin/iex is POSIX compliant"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,23 +132,6 @@ jobs:
           Remove-Item 'c:/Windows/System32/drivers/etc/hosts'
           make test_elixir
 
-  check_posix_compliant:
-    name: Check POSIX-compliant
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-        with:
-          fetch-depth: 50
-      - name: Install Shellcheck
-        run: |
-          sudo apt update
-          sudo apt install -y shellcheck
-      - name: Check POSIX-compliant
-        run: |
-          shellcheck -e SC2039,2086 bin/elixir && echo "bin/elixir is POSIX compliant"
-          shellcheck bin/elixirc && echo "bin/elixirc is POSIX compliant"
-          shellcheck bin/iex && echo "bin/iex is POSIX compliant"
-
   license_compliance:
     name: Check Licence Compliance
 


### PR DESCRIPTION
By moving this to its own file we have more control of when the action should be triggered.