### PR TITLE
Fix spec of `PartitionSupervisor.partitions/1`

### DIFF
--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -421,7 +421,7 @@ defmodule PartitionSupervisor do
   Returns the number of partitions for the partition supervisor.
   """
   @doc since: "1.14.0"
-  @spec partitions(name()) :: pos_integer()
+  @spec partitions(name()) :: non_neg_integer()
   def partitions(name) do
     name |> table() |> partitions(name)
   end


### PR DESCRIPTION
You can resize it to 0:

```elixir
iex> PartitionSupervisor.start_link(child_spec: {Agent, fn -> %{} end}, name: PS, partitions: 4)
iex> PartitionSupervisor.resize!(PS, 0)
iex> PartitionSupervisor.partitions(PS)
0
```