### PR TITLE
doc: fix errors in getting-started and mix-and-otp guides

### DIFF
--- a/lib/elixir/pages/getting-started/basic-types.md
+++ b/lib/elixir/pages/getting-started/basic-types.md
@@ -75,7 +75,7 @@ iex> trunc(3.58)
 3
 ```
 
-Finally, we work with different data types, we will learn Elixir provides several predicate functions to check for the type of a value. For example, [`is_integer`](`is_integer/1`) can be used to check if a value is an integer or not:
+Finally, as we work with different data types, we will learn that Elixir provides several predicate functions to check for the type of a value. For example, [`is_integer`](`is_integer/1`) can be used to check if a value is an integer or not:
 
 ```elixir
 iex> is_integer(1)
@@ -310,4 +310,4 @@ false
 
 The comparison operators in Elixir can compare across any data type. We say these operators perform _structural comparison_. For more information, you can read our documentation on [Structural vs Semantic comparisons](`Kernel#module-structural-comparison`).
 
-Elixir also provides data-types for expressing collections, such as lists and tuples, which we learn next. When we talk about concurrency and fault-tolerance via processes, we will also discuss ports, pids, and references, but that will come on later chapters. Let's move forward.
+Elixir also provides data-types for expressing collections, such as lists and tuples, which we'll learn next. When we talk about concurrency and fault-tolerance via processes, we will also discuss ports, pids, and references, but that will come in later chapters. Let's move forward.

--- a/lib/elixir/pages/mix-and-otp/config-and-distribution.md
+++ b/lib/elixir/pages/mix-and-otp/config-and-distribution.md
@@ -241,7 +241,7 @@ $ mix help
 mix deps              # Lists dependencies and their status
 mix deps.clean        # Deletes the given dependencies' files
 mix deps.compile      # Compiles dependencies
-mix deps.get          # Gets all out of date dependencies
+mix deps.get          # Fetches unavailable and out of date dependencies
 mix deps.tree         # Prints the dependency tree
 mix deps.unlock       # Unlocks the given dependencies
 mix deps.update       # Updates the given dependencies

--- a/lib/elixir/pages/mix-and-otp/task-and-gen-tcp.md
+++ b/lib/elixir/pages/mix-and-otp/task-and-gen-tcp.md
@@ -143,7 +143,7 @@ With this change, we are saying that we want to run `KV.Server.accept(4040)` as 
 Now that the server is part of the supervision tree, it should start automatically when we run the application. Run `iex -S mix` to boot the app and use the `telnet` client to make sure that everything still works:
 
 ```console
-$ telnet 127.0.0.1 4321
+$ telnet 127.0.0.1 4040
 Trying 127.0.0.1...
 Connected to localhost.
 Escape character is '^]'.
@@ -158,7 +158,7 @@ Yes, it works! However, can it handle more than one client?
 Try to connect two telnet clients at the same time. When you do so, you will notice that the second client doesn't echo:
 
 ```console
-$ telnet 127.0.0.1 4321
+$ telnet 127.0.0.1 4040
 Trying 127.0.0.1...
 Connected to localhost.
 Escape character is '^]'.


### PR DESCRIPTION
Fixes a few documentation errors across two guides:

- `task-and-gen-tcp.md`: telnet examples used port `4321` instead of `4040`, contradicting the surrounding text
- `config-and-distribution.md`: updated `mix deps.get` description to match actual `mix help` output
- `basic-types.md`: fixed three grammatical errors for easier flow