### PR TITLE
Do not reset quote level on calls in `has_unquotes/2`

### DIFF
--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -55,7 +55,7 @@ end;
 has_unquotes({{'.', _, [_, unquote]}, _, [_]}, _) -> true;
 has_unquotes({Var, _, Ctx}, _) when is_atom(Var), is_atom(Ctx) -> false;
 has_unquotes({Name, _, Args}, QuoteLevel) when is_list(Args) ->
-  has_unquotes(Name) orelse lists:any(fun(Child) -> has_unquotes(Child, QuoteLevel) end, Args);
+  has_unquotes(Name, QuoteLevel) orelse lists:any(fun(Child) -> has_unquotes(Child, QuoteLevel) end, Args);
 has_unquotes({Left, Right}, QuoteLevel) ->
   has_unquotes(Left, QuoteLevel) orelse has_unquotes(Right, QuoteLevel);
 has_unquotes(List, QuoteLevel) when is_list(List) ->


### PR DESCRIPTION
The bug was introduced in 146fb4e3fffa61815babfd5c2b18d4fd16960691 and missed in https://github.com/elixir-lang/elixir/pull/12836
I'm not sure if it affects any valid code