### PR TITLE
Return {0, -1} for missing files in last_modified_and_size/1

### DIFF
--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -500,7 +500,7 @@ defmodule Mix.Compilers.Elixir do
 
   defp stale_external?({external, {mtime, size}, digest}, sources_stats) do
     case sources_stats do
-      %{^external => {0, 0}} ->
+      %{^external => {0, -1}} ->
         digest != nil
 
       %{^external => {last_mtime, last_size}} ->

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -249,8 +249,8 @@ defmodule Mix.Utils do
   Returns the date the given path was last modified in posix time
   and the size.
 
-  If the path does not exist, it returns the Unix epoch
-  (1970-01-01 00:00:00).
+  If the path does not exist, it returns `{0, -1}` (the Unix epoch
+  with size -1 to distinguish from actual 0-byte files).
   """
   def last_modified_and_size(path) do
     now = System.os_time(:second)
@@ -268,7 +268,7 @@ defmodule Mix.Utils do
         {mtime, size}
 
       {:error, _} ->
-        {0, 0}
+        {0, -1}
     end
   end
 

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -58,6 +58,10 @@ defmodule Mix.UtilsTest do
     assert Mix.Utils.extract_files([""], ".ex") == []
   end
 
+  test "last_modified_and_size returns {0, -1} for missing files" do
+    assert Mix.Utils.last_modified_and_size("nonexistent") == {0, -1}
+  end
+
   test "extract stale" do
     # 2038-01-01 00:00:00
     time = 2_145_916_800


### PR DESCRIPTION
Closes #15258.

`last_modified_and_size/1` returns `{0, 0}` for both missing files and existing 0-byte files with epoch-0 mtime. The `{0, 0}` branch in `stale_external?` assumed the file was missing, causing perpetual recompilation.

This changes the sentinel for missing files to `{0, -1}`, which cannot conflict with any real disk entry, and updates the pattern match in `stale_external?` accordingly.