### PR TITLE
lib/elixir/lib/process.ex: Fix dead link to what was "The need for monitoring" but is now "Links and monitors"

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -534,7 +534,7 @@ defmodule Process do
   If the process is already dead when calling `Process.monitor/1`, a
   `:DOWN` message is delivered immediately.
 
-  See ["The need for monitoring"](genservers.md#the-need-for-monitoring)
+  See ["Links and monitors"](genservers.md#links-and-monitors)
   for an example. See `:erlang.monitor/2` for more information.
 
   Inlined by the compiler.


### PR DESCRIPTION
Fixes: commit ce64fc364d368705759d0982b72a4ba98572caa6 ("Revamp  Mix & OTP guides (#14637)")
Sponsored-by: https://beaverlabs.net