### PR TITLE
Add ready to copy example in test_ignore_filters doc for frequent use case

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -267,8 +267,19 @@ defmodule Mix.Tasks.Test do
       ignored will emit a warning.
 
       Mix ignores files ending in `_helper.exs` by default, as well as any file
-      included in the project's `:elixirc_paths`. You may choose to disable all
-      warnings by ignoring all files with `[fn _ -> true end]`.
+      included in the project's `:elixirc_paths`.
+
+      For example, to ignore all files in a `test/support/` folder:
+
+          def project do
+            [
+              ...,
+              test_ignore_filters: [&String.starts_with?(&1, "test/support/")]
+            ]
+          end
+
+      You may choose to disable all warnings by ignoring all files with
+      `[fn _ -> true end]`.
 
       Paths are relative to the project root and separated by `/`, even on Windows.
 


### PR DESCRIPTION
Every time I need to use this and forget what is expected, I end up copy-pasting from a project rather than the docs.

I thought having a ready-to-copy example covering a very common case could be helpful.