### PR TITLE
Fix Logger.Utils.truncate_n UTF-8 range for two-byte code points

### DIFF
--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -228,7 +228,7 @@ defmodule Logger.Utils do
   end
 
   def truncate_n(int, n) when int in 0..127, do: {int, n - 1}
-  def truncate_n(int, n) when int in 127..0x07FF, do: {int, n - 2}
+  def truncate_n(int, n) when int in 128..0x07FF, do: {int, n - 2}
   def truncate_n(int, n) when int in 0x800..0xFFFF, do: {int, n - 3}
   def truncate_n(int, n) when int >= 0x10000 and is_integer(int), do: {int, n - 4}
 


### PR DESCRIPTION
## Summary

- Adjust the two-byte UTF-8 code point guard from `127..0x07FF` to `128..0x07FF`. Two-byte UTF-8 sequences start at U+0080 (128); U+007F (127) is still a single byte. The old range overlapped the `0..127` clause and could misclassify U+007F if clause order ever changed.
- Add regression tests in `Logger.UtilsTest` for U+007F/U+0080 byte boundaries.