### PR TITLE
Show remaining runs when using `--repeat-until-failure`

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -570,7 +570,7 @@ defmodule ExUnit do
   end
 
   defp maybe_repeated_run(options, seed, load_us, repeat) do
-    options = Keyword.put(options, :repeat_until_failure_remaining, repeat)
+    options = Keyword.put(options, :remaining_runs, repeat)
 
     case ExUnit.Runner.run(options, load_us) do
       {%{failures: 0}, {async_modules, sync_modules}}

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -570,6 +570,8 @@ defmodule ExUnit do
   end
 
   defp maybe_repeated_run(options, seed, load_us, repeat) do
+    options = Keyword.put(options, :repeat_until_failure_remaining, repeat)
+
     case ExUnit.Runner.run(options, load_us) do
       {%{failures: 0}, {async_modules, sync_modules}}
       when repeat > 0 and (sync_modules != [] or async_modules != []) ->

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -13,8 +13,8 @@ defmodule ExUnit.CLIFormatter do
 
   def init(opts) do
     remaining =
-      if opts[:repeat_until_failure] > 0 do
-        ", remaining_runs: #{opts[:repeat_until_failure_remaining]}"
+      if opts[:remaining_runs] > 0 do
+        ", remaining_runs: #{opts[:remaining_runs]}"
       else
         ""
       end

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -12,7 +12,18 @@ defmodule ExUnit.CLIFormatter do
   ## Callbacks
 
   def init(opts) do
-    IO.puts("Running ExUnit with seed: #{opts[:seed]}, max_cases: #{opts[:max_cases]}")
+    remaining =
+      if opts[:repeat_until_failure] > 0 do
+        ", remaining_runs: #{opts[:repeat_until_failure_remaining]}"
+      else
+        ""
+      end
+
+    IO.puts([
+      "Running ExUnit with seed: #{opts[:seed]}, max_cases: #{opts[:max_cases]}",
+      remaining
+    ])
+
     print_filters(opts, :exclude)
     print_filters(opts, :include)
     IO.puts("")

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -13,7 +13,7 @@ defmodule ExUnit.CLIFormatter do
 
   def init(opts) do
     remaining =
-      if opts[:remaining_runs] > 0 do
+      if opts[:repeat_until_failure] > 0 do
         ", remaining_runs: #{opts[:remaining_runs]}"
       else
         ""

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -1021,6 +1021,8 @@ defmodule ExUnitTest do
       runs = String.split(output, "Running ExUnit", trim: true)
       # 6 runs in total, 5 repeats
       assert length(runs) == 6
+      assert output =~ "remaining_runs: 5"
+      assert output =~ "remaining_runs: 0"
     end
 
     test "repeats tests up to the configured number of times with groups" do
@@ -1039,6 +1041,8 @@ defmodule ExUnitTest do
       runs = String.split(output, "Running ExUnit", trim: true)
       # 6 runs in total, 5 repeats
       assert length(runs) == 6
+      assert output =~ "remaining_runs: 5"
+      assert output =~ "remaining_runs: 0"
     end
 
     test "stops on failure" do
@@ -1080,6 +1084,7 @@ defmodule ExUnitTest do
       # four runs in total, the first two repeats work fine, the third repeat (4th run)
       # fails, therefore we stop
       assert length(runs) == 4
+      assert output =~ "remaining_runs: 2"
       assert List.last(runs) =~ "Expected truthy, got false"
     end
   end


### PR DESCRIPTION
The --repeat-until-failure can be very useful for finding flaky tests, however sometimes it is hard to gauge how long it has left to run before it can be considered successful.

This commit adds a small output showing the number of remaining runs when the `--repeat-until-failure` flag is used.

It looks like:

```
Running ExUnit with seed: 382462, max_cases: 32, remaining_runs: 3
Excluding tags: [windows: true]

.......
Finished in 0.02 seconds (0.00s async, 0.02s sync)

Result: 7 passed
Running ExUnit with seed: 422319, max_cases: 32, remaining_runs: 2
Excluding tags: [windows: true]

.......
Finished in 0.00 seconds (0.00s async, 0.00s sync)
```
