### PR TITLE
Fix parser crash on missing parentheses on expression following operator \"not in\" warning

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -1295,6 +1295,14 @@ warn_pipe(_Token, _) ->
   ok.
 
 %% TODO: Make this an error on v2.0
+warn_no_parens_after_do_op({{in_op, Location, Op, _InLocation}, _}) ->
+  {Line, _, _} = Location,
+
+  warn(
+    Line,
+    "missing parentheses on expression following operator \"" ++ atom_to_list(Op) ++ "\", "
+    "you must add parentheses to avoid ambiguities"
+  );
 warn_no_parens_after_do_op({{_Type, Location, Op}, _}) ->
   {Line, _, _} = Location,
 

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1953,6 +1953,18 @@ defmodule Kernel.WarningTest do
     )
   end
 
+  test "do+end with not in operator without explicit parentheses" do
+    assert_warn_eval(
+      ["nofile:3\n", "missing parentheses on expression following operator \"not in\""],
+      """
+      quote do
+        case do
+        end not in no_parens 1, 2
+      end
+      """
+    )
+  end
+
   test "variable is being expanded to function call (on_undefined_variable: warn)" do
     capture_io(:stderr, fn ->
       Code.put_compiler_option(:on_undefined_variable, :warn)


### PR DESCRIPTION
Fixes https://github.com/elixir-lang/elixir/issues/15010