### PR TITLE
Remove redundant clause triggering warning in tests

### DIFF
--- a/lib/elixir/test/elixir/fixtures/dialyzer/with.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/with.ex
@@ -12,9 +12,6 @@ defmodule Dialyzer.With do
       :other_error ->
         :other_error
 
-      {:error, msg} when is_list(msg) or is_tuple(msg) ->
-        :error
-
       {:error, msg} when is_list(msg) when is_tuple(msg) ->
         :error
 


### PR DESCRIPTION

Fixes:

```elixir
warning: this guard will never succeed:

        is_tuple(msg)

    because it returns type:

        dynamic(false)

    where "msg" was given the type:

        # type: dynamic(not atom() and not {...})
        # from: test/elixir/fixtures/dialyzer/with.ex
        {:error, msg}

    type warning found at:
    │
 18 │       {:error, msg} when is_list(msg) when is_tuple(msg) ->
    │                                            ~
    │
    └─ test/elixir/fixtures/dialyzer/with.ex:18:44: Dialyzer.With.with_else/0
```