### PR TITLE
Docs: replace binary_size with byte_size in Protocol moduledoc

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -21,7 +21,7 @@ defmodule Protocol do
   the data structure.
 
   Although Elixir includes specific functions such as `tuple_size`,
-  `binary_size` and `map_size`, sometimes we want to be able to
+  `byte_size` and `map_size`, sometimes we want to be able to
   retrieve the size of a data structure regardless of its type.
   In Elixir we can write polymorphic code, i.e. code that works
   with different shapes/types, by using protocols. A size protocol


### PR DESCRIPTION
`binary_size/1` doesn’t exist. 
I think, the intended function is `Kernel.byte_size/1`.