### PR TITLE
Fix spelling typos in docs and comments

### DIFF
--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -577,7 +577,7 @@ defmodule Module.Types.Of do
         :integer when alignment_value == :default ->
           {0, context}
 
-        # There is no size, so the aligment depends on the type.
+        # There is no size, so the alignment depends on the type.
         # If the type is exclusively a binary, then it is aligned.
         :bitstring when alignment_value == :default ->
           if bitstring_no_binary_type?(actual), do: {:unknown, context}, else: {0, context}

--- a/lib/elixir/pages/references/gradual-set-theoretic-types.md
+++ b/lib/elixir/pages/references/gradual-set-theoretic-types.md
@@ -141,7 +141,7 @@ In the examples above, all map keys were atoms, but we can also use other types 
 %{..., binary() or atom() => integer()}
 ```
 
-Currently, the type system only tracks the top of each individial type as the domain keys. For example, if you say:
+Currently, the type system only tracks the top of each individual type as the domain keys. For example, if you say:
 
 ```elixir
 %{list(integer()) => integer(), list(binary()) => binary()}


### PR DESCRIPTION
This PR fixes minor spelling typos in documentation and comments. 