### PR TITLE
Add another example to `Integer.parse/1`

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -289,8 +289,8 @@ defmodule Integer do
       iex> Integer.parse("three")
       :error
 
-      iex> Integer.parse("37 war elephants")
-      {37, " war elephants"}
+      iex> Integer.parse("404 not found")
+      {404, " not found"}
 
       iex> Integer.parse("34", 10)
       {34, ""}


### PR DESCRIPTION
"Remainder" does not mean the mathematical definition of the term.

I just tripped over this and thought maybe another, explicitly weird example might be helpful.