### PR TITLE
count_until: ensure is_integer when raising argument error

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -780,7 +780,7 @@ defmodule Enum do
     end
   end
 
-  def count_until(_enumerable, limit) do
+  def count_until(_enumerable, limit) when is_integer(limit) do
     raise ArgumentError, "expected limit to be greater than 0, got: #{limit}"
   end
 
@@ -805,7 +805,7 @@ defmodule Enum do
     end
   end
 
-  def count_until(_enumerable, _fun, limit) do
+  def count_until(_enumerable, _fun, limit) when is_integer(limit) do
     raise ArgumentError, "expected limit to be greater than 0, got: #{limit}"
   end
 


### PR DESCRIPTION
adds `when is_integer(limit)` to the `Enum.count_until` argument errors from #15029, making sure FunctionClauseError is still raised for non integer limits