### PR TITLE
Fix compiler crash on invalid nested bitstring

### DIFF
--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -115,7 +115,9 @@ concat_or_prepend_bitstring(Meta, {'<<>>', PartsMeta, Parts} = ELeft, ERight, Ac
           [{'::', Meta, [ELeft, ERight]} | Acc]
       end;
     {bitstring, _, nil} ->
-      lists:reverse(Parts, Acc)
+      lists:reverse(Parts, Acc);
+    _ ->
+      [{'::', Meta, [ELeft, ERight]} | Acc]
   end;
 concat_or_prepend_bitstring(Meta, ELeft, ERight, Acc, _E, _RequireSize) ->
   [{'::', Meta, [ELeft, ERight]} | Acc].

--- a/lib/elixir/test/elixir/kernel/binary_test.exs
+++ b/lib/elixir/test/elixir/kernel/binary_test.exs
@@ -200,9 +200,7 @@ defmodule Kernel.BinaryTest do
     assert_compile_error(message, fn ->
       # We need to wrap the example below in a module because
       # we attempt to continue compilation when inside a function
-      Code.compile_string(
-        "defmodule Repro do\n  def run, do:  <<(<<1>>)::integer>>\nend\n"
-      )
+      Code.compile_string("defmodule Repro do\n  def run, do:  <<(<<1>>)::integer>>\nend")
     end)
   end
 

--- a/lib/elixir/test/elixir/kernel/binary_test.exs
+++ b/lib/elixir/test/elixir/kernel/binary_test.exs
@@ -198,8 +198,10 @@ defmodule Kernel.BinaryTest do
     end)
 
     assert_compile_error(message, fn ->
+      # We need to wrap the example below in a module because
+      # we attempt to continue compilation when inside a function
       Code.compile_string(
-        "defmodule Repro do\n  def run do\n    <<(<<1>>)::integer>>\n  end\nend\n"
+        "defmodule Repro do\n  def run, do:  <<(<<1>>)::integer>>\nend\n"
       )
     end)
   end

--- a/lib/elixir/test/elixir/kernel/binary_test.exs
+++ b/lib/elixir/test/elixir/kernel/binary_test.exs
@@ -196,6 +196,12 @@ defmodule Kernel.BinaryTest do
     assert_compile_error(message, fn ->
       Code.eval_string(~s[<<"foo"::float>>])
     end)
+
+    assert_compile_error(message, fn ->
+      Code.compile_string(
+        "defmodule Repro do\n  def run do\n    <<(<<1>>)::integer>>\n  end\nend\n"
+      )
+    end)
   end
 
   @bitstring <<"foo", 16::4>>


### PR DESCRIPTION
This PR fixes a crash when handling invalid bitstring:

```
iex(1)> Code.compile_string("""
        defmodule Repro do
          def run do
            <<(<<1>>)::integer>>
          end
        end
        """)
error: conflicting type specification for bit field: "integer" and "bitstring"
└─ nofile:3:14: Repro.run/0

** (CaseClauseError) no case clause matching:

    {:integer, [], nil}

    (elixir 1.20.0-rc.4) src/elixir_bitstring.erl:105: :elixir_bitstring.concat_or_prepend_bitstring/6
    (elixir 1.20.0-rc.4) src/elixir_bitstring.erl:50: :elixir_bitstring.expand/8
    (elixir 1.20.0-rc.4) src/elixir_bitstring.erl:25: :elixir_bitstring.expand/5
    (elixir 1.20.0-rc.4) src/elixir_clauses.erl:195: :elixir_clauses.def/3
    (elixir 1.20.0-rc.4) src/elixir_def.erl:198: :elixir_def."-store_definition/10-lc$^0/1-0-"/3
    (elixir 1.20.0-rc.4) src/elixir_def.erl:199: :elixir_def.store_definition/10
    nofile:2: (module)
    iex:1: (file)
```

With the changes:
```
iex(1)> Code.compile_string("""
        defmodule Repro do
          def run do
            <<(<<1>>)::integer>>
          end
        end
        """)
error: conflicting type specification for bit field: "integer" and "bitstring"
└─ nofile:3:14: Repro.run/0

** (CompileError) nofile: cannot compile module Repro (errors have been logged)
    (elixir 1.20.0-rc.4) src/elixir_module.erl:192: anonymous fn/11 in :elixir_module.compile/7
    iex:1: (file)
```