### PR TITLE
Warn when defining @type record(), fixes CI on OTP29

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -255,9 +255,20 @@ defmodule Kernel.Typespec do
 
       case type_to_signature(expr) do
         {name, arity} = type_pair ->
-          if built_in_type?(name, arity) do
-            message = "type #{name}/#{arity} is a built-in type and it cannot be redefined"
-            compile_error(env, message)
+          cond do
+            # This is a built-in type since OTP 29 but it just generates a warning for now
+            {name, arity} == {:record, 0} ->
+              IO.warn("type #{name}/#{arity} is overriding a built-in type",
+                file: file,
+                line: line
+              )
+
+            built_in_type?(name, arity) ->
+              message = "type #{name}/#{arity} is a built-in type and it cannot be redefined"
+              compile_error(env, message)
+
+            true ->
+              :ok
           end
 
           if Map.has_key?(type_pairs, type_pair) do

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -681,15 +681,17 @@ defmodule TypespecTest do
       end
     end
 
-    test "@type can be named record" do
-      bytecode =
-        test_module do
-          @type record :: binary
-          @spec foo?(record) :: boolean
-          def foo?(_), do: true
-        end
+    test "@type named record/0 warns" do
+      assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
+               bytecode =
+                 test_module do
+                   @type record :: binary
+                   @spec foo?(record) :: boolean
+                   def foo?(_), do: true
+                 end
 
-      assert [type: {:record, {:type, _, :binary, []}, []}] = types(bytecode)
+               assert [type: {:record, {:type, _, :binary, []}, []}] = types(bytecode)
+             end) =~ "type record/0 is overriding a built-in type"
     end
 
     test "@type with an invalid map notation" do


### PR DESCRIPTION
Quoting https://www.erlang.org/eeps/eep-0079#backward-compatibility:

> The type `record/0` is now defined, which will result in a warning if an application has a local definition with the same now.