### PR TITLE
CI: Shorten job names so they fit on GH actions sidebar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   test_linux:
-    name: Ubuntu 24.04, Erlang/OTP ${{ matrix.otp_version }}${{ matrix.deterministic && ' (deterministic)' || '' }}${{ matrix.coverage && ' (coverage)' || '' }}
+    name: Ubuntu 24.04, OTP ${{ matrix.otp_version }}${{ matrix.deterministic && ' (deterministic)' || '' }}${{ matrix.coverage && ' (coverage)' || '' }}
     runs-on: ubuntu-24.04
 
     strategy:
@@ -106,7 +106,7 @@ jobs:
           path: cover/*
 
   test_windows:
-    name: Windows Server 2022, Erlang/OTP ${{ matrix.otp_version }}
+    name: Windows Server 2022, OTP ${{ matrix.otp_version }}
     runs-on: windows-2022
 
     strategy:


### PR DESCRIPTION
You can have more context of what's the job platform on the side-bar, specially for the Windows ones.

### Before:

<img width="1109" height="839" alt="image" src="https://github.com/user-attachments/assets/3038c630-a44a-490c-948b-8d313a19bf04" />

### After:
<img width="1209" height="839" alt="image" src="https://github.com/user-attachments/assets/ad3f49b9-d562-452f-b2dd-efb839d2129f" />
