### PR TITLE
Keep credentials for release branch tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,8 @@ jobs:
             "$GITHUB_REF_NAME"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # zizmor: ignore[artipacked]
         if: github.ref_type == 'branch'
-        with:
-          persist-credentials: false
 
       - name: Update ${{ github.ref_name }}-latest
         if: github.ref_type == 'branch'


### PR DESCRIPTION
The checkout in create_draft_release needs credentials to push the branch-latest tag to origin.

(Broken in #15114)