### PR TITLE
Bdd negation and difference optimizations

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -6190,7 +6190,8 @@ defmodule Module.Types.Descr do
     end
   end
 
-  # Lazy negation: eliminate the union, then perform normal negation (switching leaves)
+  # {lit, c, u, d} = (lit and c) or u or (not lit and d), so
+  # its negation is ((lit and not c) or (not lit and not d)) and not u.
   def bdd_negation(:bdd_top), do: :bdd_bot
   def bdd_negation(:bdd_bot), do: :bdd_top
   def bdd_negation({_, _} = pair), do: {pair, :bdd_bot, :bdd_bot, :bdd_top}

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -5749,7 +5749,7 @@ defmodule Module.Types.Descr do
   defp tuple_insert_static(descr, index, type) do
     Map.update!(descr, :tuple, fn bdd ->
       bdd_map(bdd, fn {tag, elements} ->
-        # Iff the tuple is open, then we want List.insert_at to put the new element at the correct
+        # If the tuple is open, then we want List.insert_at to put the new element at the correct
         # index, which requires filling the tuple with `term()` values first.
         # Closed tuples of an incorrect size will be ignored (they are cancelled by the earlier
         # intersection with `tuple_of_size_at_least`).

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -5901,6 +5901,8 @@ defmodule Module.Types.Descr do
   defp bdd_difference_union(i, u1, u2),
     do: bdd_difference(i, bdd_union(u1, u2))
 
+  # We avoid unions because they are lazy and we prune
+  # intersections more actively.
   defp bdd_negation_union(u1, u2) do
     bdd_intersection(bdd_negation(u1), bdd_negation(u2))
   end
@@ -6204,11 +6206,7 @@ defmodule Module.Types.Descr do
     inner =
       {lit, bdd_negation(c), :bdd_bot, bdd_negation(d)}
 
-    case u do
-      :bdd_bot -> inner
-      _ -> bdd_intersection(inner, bdd_negation(u))
-    end
-    |> case do
+    case bdd_intersection(inner, bdd_negation(u)) do
       # Full simplification necessary for e.g. formatter.ex compilation
       {_lit, c, u, c} -> bdd_union(u, c)
       x -> x

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -6196,7 +6196,18 @@ defmodule Module.Types.Descr do
   def bdd_negation({_, _} = pair), do: {pair, :bdd_bot, :bdd_bot, :bdd_top}
 
   def bdd_negation({lit, c, u, d}) do
-    {lit, bdd_negation(bdd_union(c, u)), :bdd_bot, bdd_negation(bdd_union(d, u))}
+    inner =
+      {lit, bdd_negation(c), :bdd_bot, bdd_negation(d)}
+
+    case u do
+      :bdd_bot -> inner
+      _ -> bdd_intersection(inner, bdd_negation(u))
+    end
+    |> case do
+      # Full simplification necessary for e.g. formatter.ex compilation
+      {lit, c, u, c} -> bdd_union(u, c)
+      x -> x
+    end
   end
 
   def bdd_to_dnf(bdd), do: bdd_to_dnf([], [], [], bdd)

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -5879,7 +5879,7 @@ defmodule Module.Types.Descr do
             end
 
           {:eq, _, {lit, c2, u2, _d2}} ->
-            {lit, bdd_negation(bdd_union(c2, u2)), :bdd_bot, :bdd_bot}
+            {lit, bdd_negation_union(c2, u2), :bdd_bot, :bdd_bot}
 
           {:eq, {lit, _c1, u1, d1}, _} ->
             {lit, :bdd_bot, :bdd_bot, bdd_union(d1, u1)}
@@ -5900,6 +5900,10 @@ defmodule Module.Types.Descr do
 
   defp bdd_difference_union(i, u1, u2),
     do: bdd_difference(i, bdd_union(u1, u2))
+
+  defp bdd_negation_union(u1, u2) do
+    bdd_intersection(bdd_negation(u1), bdd_negation(u2))
+  end
 
   ## Optimize differences
 

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -6210,7 +6210,7 @@ defmodule Module.Types.Descr do
     end
     |> case do
       # Full simplification necessary for e.g. formatter.ex compilation
-      {lit, c, u, c} -> bdd_union(u, c)
+      {_lit, c, u, c} -> bdd_union(u, c)
       x -> x
     end
   end

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -5749,6 +5749,17 @@ defmodule Module.Types.Descr do
   defp tuple_insert_static(descr, index, type) do
     Map.update!(descr, :tuple, fn bdd ->
       bdd_map(bdd, fn {tag, elements} ->
+        # Iff the tuple is open, then we want List.insert_at to put the new element at the correct
+        # index, which requires filling the tuple with `term()` values first.
+        # Closed tuples of an incorrect size will be ignored (they are cancelled by the earlier
+        # intersection with `tuple_of_size_at_least`).
+        elements =
+          if tag == :open and length(elements) < index do
+            tuple_fill(elements, index)
+          else
+            elements
+          end
+
         {tag, List.insert_at(elements, index, type)}
       end)
     end)


### PR DESCRIPTION
Those slow downs happen when using `bdd_intersection / bdd_difference` over `tuple_intersection / tuple_difference`:

2) Found what was causing the formatter.ex slowdown when not using bdd_intersection: it was a blow-up in bdd_negation. Added a new formula for it.

3) Found out what was causing the slowdown for macro.ex 4s tc times: some blowup in bdd_diff related to negation.

Also fixed a bug on tuple_insert_at.