### PR TITLE
Do not use opaque type for URI authority

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -34,10 +34,8 @@ defmodule URI do
 
   # We don't use opaque because URIs can be inlined,
   # either via module attributes or by the compiler.
-  @typep opaque_authority :: nil | binary
-
-  @typedoc deprecated: "The authority field is deprecated"
-  @type authority :: opaque_authority()
+  @doc deprecated: "The authority field is deprecated"
+  @type authority :: nil | binary
 
   @type t :: %__MODULE__{
           scheme: nil | binary,


### PR DESCRIPTION
https://github.com/elixir-lang/elixir/issues/14837, same as https://github.com/elixir-lang/elixir/commit/7c13e99412cab2c9c8049ce6989c5497944daf87.

`URI`s can also be inlined and cause similar issues that can't be fixed by `generated` anymore (same with a module attr containing a URI).

Example repro:

```elixir
  @spec inlined :: URI.t()
  def inlined, do: URI.new!("example.com")
```

```elixir
lib/repro.ex:27:contract_with_opaque
The @spec for Example.inlined/0 has an opaque
subtype %URI{
  :authority => URI.authority(),
  :fragment => nil | binary(),
  :host => nil | binary(),
  :path => nil | binary(),
  :port => nil | char(),
  :query => nil | binary(),
  :scheme => nil | binary(),
  :userinfo => nil | binary()
} which is violated by the success typing.

Success typing:
() :: %URI{
  :authority => nil,
  :fragment => nil,
  :host => nil,
  :path => <<_::88>>,
  :port => nil,
  :query => nil,
  :scheme => nil,
  :userinfo => nil
}
```

Not sure if we're still backporting, but if yes I think this probably should be?