### PR TITLE
Add pointer to CLI config in Mix.Task.preferred_cli_env/1

### DIFF
--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -262,6 +262,9 @@ defmodule Mix.Task do
 
   @doc """
   Available for backwards compatibility.
+
+  See the [CLI configuration](Mix.Project.html#module-cli-configuration)
+  section in the `Mix.Project` documentation.
   """
   @deprecated "Configure the environment in your mix.exs"
   defdelegate preferred_cli_env(task), to: Mix.CLI


### PR DESCRIPTION
This function just shows up in tools that search for function names (I use Dash.app personally) and a pointer would be helpful there IMO 🙃 