### PR TITLE
Improve ExUnit failure/success output

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -372,11 +372,19 @@ defmodule ExUnit.CLIFormatter do
     passed_total =
       test_type_counts - config.failure_counter - config.skipped_counter - config.invalid_counter
 
-    # Passed line: "Passed: 447/455 (53/54 doctests, 393/403 tests)"
-    passed_breakdown = format_passed_breakdown(test_counter, config.failure_type_counter)
+    # Passed line: "Passed: 447/455 (53/54 doctests, 393/403 tests)" or
+    # "Passed: 455 (70 tests, 14 properties)" when all pass
+    all_passed? = passed_total == test_type_counts
+
+    passed_breakdown =
+      format_passed_breakdown(test_counter, config.failure_type_counter, all_passed?)
 
     passed_line =
-      "Passed: #{passed_total}/#{test_type_counts}"
+      if all_passed? do
+        "Passed: #{passed_total}"
+      else
+        "Passed: #{passed_total}/#{test_type_counts}"
+      end
       |> if_true(passed_breakdown != "", &(&1 <> " (#{passed_breakdown})"))
 
     # Failed line: "Failed: 8 tests, 1 property"
@@ -389,7 +397,7 @@ defmodule ExUnit.CLIFormatter do
       end
 
     message =
-      passed_line
+      ("\n" <> passed_line)
       |> if_true(
         config.invalid_counter > 0,
         &(&1 <> ", #{config.invalid_counter} invalid")
@@ -446,7 +454,7 @@ defmodule ExUnit.CLIFormatter do
     |> Enum.join(", ")
   end
 
-  defp format_passed_breakdown(test_counter, failure_type_counter) do
+  defp format_passed_breakdown(test_counter, failure_type_counter, all_passed?) do
     # If there are no different test types, we just print "Passed: N/N"
     # without the type.
     if map_size(test_counter) in 0..1 do
@@ -457,9 +465,14 @@ defmodule ExUnit.CLIFormatter do
       |> Enum.sort()
       |> Enum.map_join(", ", fn type ->
         total = Map.fetch!(test_counter, type)
-        failed = Map.get(failure_type_counter, type, 0)
-        passed = total - failed
-        "#{passed}/#{total} #{pluralize_type(total, type)}"
+
+        if all_passed? do
+          "#{total} #{pluralize_type(total, type)}"
+        else
+          failed = Map.get(failure_type_counter, type, 0)
+          passed = total - failed
+          "#{passed}/#{total} #{pluralize_type(total, type)}"
+        end
       end)
     end
   end

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -36,7 +36,7 @@ defmodule ExUnit.CallbacksTest do
       end
     end
 
-    assert capture_io(fn -> ExUnit.run() end) =~ "Passed: 1/1"
+    assert capture_io(fn -> ExUnit.run() end) =~ "Passed: 1"
   end
 
   test "named callbacks run custom code in order" do
@@ -66,7 +66,7 @@ defmodule ExUnit.CallbacksTest do
       defp store_5(context), do: store(context, 5)
     end
 
-    assert capture_io(fn -> ExUnit.run() end) =~ "Passed: 1/1"
+    assert capture_io(fn -> ExUnit.run() end) =~ "Passed: 1"
   end
 
   test "named callbacks support {module, function} tuples" do
@@ -87,7 +87,7 @@ defmodule ExUnit.CallbacksTest do
       def setup_3(_), do: [setup_3: true]
     end
 
-    assert capture_io(fn -> ExUnit.run() end) =~ "Passed: 1/1"
+    assert capture_io(fn -> ExUnit.run() end) =~ "Passed: 1"
   end
 
   test "doesn't choke on setup errors" do
@@ -253,7 +253,7 @@ defmodule ExUnit.CallbacksTest do
 
     output = capture_io(fn -> ExUnit.run() end)
     assert output =~ "on_exit run"
-    assert output =~ "Passed: 1/1"
+    assert output =~ "Passed: 1"
   end
 
   test "runs multiple on_exit exits and overrides by ref" do

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -1084,7 +1084,7 @@ defmodule ExUnit.DocTestTest do
       doctest ExUnit.DocTestTest.Numbered
     end
 
-    assert capture_io(fn -> ExUnit.run() end) =~ "Passed: 1/1"
+    assert capture_io(fn -> ExUnit.run() end) =~ "Passed: 1"
   end
 
   test "IEx prompt contains host" do
@@ -1253,7 +1253,7 @@ defmodule ExUnit.DocTestTest do
       end
 
       output = capture_io(fn -> ExUnit.run() end)
-      assert output =~ "Passed: 2/2"
+      assert output =~ "Passed: 2"
     end
 
     test "failing" do

--- a/lib/ex_unit/test/ex_unit/register_test.exs
+++ b/lib/ex_unit/test/ex_unit/register_test.exs
@@ -42,7 +42,7 @@ defmodule ExUnit.RegisterTest do
 
     assert capture_io(fn ->
              assert ExUnit.run() == %{failures: 0, skipped: 0, total: 2, excluded: 0}
-           end) =~ "Passed: 2/2 (1/1 property, 1/1 test)"
+           end) =~ "Passed: 2 (1 property, 1 test)"
   end
 
   test "plural test types" do
@@ -96,6 +96,6 @@ defmodule ExUnit.RegisterTest do
 
     assert capture_io(fn ->
              assert ExUnit.run() == %{failures: 0, skipped: 0, total: 4, excluded: 0}
-           end) =~ "Passed: 4/4 (2/2 properties, 2/2 tests)"
+           end) =~ "Passed: 4 (2 properties, 2 tests)"
   end
 end

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -33,7 +33,7 @@ defmodule ExUnitTest do
     assert capture_io(fn ->
              assert ExUnit.async_run() |> ExUnit.await_run() ==
                       %{failures: 0, skipped: 0, total: 0, excluded: 0}
-           end) =~ "\nPassed: 0/0\n"
+           end) =~ "\nPassed: 0\n"
   end
 
   test "supports rerunning given modules" do
@@ -139,7 +139,7 @@ defmodule ExUnitTest do
     assert result =~ ~r"\* test true \[.*test/ex_unit_test.exs:#{line}\]"
 
     assert result =~ "Showing results so far..."
-    assert result =~ "Passed: 0/0"
+    assert result =~ "Passed: 0"
   end
 
   test "doesn't hang on exits" do
@@ -332,11 +332,11 @@ defmodule ExUnitTest do
 
     {result, output} = run_with_filter([exclude: [even: true]], [ParityTest])
     assert result == %{failures: 0, skipped: 0, excluded: 1, total: 4}
-    assert output =~ "Passed: 3/3"
+    assert output =~ "Passed: 3"
 
     {result, output} = run_with_filter([exclude: :even], [ParityTest])
     assert result == %{failures: 0, skipped: 0, excluded: 3, total: 4}
-    assert output =~ "Passed: 1/1"
+    assert output =~ "Passed: 1"
 
     {result, output} = run_with_filter([exclude: :even, include: [even: true]], [ParityTest])
     assert result == %{failures: 1, skipped: 0, excluded: 2, total: 4}
@@ -511,7 +511,7 @@ defmodule ExUnitTest do
     {result, output} = run_with_filter([exclude: :module], [])
 
     assert result == %{failures: 0, skipped: 0, excluded: 2, total: 2}
-    assert output =~ "Passed: 0/0"
+    assert output =~ "Passed: 0"
 
     {result, output} =
       [exclude: :test, include: [module: "ExUnitTest.SecondTestModule"]]
@@ -644,7 +644,7 @@ defmodule ExUnitTest do
 
     assert capture_io(fn ->
              assert ExUnit.run() == %{failures: 0, skipped: 0, total: 3, excluded: 0}
-           end) =~ "Passed: 3/3"
+           end) =~ "Passed: 3"
   end
 
   # Skipped and excluded tests should be included in the stats
@@ -727,7 +727,7 @@ defmodule ExUnitTest do
     end
 
     configure_and_reload_on_exit(trace: true)
-    assert capture_io(fn -> ExUnit.run() end) =~ "Passed: 0/0"
+    assert capture_io(fn -> ExUnit.run() end) =~ "Passed: 0"
 
     defmodule EmptyGroupedParameterizedTests do
       use ExUnit.Case, async: true, parameterize: [], group: :example
@@ -738,7 +738,7 @@ defmodule ExUnitTest do
     end
 
     configure_and_reload_on_exit(trace: true)
-    assert capture_io(fn -> ExUnit.run() end) =~ "Passed: 0/0"
+    assert capture_io(fn -> ExUnit.run() end) =~ "Passed: 0"
   end
 
   describe "after_suite/1" do
@@ -1103,7 +1103,7 @@ defmodule ExUnitTest do
       end)
 
     assert output =~ "All tests have been excluded.\n"
-    assert output =~ "Passed: 0/0"
+    assert output =~ "Passed: 0"
   end
 
   test "tests are run in compile order (FIFO)" do


### PR DESCRIPTION
With failed tests:

<img width="1148" height="168" alt="CleanShot 2026-03-10 at 08 44 07@2x" src="https://github.com/user-attachments/assets/bb473136-961b-438d-bd9b-4ba391b21653" />

With no failed tests:

<img width="1112" height="126" alt="CleanShot 2026-03-10 at 09 14 55@2x" src="https://github.com/user-attachments/assets/fc9ab867-2da9-48a4-80c9-d3d82455e614" />
