### PR TITLE
fix(xref): raise on --min-cycle-label <= 0

### DIFF
--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -1238,6 +1238,10 @@ defmodule Mix.Tasks.Xref do
           Mix.raise("--min-cycle-label requires the --label option to be given")
         end
 
+        if integer <= 0 do
+          Mix.raise("--min-cycle-label must be greater than 0")
+        end
+
         integer
       else
         1

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -579,6 +579,12 @@ defmodule Mix.Tasks.XrefTest do
       """)
     end
 
+    test "bad min_cycle_label" do
+      assert_raise Mix.Error, "--min-cycle-label must be greater than 0", fn ->
+        assert_graph(["--format", "cycles", "--label", "compile", "--min-cycle-label", "0"], "")
+      end
+    end
+
     test "cycles with min_cycle_size greater than actual length" do
       assert_graph(["--format", "cycles", "--min-cycle-size", "3"], """
       No cycles found


### PR DESCRIPTION
Provides an error message in favor of

```
mix xref graph --format cycles --min-cycle-label 0 --label compile-connected
** (FunctionClauseError) no function clause matching in Enum.count_until/3

    The following arguments were given to Enum.count_until/3:

        # 1
        [{"lib/foo.ex", nil}, {"lib/bar.ex", nil}]

        # 2
        #Function<4.83728021/1 in Mix.Tasks.Xref.cycle_filter_fn/1>

        # 3
        0

    Attempted function clauses (showing 1 out of 1):

        def count_until(enumerable, fun, limit) when is_integer(limit) and limit > 0

    (elixir 1.19.4) lib/enum.ex:783: Enum.count_until/3
    (mix 1.19.4) lib/mix/tasks/xref.ex:1247: anonymous fn/3 in Mi
```