### PR TITLE
Add missing catch-all in :elixir_import.is_sigil/1

### DIFF
--- a/lib/elixir/src/elixir_import.erl
+++ b/lib/elixir/src/elixir_import.erl
@@ -194,7 +194,8 @@ is_sigil({Name, 2}) ->
         [H|T] when H >= $A, H =< $Z ->
               lists:all(fun(L) -> (L >= $0 andalso L =< $9)
                                   orelse (L>= $A andalso L =< $Z)
-                        end, T)
+                        end, T);
+        _ -> false
       end;
     _ ->
       false

--- a/lib/elixir/test/elixir/kernel/import_test.exs
+++ b/lib/elixir/test/elixir/kernel/import_test.exs
@@ -180,6 +180,12 @@ defmodule Kernel.ImportTest do
     defmacro bor(x, _), do: x
   end
 
+  defmodule ModuleWithInvalidSigils do
+    def sigil_ab(string, []), do: string
+    def sigil_1(string, []), do: string
+    def helper(x), do: x
+  end
+
   test "import only sigils" do
     import Kernel, except: [sigil_w: 2]
     import ModuleWithSigils, only: :sigils
@@ -202,6 +208,14 @@ defmodule Kernel.ImportTest do
     assert ~I'10' == 10
     assert ~III'10' == 30
     assert ~w(abc def) == ["abc", "def"]
+  end
+
+  test "import only sigils ignores malformed sigil names" do
+    import ModuleWithInvalidSigils, only: :sigils
+
+    assert Macro.Env.lookup_import(__ENV__, {:sigil_ab, 2}) == []
+    assert Macro.Env.lookup_import(__ENV__, {:sigil_1, 2}) == []
+    assert Macro.Env.lookup_import(__ENV__, {:helper, 1}) == []
   end
 
   test "import only removes the non-import part" do


### PR DESCRIPTION
Fixes a compiler crash when importing a module with only: :sigils option when the imported module exports non sigil symbols with `sigil_` prefix


Fixes #15263