### PR TITLE
CI: Fix continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,11 @@ jobs:
 
       - name: Erlang test suite
         run: make test_erlang
-        continue-on-error: ${{ matrix.development }}
+        continue-on-error: ${{ matrix.development == true }}
 
       - name: Elixir test suite
         run: make test_elixir
-        continue-on-error: ${{ matrix.development }}
+        continue-on-error: ${{ matrix.development == true }}
         env:
           COVER: "${{ matrix.coverage }}"
 


### PR DESCRIPTION
If a test fails, `continue-on-error` will not be evaluated, if it's not set.

https://github.com/eksperimental-forks/elixir/actions/runs/19824449905/job/56794214695#step:9:46

    2196 doctests, 4913 tests, 1 failure (18 excluded)
    make: *** [Makefile:289: test_stdlib] Error 2
    Error: Process completed with exit code 2.
    Error: The step failed and an error occurred when attempting to determine whether to continue on error.
    Error: The template is not valid. .github/workflows/ci.yml (Line: 78, Col: 28): Unexpected value ''