### PR TITLE
Revert "Fix unnecessary recompilation when dbg_callback is modified at runtime"

### DIFF
--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -63,11 +63,6 @@ start(_Type, _Args) ->
       application:set_env(elixir, ansi_enabled, prim_tty:isatty(stdout) == true)
   end,
 
-  %% Store the initial dbg_callback value before any runtime modifications.
-  %% This allows Mix compiler to detect config changes vs runtime changes
-  %% (e.g., Kino wrapping dbg_callback at runtime should not trigger recompilation).
-  {ok, InitialDbgCallback} = application:get_env(elixir, dbg_callback),
-
   Tokenizer = case code:ensure_loaded('Elixir.String.Tokenizer') of
     {module, Mod} -> Mod;
     _ -> elixir_tokenizer
@@ -96,7 +91,6 @@ start(_Type, _Args) ->
     {ignore_already_consolidated, false},
     {ignore_module_conflict, false},
     {infer_signatures, [elixir]},
-    {initial_dbg_callback, InitialDbgCallback},
     {module_definition, compiled},
     {no_warn_undefined, []},
     {on_undefined_variable, raise},

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -311,13 +311,7 @@ defmodule Mix.Compilers.Elixir do
   end
 
   defp deps_config_compile_env_apps(deps_config) do
-    # Use initial_dbg_callback instead of dbg_callback to ignore runtime modifications.
-    # Tools like Kino modify dbg_callback at runtime to customize dbg/2 behavior,
-    # but this should not trigger recompilation since the config hasn't actually changed.
-    # initial_dbg_callback is set when :elixir app starts, before any runtime modifications.
-    initial_dbg = :elixir_config.get(:initial_dbg_callback)
-
-    if deps_config[:dbg] != initial_dbg do
+    if deps_config[:dbg] != Application.fetch_env!(:elixir, :dbg_callback) do
       [:elixir]
     else
       []

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -278,11 +278,9 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
 
-      # Simulate a config change by updating both dbg_callback and initial_dbg_callback.
-      # This represents the case where the user actually changed the config file.
+      # Change the dbg_callback at runtime
       File.touch!("_build/dev/lib/sample/.mix/compile.elixir", @old_time)
       Application.put_env(:elixir, :dbg_callback, {__MODULE__, :dbg, []})
-      :elixir_config.put(:initial_dbg_callback, {__MODULE__, :dbg, []})
 
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
@@ -291,35 +289,6 @@ defmodule Mix.Tasks.Compile.ElixirTest do
     end)
   after
     Application.put_env(:elixir, :dbg_callback, {Macro, :dbg, []})
-    :elixir_config.put(:initial_dbg_callback, {Macro, :dbg, []})
-  end
-
-  test "does not recompile when dbg_callback is modified at runtime but initial is unchanged" do
-    in_fixture("no_mixfile", fn ->
-      Mix.Project.push(MixTest.Case.Sample)
-
-      File.write!("lib/a.ex", """
-      defmodule A do
-        def a, do: dbg(:ok)
-      end
-      """)
-
-      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
-      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
-
-      # Simulate a tool like Kino modifying dbg_callback at runtime.
-      # Since initial_dbg_callback remains unchanged, this should NOT trigger recompilation.
-      original_dbg = Application.fetch_env!(:elixir, :dbg_callback)
-      :elixir_config.put(:initial_dbg_callback, original_dbg)
-      Application.put_env(:elixir, :dbg_callback, {SomeDebugTool, :dbg, [original_dbg]})
-
-      # Should NOT trigger recompilation since initial_dbg_callback is unchanged
-      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:noop, []}
-      refute_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
-    end)
-  after
-    Application.put_env(:elixir, :dbg_callback, {Macro, :dbg, []})
-    :elixir_config.put(:initial_dbg_callback, {Macro, :dbg, []})
   end
 
   test "recompiles files on debug_info flag" do


### PR DESCRIPTION
This reverts commit c80a3b1a0e8471e6396b50ad8ed2c5817fabe4c2.

We will change it on Kino and Livebook to make the behaviour opt-in.

Closes #15178.