### PR TITLE
Improve typespecs for `t:ExUnit.configure_opts/0`

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -117,11 +117,11 @@ defmodule ExUnit do
                diff_delete: atom(),
                diff_delete_whitespace: IO.ANSI.ansidata()
              ]}
-          | {:exclude, keyword()}
+          | {:exclude, atom() | [atom() | {atom(), any()}]}
           | {:exit_status, non_neg_integer()}
           | {:failures_manifest_path, String.t()}
           | {:formatters, [module()]}
-          | {:include, keyword()}
+          | {:include, atom() | [atom() | {atom(), any()}]}
           | {:max_cases, pos_integer()}
           | {:max_failures, pos_integer() | :infinity}
           | {:only_test_ids, [test_id()]}


### PR DESCRIPTION
`:exclude` can be:
- an atom
- a list of atoms and keyword elements

Based on the documentation, we can see that:

- `:exclude` can be a tag, and tags can be atoms:
  - https://github.com/elixir-lang/elixir/blob/a2a669eb7b72d74ccc11a652f2f089ceb24b1b84/lib/ex_unit/lib/ex_unit/case.ex#L120
  - https://github.com/elixir-lang/elixir/blob/a2a669eb7b72d74ccc11a652f2f089ceb24b1b84/lib/ex_unit/lib/ex_unit/case.ex#L256

- The can be list of atoms combined with keyword lists::
    - https://github.com/elixir-lang/elixir/blob/a2a669eb7b72d74ccc11a652f2f089ceb24b1b84/lib/mix/test/test_helper.exs#L62-L64

`:include` works same way as `:exclude`, so same rules apply.