### PR TITLE
Validate keyword lists in `Keyword.equal?/2`

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -965,6 +965,15 @@ defmodule Keyword do
   """
   @spec equal?(t, t) :: boolean
   def equal?(left, right) when is_list(left) and is_list(right) do
+    if not keyword?(left) do
+      raise ArgumentError, "expected a keyword list as the first argument, got: #{inspect(left)}"
+    end
+
+    if not keyword?(right) do
+      raise ArgumentError,
+            "expected a keyword list as the second argument, got: #{inspect(right)}"
+    end
+
     :lists.sort(left) === :lists.sort(right)
   end
 

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -242,4 +242,27 @@ defmodule KeywordTest do
     assert Keyword.split_with([a: "1", a: 1, b: 2], fn {k, v} -> k in [:a] and is_integer(v) end) ==
              {[a: 1], [a: "1", b: 2]}
   end
+
+  test "equal?/2" do
+    assert Keyword.equal?([], [])
+    assert Keyword.equal?([a: 1], a: 1)
+    assert Keyword.equal?([a: 1, b: 2], b: 2, a: 1)
+    refute Keyword.equal?([a: 1, b: 2], b: 1, a: 2)
+
+    assert Keyword.equal?([a: 1, b: 2, a: 3], b: 2, a: 3, a: 1)
+
+    refute Keyword.equal?([a: 1.0], a: 1)
+
+    message = "expected a keyword list as the first argument, got: [1, 2]"
+
+    assert_raise ArgumentError, message, fn ->
+      Keyword.equal?([1, 2], a: 1)
+    end
+
+    message = "expected a keyword list as the second argument, got: [1, 2]"
+
+    assert_raise ArgumentError, message, fn ->
+      Keyword.equal?([a: 1], [1, 2])
+    end
+  end
 end


### PR DESCRIPTION
`Keyword.equal?/2` was accepting non-keyword lists, returning potentially misleading results and violating its type specification.

```elixir
iex> Keyword.equal?([1, :foo, "bar"], ["bar", 1, :foo])
true
```