### PR TITLE
Fix false type warning when using is_struct/is_map_key on hd/tl of untyped lists

### DIFF
--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -851,8 +851,9 @@ defmodule Module.Types.Apply do
     end
   end
 
-  defp remote_apply(:erlang, :hd, _info, [list], stack) do
+  defp remote_apply(:erlang, :hd, info, [list], stack) do
     case list_hd(list) do
+      {:ok, :term} -> remote_apply(info, [list], stack)
       {:ok, value_type} -> {:ok, return(value_type, [list], stack)}
       :badnonemptylist -> {:error, badremote(:erlang, :hd, [list])}
     end
@@ -866,8 +867,9 @@ defmodule Module.Types.Apply do
     end
   end
 
-  defp remote_apply(:erlang, :tl, _info, [list], stack) do
+  defp remote_apply(:erlang, :tl, info, [list], stack) do
     case list_tl(list) do
+      {:ok, :term} -> remote_apply(info, [list], stack)
       {:ok, value_type} -> {:ok, return(value_type, [list], stack)}
       :badnonemptylist -> {:error, badremote(:erlang, :tl, [list])}
     end

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -78,6 +78,8 @@ defmodule Module.Types.ExprTest do
       assert typecheck!([x = [123, :foo]], hd(x)) == dynamic(union(atom([:foo]), integer()))
       assert typecheck!([x = [123 | :foo]], hd(x)) == dynamic(integer())
 
+      assert typecheck!([x], is_list(x) and is_map(hd(x)), hd(x)) == dynamic()
+
       assert typeerror!(hd([])) |> strip_ansi() ==
                ~l"""
                incompatible types given to Kernel.hd/1:

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -650,6 +650,12 @@ defmodule Module.Types.PatternTest do
              |> equal?(dynamic(negation(open_map(__struct__: atom()))))
 
       assert typecheck!([x], not is_struct(x, URI), x) == dynamic()
+
+      assert typecheck!([x], is_list(x) and is_struct(hd(x)), x) ==
+               dynamic(non_empty_list(term(), term()))
+
+      assert typecheck!([x], is_list(x) and is_struct(hd(x), URI), x) ==
+               dynamic(non_empty_list(term(), term()))
     end
 
     test "is_binary/1" do


### PR DESCRIPTION
For `hd` and `tl`, there is a special handler that determines the type of the element in the list. For untyped lists, i.e., `non_empty_list(term(), term())`, it previously returned `term()` which fails compatibility checks against specific types such as `open_map()`. This triggered a false positive in type checking for guards in the expansion of `is_struct(hd(x))`, because the type checker could not recognize that the preceding `is_map` expansion had already checked the value.

The solution is to use the generic signature handler for `term()` types, as it will return `dynamic()` as appropriate, since that is what the signature declares anyway.

Closes #15198 