### PR TITLE
Fix `URI.merge` leaking `:+` marker when base path is empty string

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -964,6 +964,7 @@ defmodule URI do
   end
 
   defp merge_paths(nil, rel_path), do: merge_paths("/", rel_path)
+  defp merge_paths("", rel_path), do: merge_paths("/", rel_path)
   defp merge_paths(_, "/" <> _ = rel_path), do: remove_dot_segments_from_path(rel_path)
 
   defp merge_paths(base_path, rel_path) do

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -1044,5 +1044,11 @@ defmodule URITest do
       assert URI.merge(base, "/foo") |> to_string() == "http://example.com/foo"
       assert URI.merge(base, "foo") |> to_string() == "http://example.com/foo"
     end
+
+    test "merges when base path is empty string" do
+      base = %URI{scheme: "http", host: "example.com", path: ""}
+      assert URI.merge(base, "foo") |> to_string() == "http://example.com/foo"
+      assert URI.merge(base, "/bar") |> to_string() == "http://example.com/bar"
+    end
   end
 end


### PR DESCRIPTION
When merging URIs where the base has `path: ""`, the internal `:+` marker used to track the join point between base and relative paths was being converted to a literal "+" in the output.

```elixir
iex(1)> base = %URI{scheme: "http", host: "example.com", path: ""}
iex(2)> URI.merge(base, "foo") |> to_string()
"http://example.com/+/foo"
```