### PR TITLE
Remove double quotes from printed strings in Enum.each example

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -973,8 +973,8 @@ defmodule Enum do
   ## Examples
 
       Enum.each(["some", "example"], fn x -> IO.puts(x) end)
-      "some"
-      "example"
+      some
+      example
       #=> :ok
 
   """


### PR DESCRIPTION
Here is what I see when I try the example:

6🧪 Enum.each(["some", "example"], fn x -> IO.puts(x) end) some
example
:ok

The doc needs to be updated.