### PR TITLE
docs: fix grammar in basic-types getting-started page

### DIFF
--- a/lib/elixir/pages/getting-started/basic-types.md
+++ b/lib/elixir/pages/getting-started/basic-types.md
@@ -75,7 +75,7 @@ iex> trunc(3.58)
 3
 ```
 
-Finally, we work with different data types, we will learn Elixir provides several predicate functions to check for the type of a value. For example, [`is_integer`](`is_integer/1`) can be used to check if a value is an integer or not:
+Finally, as we work with different data types, we will learn that Elixir provides several predicate functions to check for the type of a value. For example, [`is_integer`](`is_integer/1`) can be used to check if a value is an integer or not:
 
 ```elixir
 iex> is_integer(1)


### PR DESCRIPTION

**Repo:** elixir-lang/elixir (⭐ 24000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Fixes an ungrammatical sentence in the "Basic types" getting-started guide. The original reads "Finally, we work with different data types, we will learn Elixir provides several predicate functions..." which is a comma splice with a missing conjunction. Updated to "Finally, as we work with different data types, we will learn that Elixir provides several predicate functions..."

## Why
The getting-started guide is the first point of contact for new Elixir users. Grammatical clarity here matters for readability, and the existing sentence is awkward enough to trip readers up. This is a minimal, low-risk docs fix.

## Testing
Docs-only change; no runtime impact. Verified the rendered Markdown still reads correctly and cross-reference links (`` `is_integer/1` ``) are untouched.

## Risk
Low — single-sentence prose change in a Markdown guide, no code or link targets affected.
