### PR TITLE
Allow specifying SEED when running tests

### DIFF
--- a/lib/eex/test/test_helper.exs
+++ b/lib/eex/test/test_helper.exs
@@ -8,8 +8,13 @@
 Code.require_file("../../elixir/scripts/cover_record.exs", __DIR__)
 CoverageRecorder.maybe_record("eex")
 
-ExUnit.start(
-  trace: !!System.get_env("TRACE"),
-  include: line_include,
-  exclude: line_exclude
-)
+maybe_seed_opt = if seed = System.get_env("SEED"), do: [seed: String.to_integer(seed)], else: []
+
+ex_unit_opts =
+  [
+    trace: !!System.get_env("TRACE"),
+    include: line_include,
+    exclude: line_exclude
+  ] ++ maybe_seed_opt
+
+ExUnit.start(ex_unit_opts)

--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -140,12 +140,18 @@ re_import_exclude =
     [:re_import]
   end
 
-ExUnit.start(
-  trace: !!System.get_env("TRACE"),
-  exclude:
-    epmd_exclude ++
-      os_exclude ++
-      line_exclude ++ distributed_exclude ++ source_exclude ++ cover_exclude ++ re_import_exclude,
-  include: line_include,
-  assert_receive_timeout: String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT", "300"))
-)
+maybe_seed_opt = if seed = System.get_env("SEED"), do: [seed: String.to_integer(seed)], else: []
+
+ex_unit_opts =
+  [
+    trace: !!System.get_env("TRACE"),
+    exclude:
+      epmd_exclude ++
+        os_exclude ++
+        line_exclude ++
+        distributed_exclude ++ source_exclude ++ cover_exclude ++ re_import_exclude,
+    include: line_include,
+    assert_receive_timeout: String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT", "300"))
+  ] ++ maybe_seed_opt
+
+ExUnit.start(ex_unit_opts)

--- a/lib/ex_unit/test/test_helper.exs
+++ b/lib/ex_unit/test/test_helper.exs
@@ -8,9 +8,14 @@
 Code.require_file("../../elixir/scripts/cover_record.exs", __DIR__)
 CoverageRecorder.maybe_record("ex_unit")
 
-ExUnit.start(
-  trace: !!System.get_env("TRACE"),
-  include: line_include,
-  exclude: line_exclude,
-  assert_receive_timeout: String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT", "300"))
-)
+maybe_seed_opt = if seed = System.get_env("SEED"), do: [seed: String.to_integer(seed)], else: []
+
+ex_unit_opts =
+  [
+    trace: !!System.get_env("TRACE"),
+    include: line_include,
+    exclude: line_exclude,
+    assert_receive_timeout: String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT", "300"))
+  ] ++ maybe_seed_opt
+
+ExUnit.start(ex_unit_opts)

--- a/lib/iex/test/test_helper.exs
+++ b/lib/iex/test/test_helper.exs
@@ -39,12 +39,17 @@ cover_exclude =
     []
   end
 
-ExUnit.start(
-  trace: !!System.get_env("TRACE"),
-  include: line_include,
-  exclude: line_exclude ++ erlang_doc_exclude ++ source_exclude ++ cover_exclude,
-  assert_receive_timeout: String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT", "300"))
-)
+maybe_seed_opt = if seed = System.get_env("SEED"), do: [seed: String.to_integer(seed)], else: []
+
+ex_unit_opts =
+  [
+    trace: !!System.get_env("TRACE"),
+    include: line_include,
+    exclude: line_exclude ++ erlang_doc_exclude ++ source_exclude ++ cover_exclude,
+    assert_receive_timeout: String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT", "300"))
+  ] ++ maybe_seed_opt
+
+ExUnit.start(ex_unit_opts)
 
 defmodule IEx.Case do
   use ExUnit.CaseTemplate

--- a/lib/logger/test/test_helper.exs
+++ b/lib/logger/test/test_helper.exs
@@ -8,12 +8,17 @@
 Code.require_file("../../elixir/scripts/cover_record.exs", __DIR__)
 CoverageRecorder.maybe_record("logger")
 
-ExUnit.start(
-  trace: !!System.get_env("TRACE"),
-  include: line_include,
-  exclude: line_exclude,
-  assert_receive_timeout: String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT", "300"))
-)
+maybe_seed_opt = if seed = System.get_env("SEED"), do: [seed: String.to_integer(seed)], else: []
+
+ex_unit_opts =
+  [
+    trace: !!System.get_env("TRACE"),
+    include: line_include,
+    exclude: line_exclude,
+    assert_receive_timeout: String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT", "300"))
+  ] ++ maybe_seed_opt
+
+ExUnit.start(ex_unit_opts)
 
 defmodule Logger.Case do
   use ExUnit.CaseTemplate

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -54,14 +54,19 @@ re_import_exclude =
 Code.require_file("../../elixir/scripts/cover_record.exs", __DIR__)
 CoverageRecorder.maybe_record("mix")
 
-ExUnit.start(
-  trace: !!System.get_env("TRACE"),
-  exclude:
-    epmd_exclude ++
-      os_exclude ++ git_exclude ++ line_exclude ++ cover_exclude ++ re_import_exclude,
-  include: line_include,
-  assert_receive_timeout: String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT", "300"))
-)
+maybe_seed_opt = if seed = System.get_env("SEED"), do: [seed: String.to_integer(seed)], else: []
+
+ex_unit_opts =
+  [
+    trace: !!System.get_env("TRACE"),
+    exclude:
+      epmd_exclude ++
+        os_exclude ++ git_exclude ++ line_exclude ++ cover_exclude ++ re_import_exclude,
+    include: line_include,
+    assert_receive_timeout: String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT", "300"))
+  ] ++ maybe_seed_opt
+
+ExUnit.start(ex_unit_opts)
 
 defmodule MixTest.Case do
   use ExUnit.CaseTemplate


### PR DESCRIPTION
this is helpful when reproducing flaky test failures