### PR TITLE
Deduplicate tuple DNF entries

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -5278,7 +5278,9 @@ defmodule Module.Types.Descr do
         {tag, elements} -> tuple_eliminate_negations(tag, elements, negs)
       end
     end)
-    |> Enum.uniq()
+    # We want to avoid each_singleton? from failing,
+    # so we remove contiguous duplicates (cheaper than uniq)
+    |> Enum.dedup()
   end
 
   defp tuple_bdd_to_dnf_with_negations(bdd) do

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -5278,6 +5278,7 @@ defmodule Module.Types.Descr do
         {tag, elements} -> tuple_eliminate_negations(tag, elements, negs)
       end
     end)
+    |> Enum.uniq()
   end
 
   defp tuple_bdd_to_dnf_with_negations(bdd) do

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -1422,6 +1422,16 @@ defmodule Module.Types.DescrTest do
       refute singleton?(open_tuple([]))
       refute singleton?(union(tuple([atom([:value])]), tuple([atom([:other_value])])))
       refute singleton?(union(tuple([atom([:value])]), closed_map(other: atom([:value]))))
+
+      # Both BDD lines produce the same singleton tuple, so the tuple DNF must not duplicate it.
+      a = tuple([union(integer(), atom([:ok])), atom([:x])])
+      b = tuple([integer(), atom([:x, :y])])
+      c = tuple([integer(), union(atom([:x]), binary())])
+
+      t = union(difference(a, b), difference(a, c))
+      # Semantically t ~= {:ok, :x}, confirmed by equal?
+      assert equal?(t, tuple([atom([:ok]), atom([:x])]))
+      assert singleton?(t)
     end
   end
 


### PR DESCRIPTION
Proposal on top of #15196.

This keeps the tuple negation elimination optimization while deduplicating the final no-negations tuple DNF, plus a regression test for a singleton tuple represented by duplicate BDD lines.