### PR TITLE
Raise clearer error when reserved word used at the top level of defmodule

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5222,7 +5222,7 @@ defmodule Kernel do
 
   defmacro defmodule(alias, [{:do, _block}, {atom, _} | _]) when is_atom(atom) do
     raise ArgumentError,
-          "unexpected reserved word at the top-level of the \"defmodule #{Macro.to_string(alias)}\" block: #{atom}"
+          "unexpected reserved word at the top-level of the \"defmodule #{Macro.to_string(alias)}\" do-block: #{atom}"
   end
 
   defp module_meta({_, meta, _}), do: meta

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -1006,7 +1006,7 @@ defmodule Kernel.ErrorsTest do
   test "reserved word used at module top-level" do
     assert_eval_raise(
       ArgumentError,
-      ["unexpected reserved word at the top-level of the \"defmodule Foo\" block: catch"],
+      ["unexpected reserved word at the top-level of the \"defmodule Foo\" do-block: catch"],
       """
       defmodule Foo do
         def foo, do: :foo catch :bar


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/15121.