### PR TITLE
Optimise for empty list of keys

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -547,6 +547,8 @@ defmodule Map do
     :erlang.error({:badmap, non_map})
   end
 
+  defp take([], _map, []), do: %{}
+
   defp take([], _map, acc) do
     :maps.from_list(acc)
   end


### PR DESCRIPTION
Current implementation will go through `take/3` internal function that will call `:maps.from_list/1` on empty list. Instead of going through all that steps we can bailout quickly with constant if we do not want any key.
