### PR TITLE
Optimize Keyword.validate/2 to avoid building new list

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -270,34 +270,34 @@ defmodule Keyword do
   @spec validate(keyword(), values :: [atom() | {atom(), term()}]) ::
           {:ok, keyword()} | {:error, [atom]}
   def validate(keyword, values) when is_list(keyword) and is_list(values) do
-    validate(keyword, values, [], [], [])
+    validate(keyword, values, [], keyword, [])
   end
 
-  defp validate([{key, _} = pair | keyword], values1, values2, acc, bad_keys) when is_atom(key) do
+  defp validate([{key, _} | keyword], values1, values2, original, bad_keys) when is_atom(key) do
     case find_key!(key, values1, values2) do
       {values1, values2} ->
-        validate(keyword, values1, values2, [pair | acc], bad_keys)
+        validate(keyword, values1, values2, original, bad_keys)
 
       :error ->
         case find_key!(key, values2, values1) do
           {values1, values2} ->
-            validate(keyword, values1, values2, [pair | acc], bad_keys)
+            validate(keyword, values1, values2, original, bad_keys)
 
           :error ->
-            validate(keyword, values1, values2, acc, [key | bad_keys])
+            validate(keyword, values1, values2, original, [key | bad_keys])
         end
     end
   end
 
-  defp validate([], values1, values2, acc, []) do
-    {:ok, move_pairs!(values1, move_pairs!(values2, acc))}
+  defp validate([], values1, values2, original, []) do
+    {:ok, move_pairs!(values1, move_pairs!(values2, original))}
   end
 
-  defp validate([], _values1, _values2, _acc, bad_keys) do
+  defp validate([], _values1, _values2, _original, bad_keys) do
     {:error, bad_keys}
   end
 
-  defp validate([pair | _], _values1, _values2, _acc, []) do
+  defp validate([pair | _], _values1, _values2, _original, []) do
     raise ArgumentError,
           "expected a keyword list as first argument, got invalid entry: #{inspect(pair)}"
   end


### PR DESCRIPTION
Maybe I'm missing something, but as far as I can tell, there is no need to re-build that kw-list, since in the case there is a "bad_key" we're not using the acc anyway?
So we just end up reversing the list for no reason - this new version just returns the original as is, which is less work:

```elixir
# main
iex> Keyword.validate!([a: 1, b: 2], [:a, :b])
[b: 2, a: 1]
# this branch
iex> Keyword.validate!([a: 1, b: 2], [:a, :b])
[a: 1, b: 2]
```

Confirmed with a quick [benchmark](https://github.com/sabiwara/elixir_benches/commit/2c6e4a3eec2af4b5338de4ea932cc3dc1fd98ff7) that this reduces the memory footprint:

```
Comparison: 
candidate        7.63 M
original         6.76 M - 1.13x slower +16.80 ns

Memory usage statistics:

Name         Memory usage
candidate           264 B
original            424 B - 1.61x memory usage +160 B
```
