### PR TITLE
doc: observer example create_bucket

### DIFF
--- a/lib/elixir/pages/mix-and-otp/dynamic-supervisor.md
+++ b/lib/elixir/pages/mix-and-otp/dynamic-supervisor.md
@@ -222,7 +222,7 @@ In the Applications tab, you will see all applications currently running in your
 Not only that, as you create new buckets on the terminal, you should see new processes spawned in the supervision tree shown in Observer:
 
 ```elixir
-iex> KV.lookup_bucket("shopping")
+iex> KV.create_bucket("shopping")
 #PID<0.89.0>
 ```
 


### PR DESCRIPTION
I was following along the `MIX & OTP` guide in the docs and was confused by the last iex example in the `dynamic-supervisor.md`. I think it should have been `KV.create_bucket("shopping")` instead of `KV.lookup_bucket("shopping")`.

Line: https://github.com/elixir-lang/elixir/blob/main/lib/elixir/pages/mix-and-otp/dynamic-supervisor.md?plain=1#L225
Hexdocs: https://hexdocs.pm/elixir/dynamic-supervisor.html#observer