### PR TITLE
Add `nil` as documented :name option for GenServer.start_link

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -232,6 +232,8 @@ defmodule GenServer do
   a name on start via the `:name` option. Registered names are also
   automatically cleaned up on termination. The supported values are:
 
+    * `nil` (default) - the GenServer is not registered with a name.
+
     * an atom - the GenServer is registered locally (to the current node)
       with the given name using `Process.register/2`.
 
@@ -858,7 +860,7 @@ defmodule GenServer do
   @type on_start :: {:ok, pid} | :ignore | {:error, {:already_started, pid} | term}
 
   @typedoc "The GenServer name"
-  @type name :: atom | {:global, term} | {:via, module, term}
+  @type name :: nil | atom | {:global, term} | {:via, module, term}
 
   @typedoc "Options used by the `start*` functions"
   @type options :: [option]


### PR DESCRIPTION
Hey folks, this is just a tiny documentation improvement.

When explicitly passing `nil` as the `:name` option for GenServer.start_link, the GenServer is started without a registered name (just like if no `:name` option had been passed).
I found this potentially confusing since `nil` is technically also an atom and reading the current version of the docs might lead someone to believe it might be possible to register a GenServer with the atom name `nil`.