### PR TITLE
Fix dialyzer warnings on EEx.eval_string

### DIFF
--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -364,6 +364,7 @@ defmodule EEx do
   ### Helpers
 
   defp do_eval(compiled, bindings, options) do
+    options = Keyword.take(options, [:file, :line, :module, :prune_binding])
     {result, _} = Code.eval_quoted(compiled, bindings, options)
     result
   end

--- a/lib/elixir/test/elixir/fixtures/dialyzer/regressions.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/regressions.ex
@@ -11,4 +11,8 @@ defmodule Dialyzer.Regressions do
       migrate: true
     )
   end
+
+  def eex_eval_opts do
+    EEx.eval_string("foo <%= bar %>", [bar: "baz"], trim: true)
+  end
 end

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -36,6 +36,7 @@ defmodule Kernel.DialyzerTest do
       ArgumentError,
       Atom,
       Code,
+      EEx,
       Enum,
       Exception,
       ExUnit.AssertionError,


### PR DESCRIPTION
See https://github.com/elixir-lang/elixir/issues/14837#issuecomment-3528301836

As mentioned on https://github.com/elixir-lang/elixir/pull/14928, this has a small performance cost. Alternatively the spec of `Code.eval_quoted` can be changed to be "open"

edit: Actually, I think `EEx.eval_file` is probably not warning thanks to `Keyword.put_new` [here](https://github.com/elixir-lang/elixir/blob/abd73a841f07cba0a5a597796f53f44f50da15a1/lib/eex/lib/eex.ex#L322)