### PR TITLE
Fix `Integer.undigits/`2 to validate negative out-of-range digits

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -297,8 +297,9 @@ defmodule Integer do
 
   defp undigits([], _base, acc), do: acc
 
-  defp undigits([digit | _], base, _) when is_integer(digit) and digit >= base,
-    do: raise(ArgumentError, "invalid digit #{digit} in base #{base}")
+  defp undigits([digit | _], base, _)
+       when is_integer(digit) and (digit >= base or digit <= -base),
+       do: raise(ArgumentError, "invalid digit #{digit} in base #{base}")
 
   defp undigits([digit | tail], base, acc) when is_integer(digit),
     do: undigits(tail, base, acc * base + digit)

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -144,6 +144,14 @@ defmodule IntegerTest do
     assert_raise ArgumentError, "invalid digit 17 in base 16", fn ->
       Integer.undigits([1, 2, 17], 16)
     end
+
+    assert_raise ArgumentError, "invalid digit -10 in base 10", fn ->
+      Integer.undigits([-10], 10)
+    end
+
+    assert_raise ArgumentError, "invalid digit -17 in base 16", fn ->
+      Integer.undigits([1, 2, -17], 16)
+    end
   end
 
   test "parse/2" do


### PR DESCRIPTION
The validation was asymmetric - it rejected positive digits >= base but silently accepted negative digits <= -base. This fix adds the missing check for negative out-of-range digits.

```elixir
iex> Integer.undigits([100])
** (ArgumentError) invalid digit 100 in base 10
    (elixir 1.18.4) lib/integer.ex:229: Integer.undigits/3
    iex:9: (file)
iex(9)> Integer.undigits([-100])
-100
```