### PR TITLE
Fix spec for t:ExUnit.Callbacks.child_spec_overrides/2

### DIFF
--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -169,11 +169,7 @@ defmodule ExUnit.Callbacks do
       end
   """
 
-  @type child_spec_overrides :: [
-          restart: :permanent | :transient | :temporary,
-          shutdown: :brutal_kill | timeout(),
-          type: :worker | :supervisor
-        ]
+  @type child_spec_overrides :: Supervisor.child_spec_overrides()
 
   @doc false
   def __register__(module) do


### PR DESCRIPTION
Found out about this here: https://github.com/getsentry/sentry-elixir/actions/runs/20060145541/job/57534823122

I'm aware of https://github.com/elixir-lang/elixir/pull/14611 but I think in this case it might just be borked. We can totally pass things like `:id` and whatnot here, after all the implementation is just forwarding cleanly to `Supervisor.child_spec/2`. Ideally we'd remove this type altogether but I’m trying to be considerate of breaking changes (`ExUnit.Callbacks.child_spec_overrides/0` is public API and released).