### PR TITLE
Fix unnecessary recompilation when dbg_callback is modified at runtime

### DIFF
--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -67,12 +67,7 @@ start(_Type, _Args) ->
   %% Store the initial dbg_callback value before any runtime modifications.
   %% This allows Mix compiler to detect config changes vs runtime changes
   %% (e.g., Kino wrapping dbg_callback at runtime should not trigger recompilation).
-  case application:get_env(elixir, dbg_callback) of
-    {ok, DbgCallback} ->
-      application:set_env(elixir, dbg_callback_initial, DbgCallback);
-    undefined ->
-      ok
-  end,
+  {ok, InitialDbgCallback} = application:get_env(elixir, dbg_callback),
 
   Tokenizer = case code:ensure_loaded('Elixir.String.Tokenizer') of
     {module, Mod} -> Mod;
@@ -100,6 +95,7 @@ start(_Type, _Args) ->
     {docs, true},
     {ignore_already_consolidated, false},
     {ignore_module_conflict, false},
+    {initial_dbg_callback, InitialDbgCallback},
     {infer_signatures, [elixir]},
     {on_undefined_variable, raise},
     {parser_options, [{columns, true}]},

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -64,6 +64,16 @@ start(_Type, _Args) ->
       application:set_env(elixir, ansi_enabled, prim_tty:isatty(stdout) == true)
   end,
 
+  %% Store the initial dbg_callback value before any runtime modifications.
+  %% This allows Mix compiler to detect config changes vs runtime changes
+  %% (e.g., Kino wrapping dbg_callback at runtime should not trigger recompilation).
+  case application:get_env(elixir, dbg_callback) of
+    {ok, DbgCallback} ->
+      application:set_env(elixir, dbg_callback_initial, DbgCallback);
+    undefined ->
+      ok
+  end,
+
   Tokenizer = case code:ensure_loaded('Elixir.String.Tokenizer') of
     {module, Mod} -> Mod;
     _ -> elixir_tokenizer

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -287,7 +287,13 @@ defmodule Mix.Compilers.Elixir do
   end
 
   defp deps_config_compile_env_apps(deps_config) do
-    if deps_config[:dbg] != Application.fetch_env!(:elixir, :dbg_callback) do
+    # Use dbg_callback_initial instead of dbg_callback to ignore runtime modifications.
+    # Tools like Kino modify dbg_callback at runtime to customize dbg/2 behavior,
+    # but this should not trigger recompilation since the config hasn't actually changed.
+    # dbg_callback_initial is set when :elixir app starts, before any runtime modifications.
+    initial_dbg = Application.fetch_env!(:elixir, :dbg_callback_initial)
+
+    if deps_config[:dbg] != initial_dbg do
       [:elixir]
     else
       []

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -287,11 +287,11 @@ defmodule Mix.Compilers.Elixir do
   end
 
   defp deps_config_compile_env_apps(deps_config) do
-    # Use dbg_callback_initial instead of dbg_callback to ignore runtime modifications.
+    # Use initial_dbg_callback instead of dbg_callback to ignore runtime modifications.
     # Tools like Kino modify dbg_callback at runtime to customize dbg/2 behavior,
     # but this should not trigger recompilation since the config hasn't actually changed.
-    # dbg_callback_initial is set when :elixir app starts, before any runtime modifications.
-    initial_dbg = Application.fetch_env!(:elixir, :dbg_callback_initial)
+    # initial_dbg_callback is set when :elixir app starts, before any runtime modifications.
+    initial_dbg = :elixir_config.get(:initial_dbg_callback)
 
     if deps_config[:dbg] != initial_dbg do
       [:elixir]

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -278,9 +278,11 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
 
-      # Change the dbg_callback at runtime
+      # Simulate a config change by updating both dbg_callback and dbg_callback_initial.
+      # This represents the case where the user actually changed the config file.
       File.touch!("_build/dev/lib/sample/.mix/compile.elixir", @old_time)
       Application.put_env(:elixir, :dbg_callback, {__MODULE__, :dbg, []})
+      Application.put_env(:elixir, :dbg_callback_initial, {__MODULE__, :dbg, []})
 
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
@@ -289,6 +291,35 @@ defmodule Mix.Tasks.Compile.ElixirTest do
     end)
   after
     Application.put_env(:elixir, :dbg_callback, {Macro, :dbg, []})
+    Application.put_env(:elixir, :dbg_callback_initial, {Macro, :dbg, []})
+  end
+
+  test "does not recompile when dbg_callback is modified at runtime but initial is unchanged" do
+    in_fixture("no_mixfile", fn ->
+      Mix.Project.push(MixTest.Case.Sample)
+
+      File.write!("lib/a.ex", """
+      defmodule A do
+        def a, do: dbg(:ok)
+      end
+      """)
+
+      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
+      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+
+      # Simulate a tool like Kino modifying dbg_callback at runtime.
+      # Since dbg_callback_initial remains unchanged, this should NOT trigger recompilation.
+      original_dbg = Application.fetch_env!(:elixir, :dbg_callback)
+      Application.put_env(:elixir, :dbg_callback_initial, original_dbg)
+      Application.put_env(:elixir, :dbg_callback, {SomeDebugTool, :dbg, [original_dbg]})
+
+      # Should NOT trigger recompilation since dbg_callback_initial is unchanged
+      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:noop, []}
+      refute_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+    end)
+  after
+    Application.put_env(:elixir, :dbg_callback, {Macro, :dbg, []})
+    Application.put_env(:elixir, :dbg_callback_initial, {Macro, :dbg, []})
   end
 
   test "recompiles files when config changes export dependencies" do


### PR DESCRIPTION
## Problem

Tools like Kino modify `dbg_callback` at runtime to customize `dbg/2` behavior. Previously, this runtime modification would trigger unnecessary recompilation on server start, even though the config hadn't actually changed.

This is problematic for Phoenix projects with `code_reloader: true`.

## Solution

Store the initial `dbg_callback` value in `initial_dbg_callback` when the `:elixir` app starts. Mix compiler now compares against `initial_dbg_callback` instead of `dbg_callback`.

The key insight is that `dbg/2` is a compile-time macro, so runtime modifications to `dbg_callback` don't affect already-compiled code. Only actual config changes (reflected in `initial_dbg_callback`) should trigger recompilation.

## Changes

- `lib/elixir/src/elixir.erl`: Store `initial_dbg_callback` on app start
- `lib/mix/lib/mix/compilers/elixir.ex`: Compare against `initial_dbg_callback`
- Added test case for runtime modification scenario

---

I'm currently using Elixir 1.19.4 with Kino in a Phoenix project and experiencing this issue. A backport to v1.19 would be appreciated.