### PR TITLE
Fix Kernel defstruct types docs phrasing

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5593,8 +5593,8 @@ defmodule Kernel do
   ## Types
 
   It is recommended to define types for structs. By convention, such a type
-  is called `t`. To define a struct inside a type, the struct literal syntax
-  is used:
+  is called `t`. To define a type for a struct, the struct literal syntax is
+  used:
 
       defmodule User do
         defstruct name: "John", age: 25


### PR DESCRIPTION
In docstring of defstruct in `lib/elixir/lib/kernel.ex` it says :
  "To define a struct inside a type, the struct literal syntax is used..."
The phrasing is easy to misread as "you are defining the struct in typespec", which we're not.

This PR changes the recent wording to "To define a type for a struct, the struct literal syntax is  used".