### PR TITLE
Add ExUnit.JSONFormatter for structured test output

### DIFF
--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -9,6 +9,10 @@ defmodule ExUnit.Formatter do
   Formatters are `GenServer`s specified during ExUnit configuration
   that receive a series of events as casts.
 
+  Elixir ships with two built-in formatters: `ExUnit.CLIFormatter` (the
+  default, human-readable output) and `ExUnit.JSONFormatter` (structured
+  JSON output for programmatic consumption).
+
   The following events are possible:
 
     * `{:suite_started, opts}` -

--- a/lib/ex_unit/lib/ex_unit/json_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/json_formatter.ex
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
+defmodule ExUnit.JSONFormatter do
+  @moduledoc """
+  A formatter that outputs test results as a single JSON document.
+
+  This formatter is useful for CI systems, editors, and tools that
+  consume test results programmatically. It outputs a single JSON
+  document to standard output when the test suite finishes.
+
+  ## Usage
+
+  You can use this formatter via the `--formatter` flag:
+
+      $ mix test --formatter ExUnit.JSONFormatter
+
+  Or configure it directly in your `test_helper.exs`:
+
+      ExUnit.configure(formatters: [ExUnit.JSONFormatter])
+
+  > #### Tip {: .tip}
+  >
+  > You may want to use `--no-color` when using this formatter to
+  > avoid ANSI escape codes in error messages from other output.
+
+  ## Output format
+
+  The output is a JSON object with the following keys:
+
+    * `"seed"` - the random seed used for test ordering
+    * `"summary"` - an object with test counts and duration
+    * `"tests"` - an array of test result objects
+    * `"module_failures"` - an array of module-level failures (from `setup_all`)
+
+  Each test object contains:
+
+    * `"module"` - the test module name
+    * `"name"` - the test name
+    * `"file"` - the test file path (relative to project root)
+    * `"line"` - the line number
+    * `"state"` - one of `"passed"`, `"failed"`, `"skipped"`, `"excluded"`, `"invalid"`
+    * `"time_us"` - the test duration in microseconds
+    * `"tags"` - user-defined tags (internal ExUnit tags are filtered out)
+    * `"failures"` - an array of failure details (empty for passing tests)
+
+  Each failure object contains:
+
+    * `"kind"` - the failure kind (`"assertion"`, `"error"`, `"exit"`, `"throw"`)
+    * `"message"` - the formatted error message
+    * `"stacktrace"` - an array of stacktrace frame objects
+    * `"assertion"` - (only for assertion failures) an object with
+      `"left"`, `"right"`, and `"expr"` keys
+
+  Tests are sorted deterministically by `{file, line, name}` regardless
+  of execution order.
+  """
+
+  @moduledoc since: "1.20.0"
+
+  use GenServer
+
+  # Internal ExUnit tag keys to exclude from the "tags" field.
+  @internal_tag_keys [
+    :registered,
+    :file,
+    :line,
+    :describe,
+    :describe_line,
+    :async,
+    :module,
+    :test,
+    :test_type
+  ]
+
+  @doc false
+  def init(opts) do
+    config = %{
+      seed: opts[:seed],
+      tests: [],
+      modules: []
+    }
+
+    {:ok, config}
+  end
+
+  @doc false
+  def handle_cast({:suite_started, _opts}, config) do
+    {:noreply, config}
+  end
+
+  def handle_cast({:test_finished, %ExUnit.Test{} = test}, config) do
+    {:noreply, %{config | tests: [test | config.tests]}}
+  end
+
+  def handle_cast({:module_finished, %ExUnit.TestModule{state: {:failed, _}} = module}, config) do
+    {:noreply, %{config | modules: [module | config.modules]}}
+  end
+
+  def handle_cast({:module_finished, _module}, config) do
+    {:noreply, config}
+  end
+
+  def handle_cast({:suite_finished, times_us}, config) do
+    tests = config.tests |> Enum.reverse() |> sort_tests()
+    summary = build_summary(tests, times_us)
+
+    document = %{
+      seed: config.seed,
+      summary: summary,
+      tests: Enum.map(tests, &encode_test/1),
+      module_failures: config.modules |> Enum.reverse() |> Enum.map(&encode_module_failure/1)
+    }
+
+    IO.write(:json.encode(document))
+    {:noreply, config}
+  end
+
+  def handle_cast({:sigquit, _current}, config) do
+    tests = config.tests |> Enum.reverse() |> sort_tests()
+    summary = build_summary(tests, %{run: 0})
+
+    document = %{
+      seed: config.seed,
+      summary: Map.put(summary, :aborted, true),
+      tests: Enum.map(tests, &encode_test/1),
+      module_failures: config.modules |> Enum.reverse() |> Enum.map(&encode_module_failure/1)
+    }
+
+    IO.write(:json.encode(document))
+    {:noreply, config}
+  end
+
+  def handle_cast(_event, config) do
+    {:noreply, config}
+  end
+
+  ## Encoding
+
+  defp encode_test(%ExUnit.Test{} = test) do
+    %{
+      module: inspect(test.module),
+      name: to_string(test.name),
+      file: relative_path(test.tags[:file]),
+      line: test.tags[:line],
+      state: encode_state(test.state),
+      time_us: test.time,
+      tags: encode_tags(test.tags),
+      failures: encode_failures(test.state)
+    }
+  end
+
+  defp encode_module_failure(%ExUnit.TestModule{} = module) do
+    %{
+      module: inspect(module.name),
+      file: relative_path(module.file),
+      failures: encode_failures(module.state)
+    }
+  end
+
+  defp encode_state(nil), do: "passed"
+  defp encode_state({:failed, _}), do: "failed"
+  defp encode_state({:skipped, _}), do: "skipped"
+  defp encode_state({:excluded, _}), do: "excluded"
+  defp encode_state({:invalid, _}), do: "invalid"
+
+  defp encode_tags(tags) when is_map(tags) do
+    tags
+    |> Enum.reject(&internal_tag?/1)
+    |> Map.new(fn {key, value} -> {to_string(key), encode_tag_value(value)} end)
+  end
+
+  defp encode_tags(_), do: %{}
+
+  defp internal_tag?({_key, :ex_unit_no_meaningful_value}), do: true
+  defp internal_tag?({key, _value}) when key in @internal_tag_keys, do: true
+
+  defp internal_tag?({key, _value}) when is_atom(key) do
+    key |> Atom.to_string() |> String.starts_with?("ex_")
+  end
+
+  defp internal_tag?(_), do: false
+
+  # NOTE: is_boolean/1 must come before is_atom/1 since true/false are atoms
+  defp encode_tag_value(value) when is_boolean(value), do: value
+  defp encode_tag_value(value) when is_atom(value), do: to_string(value)
+  defp encode_tag_value(value) when is_binary(value), do: value
+  defp encode_tag_value(value) when is_number(value), do: value
+  defp encode_tag_value(value) when is_list(value), do: Enum.map(value, &encode_tag_value/1)
+
+  defp encode_tag_value(value) when is_map(value),
+    do: Map.new(value, fn {k, v} -> {to_string(k), encode_tag_value(v)} end)
+
+  defp encode_tag_value(value), do: inspect(value)
+
+  defp encode_failures({:failed, failures}) when is_list(failures) do
+    Enum.map(failures, &encode_failure/1)
+  end
+
+  defp encode_failures(_), do: []
+
+  defp encode_failure({kind, error, stacktrace}) do
+    base = %{
+      kind: encode_failure_kind(kind, error),
+      message: format_error_message(error),
+      stacktrace: encode_stacktrace(stacktrace)
+    }
+
+    maybe_add_assertion(base, error)
+  end
+
+  defp encode_failure_kind(_kind, %ExUnit.AssertionError{}), do: "assertion"
+  defp encode_failure_kind(:error, _), do: "error"
+  defp encode_failure_kind(:exit, _), do: "exit"
+  defp encode_failure_kind(:throw, _), do: "throw"
+  defp encode_failure_kind(kind, _), do: inspect(kind)
+
+  defp format_error_message(error) when is_exception(error), do: Exception.message(error)
+  defp format_error_message(error), do: inspect(error)
+
+  defp maybe_add_assertion(base, %ExUnit.AssertionError{} = error) do
+    assertion = %{
+      left: inspect_value(error.left),
+      right: inspect_value(error.right),
+      expr: format_expr(error.expr)
+    }
+
+    Map.put(base, :assertion, assertion)
+  end
+
+  defp maybe_add_assertion(base, _), do: base
+
+  defp inspect_value(value) do
+    no_value = ExUnit.AssertionError.no_value()
+    if value == no_value, do: nil, else: inspect(value)
+  end
+
+  defp format_expr(nil), do: nil
+  defp format_expr(expr), do: Macro.to_string(expr)
+
+  defp encode_stacktrace(stacktrace) when is_list(stacktrace) do
+    Enum.map(stacktrace, &encode_stacktrace_frame/1)
+  end
+
+  defp encode_stacktrace(_), do: []
+
+  defp encode_stacktrace_frame({module, function, arity, location}) do
+    %{
+      module: inspect(module),
+      function: to_string(function),
+      arity: normalize_arity(arity),
+      file: location_file(location),
+      line: location[:line]
+    }
+  end
+
+  defp encode_stacktrace_frame(_),
+    do: %{module: nil, function: nil, arity: nil, file: nil, line: nil}
+
+  defp normalize_arity(arity) when is_integer(arity), do: arity
+  defp normalize_arity(args) when is_list(args), do: length(args)
+  defp normalize_arity(_), do: nil
+
+  defp location_file(location) when is_list(location) do
+    case Keyword.get(location, :file) do
+      nil -> nil
+      file -> relative_path(to_string(file))
+    end
+  end
+
+  defp location_file(_), do: nil
+
+  ## Helpers
+
+  defp build_summary(tests, times_us) do
+    counts =
+      Enum.reduce(tests, %{passed: 0, failed: 0, skipped: 0, excluded: 0, invalid: 0}, fn test,
+                                                                                          acc ->
+        increment_count(acc, encode_state(test.state))
+      end)
+
+    %{
+      total: length(tests),
+      passed: counts.passed,
+      failed: counts.failed,
+      skipped: counts.skipped,
+      excluded: counts.excluded,
+      invalid: counts.invalid,
+      duration_us: extract_duration(times_us)
+    }
+  end
+
+  defp increment_count(acc, "passed"), do: Map.update!(acc, :passed, &(&1 + 1))
+  defp increment_count(acc, "failed"), do: Map.update!(acc, :failed, &(&1 + 1))
+  defp increment_count(acc, "skipped"), do: Map.update!(acc, :skipped, &(&1 + 1))
+  defp increment_count(acc, "excluded"), do: Map.update!(acc, :excluded, &(&1 + 1))
+  defp increment_count(acc, "invalid"), do: Map.update!(acc, :invalid, &(&1 + 1))
+
+  defp extract_duration(%{run: run}) when is_integer(run), do: run
+  defp extract_duration(_), do: 0
+
+  defp sort_tests(tests) do
+    Enum.sort_by(tests, fn test ->
+      {test.tags[:file] || "", test.tags[:line] || 0, to_string(test.name)}
+    end)
+  end
+
+  defp relative_path(nil), do: nil
+  defp relative_path(path) when is_binary(path), do: Path.relative_to_cwd(path)
+  defp relative_path(path), do: to_string(path)
+end

--- a/lib/ex_unit/test/ex_unit/json_formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/json_formatter_test.exs
@@ -1,0 +1,603 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
+Code.require_file("../test_helper.exs", __DIR__)
+
+defmodule ExUnit.JSONFormatterTest do
+  use ExUnit.Case, async: true
+
+  defp decode(iodata) do
+    :json.decode(IO.iodata_to_binary(iodata))
+  end
+
+  defp passing_test(opts \\ []) do
+    tags = %{
+      file: opts[:file] || "test/my_test.exs",
+      line: opts[:line] || 10,
+      module: MyTest,
+      test: :"test passes",
+      test_type: :test,
+      describe: nil,
+      describe_line: nil,
+      async: false,
+      registered: %{}
+    }
+
+    tags = Map.merge(tags, Map.new(opts[:extra_tags] || []))
+
+    %ExUnit.Test{
+      name: opts[:name] || :"test passes",
+      module: opts[:module] || MyTest,
+      state: nil,
+      time: opts[:time] || 1234,
+      tags: tags,
+      logs: ""
+    }
+  end
+
+  defp failed_test(opts \\ []) do
+    error = %ExUnit.AssertionError{
+      message: "Assertion with == failed",
+      expr: quote(do: assert(1 == 2)),
+      left: 1,
+      right: 2
+    }
+
+    stacktrace = [
+      {MyTest, :"test fails", 1, [file: ~c"test/my_test.exs", line: 16]}
+    ]
+
+    tags = %{
+      file: "test/my_test.exs",
+      line: opts[:line] || 15,
+      module: MyTest,
+      test: :"test fails",
+      test_type: :test,
+      describe: nil,
+      describe_line: nil,
+      async: false,
+      registered: %{}
+    }
+
+    %ExUnit.Test{
+      name: :"test fails",
+      module: MyTest,
+      state: {:failed, [{:error, error, stacktrace}]},
+      time: 2345,
+      tags: tags,
+      logs: ""
+    }
+  end
+
+  defp skipped_test do
+    tags = %{
+      file: "test/my_test.exs",
+      line: 20,
+      module: MyTest,
+      test: :"test skipped",
+      test_type: :test,
+      describe: nil,
+      describe_line: nil,
+      async: false,
+      registered: %{}
+    }
+
+    %ExUnit.Test{
+      name: :"test skipped",
+      module: MyTest,
+      state: {:skipped, "not implemented"},
+      time: 0,
+      tags: tags,
+      logs: ""
+    }
+  end
+
+  defp excluded_test do
+    tags = %{
+      file: "test/my_test.exs",
+      line: 25,
+      module: MyTest,
+      test: :"test excluded",
+      test_type: :test,
+      describe: nil,
+      describe_line: nil,
+      async: false,
+      registered: %{}
+    }
+
+    %ExUnit.Test{
+      name: :"test excluded",
+      module: MyTest,
+      state: {:excluded, "slow test"},
+      time: 0,
+      tags: tags,
+      logs: ""
+    }
+  end
+
+  defp invalid_test do
+    failed_module = %ExUnit.TestModule{
+      name: FailingModule,
+      file: "test/failing_test.exs",
+      state: {:failed, [{:error, %RuntimeError{message: "setup_all failed"}, []}]},
+      tests: []
+    }
+
+    tags = %{
+      file: "test/failing_test.exs",
+      line: 5,
+      module: FailingModule,
+      test: :"test invalidated",
+      test_type: :test,
+      describe: nil,
+      describe_line: nil,
+      async: false,
+      registered: %{}
+    }
+
+    %ExUnit.Test{
+      name: :"test invalidated",
+      module: FailingModule,
+      state: {:invalid, failed_module},
+      time: 0,
+      tags: tags,
+      logs: ""
+    }
+  end
+
+  describe "encode_state" do
+    test "maps nil to passed" do
+      test = passing_test()
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      assert result["state"] == "passed"
+    end
+
+    test "maps failed state" do
+      test = failed_test()
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      assert result["state"] == "failed"
+    end
+
+    test "maps skipped state" do
+      test = skipped_test()
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      assert result["state"] == "skipped"
+    end
+
+    test "maps excluded state" do
+      test = excluded_test()
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      assert result["state"] == "excluded"
+    end
+
+    test "maps invalid state" do
+      test = invalid_test()
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      assert result["state"] == "invalid"
+    end
+  end
+
+  describe "passing test encoding" do
+    test "encodes basic fields" do
+      test = passing_test()
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+
+      assert result["module"] == "MyTest"
+      assert result["name"] == "test passes"
+      assert result["line"] == 10
+      assert result["time_us"] == 1234
+      assert result["failures"] == []
+    end
+
+    test "file path is relative" do
+      test = passing_test()
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      refute String.starts_with?(result["file"], "/")
+    end
+  end
+
+  describe "failed test encoding" do
+    test "includes failure details" do
+      test = failed_test()
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      [failure] = result["failures"]
+
+      assert failure["kind"] == "assertion"
+      assert failure["message"] =~ "Assertion with == failed"
+      assert is_list(failure["stacktrace"])
+    end
+
+    test "includes structured assertion details" do
+      test = failed_test()
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      [failure] = result["failures"]
+
+      assert failure["assertion"]["left"] == "1"
+      assert failure["assertion"]["right"] == "2"
+      assert failure["assertion"]["expr"] =~ "assert"
+    end
+
+    test "encodes stacktrace frames" do
+      test = failed_test()
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      [failure] = result["failures"]
+      [frame] = failure["stacktrace"]
+
+      assert frame["module"] == "MyTest"
+      assert frame["function"] == "test fails"
+      assert frame["arity"] == 1
+      assert frame["line"] == 16
+    end
+  end
+
+  describe "tag filtering" do
+    test "filters internal ExUnit tags" do
+      test = passing_test()
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      tags = result["tags"]
+
+      refute Map.has_key?(tags, "file")
+      refute Map.has_key?(tags, "line")
+      refute Map.has_key?(tags, "module")
+      refute Map.has_key?(tags, "test")
+      refute Map.has_key?(tags, "test_type")
+      refute Map.has_key?(tags, "describe")
+      refute Map.has_key?(tags, "describe_line")
+      refute Map.has_key?(tags, "async")
+      refute Map.has_key?(tags, "registered")
+    end
+
+    test "preserves user-defined tags" do
+      test = passing_test(extra_tags: [priority: :high, timeout: 5000])
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      tags = result["tags"]
+
+      assert tags["priority"] == "high"
+      assert tags["timeout"] == 5000
+    end
+
+    test "serializes tag value types correctly" do
+      test =
+        passing_test(
+          extra_tags: [
+            bool_tag: true,
+            atom_tag: :fast,
+            string_tag: "hello",
+            number_tag: 42,
+            list_tag: [1, :two, "three"],
+            map_tag: %{nested: "value", count: 3}
+          ]
+        )
+
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      tags = result["tags"]
+
+      assert tags["bool_tag"] == true
+      assert tags["atom_tag"] == "fast"
+      assert tags["string_tag"] == "hello"
+      assert tags["number_tag"] == 42
+      assert tags["list_tag"] == [1, "two", "three"]
+      assert tags["map_tag"] == %{"nested" => "value", "count" => 3}
+    end
+  end
+
+  describe "deterministic sort order" do
+    test "sorts by file, line, name" do
+      test_a = passing_test(name: :"test z_last", file: "test/a_test.exs", line: 10)
+      test_b = passing_test(name: :"test a_first", file: "test/b_test.exs", line: 5)
+      test_c = passing_test(name: :"test middle", file: "test/a_test.exs", line: 20)
+
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test_b}, config)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test_c}, config)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test_a}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      names = Enum.map(output["tests"], & &1["name"])
+
+      assert names == ["test z_last", "test middle", "test a_first"]
+    end
+  end
+
+  describe "summary" do
+    test "includes correct counts" do
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+
+      {:noreply, config} =
+        ExUnit.JSONFormatter.handle_cast({:test_finished, passing_test()}, config)
+
+      {:noreply, config} =
+        ExUnit.JSONFormatter.handle_cast(
+          {:test_finished, passing_test(name: :"test passes 2", line: 11)},
+          config
+        )
+
+      {:noreply, config} =
+        ExUnit.JSONFormatter.handle_cast({:test_finished, failed_test()}, config)
+
+      {:noreply, config} =
+        ExUnit.JSONFormatter.handle_cast({:test_finished, skipped_test()}, config)
+
+      {:noreply, config} =
+        ExUnit.JSONFormatter.handle_cast({:test_finished, excluded_test()}, config)
+
+      {:noreply, config} =
+        ExUnit.JSONFormatter.handle_cast({:test_finished, invalid_test()}, config)
+
+      output = capture_json(config, %{run: 50_000})
+      summary = output["summary"]
+
+      assert summary["total"] == 6
+      assert summary["passed"] == 2
+      assert summary["failed"] == 1
+      assert summary["skipped"] == 1
+      assert summary["excluded"] == 1
+      assert summary["invalid"] == 1
+      assert summary["duration_us"] == 50_000
+    end
+
+    test "includes seed" do
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 12345)
+      output = capture_json(config, %{run: 1000})
+
+      assert output["seed"] == 12345
+    end
+  end
+
+  describe "module failures" do
+    test "tracks setup_all failures" do
+      module = %ExUnit.TestModule{
+        name: FailingModule,
+        file: "test/failing_test.exs",
+        state: {:failed, [{:error, %RuntimeError{message: "setup_all failed"}, []}]},
+        tests: []
+      }
+
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:module_finished, module}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [mod_failure] = output["module_failures"]
+
+      assert mod_failure["module"] == "FailingModule"
+      [failure] = mod_failure["failures"]
+      assert failure["kind"] == "error"
+      assert failure["message"] == "setup_all failed"
+    end
+
+    test "ignores passing modules" do
+      module = %ExUnit.TestModule{
+        name: PassingModule,
+        file: "test/passing_test.exs",
+        state: nil,
+        tests: []
+      }
+
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:module_finished, module}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      assert output["module_failures"] == []
+    end
+  end
+
+  describe "sigquit" do
+    test "outputs partial results with aborted flag" do
+      test = passing_test()
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          ExUnit.JSONFormatter.handle_cast({:sigquit, []}, config)
+        end)
+
+      result = decode(output)
+      assert result["summary"]["aborted"] == true
+      assert length(result["tests"]) == 1
+    end
+  end
+
+  describe "full GenServer lifecycle" do
+    test "produces valid JSON through complete lifecycle" do
+      {:ok, pid} = GenServer.start_link(ExUnit.JSONFormatter, seed: 42)
+
+      GenServer.cast(pid, {:suite_started, [seed: 42]})
+      GenServer.cast(pid, {:test_finished, passing_test()})
+      GenServer.cast(pid, {:test_finished, failed_test()})
+
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          # Set the GenServer's group leader to the captured IO process
+          # so that its IO.write output is captured
+          Process.group_leader(pid, Process.group_leader())
+          GenServer.cast(pid, {:suite_finished, %{run: 50_000, async: nil, load: nil}})
+          # Wait for the cast to be processed
+          :sys.get_state(pid)
+        end)
+
+      result = decode(output)
+
+      assert is_integer(result["seed"])
+      assert is_map(result["summary"])
+      assert is_list(result["tests"])
+      assert is_list(result["module_failures"])
+      assert length(result["tests"]) == 2
+
+      GenServer.stop(pid)
+    end
+  end
+
+  describe "non-assertion failures" do
+    test "encodes runtime errors" do
+      stacktrace = [{MyTest, :"test crashes", 1, [file: ~c"test/my_test.exs", line: 30]}]
+
+      tags = %{
+        file: "test/my_test.exs",
+        line: 30,
+        module: MyTest,
+        test: :"test crashes",
+        test_type: :test,
+        describe: nil,
+        describe_line: nil,
+        async: false,
+        registered: %{}
+      }
+
+      test = %ExUnit.Test{
+        name: :"test crashes",
+        module: MyTest,
+        state: {:failed, [{:error, %RuntimeError{message: "boom"}, stacktrace}]},
+        time: 500,
+        tags: tags,
+        logs: ""
+      }
+
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      [failure] = result["failures"]
+
+      assert failure["kind"] == "error"
+      assert failure["message"] == "boom"
+      refute Map.has_key?(failure, "assertion")
+    end
+
+    test "encodes exit failures" do
+      tags = %{
+        file: "test/my_test.exs",
+        line: 35,
+        module: MyTest,
+        test: :"test exits",
+        test_type: :test,
+        describe: nil,
+        describe_line: nil,
+        async: false,
+        registered: %{}
+      }
+
+      test = %ExUnit.Test{
+        name: :"test exits",
+        module: MyTest,
+        state: {:failed, [{:exit, :shutdown, []}]},
+        time: 100,
+        tags: tags,
+        logs: ""
+      }
+
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      [failure] = result["failures"]
+
+      assert failure["kind"] == "exit"
+    end
+
+    test "encodes throw failures" do
+      tags = %{
+        file: "test/my_test.exs",
+        line: 40,
+        module: MyTest,
+        test: :"test throws",
+        test_type: :test,
+        describe: nil,
+        describe_line: nil,
+        async: false,
+        registered: %{}
+      }
+
+      test = %ExUnit.Test{
+        name: :"test throws",
+        module: MyTest,
+        state: {:failed, [{:throw, "nope", []}]},
+        time: 100,
+        tags: tags,
+        logs: ""
+      }
+
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, config} = ExUnit.JSONFormatter.handle_cast({:test_finished, test}, config)
+
+      output = capture_json(config, %{run: 10_000})
+      [result] = output["tests"]
+      [failure] = result["failures"]
+
+      assert failure["kind"] == "throw"
+    end
+  end
+
+  describe "ignores unknown events" do
+    test "handles unknown cast events gracefully" do
+      {:ok, config} = ExUnit.JSONFormatter.init(seed: 42)
+      {:noreply, ^config} = ExUnit.JSONFormatter.handle_cast({:test_started, %{}}, config)
+      {:noreply, ^config} = ExUnit.JSONFormatter.handle_cast(:max_failures_reached, config)
+      {:noreply, ^config} = ExUnit.JSONFormatter.handle_cast({:module_started, %{}}, config)
+    end
+  end
+
+  # Helper to drive suite_finished and capture JSON output
+  defp capture_json(config, times_us) do
+    output =
+      ExUnit.CaptureIO.capture_io(fn ->
+        ExUnit.JSONFormatter.handle_cast({:suite_finished, times_us}, config)
+      end)
+
+    decode(output)
+  end
+end

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -141,7 +141,8 @@ defmodule Mix.Tasks.Test do
     * `--force` - forces compilation regardless of modification times
 
     * `--formatter` - sets the formatter module that will print the results.
-      Defaults to ExUnit's built-in CLI formatter
+      Defaults to ExUnit's built-in CLI formatter. Use `--formatter ExUnit.JSONFormatter`
+      for structured JSON output suitable for CI systems, editors, and other tools
 
     * `--include` - includes tests that match the filter. This option may be given
       several times to apply different filters, such as `--include ci --include slow`


### PR DESCRIPTION
## Summary

Adds `ExUnit.JSONFormatter`, a built-in formatter that outputs test results as a single JSON document to stdout. This makes test results programmatically consumable by CI systems, editors, AI coding assistants, and other tools without parsing human-readable text.

**Usage:**

```
$ elixir_test --formatter ExUnit.JSONFormatter --no-color
```

Since Elixir 1.18 ships with the `:json` module (OTP 27+), this formatter has **zero new dependencies**.

## Motivation

The only built-in formatter today is `ExUnit.CLIFormatter`, which produces human-readable, ANSI-colored output. Tools that consume test results programmatically must parse this text, which is fragile and lossy. A structured JSON output solves this cleanly.

Use cases:
- **CI/CD pipelines** — parse failures, track test counts, detect regressions
- **Editor/IDE integration** — jump to failing test locations, show inline diagnostics
- **AI coding assistants** — structured input for automated debugging workflows
- **Test analytics** — aggregate timing data, identify flaky tests

## Design decisions

- **Minimal** — ~310 lines, handles the 4 core events + `sigquit`. No configuration options, no streaming, no file output. Policy decisions (truncation, filtering, grouping) are left to consumers.
- **Matches CLIFormatter conventions** — plain map state (not a struct), `@doc false` on callbacks, same event handling pattern.
- **Deterministic output** — tests sorted by `{file, line, name}` regardless of execution order or random seed.
- **Structured failures** — assertion errors include `left`, `right`, and `expr` fields. Non-assertion failures (runtime errors, exits, throws) include kind and message.
- **Filtered tags** — internal ExUnit tags (`:file`, `:line`, `:module`, `:test`, `:async`, etc.) are excluded; user-defined tags are preserved.
- **No schema version field** — the schema can evolve additively (new fields are non-breaking for consumers).
- **`module_failures` always present** — empty array when no `setup_all` failures, for consistent structure.

## What is NOT included

This PR intentionally keeps the formatter minimal. Features like file output, failure filtering, error grouping, compact output modes, and coverage integration are available in the [ex_unit_json](https://hex.pm/packages/ex_unit_json) library for projects that need them.

## Output example

```json
{
  "seed": 12345,
  "summary": {
    "total": 3, "passed": 2, "failed": 1,
    "skipped": 0, "excluded": 0, "invalid": 0,
    "duration_us": 54321
  },
  "tests": [
    {
      "module": "MyTest", "name": "test addition",
      "file": "test/my_test.exs", "line": 5,
      "state": "passed", "time_us": 1234,
      "tags": {}, "failures": []
    },
    {
      "module": "MyTest", "name": "test subtraction",
      "file": "test/my_test.exs", "line": 10,
      "state": "failed", "time_us": 2345,
      "tags": {},
      "failures": [{
        "kind": "assertion",
        "message": "Assertion with == failed",
        "assertion": {"left": "3", "right": "4", "expr": "assert 3 == 4"},
        "stacktrace": [{"module": "MyTest", "function": "test subtraction", "arity": 1, "file": "test/my_test.exs", "line": 12}]
      }]
    }
  ],
  "module_failures": []
}
```

## Files changed

| File | Change |
|------|--------|
| `lib/ex_unit/lib/ex_unit/json_formatter.ex` | New formatter module |
| `lib/ex_unit/test/ex_unit/json_formatter_test.exs` | 24 tests covering all paths |
| `lib/ex_unit/lib/ex_unit/formatter.ex` | Mention JSONFormatter in moduledoc |
| `lib/mix/lib/mix/tasks/test.ex` | Mention JSONFormatter in `--formatter` docs |

## Test plan

- [x] 24 dedicated tests covering: state mapping, encoding, tag filtering, tag type serialization (including lists/maps), deterministic sorting, summary counts (including invalid state), module failures, sigquit, full GenServer lifecycle, non-assertion failures (errors/exits/throws), unknown events
- [x] Full ExUnit suite passes (54 doctests + 425 tests, 0 failures)
- [x] `bin/mix format` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
