### PR TITLE
Purge and delete modules if after_compile/2 callback fails

### DIFF
--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -241,6 +241,8 @@ compile(Meta, Module, ModuleAsCharlist, Block, Vars, Prune, E) ->
     {module, Module, Binary, Result}
   catch
     error:undef:Stacktrace ->
+      code:purge(Module),
+      code:delete(Module),
       case Stacktrace of
         [{Module, Fun, Args, _Info} | _] = Stack when is_list(Args) ->
           compile_undef(Module, Fun, length(Args), Stack);
@@ -248,7 +250,11 @@ compile(Meta, Module, ModuleAsCharlist, Block, Vars, Prune, E) ->
           compile_undef(Module, Fun, Arity, Stack);
         Stack ->
           erlang:raise(error, undef, Stack)
-      end
+      end;
+    Kind:Reason:Stacktrace ->
+        code:purge(Module),
+        code:delete(Module),
+        erlang:raise(Kind, Reason, Stacktrace)
   after
     put_compiler_modules(CompilerModules),
     ets:delete(DataSet),

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -92,6 +92,8 @@ defmodule ModuleTest do
                  fn ->
                    Module.create(ModuleTest.Raise, contents, __ENV__)
                  end
+
+    refute Code.loaded?(ModuleTest.Raise)
   end
 
   test "supports read access to module from __after_compile__/2" do


### PR DESCRIPTION
This probably doesn't have an impact in regular use cases, but it should fix the following gotcha in Livebook: https://github.com/livebook-dev/livebook/issues/3162.

I'm not sure if I'm missing any case where we might want to keep a module for which the callback failed.