### PR TITLE
fix: fixes missing space typo in compiler error message

### DIFF
--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -367,7 +367,7 @@ format_error({invalid_match_append, Arg}) ->
 cannot_invoke_or_maybe_require(Receiver, Fun, Arity) ->
   try
     true = lists:member({Fun, Arity}, Receiver:'__info__'(macros)),
-    ["you must require the module", 'Elixir.Macro':to_string(Receiver), " before invoking macro"]
+    ["you must require the module ", 'Elixir.Macro':to_string(Receiver), " before invoking macro"]
   catch
     _:_ -> "cannot invoke remote function"
   end.

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -810,7 +810,7 @@ defmodule Kernel.ExpansionTest do
 
     test "in guards with macros" do
       message =
-        ~r"you must require the moduleInteger before invoking macro Integer.is_even/1 inside a guard"
+        ~r"you must require the module Integer before invoking macro Integer.is_even/1 inside a guard"
 
       assert_compile_error(message, fn ->
         expand(quote(do: fn arg when Integer.is_even(arg) -> arg end))


### PR DESCRIPTION
:wave: 