### PR TITLE
Add shorthand syntax for keywords and maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ The type system was made possible thanks to a partnership between [CNRS](https:/
   * [Calendar] Optimize `date_from_iso_days` by using the Neri-Schneider algorithm
   * [Enum] Add `Enum.min_max` sorter
   * [Integer] Add `Integer.ceil_div/2`
+  * [Kernel] Add shorthand syntax for keywords and maps, where `%{x:, y:}` is equivalent to `%{x: x, y: y}`
   * [Kernel] Print intermediate results of `dbg` for pipes
   * [Kernel] Warn on unused requires
   * [Regex] Add `Regex.import/1` to import regexes defined with `/E`

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -677,6 +677,14 @@ tokenize(String, Line, Column, OriginalScope, Tokens) ->
           Token = {kw_identifier, {Line, Column, Unencoded}, Atom},
           tokenize(T, Line, Column + Length + 1, Scope, [Token | Tokens]);
 
+        [$: | T] when hd(T) =:= $,; hd(T) =:= $]; hd(T) =:= $}; hd(T) =:= $) ->
+          Token = {kw_identifier_shorthand, {Line, Column, Unencoded}, Atom},
+          tokenize(T, Line, Column + Length + 1, Scope, [Token | Tokens]);
+
+        [$:] ->
+          Token = {kw_identifier_shorthand, {Line, Column, Unencoded}, Atom},
+          tokenize([], Line, Column + Length + 1, Scope, [Token | Tokens]);
+
         [$: | T] when hd(T) =/= $: ->
           AtomName = atom_to_list(Atom) ++ [$:],
           Reason = {?LOC(Line, Column), "keyword argument must be followed by space after: ", AtomName},

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -89,6 +89,22 @@ kw_test() ->
   [{kw_identifier, {1, 1, _}, foo}, {bin_string, {1, 6, nil}, [<<"bar">>]}] = tokenize("foo: \"bar\""),
   [{kw_identifier, {1, 1, _}, '+'}, {bin_string, {1, 6, nil}, [<<"bar">>]}] = tokenize("\"+\": \"bar\"").
 
+kw_shorthand_test() ->
+  [{'[', _}, {kw_identifier_shorthand, {1, 2, _}, x}, {']', _}] = tokenize("[x:]"),
+  [{'[', _},
+   {kw_identifier_shorthand, {1, 2, _}, foo},
+   {',', _},
+   {kw_identifier_shorthand, {1, 8, _}, bar},
+   {']', _}] = tokenize("[foo:, bar:]"),
+  [{'[', _},
+   {kw_identifier_shorthand, {1, 2, _}, x},
+   {',', _},
+   {kw_identifier, {1, 6, _}, y},
+   {int, _, "1"},
+   {']', _}] = tokenize("[x:, y: 1]"),
+  [{'{', _}, {kw_identifier_shorthand, {1, 2, _}, x}, {'}', _}] = tokenize("{x:}"),
+  [{'(', _}, {kw_identifier_shorthand, {1, 2, _}, x}, {')', _}] = tokenize("(x:)").
+
 int_test() ->
   [{int, {1, 1, 123}, "123"}] = tokenize("123"),
   [{int, {1, 1, 123}, "123"}, {';', {1, 4, 0}}] = tokenize("123;"),


### PR DESCRIPTION
This PR adds value-omission shorthand for atom-keyed maps and keywords:

```elixir
%{user:, conn:}  # => %{user: user, conn: conn}
[foo:, bar:]     # => [foo: foo, bar: bar]
f(name:, age:)   # => f(name: name, age: age)
```

It also works with map updates:

```elixir
%{map | a:, b:}  # => %{map | a: a, b: b}
```

## This is not a revival of the `%{a, b}` syntax

I know this topic has a long history. There were several proposals for ES6-style `%{a, b}` syntax:

- [Proposal: Short Hand Property Names](https://groups.google.com/g/elixir-lang-core/c/XxnrGgZsyVc) (elixir-lang-core)
- [Consider supporting a map shorthand syntax](https://groups.google.com/g/elixir-lang-core/c/NoUo2gqQR3I) (elixir-lang-core)
- [Shorthand syntax for maps](https://groups.google.com/g/elixir-lang-talk/c/Hd6GL-oi2uA) (elixir-lang-talk)
- [ES6-ish property value shorthands for maps?](https://elixirforum.com/t/es6-ish-property-value-shorthands-for-maps/1524) (Elixir Forum)
- [Has Map shorthand syntax caused you any problems?](https://elixirforum.com/t/has-map-shorthand-syntax-in-other-languages-caused-you-any-problems/15403) (Elixir Forum)

@josevalim was clear that `%{a, b}` syntax has "zero chance" to be accepted — mostly because `%{a, b}` vs `{a, b}` differs by one character, making it too easy to confuse maps and tuples when reading code.

The colon-based syntax `%{a:, b:}` doesn't have this problem. The `:` is already the visual signal for "key-value pair" everywhere in Elixir, and it stays there. No new ambiguity is added.

## Prior art

Ruby 3.1 added exactly this syntax:

```ruby
{x:, y:}      # => {x: x, y: y}
foo(x:, y:)   # => foo(x: x, y: y)
```

The pattern is also known as "field punning" and exists in Rust (struct field init shorthand) and OCaml.

## Why I think this fits Elixir now

- `%{user: user, conn: conn}` is already common in Elixir code
- This just removes the repetition without changing how we write code
- The shorthand only works for atom keys — same rules as today
- String keys still need `=>`, nothing is mixed up

Sorry for skipping a forum discussion and going straight to PR. Happy to move the conversation there if needed.
