### PR TITLE
Hash-cons and simplify descriptor BDDs

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -5833,10 +5833,10 @@ defmodule Module.Types.Descr do
             bdd_split(lit, bdd_union(c1, c2), bdd_union(u1, u2), bdd_union(d1, d2))
 
           {:eq, {lit, _, u1, d1, _}, _} ->
-            bdd_split(lit, :bdd_bot, bdd_union(u1, lit), d1)
+            bdd_union(d1, bdd_union(u1, lit))
 
           {:eq, _, {lit, _, u2, d2, _}} ->
-            bdd_split(lit, :bdd_bot, bdd_union(u2, lit), d2)
+            bdd_union(d2, bdd_union(u2, lit))
 
           {:eq, _, _} ->
             bdd1
@@ -5920,11 +5920,25 @@ defmodule Module.Types.Descr do
               bdd_split(lit, c, :bdd_bot, d)
             end
 
+          # so this is: we have lit \ ((lit and c2) or u2 or ((not lit) and d2)
+          # which is (lit and not c2) or (lit and not u2)
           {:eq, _, {lit, c2, u2, _d2, _}} ->
-            bdd_split(lit, bdd_negation_union(c2, u2), :bdd_bot, :bdd_bot)
+            bdd_union(
+              bdd_intersection(lit, bdd_negation(c2)),
+              bdd_intersection(lit, bdd_negation(u2))
+            )
 
+          # bdd_difference(lit, c2) |> bdd_union(bdd_difference(lit, u2))
+
+          # bdd_split(lit, bdd_intersection(bdd_negation(c2), bdd_negation(u2)), :bdd_bot, :bdd_bot)
+
+          # this is (lit and c1) or u1 or (not lit and d1) \ lit
+          # which is (u1 \ lit) or (not lit and d1)
+          # which is (u1 and not lit) or (d1 and not lit)
           {:eq, {lit, _c1, u1, d1, _}, _} ->
-            bdd_split(lit, :bdd_bot, :bdd_bot, bdd_union(d1, u1))
+            bdd_union(bdd_difference(u1, lit), bdd_difference(d1, lit))
+
+          # bdd_split(lit, :bdd_bot, :bdd_bot, bdd_union(d1, u1))
 
           {:eq, _, _} ->
             :bdd_bot
@@ -6141,11 +6155,15 @@ defmodule Module.Types.Descr do
               bdd_intersection_eq(d1, d2, u1, u2)
             )
 
+          # Important! lit must be put into the union/assumptions, to give it a go a simplification
           {:eq, {lit, c1, u1, _, _}, _} ->
-            bdd_split(lit, bdd_union(c1, u1), :bdd_bot, :bdd_bot)
+            # bdd_split(lit, :bdd_top, u1, d1}
+            bdd_union(c1, bdd_union(u1, lit))
 
           {:eq, _, {lit, c2, u2, _, _}} ->
-            bdd_split(lit, bdd_union(c2, u2), :bdd_bot, :bdd_bot)
+            bdd_union(c2, bdd_union(u2, lit))
+
+          # bdd_split(lit, bdd_union(c2, u2), :bdd_bot, :bdd_bot)
 
           {:eq, bdd, _} ->
             bdd

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -48,10 +48,16 @@ defmodule Module.Types.Descr do
   # Remark: those are explicit BDD constructors. The functional constructors are `bdd_new/1` and `bdd_new/3`.
   @fun_top {:negation, %{}}
   @atom_top {:negation, :sets.new(version: 2)}
-  @map_top {:open, @fields_new, :erlang.phash2({:open, @fields_new})}
-  @non_empty_list_top {:term, :term, :erlang.phash2({:term, :term})}
-  @tuple_top {:open, [], :erlang.phash2({:open, []})}
-  @map_empty {:closed, @fields_new, :erlang.phash2({:closed, @fields_new})}
+  @map_top {:erlang.phash2({:open, @fields_new}), :open, @fields_new}
+  @non_empty_list_top {:erlang.phash2({:term, :term}), :term, :term}
+  @tuple_top {:erlang.phash2({:open, []}), :open, []}
+  @map_empty {:erlang.phash2({:closed, @fields_new}), :closed, @fields_new}
+
+  defmacrop bdd_leaf(arg1, arg2) do
+    quote do
+      {_, unquote(arg1), unquote(arg2)}
+    end
+  end
 
   # The top BDD for each arity.
   @fun_bdd_top :bdd_top
@@ -834,13 +840,13 @@ defmodule Module.Types.Descr do
   # A bdd leaf can be trivially printed in negated format
   # but we don't count it towards the amount of negatives.
   defp print_as_negated_bdd(top, top), do: 1
-  defp print_as_negated_bdd({_, _, _}, _top), do: 0
+  defp print_as_negated_bdd(bdd_leaf(_, _), _top), do: 0
   defp print_as_negated_bdd(bdd, top), do: if(negated_bdd?(bdd, top), do: 1, else: -100)
 
-  defp negated_bdd?({top, bdd, :bdd_bot, :bdd_bot, _}, top),
+  defp negated_bdd?({_, top, bdd, :bdd_bot, :bdd_bot}, top),
     do: negated_bdd?(bdd, top)
 
-  defp negated_bdd?({_, :bdd_bot, :bdd_bot, bdd, _}, top),
+  defp negated_bdd?({_, _, :bdd_bot, :bdd_bot, bdd}, top),
     do: bdd in [:bdd_top, top] or negated_bdd?(bdd, top)
 
   defp negated_bdd?(_, _), do: false
@@ -2175,7 +2181,7 @@ defmodule Module.Types.Descr do
   defp non_empty_list_literals_intersection(list_literals) do
     try do
       Enum.reduce(list_literals, {:term, :term}, fn
-        {next_list, next_last, _}, {list, last} ->
+        bdd_leaf(next_list, next_last), {list, last} ->
           {non_empty_intersection!(list, next_list), non_empty_intersection!(last, next_last)}
 
         {next_list, next_last}, {list, last} ->
@@ -2233,7 +2239,7 @@ defmodule Module.Types.Descr do
   @compile {:inline, list_union: 2}
   defp list_union(bdd1, bdd2), do: bdd_union(bdd1, bdd2)
 
-  defp list_top?({:term, :term, _}), do: true
+  defp list_top?(bdd_leaf(:term, :term)), do: true
   defp list_top?(_), do: false
 
   @doc """
@@ -2352,7 +2358,7 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp list_leaf_intersection({list1, last1, _}, {list2, last2, _}) do
+  defp list_leaf_intersection(bdd_leaf(list1, last1), bdd_leaf(list2, last2)) do
     try do
       list = non_empty_intersection!(list1, list2)
       last = non_empty_intersection!(last1, last2)
@@ -2362,10 +2368,10 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp list_difference({:term, :term, _}, {:term, :term, _}),
+  defp list_difference(bdd_leaf(:term, :term), bdd_leaf(:term, :term)),
     do: :bdd_bot
 
-  defp list_difference({:term, :term, _}, bdd2),
+  defp list_difference(bdd_leaf(:term, :term), bdd2),
     do: bdd_negation(bdd2)
 
   # Computes the difference between two BDD (Binary Decision Diagram) list types.
@@ -2377,7 +2383,7 @@ defmodule Module.Types.Descr do
   #    b) If only the last type differs, subtracts it
   # 3. Base case: adds bdd2 type to negations of bdd1 type
   # The result may be larger than the initial bdd1, which is maintained in the accumulator.
-  defp list_difference({list1, last1, _} = bdd1, {list2, last2, _} = bdd2) do
+  defp list_difference(bdd_leaf(list1, last1) = bdd1, bdd_leaf(list2, last2) = bdd2) do
     if subtype?(list1, list2) do
       if subtype?(last1, last2),
         do: :bdd_bot,
@@ -2390,7 +2396,7 @@ defmodule Module.Types.Descr do
   defp list_difference(bdd1, bdd2),
     do: bdd_difference(bdd1, bdd2, &list_leaf_difference/3)
 
-  defp list_leaf_difference({list1, last1, _}, {list2, last2, _}, _) do
+  defp list_leaf_difference(bdd_leaf(list1, last1), bdd_leaf(list2, last2), _) do
     if disjoint?(list1, list2) or disjoint?(last1, last2) do
       :disjoint
     else
@@ -2872,13 +2878,13 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp map_union({:open, fields, _} = leaf, _) when is_fields_empty(fields),
+  defp map_union(bdd_leaf(:open, fields) = leaf, _) when is_fields_empty(fields),
     do: leaf
 
-  defp map_union(_, {:open, fields, _} = leaf) when is_fields_empty(fields),
+  defp map_union(_, bdd_leaf(:open, fields) = leaf) when is_fields_empty(fields),
     do: leaf
 
-  defp map_union({tag1, fields1, _}, {tag2, fields2, _}) do
+  defp map_union(bdd_leaf(tag1, fields1), bdd_leaf(tag2, fields2)) do
     case maybe_optimize_map_union(tag1, fields1, tag2, fields2) do
       {tag, fields} -> bdd_leaf_new(tag, fields)
       nil -> bdd_union(bdd_leaf_new(tag1, fields1), bdd_leaf_new(tag2, fields2))
@@ -3035,11 +3041,11 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp map_intersection({:open, [], _}, bdd), do: bdd
-  defp map_intersection(bdd, {:open, [], _}), do: bdd
+  defp map_intersection(bdd_leaf(:open, []), bdd), do: bdd
+  defp map_intersection(bdd, bdd_leaf(:open, [])), do: bdd
   defp map_intersection(bdd1, bdd2), do: bdd_intersection(bdd1, bdd2, &map_leaf_intersection/2)
 
-  defp map_leaf_intersection({tag1, fields1, _}, {tag2, fields2, _}) do
+  defp map_leaf_intersection(bdd_leaf(tag1, fields1), bdd_leaf(tag2, fields2)) do
     try do
       {tag, fields} = map_literal_intersection(tag1, fields1, tag2, fields2)
       bdd_leaf_new(tag, fields)
@@ -3048,10 +3054,10 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp map_difference(_, {:open, [], _}),
+  defp map_difference(_, bdd_leaf(:open, [])),
     do: :bdd_bot
 
-  defp map_difference({:open, [], _}, {_, _, _, _, _} = bdd2),
+  defp map_difference(bdd_leaf(:open, []), bdd2),
     do: bdd_negation(bdd2)
 
   defp map_difference(bdd1, bdd2),
@@ -3064,7 +3070,7 @@ defmodule Module.Types.Descr do
   #
   # Outside of this particular scenario, the `a_int` optimization has been useful,
   # but we haven't measured benefits for `a_union`.
-  defp map_leaf_difference({tag, fields, _}, {:open, [{key, v2}], _}, type) do
+  defp map_leaf_difference(bdd_leaf(tag, fields), bdd_leaf(:open, [{key, v2}]), type) do
     {found?, v1} =
       case fields_find(key, fields) do
         {:ok, value} -> {true, value}
@@ -3085,7 +3091,7 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp map_leaf_difference({tag, fields, _}, {neg_tag, neg_fields, _}, type) do
+  defp map_leaf_difference(bdd_leaf(tag, fields), bdd_leaf(neg_tag, neg_fields), type) do
     case map_difference_strategy(fields, neg_fields, tag, neg_tag) do
       :disjoint ->
         :disjoint
@@ -3347,7 +3353,7 @@ defmodule Module.Types.Descr do
   end
 
   # Optimization for bdd leafs
-  defp map_fetch_key_static(%{map: {tag, fields, _}}, key) do
+  defp map_fetch_key_static(%{map: bdd_leaf(tag, fields)}, key) do
     case fields_find(key, fields) do
       {:ok, value} -> pop_optional_static(value)
       :error when tag == :open -> {true, term()}
@@ -4626,7 +4632,7 @@ defmodule Module.Types.Descr do
 
     without_negs =
       without_negs
-      |> Enum.group_by(fn {tag, fields, _} -> {tag, fields_keys(fields)} end)
+      |> Enum.group_by(fn bdd_leaf(tag, fields) -> {tag, fields_keys(fields)} end)
       |> Enum.flat_map(fn {_, maps} -> map_non_negated_fuse(maps) end)
 
     without_negs ++ with_negs
@@ -4914,14 +4920,14 @@ defmodule Module.Types.Descr do
 
   defp tuple_new(tag, elements), do: bdd_leaf_new(tag, elements)
 
-  defp tuple_intersection({:open, [], _}, bdd), do: bdd
-  defp tuple_intersection(bdd, {:open, [], _}), do: bdd
+  defp tuple_intersection(bdd_leaf(:open, []), bdd), do: bdd
+  defp tuple_intersection(bdd, bdd_leaf(:open, [])), do: bdd
 
   defp tuple_intersection(bdd1, bdd2) do
     bdd_intersection(bdd1, bdd2, &tuple_leaf_intersection/2)
   end
 
-  defp tuple_leaf_intersection({tag1, elements1, _}, {tag2, elements2, _}) do
+  defp tuple_leaf_intersection(bdd_leaf(tag1, elements1), bdd_leaf(tag2, elements2)) do
     case tuple_literal_intersection(tag1, elements1, tag2, elements2) do
       {tag, elements} -> bdd_leaf_new(tag, elements)
       :empty -> :bdd_bot
@@ -4972,16 +4978,16 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp tuple_difference(_, {:open, [], _}),
+  defp tuple_difference(_, bdd_leaf(:open, [])),
     do: :bdd_bot
 
-  defp tuple_difference({:open, [], _}, {_, _, _, _, _} = bdd2),
+  defp tuple_difference(bdd_leaf(:open, []), bdd2),
     do: bdd_negation(bdd2)
 
   defp tuple_difference(bdd1, bdd2),
     do: bdd_difference(bdd1, bdd2, &tuple_leaf_difference/3)
 
-  defp tuple_leaf_difference({tag1, elements1, _}, {tag2, elements2, _}, _) do
+  defp tuple_leaf_difference(bdd_leaf(tag1, elements1), bdd_leaf(tag2, elements2), _) do
     case tuple_sizes_strategy(tag1, length(elements1), tag2, length(elements2)) do
       :disjoint -> :disjoint
       other -> tuple_leaf_difference(elements1, elements2, other == :left_subtype_of_right)
@@ -5003,7 +5009,7 @@ defmodule Module.Types.Descr do
   defp non_empty_tuple_literals_intersection(tuples) do
     try do
       Enum.reduce(tuples, {:open, []}, fn
-        {next_tag, next_elements, _}, {tag, elements} ->
+        bdd_leaf(next_tag, next_elements), {tag, elements} ->
           case tuple_literal_intersection(tag, elements, next_tag, next_elements) do
             :empty -> throw(:empty)
             next -> next
@@ -5188,8 +5194,8 @@ defmodule Module.Types.Descr do
     do: leaf
 
   defp tuple_union(
-         {tag1, elements1, _} = tuple1,
-         {tag2, elements2, _} = tuple2
+         bdd_leaf(tag1, elements1) = tuple1,
+         bdd_leaf(tag2, elements2) = tuple2
        ) do
     case maybe_optimize_tuple_union({tag1, elements1}, {tag2, elements2}) do
       {tag, elements} -> bdd_leaf_new(tag, elements)
@@ -5467,7 +5473,7 @@ defmodule Module.Types.Descr do
   defp tuple_fetch_static(descr, index) when is_integer(index) do
     case descr do
       :term -> {true, term()}
-      %{tuple: {tag, elements, _}} -> tuple_fetch_element(elements, index, tag)
+      %{tuple: bdd_leaf(tag, elements)} -> tuple_fetch_element(elements, index, tag)
       %{tuple: bdd} -> tuple_bdd_fetch_static(bdd, index)
       %{} -> {false, none()}
     end
@@ -5758,10 +5764,10 @@ defmodule Module.Types.Descr do
             bdd_compute_hash: 4,
             bdd_leaf_value: 1,
             bdd_equal?: 2}
-  defp bdd_leaf_new(arg1, arg2), do: {arg1, arg2, :erlang.phash2({arg1, arg2})}
+  defp bdd_leaf_new(arg1, arg2), do: {:erlang.phash2({arg1, arg2}), arg1, arg2}
 
   defp bdd_node_new(lit, c, u, d),
-    do: {lit, c, u, d, bdd_compute_hash(lit, c, u, d)}
+    do: {bdd_compute_hash(lit, c, u, d), lit, c, u, d}
 
   defp bdd_compute_hash(lit, c, u, d),
     do: :erlang.phash2({bdd_hash(lit), bdd_hash(c), bdd_hash(u), bdd_hash(d)})
@@ -5773,15 +5779,15 @@ defmodule Module.Types.Descr do
 
   defp bdd_normalize(bdd), do: bdd
 
-  defp bdd_leaf_value({arg1, arg2, _hash}), do: {arg1, arg2}
+  defp bdd_leaf_value(bdd_leaf(arg1, arg2)), do: {arg1, arg2}
   defp bdd_leaf_value({arg1, arg2}), do: {arg1, arg2}
 
   defp bdd_hash(:bdd_bot), do: 0
   defp bdd_hash(:bdd_top), do: 1
   defp bdd_hash({arg1, arg2}), do: :erlang.phash2({arg1, arg2})
-  defp bdd_hash({_, _, hash}), do: hash
+  defp bdd_hash({hash, _, _}), do: hash
   defp bdd_hash({lit, c, u, d}), do: bdd_compute_hash(lit, c, u, d)
-  defp bdd_hash({_, _, _, _, hash}), do: hash
+  defp bdd_hash({hash, _, _, _, _}), do: hash
 
   defp bdd_equal?(bdd, bdd), do: true
   defp bdd_equal?(:bdd_bot, _), do: false
@@ -5789,13 +5795,13 @@ defmodule Module.Types.Descr do
   defp bdd_equal?(_, :bdd_bot), do: false
   defp bdd_equal?(_, :bdd_top), do: false
 
-  defp bdd_equal?({arg1, arg2}, {arg1, arg2, _}), do: true
-  defp bdd_equal?({arg1, arg2, _}, {arg1, arg2}), do: true
-  defp bdd_equal?({arg1, arg2, hash}, {arg1, arg2, hash}), do: true
+  defp bdd_equal?({arg1, arg2}, bdd_leaf(arg1, arg2)), do: true
+  defp bdd_equal?(bdd_leaf(arg1, arg2), {arg1, arg2}), do: true
+  defp bdd_equal?(bdd_leaf(arg1, arg2), bdd_leaf(arg1, arg2)), do: true
   defp bdd_equal?({_, _, _, _} = bdd1, bdd2), do: bdd_equal?(bdd_normalize(bdd1), bdd2)
   defp bdd_equal?(bdd1, {_, _, _, _} = bdd2), do: bdd_equal?(bdd1, bdd_normalize(bdd2))
 
-  defp bdd_equal?({lit1, c1, u1, d1, hash}, {lit2, c2, u2, d2, hash}) do
+  defp bdd_equal?({hash, lit1, c1, u1, d1}, {hash, lit2, c2, u2, d2}) do
     bdd_equal?(lit1, lit2) and bdd_equal?(c1, c2) and bdd_equal?(u1, u2) and
       bdd_equal?(d1, d2)
   end
@@ -5823,19 +5829,19 @@ defmodule Module.Types.Descr do
 
       _ ->
         case bdd_compare(bdd1, bdd2) do
-          {:lt, {lit1, c1, u1, d1, _}, bdd2} ->
+          {:lt, {_, lit1, c1, u1, d1}, bdd2} ->
             bdd_split(lit1, c1, bdd_union(u1, bdd2), d1)
 
-          {:gt, bdd1, {lit2, c2, u2, d2, _}} ->
+          {:gt, bdd1, {_, lit2, c2, u2, d2}} ->
             bdd_split(lit2, c2, bdd_union(bdd1, u2), d2)
 
-          {:eq, {lit, c1, u1, d1, _}, {_, c2, u2, d2, _}} ->
+          {:eq, {_, lit, c1, u1, d1}, {_, _, c2, u2, d2}} ->
             bdd_split(lit, bdd_union(c1, c2), bdd_union(u1, u2), bdd_union(d1, d2))
 
-          {:eq, {lit, _, u1, d1, _}, _} ->
+          {:eq, {_, lit, _, u1, d1}, _} ->
             bdd_union(d1, bdd_union(u1, lit))
 
-          {:eq, _, {lit, _, u2, d2, _}} ->
+          {:eq, _, {_, lit, _, u2, d2}} ->
             bdd_union(d2, bdd_union(u2, lit))
 
           {:eq, _, _} ->
@@ -5865,7 +5871,7 @@ defmodule Module.Types.Descr do
 
       _ ->
         case bdd_compare(bdd1, bdd2) do
-          {:lt, {lit1, c1, u1, d1, _}, bdd2} ->
+          {:lt, {_, lit1, c1, u1, d1}, bdd2} ->
             bdd_split(
               lit1,
               bdd_difference(c1, bdd2),
@@ -5873,7 +5879,7 @@ defmodule Module.Types.Descr do
               bdd_difference(d1, bdd2)
             )
 
-          {:gt, bdd1, {lit2, c2, u2, d2, _}} ->
+          {:gt, bdd1, {_, lit2, c2, u2, d2}} ->
             # The proper formula is:
             #
             #     b1 and not (c2 or u2) : bdd_bot : b1 and not (d2 or u2)
@@ -5888,7 +5894,7 @@ defmodule Module.Types.Descr do
               bdd_difference(bdd1_minus_u2, d2)
             )
 
-          {:eq, {lit, c1, u1, d1, _}, {_, c2, u2, d2, _}} ->
+          {:eq, {_, lit, c1, u1, d1}, {_, _, c2, u2, d2}} ->
             # The formula is:
             # {a1, (C1 or U1) and not (C2 or U2), :bdd_bot, (D1 or U1) and not (D2 or U2)} when a1 == a2
             #
@@ -5920,13 +5926,13 @@ defmodule Module.Types.Descr do
               bdd_split(lit, c, :bdd_bot, d)
             end
 
-          {:eq, _, {lit, c2, u2, _d2, _}} ->
+          {:eq, _, {_, lit, c2, u2, _d2}} ->
             bdd_split(lit, bdd_negation_union(c2, u2), :bdd_bot, :bdd_bot)
 
           # this is (lit and c1) or u1 or (not lit and d1) \ lit
           # which is (u1 \ lit) or (not lit and d1)
           # which is (u1 and not lit) or (d1 and not lit)
-          {:eq, {lit, _c1, u1, d1, _}, _} ->
+          {:eq, {_, lit, _c1, u1, d1}, _} ->
             bdd_union(bdd_difference(u1, lit), bdd_difference(d1, lit))
 
           {:eq, _, _} ->
@@ -5950,7 +5956,7 @@ defmodule Module.Types.Descr do
 
   ## Optimize differences
 
-  defp bdd_difference({_, _, _} = a1, {_, _, _} = a2, leaf_compare) do
+  defp bdd_difference(bdd_leaf(_, _) = a1, bdd_leaf(_, _) = a2, leaf_compare) do
     case leaf_compare.(a1, a2, :none) do
       :disjoint -> a1
       :subtype -> :bdd_bot
@@ -5961,7 +5967,7 @@ defmodule Module.Types.Descr do
 
   # We could use bdd_expand but there was a bug in earlier versions
   # of the Erlang compiler which would emit bad ,code, so we match one by one.
-  defp bdd_difference({_, _, _, _, _} = bdd1, {_, _, _} = a2, leaf_compare),
+  defp bdd_difference({_, _, _, _, _} = bdd1, bdd_leaf(_, _) = a2, leaf_compare),
     do:
       bdd_difference(
         bdd1,
@@ -5971,7 +5977,7 @@ defmodule Module.Types.Descr do
         leaf_compare
       )
 
-  defp bdd_difference({_, _, _} = a1, {_, _, _, _, _} = bdd2, leaf_compare),
+  defp bdd_difference(bdd_leaf(_, _) = a1, {_, _, _, _, _} = bdd2, leaf_compare),
     do:
       bdd_difference(
         bdd_node_new(a1, :bdd_top, :bdd_bot, :bdd_bot),
@@ -6016,8 +6022,8 @@ defmodule Module.Types.Descr do
   #     ((U1 and not a2) or (D1 and not D2)) and not U2 and not D2
   #
   defp bdd_difference(
-         {a1, :bdd_top, u1, :bdd_bot, _},
-         {a2, c2, u2, d2, _},
+         {_, a1, :bdd_top, u1, :bdd_bot},
+         {_, a2, c2, u2, d2},
          bdd1,
          bdd2,
          leaf_compare
@@ -6049,7 +6055,13 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp bdd_difference({a1, c1, u1, d1, _}, {a2, :bdd_top, u2, d2, _}, bdd1, bdd2, leaf_compare) do
+  defp bdd_difference(
+         {_, a1, c1, u1, d1},
+         {_, a2, :bdd_top, u2, d2},
+         bdd1,
+         bdd2,
+         leaf_compare
+       ) do
     type = if d1 == :bdd_bot, do: :none, else: :union
 
     case leaf_compare.(a1, a2, type) do
@@ -6105,7 +6117,7 @@ defmodule Module.Types.Descr do
 
         _ ->
           case bdd_compare(bdd1, bdd2) do
-            {:lt, {lit1, c1, u1, d1, _}, bdd2} ->
+            {:lt, {_, lit1, c1, u1, d1}, bdd2} ->
               bdd_split(
                 lit1,
                 bdd_intersection(c1, bdd2),
@@ -6113,7 +6125,7 @@ defmodule Module.Types.Descr do
                 bdd_intersection(d1, bdd2)
               )
 
-            {:gt, bdd1, {lit2, c2, u2, d2, _}} ->
+            {:gt, bdd1, {_, lit2, c2, u2, d2}} ->
               bdd_split(
                 lit2,
                 bdd_intersection(bdd1, c2),
@@ -6137,7 +6149,7 @@ defmodule Module.Types.Descr do
             # unions in place whenever possible. This change has reduced the algorithmic
             # complexity in the past, but perhaps it is rendered less useful now due to
             # the eager literal intersections.
-            {:eq, {lit, c1, u1, d1, _}, {_, c2, u2, d2, _}} ->
+            {:eq, {_, lit, c1, u1, d1}, {_, _, c2, u2, d2}} ->
               bdd_split(
                 lit,
                 bdd_intersection_eq(c1, c2, u1, u2),
@@ -6145,10 +6157,10 @@ defmodule Module.Types.Descr do
                 bdd_intersection_eq(d1, d2, u1, u2)
               )
 
-            {:eq, {lit, c1, u1, _, _}, _} ->
+            {:eq, {_, lit, c1, u1, _}, _} ->
               bdd_split(lit, bdd_union(c1, u1), :bdd_bot, :bdd_bot)
 
-            {:eq, _, {lit, c2, u2, _, _}} ->
+            {:eq, _, {_, lit, c2, u2, _}} ->
               bdd_split(lit, bdd_union(c2, u2), :bdd_bot, :bdd_bot)
 
             {:eq, bdd, _} ->
@@ -6180,17 +6192,17 @@ defmodule Module.Types.Descr do
   end
 
   # Intersections are great because they allow us to cut down
-  # the number of nodes in the tree. So whenever we have a leaf,
-  # we propagate it throughout the whole tree, cutting down nodes.
-  defp bdd_intersection({_, _, _} = leaf1, {_, _, _} = leaf2, leaf_intersection) do
+  # the number of nodes in the tree. So whenever we have a non-open
+  # leaf, we propagate it throughout the whole tree, cutting down nodes.
+  defp bdd_intersection(bdd_leaf(_, _) = leaf1, bdd_leaf(_, _) = leaf2, leaf_intersection) do
     leaf_intersection.(leaf1, leaf2)
   end
 
-  defp bdd_intersection(bdd, {tag, _, _} = leaf, leaf_intersection) when tag != :open do
+  defp bdd_intersection(bdd, bdd_leaf(tag, _) = leaf, leaf_intersection) when tag != :open do
     bdd_non_open_leaf_intersection(leaf, bdd, leaf_intersection)
   end
 
-  defp bdd_intersection({tag, _, _} = leaf, bdd, leaf_intersection) when tag != :open do
+  defp bdd_intersection(bdd_leaf(tag, _) = leaf, bdd, leaf_intersection) when tag != :open do
     bdd_non_open_leaf_intersection(leaf, bdd, leaf_intersection)
   end
 
@@ -6206,12 +6218,12 @@ defmodule Module.Types.Descr do
   #     (a1 and a2 and C1) or (a2 and U1) or (a2 and not a1 and D1)
   #
   # When C1 = :bdd_top, (a1 and a2) or (a2 and U2) or (a2 and not a1 and D2)
-  # When C2 = :bdd_bot, (a2 and U2) or (a2 and not a1 and D2)
-  defp bdd_non_open_leaf_intersection(leaf1, {_, _, _} = leaf2, leaf_intersection) do
+  # When C1 = :bdd_bot, (a2 and U2) or (a2 and not a1 and D2)
+  defp bdd_non_open_leaf_intersection(leaf1, bdd_leaf(_, _) = leaf2, leaf_intersection) do
     leaf_intersection.(leaf1, leaf2)
   end
 
-  defp bdd_non_open_leaf_intersection(leaf, {a, :bdd_top, u, d, _}, leaf_intersection) do
+  defp bdd_non_open_leaf_intersection(leaf, {_, a, :bdd_top, u, d}, leaf_intersection) do
     leaf_intersection.(a, leaf)
     |> bdd_union(bdd_non_open_leaf_intersection(leaf, u, leaf_intersection))
     |> case do
@@ -6226,7 +6238,7 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp bdd_non_open_leaf_intersection(leaf, {a, :bdd_bot, u, d, _}, leaf_intersection) do
+  defp bdd_non_open_leaf_intersection(leaf, {_, a, :bdd_bot, u, d}, leaf_intersection) do
     case bdd_non_open_leaf_intersection(leaf, u, leaf_intersection) do
       result when d == :bdd_bot ->
         result
@@ -6249,15 +6261,15 @@ defmodule Module.Types.Descr do
   def bdd_negation(:bdd_bot), do: :bdd_top
   def bdd_negation({_, _} = pair), do: pair |> bdd_normalize() |> bdd_negation()
   def bdd_negation({_, _, _, _} = node), do: node |> bdd_normalize() |> bdd_negation()
-  def bdd_negation({_, _, _} = pair), do: bdd_split(pair, :bdd_bot, :bdd_bot, :bdd_top)
+  def bdd_negation(bdd_leaf(_, _) = pair), do: bdd_split(pair, :bdd_bot, :bdd_bot, :bdd_top)
 
-  def bdd_negation({lit, c, u, d, _}) do
+  def bdd_negation({_, lit, c, u, d}) do
     inner =
       bdd_split(lit, bdd_negation(c), :bdd_bot, bdd_negation(d))
 
     case bdd_intersection(inner, bdd_negation(u)) do
       # Full simplification necessary for e.g. formatter.ex compilation
-      {_lit, c, u, c, _} -> bdd_union(u, c)
+      {_, _lit, c, u, c} -> bdd_union(u, c)
       x -> x
     end
   end
@@ -6294,9 +6306,9 @@ defmodule Module.Types.Descr do
   defp bdd_covers?(:bdd_top, _lit), do: true
   defp bdd_covers?(:bdd_bot, _lit), do: false
   defp bdd_covers?({_, _} = bdd, lit), do: bdd_covers?(bdd_normalize(bdd), lit)
-  defp bdd_covers?({_, _, _} = leaf, lit), do: bdd_equal?(leaf, lit)
+  defp bdd_covers?(bdd_leaf(_, _) = leaf, lit), do: bdd_equal?(leaf, lit)
 
-  defp bdd_covers?({node_lit, c, u, d, _}, lit) do
+  defp bdd_covers?({_, node_lit, c, u, d}, lit) do
     node_lit = bdd_leaf_value(node_lit)
     lit = bdd_leaf_value(lit)
 
@@ -6322,7 +6334,7 @@ defmodule Module.Types.Descr do
     bdd_simplify(bdd_normalize(leaf), assumptions)
   end
 
-  defp bdd_simplify({_, _, _} = leaf, assumptions) do
+  defp bdd_simplify(bdd_leaf(_, _) = leaf, assumptions) do
     if bdd_has_same?(leaf, assumptions) do
       :bdd_bot
     else
@@ -6330,7 +6342,7 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp bdd_simplify({lit, c, u, d, _} = bdd, assumptions) do
+  defp bdd_simplify({_, lit, c, u, d} = bdd, assumptions) do
     if :bdd_top in assumptions or bdd_has_same?(bdd, assumptions) do
       :bdd_bot
     else
@@ -6362,7 +6374,9 @@ defmodule Module.Types.Descr do
     bdd_simplify(bdd, lit, c, u, d, pos, union, neg, [bdd_normalize(assumption) | assumptions])
   end
 
-  defp bdd_simplify(bdd, lit, c, u, d, pos, union, neg, [{_, _, _} = assumption | assumptions]) do
+  defp bdd_simplify(bdd, lit, c, u, d, pos, union, neg, [
+         bdd_leaf(_, _) = assumption | assumptions
+       ]) do
     bdd_simplify(
       bdd,
       lit,
@@ -6386,7 +6400,7 @@ defmodule Module.Types.Descr do
          union,
          neg,
          [
-           {assumption_lit, assumption_pos, assumption_union, assumption_neg, _} = assumption
+           {_, assumption_lit, assumption_pos, assumption_union, assumption_neg} = assumption
            | assumptions
          ]
        ) do
@@ -6436,7 +6450,7 @@ defmodule Module.Types.Descr do
     [{[bdd_leaf_value(lit) | pos], neg} | acc]
   end
 
-  defp bdd_to_dnf(acc, pos, neg, {_, _, _} = lit) do
+  defp bdd_to_dnf(acc, pos, neg, bdd_leaf(_, _) = lit) do
     [{[bdd_leaf_value(lit) | pos], neg} | acc]
   end
 
@@ -6447,7 +6461,7 @@ defmodule Module.Types.Descr do
   end
 
   # Lazy node: {lit, C, U, D}  ≡  (lit ∧ C) ∪ U ∪ (¬lit ∧ D)
-  defp bdd_to_dnf(acc, pos, neg, {lit, c, u, d, _}) do
+  defp bdd_to_dnf(acc, pos, neg, {_, lit, c, u, d}) do
     # U is a bdd in itself, we accumulate its lines first
     bdd_to_dnf(acc, pos, neg, u)
     # C-part
@@ -6472,11 +6486,11 @@ defmodule Module.Types.Descr do
       :bdd_top ->
         :bdd_top
 
-      {_, _, _} ->
+      bdd_leaf(_, _) ->
         {arg1, arg2} = fun.(bdd_leaf_value(bdd))
         bdd_leaf_new(arg1, arg2)
 
-      {literal, left, union, right, _} ->
+      {_, literal, left, union, right} ->
         {arg1, arg2} = fun.(bdd_leaf_value(literal))
         literal = bdd_leaf_new(arg1, arg2)
         bdd_node_new(literal, bdd_map(left, fun), bdd_map(union, fun), bdd_map(right, fun))
@@ -6491,10 +6505,10 @@ defmodule Module.Types.Descr do
       :bdd_top ->
         acc
 
-      {_, _, _} ->
+      bdd_leaf(_, _) ->
         fun.(bdd_leaf_value(bdd), acc)
 
-      {literal, left, union, right, _} ->
+      {_, literal, left, union, right} ->
         acc = fun.(bdd_leaf_value(literal), acc)
         acc = bdd_reduce(left, acc, fun)
         acc = bdd_reduce(union, acc, fun)
@@ -6506,11 +6520,11 @@ defmodule Module.Types.Descr do
   @compile {:inline, bdd_expand: 1, bdd_head: 1}
   defp bdd_expand({_, _} = pair), do: pair |> bdd_normalize() |> bdd_expand()
   defp bdd_expand({_, _, _, _} = node), do: bdd_normalize(node)
-  defp bdd_expand({_, _, _} = pair), do: bdd_node_new(pair, :bdd_top, :bdd_bot, :bdd_bot)
+  defp bdd_expand(bdd_leaf(_, _) = pair), do: bdd_node_new(pair, :bdd_top, :bdd_bot, :bdd_bot)
   defp bdd_expand(bdd), do: bdd
 
   defp bdd_head({lit, _, _, _}), do: bdd_leaf_value(lit)
-  defp bdd_head({lit, _, _, _, _}), do: bdd_leaf_value(lit)
+  defp bdd_head({_, lit, _, _, _}), do: bdd_leaf_value(lit)
   defp bdd_head(pair), do: bdd_leaf_value(pair)
 
   ## Map helpers

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -35,8 +35,6 @@ defmodule Module.Types.Descr do
   @bit_bitstring @bit_binary ||| @bit_bitstring_no_binary
   @bit_number @bit_integer ||| @bit_float
 
-  defmacro bdd_leaf(arg1, arg2), do: {arg1, arg2}
-
   # Map fields and domains are stored as orddicts (sorted key-value lists).
   @fields_new []
   defguardp is_fields_empty(fields) when fields == []
@@ -50,10 +48,10 @@ defmodule Module.Types.Descr do
   # Remark: those are explicit BDD constructors. The functional constructors are `bdd_new/1` and `bdd_new/3`.
   @fun_top {:negation, %{}}
   @atom_top {:negation, :sets.new(version: 2)}
-  @map_top {:open, @fields_new}
-  @non_empty_list_top {:term, :term}
-  @tuple_top {:open, []}
-  @map_empty {:closed, @fields_new}
+  @map_top {:open, @fields_new, :erlang.phash2({:open, @fields_new})}
+  @non_empty_list_top {:term, :term, :erlang.phash2({:term, :term})}
+  @tuple_top {:open, [], :erlang.phash2({:open, []})}
+  @map_empty {:closed, @fields_new, :erlang.phash2({:closed, @fields_new})}
 
   # The top BDD for each arity.
   @fun_bdd_top :bdd_top
@@ -437,10 +435,10 @@ defmodule Module.Types.Descr do
   defp union(:atom, v1, v2), do: atom_union(v1, v2)
   defp union(:bitmap, v1, v2), do: v1 ||| v2
   defp union(:dynamic, v1, v2), do: dynamic_union(v1, v2)
-  defp union(:list, v1, v2), do: list_union(v1, v2)
+  defp union(:list, v1, v2), do: bdd_union(v1, v2)
   defp union(:map, v1, v2), do: map_union(v1, v2)
   defp union(:optional, 1, 1), do: 1
-  defp union(:tuple, v1, v2), do: tuple_union(v1, v2)
+  defp union(:tuple, v1, v2), do: bdd_union(v1, v2)
   defp union(:fun, v1, v2), do: fun_union(v1, v2)
 
   @doc """
@@ -477,10 +475,10 @@ defmodule Module.Types.Descr do
   # Returning 0 from the callback is taken as none() for that subtype.
   defp intersection(:atom, v1, v2), do: atom_intersection(v1, v2)
   defp intersection(:bitmap, v1, v2), do: v1 &&& v2
-  defp intersection(:list, v1, v2), do: list_intersection(v1, v2)
-  defp intersection(:map, v1, v2), do: map_intersection(v1, v2)
+  defp intersection(:list, v1, v2), do: bdd_intersection(v1, v2)
+  defp intersection(:map, v1, v2), do: bdd_intersection(v1, v2)
   defp intersection(:optional, 1, 1), do: 1
-  defp intersection(:tuple, v1, v2), do: tuple_intersection(v1, v2)
+  defp intersection(:tuple, v1, v2), do: bdd_intersection(v1, v2)
   defp intersection(:fun, v1, v2), do: fun_intersection(v1, v2)
 
   defp intersection(:dynamic, v1, v2) do
@@ -566,10 +564,10 @@ defmodule Module.Types.Descr do
   # Returning 0 from the callback is taken as none() for that subtype.
   defp difference(:atom, v1, v2), do: atom_difference(v1, v2)
   defp difference(:bitmap, v1, v2), do: v1 - (v1 &&& v2)
-  defp difference(:list, v1, v2), do: list_difference(v1, v2)
-  defp difference(:map, v1, v2), do: map_difference(v1, v2)
+  defp difference(:list, v1, v2), do: bdd_difference(v1, v2)
+  defp difference(:map, v1, v2), do: bdd_difference(v1, v2)
   defp difference(:optional, 1, 1), do: 0
-  defp difference(:tuple, v1, v2), do: tuple_difference(v1, v2)
+  defp difference(:tuple, v1, v2), do: bdd_difference(v1, v2)
   defp difference(:fun, v1, v2), do: fun_difference(v1, v2)
 
   @doc """
@@ -836,13 +834,13 @@ defmodule Module.Types.Descr do
   # A bdd leaf can be trivially printed in negated format
   # but we don't count it towards the amount of negatives.
   defp print_as_negated_bdd(top, top), do: 1
-  defp print_as_negated_bdd(bdd_leaf(_, _), _top), do: 0
+  defp print_as_negated_bdd({_, _, _}, _top), do: 0
   defp print_as_negated_bdd(bdd, top), do: if(negated_bdd?(bdd, top), do: 1, else: -100)
 
-  defp negated_bdd?({top, bdd, :bdd_bot, :bdd_bot}, top),
+  defp negated_bdd?({top, bdd, :bdd_bot, :bdd_bot, _}, top),
     do: negated_bdd?(bdd, top)
 
-  defp negated_bdd?({_, :bdd_bot, :bdd_bot, bdd}, top),
+  defp negated_bdd?({_, :bdd_bot, :bdd_bot, bdd, _}, top),
     do: bdd in [:bdd_top, top] or negated_bdd?(bdd, top)
 
   defp negated_bdd?(_, _), do: false
@@ -1320,7 +1318,7 @@ defmodule Module.Types.Descr do
   # Note: Function domains are expressed as tuple types. We use separate representations
   # rather than unary functions with tuple domains to handle special cases like representing
   # functions of a specific arity (e.g., (none,none->term) for arity 2).
-  defp fun_new(arity, inputs, output), do: {:union, %{arity => bdd_leaf(inputs, output)}}
+  defp fun_new(arity, inputs, output), do: {:union, %{arity => bdd_leaf_new(inputs, output)}}
 
   # Creates a function type from a list of inputs and an output
   # where the inputs and/or output may be dynamic.
@@ -2172,12 +2170,16 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp list_new(list_type, last_type), do: bdd_leaf(list_type, last_type)
+  defp list_new(list_type, last_type), do: bdd_leaf_new(list_type, last_type)
 
   defp non_empty_list_literals_intersection(list_literals) do
     try do
-      Enum.reduce(list_literals, {:term, :term}, fn {next_list, next_last}, {list, last} ->
-        {non_empty_intersection!(list, next_list), non_empty_intersection!(last, next_last)}
+      Enum.reduce(list_literals, {:term, :term}, fn
+        {next_list, next_last, _}, {list, last} ->
+          {non_empty_intersection!(list, next_list), non_empty_intersection!(last, next_last)}
+
+        {next_list, next_last}, {list, last} ->
+          {non_empty_intersection!(list, next_list), non_empty_intersection!(last, next_last)}
       end)
     catch
       :empty -> :empty
@@ -2231,7 +2233,7 @@ defmodule Module.Types.Descr do
   @compile {:inline, list_union: 2}
   defp list_union(bdd1, bdd2), do: bdd_union(bdd1, bdd2)
 
-  defp list_top?(bdd_leaf(:term, :term)), do: true
+  defp list_top?({:term, :term, _}), do: true
   defp list_top?(_), do: false
 
   @doc """
@@ -2350,20 +2352,20 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp list_leaf_intersection(bdd_leaf(list1, last1), bdd_leaf(list2, last2)) do
+  defp list_leaf_intersection({list1, last1, _}, {list2, last2, _}) do
     try do
       list = non_empty_intersection!(list1, list2)
       last = non_empty_intersection!(last1, last2)
-      bdd_leaf(list, last)
+      bdd_leaf_new(list, last)
     catch
       :empty -> :bdd_bot
     end
   end
 
-  defp list_difference(bdd_leaf(:term, :term), bdd_leaf(:term, :term)),
+  defp list_difference({:term, :term, _}, {:term, :term, _}),
     do: :bdd_bot
 
-  defp list_difference(bdd_leaf(:term, :term), bdd2),
+  defp list_difference({:term, :term, _}, bdd2),
     do: bdd_negation(bdd2)
 
   # Computes the difference between two BDD (Binary Decision Diagram) list types.
@@ -2375,11 +2377,11 @@ defmodule Module.Types.Descr do
   #    b) If only the last type differs, subtracts it
   # 3. Base case: adds bdd2 type to negations of bdd1 type
   # The result may be larger than the initial bdd1, which is maintained in the accumulator.
-  defp list_difference(bdd_leaf(list1, last1) = bdd1, bdd_leaf(list2, last2) = bdd2) do
+  defp list_difference({list1, last1, _} = bdd1, {list2, last2, _} = bdd2) do
     if subtype?(list1, list2) do
       if subtype?(last1, last2),
         do: :bdd_bot,
-        else: bdd_leaf(list1, difference(last1, last2))
+        else: bdd_leaf_new(list1, difference(last1, last2))
     else
       bdd_difference(bdd1, bdd2, &list_leaf_difference/3)
     end
@@ -2388,7 +2390,7 @@ defmodule Module.Types.Descr do
   defp list_difference(bdd1, bdd2),
     do: bdd_difference(bdd1, bdd2, &list_leaf_difference/3)
 
-  defp list_leaf_difference(bdd_leaf(list1, last1), bdd_leaf(list2, last2), _) do
+  defp list_leaf_difference({list1, last1, _}, {list2, last2, _}, _) do
     if disjoint?(list1, list2) or disjoint?(last1, last2) do
       :disjoint
     else
@@ -2859,7 +2861,7 @@ defmodule Module.Types.Descr do
   defguardp is_optional_static(map)
             when is_map(map) and is_map_key(map, :optional)
 
-  defp map_new(tag, fields), do: bdd_leaf(tag, fields)
+  defp map_new(tag, fields), do: bdd_leaf_new(tag, fields)
 
   defp map_only?(descr), do: empty?(Map.delete(descr, :map))
 
@@ -2870,16 +2872,16 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp map_union(bdd_leaf(:open, fields) = leaf, _) when is_fields_empty(fields),
+  defp map_union({:open, fields, _} = leaf, _) when is_fields_empty(fields),
     do: leaf
 
-  defp map_union(_, bdd_leaf(:open, fields) = leaf) when is_fields_empty(fields),
+  defp map_union(_, {:open, fields, _} = leaf) when is_fields_empty(fields),
     do: leaf
 
-  defp map_union(bdd_leaf(tag1, fields1), bdd_leaf(tag2, fields2)) do
+  defp map_union({tag1, fields1, _}, {tag2, fields2, _}) do
     case maybe_optimize_map_union(tag1, fields1, tag2, fields2) do
-      {tag, fields} -> bdd_leaf(tag, fields)
-      nil -> bdd_union(bdd_leaf(tag1, fields1), bdd_leaf(tag2, fields2))
+      {tag, fields} -> bdd_leaf_new(tag, fields)
+      nil -> bdd_union(bdd_leaf_new(tag1, fields1), bdd_leaf_new(tag2, fields2))
     end
   end
 
@@ -3033,23 +3035,23 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp map_intersection(bdd_leaf(:open, []), bdd), do: bdd
-  defp map_intersection(bdd, bdd_leaf(:open, [])), do: bdd
+  defp map_intersection({:open, [], _}, bdd), do: bdd
+  defp map_intersection(bdd, {:open, [], _}), do: bdd
   defp map_intersection(bdd1, bdd2), do: bdd_intersection(bdd1, bdd2, &map_leaf_intersection/2)
 
-  defp map_leaf_intersection(bdd_leaf(tag1, fields1), bdd_leaf(tag2, fields2)) do
+  defp map_leaf_intersection({tag1, fields1, _}, {tag2, fields2, _}) do
     try do
       {tag, fields} = map_literal_intersection(tag1, fields1, tag2, fields2)
-      bdd_leaf(tag, fields)
+      bdd_leaf_new(tag, fields)
     catch
       :empty -> :bdd_bot
     end
   end
 
-  defp map_difference(_, bdd_leaf(:open, [])),
+  defp map_difference(_, {:open, [], _}),
     do: :bdd_bot
 
-  defp map_difference(bdd_leaf(:open, []), {_, _, _, _} = bdd2),
+  defp map_difference({:open, [], _}, {_, _, _, _, _} = bdd2),
     do: bdd_negation(bdd2)
 
   defp map_difference(bdd1, bdd2),
@@ -3062,7 +3064,7 @@ defmodule Module.Types.Descr do
   #
   # Outside of this particular scenario, the `a_int` optimization has been useful,
   # but we haven't measured benefits for `a_union`.
-  defp map_leaf_difference(bdd_leaf(tag, fields), bdd_leaf(:open, [{key, v2}]), type) do
+  defp map_leaf_difference({tag, fields, _}, {:open, [{key, v2}], _}, type) do
     {found?, v1} =
       case fields_find(key, fields) do
         {:ok, value} -> {true, value}
@@ -3083,7 +3085,7 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp map_leaf_difference(bdd_leaf(tag, fields), bdd_leaf(neg_tag, neg_fields), type) do
+  defp map_leaf_difference({tag, fields, _}, {neg_tag, neg_fields, _}, type) do
     case map_difference_strategy(fields, neg_fields, tag, neg_tag) do
       :disjoint ->
         :disjoint
@@ -3105,7 +3107,7 @@ defmodule Module.Types.Descr do
     if empty?(v_diff) do
       :subtype
     else
-      a_diff = bdd_leaf(tag, fields_store(key, v_diff, fields))
+      a_diff = bdd_leaf_new(tag, fields_store(key, v_diff, fields))
 
       a_type =
         case type do
@@ -3113,14 +3115,14 @@ defmodule Module.Types.Descr do
             :bdd_bot
 
           :union ->
-            bdd_leaf(tag, fields_store(key, union(v1, v2), fields))
+            bdd_leaf_new(tag, fields_store(key, union(v1, v2), fields))
 
           :intersection ->
             v_int = intersection(v1, v2)
 
             if empty?(v_int),
               do: :bdd_bot,
-              else: bdd_leaf(tag, fields_store(key, v_int, fields))
+              else: bdd_leaf_new(tag, fields_store(key, v_int, fields))
         end
 
       {:one_key_difference, a_diff, a_type}
@@ -3345,7 +3347,7 @@ defmodule Module.Types.Descr do
   end
 
   # Optimization for bdd leafs
-  defp map_fetch_key_static(%{map: bdd_leaf(tag, fields)}, key) do
+  defp map_fetch_key_static(%{map: {tag, fields, _}}, key) do
     case fields_find(key, fields) do
       {:ok, value} -> pop_optional_static(value)
       :error when tag == :open -> {true, term()}
@@ -4910,18 +4912,18 @@ defmodule Module.Types.Descr do
     {acc, dynamic?}
   end
 
-  defp tuple_new(tag, elements), do: bdd_leaf(tag, elements)
+  defp tuple_new(tag, elements), do: bdd_leaf_new(tag, elements)
 
-  defp tuple_intersection(bdd_leaf(:open, []), bdd), do: bdd
-  defp tuple_intersection(bdd, bdd_leaf(:open, [])), do: bdd
+  defp tuple_intersection({:open, [], _}, bdd), do: bdd
+  defp tuple_intersection(bdd, {:open, [], _}), do: bdd
 
   defp tuple_intersection(bdd1, bdd2) do
     bdd_intersection(bdd1, bdd2, &tuple_leaf_intersection/2)
   end
 
-  defp tuple_leaf_intersection(bdd_leaf(tag1, elements1), bdd_leaf(tag2, elements2)) do
+  defp tuple_leaf_intersection({tag1, elements1, _}, {tag2, elements2, _}) do
     case tuple_literal_intersection(tag1, elements1, tag2, elements2) do
-      {tag, elements} -> bdd_leaf(tag, elements)
+      {tag, elements} -> bdd_leaf_new(tag, elements)
       :empty -> :bdd_bot
     end
   end
@@ -4970,16 +4972,16 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp tuple_difference(_, bdd_leaf(:open, [])),
+  defp tuple_difference(_, {:open, [], _}),
     do: :bdd_bot
 
-  defp tuple_difference(bdd_leaf(:open, []), {_, _, _, _} = bdd2),
+  defp tuple_difference({:open, [], _}, {_, _, _, _, _} = bdd2),
     do: bdd_negation(bdd2)
 
   defp tuple_difference(bdd1, bdd2),
     do: bdd_difference(bdd1, bdd2, &tuple_leaf_difference/3)
 
-  defp tuple_leaf_difference(bdd_leaf(tag1, elements1), bdd_leaf(tag2, elements2), _) do
+  defp tuple_leaf_difference({tag1, elements1, _}, {tag2, elements2, _}, _) do
     case tuple_sizes_strategy(tag1, length(elements1), tag2, length(elements2)) do
       :disjoint -> :disjoint
       other -> tuple_leaf_difference(elements1, elements2, other == :left_subtype_of_right)
@@ -5000,11 +5002,18 @@ defmodule Module.Types.Descr do
 
   defp non_empty_tuple_literals_intersection(tuples) do
     try do
-      Enum.reduce(tuples, {:open, []}, fn {next_tag, next_elements}, {tag, elements} ->
-        case tuple_literal_intersection(tag, elements, next_tag, next_elements) do
-          :empty -> throw(:empty)
-          next -> next
-        end
+      Enum.reduce(tuples, {:open, []}, fn
+        {next_tag, next_elements, _}, {tag, elements} ->
+          case tuple_literal_intersection(tag, elements, next_tag, next_elements) do
+            :empty -> throw(:empty)
+            next -> next
+          end
+
+        {next_tag, next_elements}, {tag, elements} ->
+          case tuple_literal_intersection(tag, elements, next_tag, next_elements) do
+            :empty -> throw(:empty)
+            next -> next
+          end
       end)
     catch
       :empty -> :empty
@@ -5172,18 +5181,18 @@ defmodule Module.Types.Descr do
     end)
   end
 
-  defp tuple_union(bdd_leaf(:open, fields) = leaf, _) when is_fields_empty(fields),
+  defp tuple_union({:open, fields, _} = leaf, _) when is_fields_empty(fields),
     do: leaf
 
-  defp tuple_union(_, bdd_leaf(:open, fields) = leaf) when is_fields_empty(fields),
+  defp tuple_union(_, {:open, fields, _} = leaf) when is_fields_empty(fields),
     do: leaf
 
   defp tuple_union(
-         bdd_leaf(tag1, elements1) = tuple1,
-         bdd_leaf(tag2, elements2) = tuple2
+         {tag1, elements1, _} = tuple1,
+         {tag2, elements2, _} = tuple2
        ) do
     case maybe_optimize_tuple_union({tag1, elements1}, {tag2, elements2}) do
-      {tag, elements} -> bdd_leaf(tag, elements)
+      {tag, elements} -> bdd_leaf_new(tag, elements)
       nil -> bdd_union(tuple1, tuple2)
     end
   end
@@ -5458,7 +5467,7 @@ defmodule Module.Types.Descr do
   defp tuple_fetch_static(descr, index) when is_integer(index) do
     case descr do
       :term -> {true, term()}
-      %{tuple: bdd_leaf(tag, elements)} -> tuple_fetch_element(elements, index, tag)
+      %{tuple: {tag, elements, _}} -> tuple_fetch_element(elements, index, tag)
       %{tuple: bdd} -> tuple_bdd_fetch_static(bdd, index)
       %{} -> {false, none()}
     end
@@ -5741,7 +5750,64 @@ defmodule Module.Types.Descr do
 
   ## BDD helpers
 
+  @compile {:inline,
+            bdd_leaf_new: 2,
+            bdd_node_new: 4,
+            bdd_normalize: 1,
+            bdd_hash: 1,
+            bdd_compute_hash: 4,
+            bdd_leaf_value: 1,
+            bdd_equal?: 2}
+  defp bdd_leaf_new(arg1, arg2), do: {arg1, arg2, :erlang.phash2({arg1, arg2})}
+
+  defp bdd_node_new(lit, c, u, d),
+    do: {lit, c, u, d, bdd_compute_hash(lit, c, u, d)}
+
+  defp bdd_compute_hash(lit, c, u, d),
+    do: :erlang.phash2({bdd_hash(lit), bdd_hash(c), bdd_hash(u), bdd_hash(d)})
+
+  defp bdd_normalize({arg1, arg2}), do: bdd_leaf_new(arg1, arg2)
+
+  defp bdd_normalize({lit, c, u, d}),
+    do: bdd_node_new(bdd_normalize(lit), bdd_normalize(c), bdd_normalize(u), bdd_normalize(d))
+
+  defp bdd_normalize(bdd), do: bdd
+
+  defp bdd_leaf_value({arg1, arg2, _hash}), do: {arg1, arg2}
+  defp bdd_leaf_value({arg1, arg2}), do: {arg1, arg2}
+
+  defp bdd_hash(:bdd_bot), do: 0
+  defp bdd_hash(:bdd_top), do: 1
+  defp bdd_hash({arg1, arg2}), do: :erlang.phash2({arg1, arg2})
+  defp bdd_hash({_, _, hash}), do: hash
+  defp bdd_hash({lit, c, u, d}), do: bdd_compute_hash(lit, c, u, d)
+  defp bdd_hash({_, _, _, _, hash}), do: hash
+
+  defp bdd_equal?(bdd, bdd), do: true
+  defp bdd_equal?(:bdd_bot, _), do: false
+  defp bdd_equal?(:bdd_top, _), do: false
+  defp bdd_equal?(_, :bdd_bot), do: false
+  defp bdd_equal?(_, :bdd_top), do: false
+
+  defp bdd_equal?({arg1, arg2}, {arg1, arg2, _}), do: true
+  defp bdd_equal?({arg1, arg2, _}, {arg1, arg2}), do: true
+  defp bdd_equal?({arg1, arg2, hash}, {arg1, arg2, hash}), do: true
+  defp bdd_equal?({_, _, _, _} = bdd1, bdd2), do: bdd_equal?(bdd_normalize(bdd1), bdd2)
+  defp bdd_equal?(bdd1, {_, _, _, _} = bdd2), do: bdd_equal?(bdd1, bdd_normalize(bdd2))
+
+  defp bdd_equal?({lit1, c1, u1, d1, hash}, {lit2, c2, u2, d2, hash}) do
+    bdd_equal?(lit1, lit2) and bdd_equal?(c1, c2) and bdd_equal?(u1, u2) and
+      bdd_equal?(d1, d2)
+  end
+
+  defp bdd_equal?(_, _), do: false
+
+  def bdd_union(bdd, bdd), do: bdd
+
   def bdd_union(bdd1, bdd2) do
+    bdd1 = bdd_normalize(bdd1)
+    bdd2 = bdd_normalize(bdd2)
+
     case {bdd1, bdd2} do
       {:bdd_top, _bdd} ->
         :bdd_top
@@ -5757,32 +5823,33 @@ defmodule Module.Types.Descr do
 
       _ ->
         case bdd_compare(bdd1, bdd2) do
-          {:lt, {lit1, c1, u1, d1}, bdd2} ->
-            {lit1, c1, bdd_union(u1, bdd2), d1}
+          {:lt, {lit1, c1, u1, d1, _}, bdd2} ->
+            bdd_split(lit1, c1, bdd_union(u1, bdd2), d1)
 
-          {:gt, bdd1, {lit2, c2, u2, d2}} ->
-            {lit2, c2, bdd_union(bdd1, u2), d2}
+          {:gt, bdd1, {lit2, c2, u2, d2, _}} ->
+            bdd_split(lit2, c2, bdd_union(bdd1, u2), d2)
 
-          {:eq, {lit, c1, u1, d1}, {_, c2, u2, d2}} ->
-            {lit, bdd_union(c1, c2), bdd_union(u1, u2), bdd_union(d1, d2)}
+          {:eq, {lit, c1, u1, d1, _}, {_, c2, u2, d2, _}} ->
+            bdd_split(lit, bdd_union(c1, c2), bdd_union(u1, u2), bdd_union(d1, d2))
 
-          {:eq, {lit, _, u1, d1}, _} ->
-            {lit, :bdd_top, u1, d1}
+          {:eq, {lit, _, u1, d1, _}, _} ->
+            bdd_split(lit, :bdd_bot, bdd_union(u1, lit), d1)
 
-          {:eq, _, {lit, _, u2, d2}} ->
-            {lit, :bdd_top, u2, d2}
+          {:eq, _, {lit, _, u2, d2, _}} ->
+            bdd_split(lit, :bdd_bot, bdd_union(u2, lit), d2)
 
           {:eq, _, _} ->
             bdd1
         end
-        |> case do
-          {_, :bdd_top, _, :bdd_top} -> :bdd_top
-          other -> other
-        end
     end
   end
 
+  def bdd_difference(bdd, bdd), do: :bdd_bot
+
   def bdd_difference(bdd1, bdd2) do
+    bdd1 = bdd_normalize(bdd1)
+    bdd2 = bdd_normalize(bdd2)
+
     case {bdd1, bdd2} do
       {_bdd, :bdd_top} ->
         :bdd_bot
@@ -5798,19 +5865,30 @@ defmodule Module.Types.Descr do
 
       _ ->
         case bdd_compare(bdd1, bdd2) do
-          {:lt, {lit1, c1, u1, d1}, bdd2} ->
-            {lit1, bdd_difference(c1, bdd2), bdd_difference(u1, bdd2), bdd_difference(d1, bdd2)}
+          {:lt, {lit1, c1, u1, d1, _}, bdd2} ->
+            bdd_split(
+              lit1,
+              bdd_difference(c1, bdd2),
+              bdd_difference(u1, bdd2),
+              bdd_difference(d1, bdd2)
+            )
 
-          {:gt, bdd1, {lit2, c2, u2, d2}} ->
+          {:gt, bdd1, {lit2, c2, u2, d2, _}} ->
             # The proper formula is:
             #
             #     b1 and not (c2 or u2) : bdd_bot : b1 and not (d2 or u2)
             #
             # Both extremes have (b1 and not u2), so we compute it once.
             bdd1_minus_u2 = bdd_difference(bdd1, u2)
-            {lit2, bdd_difference(bdd1_minus_u2, c2), :bdd_bot, bdd_difference(bdd1_minus_u2, d2)}
 
-          {:eq, {lit, c1, u1, d1}, {_, c2, u2, d2}} ->
+            bdd_split(
+              lit2,
+              bdd_difference(bdd1_minus_u2, c2),
+              :bdd_bot,
+              bdd_difference(bdd1_minus_u2, d2)
+            )
+
+          {:eq, {lit, c1, u1, d1, _}, {_, c2, u2, d2, _}} ->
             # The formula is:
             # {a1, (C1 or U1) and not (C2 or U2), :bdd_bot, (D1 or U1) and not (D2 or U2)} when a1 == a2
             #
@@ -5822,7 +5900,12 @@ defmodule Module.Types.Descr do
               # Constrained = (C1 and not C2 and not U2)
               # Dual = (D1 and not D2 and not U2)
               # Hence:
-              {lit, bdd_difference_union(c1, c2, u2), :bdd_bot, bdd_difference_union(d1, d2, u2)}
+              bdd_split(
+                lit,
+                bdd_difference_union(c1, c2, u2),
+                :bdd_bot,
+                bdd_difference_union(d1, d2, u2)
+              )
             else
               c =
                 if c2 == :bdd_top,
@@ -5834,21 +5917,17 @@ defmodule Module.Types.Descr do
                   do: :bdd_bot,
                   else: bdd_difference(bdd_union(d1, u1), bdd_union(d2, u2))
 
-              {lit, c, :bdd_bot, d}
+              bdd_split(lit, c, :bdd_bot, d)
             end
 
-          {:eq, _, {lit, c2, u2, _d2}} ->
-            {lit, bdd_negation_union(c2, u2), :bdd_bot, :bdd_bot}
+          {:eq, _, {lit, c2, u2, _d2, _}} ->
+            bdd_split(lit, bdd_negation_union(c2, u2), :bdd_bot, :bdd_bot)
 
-          {:eq, {lit, _c1, u1, d1}, _} ->
-            {lit, :bdd_bot, :bdd_bot, bdd_union(d1, u1)}
+          {:eq, {lit, _c1, u1, d1, _}, _} ->
+            bdd_split(lit, :bdd_bot, :bdd_bot, bdd_union(d1, u1))
 
           {:eq, _, _} ->
             :bdd_bot
-        end
-        |> case do
-          {_, :bdd_bot, u, :bdd_bot} -> u
-          other -> other
         end
     end
   end
@@ -5868,7 +5947,7 @@ defmodule Module.Types.Descr do
 
   ## Optimize differences
 
-  defp bdd_difference(bdd_leaf(_, _) = a1, bdd_leaf(_, _) = a2, leaf_compare) do
+  defp bdd_difference({_, _, _} = a1, {_, _, _} = a2, leaf_compare) do
     case leaf_compare.(a1, a2, :none) do
       :disjoint -> a1
       :subtype -> :bdd_bot
@@ -5879,13 +5958,27 @@ defmodule Module.Types.Descr do
 
   # We could use bdd_expand but there was a bug in earlier versions
   # of the Erlang compiler which would emit bad ,code, so we match one by one.
-  defp bdd_difference({_, _, _, _} = bdd1, bdd_leaf(_, _) = a2, leaf_compare),
-    do: bdd_difference(bdd1, {a2, :bdd_top, :bdd_bot, :bdd_bot}, bdd1, a2, leaf_compare)
+  defp bdd_difference({_, _, _, _, _} = bdd1, {_, _, _} = a2, leaf_compare),
+    do:
+      bdd_difference(
+        bdd1,
+        bdd_node_new(a2, :bdd_top, :bdd_bot, :bdd_bot),
+        bdd1,
+        a2,
+        leaf_compare
+      )
 
-  defp bdd_difference(bdd_leaf(_, _) = a1, {_, _, _, _} = bdd2, leaf_compare),
-    do: bdd_difference({a1, :bdd_top, :bdd_bot, :bdd_bot}, bdd2, a1, bdd2, leaf_compare)
+  defp bdd_difference({_, _, _} = a1, {_, _, _, _, _} = bdd2, leaf_compare),
+    do:
+      bdd_difference(
+        bdd_node_new(a1, :bdd_top, :bdd_bot, :bdd_bot),
+        bdd2,
+        a1,
+        bdd2,
+        leaf_compare
+      )
 
-  defp bdd_difference({_, _, _, _} = bdd1, {_, _, _, _} = bdd2, leaf_compare),
+  defp bdd_difference({_, _, _, _, _} = bdd1, {_, _, _, _, _} = bdd2, leaf_compare),
     do: bdd_difference(bdd1, bdd2, bdd1, bdd2, leaf_compare)
 
   defp bdd_difference(bdd1, bdd2, _leaf_compare),
@@ -5919,7 +6012,13 @@ defmodule Module.Types.Descr do
   #
   #     ((U1 and not a2) or (D1 and not D2)) and not U2 and not D2
   #
-  defp bdd_difference({a1, :bdd_top, u1, :bdd_bot}, {a2, c2, u2, d2}, bdd1, bdd2, leaf_compare) do
+  defp bdd_difference(
+         {a1, :bdd_top, u1, :bdd_bot, _},
+         {a2, c2, u2, d2, _},
+         bdd1,
+         bdd2,
+         leaf_compare
+       ) do
     type = if c2 == :bdd_top, do: :none, else: :intersection
 
     case leaf_compare.(a1, a2, type) do
@@ -5947,13 +6046,13 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp bdd_difference({a1, c1, u1, d1}, {a2, :bdd_top, u2, d2}, bdd1, bdd2, leaf_compare) do
+  defp bdd_difference({a1, c1, u1, d1, _}, {a2, :bdd_top, u2, d2, _}, bdd1, bdd2, leaf_compare) do
     type = if d1 == :bdd_bot, do: :none, else: :union
 
     case leaf_compare.(a1, a2, type) do
       :disjoint ->
         bdd_difference(u1, a2, leaf_compare)
-        |> bdd_union(bdd_difference({a1, c1, :bdd_bot, d1}, a2))
+        |> bdd_union(bdd_difference(bdd_node_new(a1, c1, :bdd_bot, d1), a2))
         |> bdd_difference(d2, leaf_compare)
         |> bdd_difference(u2, leaf_compare)
 
@@ -5981,7 +6080,12 @@ defmodule Module.Types.Descr do
     bdd_difference(bdd1, bdd2)
   end
 
+  def bdd_intersection(bdd, bdd), do: bdd
+
   def bdd_intersection(bdd1, bdd2) do
+    bdd1 = bdd_normalize(bdd1)
+    bdd2 = bdd_normalize(bdd2)
+
     case {bdd1, bdd2} do
       {:bdd_top, bdd} ->
         bdd
@@ -5997,13 +6101,21 @@ defmodule Module.Types.Descr do
 
       _ ->
         case bdd_compare(bdd1, bdd2) do
-          {:lt, {lit1, c1, u1, d1}, bdd2} ->
-            {lit1, bdd_intersection(c1, bdd2), bdd_intersection(u1, bdd2),
-             bdd_intersection(d1, bdd2)}
+          {:lt, {lit1, c1, u1, d1, _}, bdd2} ->
+            bdd_split(
+              lit1,
+              bdd_intersection(c1, bdd2),
+              bdd_intersection(u1, bdd2),
+              bdd_intersection(d1, bdd2)
+            )
 
-          {:gt, bdd1, {lit2, c2, u2, d2}} ->
-            {lit2, bdd_intersection(bdd1, c2), bdd_intersection(bdd1, u2),
-             bdd_intersection(bdd1, d2)}
+          {:gt, bdd1, {lit2, c2, u2, d2, _}} ->
+            bdd_split(
+              lit2,
+              bdd_intersection(bdd1, c2),
+              bdd_intersection(bdd1, u2),
+              bdd_intersection(bdd1, d2)
+            )
 
           # Notice that (a, c1, u1, d1) and (a, c2, u2, d2) is described as:
           #
@@ -6021,22 +6133,22 @@ defmodule Module.Types.Descr do
           # unions in place whenever possible. This change has reduced the algorithmic
           # complexity in the past, but perhaps it is rendered less useful now due to
           # the eager literal intersections.
-          {:eq, {lit, c1, u1, d1}, {_, c2, u2, d2}} ->
-            {lit, bdd_intersection_eq(c1, c2, u1, u2), bdd_intersection(u1, u2),
-             bdd_intersection_eq(d1, d2, u1, u2)}
+          {:eq, {lit, c1, u1, d1, _}, {_, c2, u2, d2, _}} ->
+            bdd_split(
+              lit,
+              bdd_intersection_eq(c1, c2, u1, u2),
+              bdd_intersection(u1, u2),
+              bdd_intersection_eq(d1, d2, u1, u2)
+            )
 
-          {:eq, {lit, c1, u1, _}, _} ->
-            {lit, bdd_union(c1, u1), :bdd_bot, :bdd_bot}
+          {:eq, {lit, c1, u1, _, _}, _} ->
+            bdd_split(lit, bdd_union(c1, u1), :bdd_bot, :bdd_bot)
 
-          {:eq, _, {lit, c2, u2, _}} ->
-            {lit, bdd_union(c2, u2), :bdd_bot, :bdd_bot}
+          {:eq, _, {lit, c2, u2, _, _}} ->
+            bdd_split(lit, bdd_union(c2, u2), :bdd_bot, :bdd_bot)
 
           {:eq, bdd, _} ->
             bdd
-        end
-        |> case do
-          {_, :bdd_bot, u, :bdd_bot} -> u
-          other -> other
         end
     end
   end
@@ -6065,15 +6177,15 @@ defmodule Module.Types.Descr do
   # Intersections are great because they allow us to cut down
   # the number of nodes in the tree. So whenever we have a leaf,
   # we propagate it throughout the whole tree, cutting down nodes.
-  defp bdd_intersection(bdd_leaf(_, _) = leaf1, bdd_leaf(_, _) = leaf2, leaf_intersection) do
+  defp bdd_intersection({_, _, _} = leaf1, {_, _, _} = leaf2, leaf_intersection) do
     leaf_intersection.(leaf1, leaf2)
   end
 
-  defp bdd_intersection(bdd, bdd_leaf(tag, _) = leaf, leaf_intersection) when tag != :open do
+  defp bdd_intersection(bdd, {tag, _, _} = leaf, leaf_intersection) when tag != :open do
     bdd_non_open_leaf_intersection(leaf, bdd, leaf_intersection)
   end
 
-  defp bdd_intersection(bdd_leaf(tag, _) = leaf, bdd, leaf_intersection) when tag != :open do
+  defp bdd_intersection({tag, _, _} = leaf, bdd, leaf_intersection) when tag != :open do
     bdd_non_open_leaf_intersection(leaf, bdd, leaf_intersection)
   end
 
@@ -6090,11 +6202,11 @@ defmodule Module.Types.Descr do
   #
   # When C1 = :bdd_top, (a1 and a2) or (a2 and U2) or (a2 and not a1 and D2)
   # When C2 = :bdd_bot, (a2 and U2) or (a2 and not a1 and D2)
-  defp bdd_non_open_leaf_intersection(leaf1, bdd_leaf(_, _) = leaf2, leaf_intersection) do
+  defp bdd_non_open_leaf_intersection(leaf1, {_, _, _} = leaf2, leaf_intersection) do
     leaf_intersection.(leaf1, leaf2)
   end
 
-  defp bdd_non_open_leaf_intersection(leaf, {a, :bdd_top, u, d}, leaf_intersection) do
+  defp bdd_non_open_leaf_intersection(leaf, {a, :bdd_top, u, d, _}, leaf_intersection) do
     leaf_intersection.(a, leaf)
     |> bdd_union(bdd_non_open_leaf_intersection(leaf, u, leaf_intersection))
     |> case do
@@ -6109,7 +6221,7 @@ defmodule Module.Types.Descr do
     end
   end
 
-  defp bdd_non_open_leaf_intersection(leaf, {a, :bdd_bot, u, d}, leaf_intersection) do
+  defp bdd_non_open_leaf_intersection(leaf, {a, :bdd_bot, u, d, _}, leaf_intersection) do
     case bdd_non_open_leaf_intersection(leaf, u, leaf_intersection) do
       result when d == :bdd_bot ->
         result
@@ -6130,18 +6242,185 @@ defmodule Module.Types.Descr do
   # so its negation is ((lit and not c) or (not lit and not d)) and not u.
   def bdd_negation(:bdd_top), do: :bdd_bot
   def bdd_negation(:bdd_bot), do: :bdd_top
-  def bdd_negation({_, _} = pair), do: {pair, :bdd_bot, :bdd_bot, :bdd_top}
+  def bdd_negation({_, _} = pair), do: pair |> bdd_normalize() |> bdd_negation()
+  def bdd_negation({_, _, _, _} = node), do: node |> bdd_normalize() |> bdd_negation()
+  def bdd_negation({_, _, _} = pair), do: bdd_split(pair, :bdd_bot, :bdd_bot, :bdd_top)
 
-  def bdd_negation({lit, c, u, d}) do
+  def bdd_negation({lit, c, u, d, _}) do
     inner =
-      {lit, bdd_negation(c), :bdd_bot, bdd_negation(d)}
+      bdd_split(lit, bdd_negation(c), :bdd_bot, bdd_negation(d))
 
     case bdd_intersection(inner, bdd_negation(u)) do
       # Full simplification necessary for e.g. formatter.ex compilation
-      {_lit, c, u, c} -> bdd_union(u, c)
+      {_lit, c, u, c, _} -> bdd_union(u, c)
       x -> x
     end
   end
+
+  defp bdd_split(_lit, _c, :bdd_top, _d), do: :bdd_top
+
+  defp bdd_split(lit, c, u, d) do
+    lit = bdd_normalize(lit)
+
+    cond do
+      bdd_covers?(u, lit) ->
+        bdd_union(u, d)
+
+      bdd_equal?(c, d) ->
+        bdd_union(c, u)
+
+      true ->
+        c = bdd_simplify(c, [u])
+        d = bdd_simplify(d, [u])
+
+        if bdd_equal?(c, d) do
+          bdd_union(c, u)
+        else
+          bdd_split0(lit, c, u, d)
+        end
+    end
+  end
+
+  defp bdd_split0(_lit, :bdd_top, _u, :bdd_top), do: :bdd_top
+  defp bdd_split0(_lit, :bdd_bot, u, :bdd_bot), do: u
+  defp bdd_split0(lit, :bdd_top, :bdd_bot, :bdd_bot), do: lit
+  defp bdd_split0(lit, c, u, d), do: bdd_node_new(lit, c, u, d)
+
+  defp bdd_covers?(:bdd_top, _lit), do: true
+  defp bdd_covers?(:bdd_bot, _lit), do: false
+  defp bdd_covers?({_, _} = bdd, lit), do: bdd_covers?(bdd_normalize(bdd), lit)
+  defp bdd_covers?({_, _, _} = leaf, lit), do: bdd_equal?(leaf, lit)
+
+  defp bdd_covers?({node_lit, c, u, d, _}, lit) do
+    node_lit = bdd_leaf_value(node_lit)
+    lit = bdd_leaf_value(lit)
+
+    cond do
+      node_lit < lit ->
+        bdd_covers?(u, lit) or (bdd_covers?(c, lit) and bdd_covers?(d, lit))
+
+      node_lit > lit ->
+        false
+
+      true ->
+        c == :bdd_top or bdd_covers?(u, lit)
+    end
+  end
+
+  defp bdd_simplify(:bdd_bot, _assumptions), do: :bdd_bot
+
+  defp bdd_simplify(:bdd_top, assumptions) do
+    if :bdd_top in assumptions, do: :bdd_bot, else: :bdd_top
+  end
+
+  defp bdd_simplify({_, _} = leaf, assumptions) do
+    bdd_simplify(bdd_normalize(leaf), assumptions)
+  end
+
+  defp bdd_simplify({_, _, _} = leaf, assumptions) do
+    if bdd_has_same?(leaf, assumptions) do
+      :bdd_bot
+    else
+      bdd_simplify(leaf, leaf, :bdd_top, :bdd_bot, :bdd_bot, [], [], [], assumptions)
+    end
+  end
+
+  defp bdd_simplify({lit, c, u, d, _} = bdd, assumptions) do
+    if :bdd_top in assumptions or bdd_has_same?(bdd, assumptions) do
+      :bdd_bot
+    else
+      bdd_simplify(bdd, lit, c, u, d, [], [], [], assumptions)
+    end
+  end
+
+  defp bdd_simplify(_bdd, lit, c, u, d, pos, union, neg, []) do
+    c = bdd_simplify(c, pos)
+    u = bdd_simplify(u, union)
+    d = bdd_simplify(d, neg)
+
+    if bdd_equal?(c, d) do
+      bdd_union(c, u)
+    else
+      bdd_split0(lit, c, u, d)
+    end
+  end
+
+  defp bdd_simplify(bdd, lit, c, u, d, pos, union, neg, [:bdd_bot | assumptions]) do
+    bdd_simplify(bdd, lit, c, u, d, pos, union, neg, assumptions)
+  end
+
+  defp bdd_simplify(_bdd, _lit, _c, _u, _d, _pos, _union, _neg, [:bdd_top | _]) do
+    :bdd_bot
+  end
+
+  defp bdd_simplify(bdd, lit, c, u, d, pos, union, neg, [{_, _} = assumption | assumptions]) do
+    bdd_simplify(bdd, lit, c, u, d, pos, union, neg, [bdd_normalize(assumption) | assumptions])
+  end
+
+  defp bdd_simplify(bdd, lit, c, u, d, pos, union, neg, [{_, _, _} = assumption | assumptions]) do
+    bdd_simplify(
+      bdd,
+      lit,
+      c,
+      u,
+      d,
+      pos,
+      union,
+      neg,
+      [bdd_node_new(assumption, :bdd_top, :bdd_bot, :bdd_bot) | assumptions]
+    )
+  end
+
+  defp bdd_simplify(
+         bdd,
+         lit,
+         c,
+         u,
+         d,
+         pos,
+         union,
+         neg,
+         [
+           {assumption_lit, assumption_pos, assumption_union, assumption_neg, _} = assumption
+           | assumptions
+         ]
+       ) do
+    cond do
+      bdd_equal?(bdd, assumption) ->
+        :bdd_bot
+
+      assumption_lit < lit ->
+        bdd_simplify(bdd, lit, c, u, d, pos, union, neg, [assumption_union | assumptions])
+
+      assumption_lit > lit ->
+        bdd_simplify(
+          bdd,
+          lit,
+          c,
+          u,
+          d,
+          [assumption | pos],
+          [assumption | union],
+          [assumption | neg],
+          assumptions
+        )
+
+      true ->
+        bdd_simplify(
+          bdd,
+          lit,
+          c,
+          u,
+          d,
+          [assumption_pos, assumption_union | pos],
+          [assumption_union | union],
+          [assumption_neg, assumption_union | neg],
+          assumptions
+        )
+    end
+  end
+
+  defp bdd_has_same?(bdd, assumptions), do: Enum.any?(assumptions, &bdd_equal?(bdd, &1))
 
   def bdd_to_dnf(bdd), do: bdd_to_dnf([], [], [], bdd)
 
@@ -6149,17 +6428,27 @@ defmodule Module.Types.Descr do
   defp bdd_to_dnf(acc, pos, neg, :bdd_top), do: [{pos, neg} | acc]
 
   defp bdd_to_dnf(acc, pos, neg, {_, _} = lit) do
-    [{[lit | pos], neg} | acc]
+    [{[bdd_leaf_value(lit) | pos], neg} | acc]
+  end
+
+  defp bdd_to_dnf(acc, pos, neg, {_, _, _} = lit) do
+    [{[bdd_leaf_value(lit) | pos], neg} | acc]
+  end
+
+  defp bdd_to_dnf(acc, pos, neg, {lit, c, u, d}) do
+    bdd_to_dnf(acc, pos, neg, u)
+    |> bdd_to_dnf([bdd_leaf_value(lit) | pos], neg, c)
+    |> bdd_to_dnf(pos, [bdd_leaf_value(lit) | neg], d)
   end
 
   # Lazy node: {lit, C, U, D}  ≡  (lit ∧ C) ∪ U ∪ (¬lit ∧ D)
-  defp bdd_to_dnf(acc, pos, neg, {lit, c, u, d}) do
+  defp bdd_to_dnf(acc, pos, neg, {lit, c, u, d, _}) do
     # U is a bdd in itself, we accumulate its lines first
     bdd_to_dnf(acc, pos, neg, u)
     # C-part
-    |> bdd_to_dnf([lit | pos], neg, c)
+    |> bdd_to_dnf([bdd_leaf_value(lit) | pos], neg, c)
     # D-part
-    |> bdd_to_dnf(pos, [lit | neg], d)
+    |> bdd_to_dnf(pos, [bdd_leaf_value(lit) | neg], d)
   end
 
   defp bdd_compare(bdd1, bdd2) do
@@ -6178,11 +6467,14 @@ defmodule Module.Types.Descr do
       :bdd_top ->
         :bdd_top
 
-      {_, _} ->
-        fun.(bdd)
+      {_, _, _} ->
+        {arg1, arg2} = fun.(bdd_leaf_value(bdd))
+        bdd_leaf_new(arg1, arg2)
 
-      {literal, left, union, right} ->
-        {fun.(literal), bdd_map(left, fun), bdd_map(union, fun), bdd_map(right, fun)}
+      {literal, left, union, right, _} ->
+        {arg1, arg2} = fun.(bdd_leaf_value(literal))
+        literal = bdd_leaf_new(arg1, arg2)
+        bdd_node_new(literal, bdd_map(left, fun), bdd_map(union, fun), bdd_map(right, fun))
     end
   end
 
@@ -6194,11 +6486,11 @@ defmodule Module.Types.Descr do
       :bdd_top ->
         acc
 
-      {_, _} ->
-        fun.(bdd, acc)
+      {_, _, _} ->
+        fun.(bdd_leaf_value(bdd), acc)
 
-      {literal, left, union, right} ->
-        acc = fun.(literal, acc)
+      {literal, left, union, right, _} ->
+        acc = fun.(bdd_leaf_value(literal), acc)
         acc = bdd_reduce(left, acc, fun)
         acc = bdd_reduce(union, acc, fun)
         acc = bdd_reduce(right, acc, fun)
@@ -6207,11 +6499,14 @@ defmodule Module.Types.Descr do
   end
 
   @compile {:inline, bdd_expand: 1, bdd_head: 1}
-  defp bdd_expand({_, _} = pair), do: {pair, :bdd_top, :bdd_bot, :bdd_bot}
+  defp bdd_expand({_, _} = pair), do: pair |> bdd_normalize() |> bdd_expand()
+  defp bdd_expand({_, _, _, _} = node), do: bdd_normalize(node)
+  defp bdd_expand({_, _, _} = pair), do: bdd_node_new(pair, :bdd_top, :bdd_bot, :bdd_bot)
   defp bdd_expand(bdd), do: bdd
 
-  defp bdd_head({lit, _, _, _}), do: lit
-  defp bdd_head(pair), do: pair
+  defp bdd_head({lit, _, _, _}), do: bdd_leaf_value(lit)
+  defp bdd_head({lit, _, _, _, _}), do: bdd_leaf_value(lit)
+  defp bdd_head(pair), do: bdd_leaf_value(pair)
 
   ## Map helpers
 

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -436,7 +436,7 @@ defmodule Module.Types.Descr do
   defp union(:bitmap, v1, v2), do: v1 ||| v2
   defp union(:dynamic, v1, v2), do: dynamic_union(v1, v2)
   defp union(:list, v1, v2), do: bdd_union(v1, v2)
-  defp union(:map, v1, v2), do: map_union(v1, v2)
+  defp union(:map, v1, v2), do: bdd_union(v1, v2)
   defp union(:optional, 1, 1), do: 1
   defp union(:tuple, v1, v2), do: bdd_union(v1, v2)
   defp union(:fun, v1, v2), do: fun_union(v1, v2)
@@ -5920,25 +5920,14 @@ defmodule Module.Types.Descr do
               bdd_split(lit, c, :bdd_bot, d)
             end
 
-          # so this is: we have lit \ ((lit and c2) or u2 or ((not lit) and d2)
-          # which is (lit and not c2) or (lit and not u2)
           {:eq, _, {lit, c2, u2, _d2, _}} ->
-            bdd_union(
-              bdd_intersection(lit, bdd_negation(c2)),
-              bdd_intersection(lit, bdd_negation(u2))
-            )
-
-          # bdd_difference(lit, c2) |> bdd_union(bdd_difference(lit, u2))
-
-          # bdd_split(lit, bdd_intersection(bdd_negation(c2), bdd_negation(u2)), :bdd_bot, :bdd_bot)
+            bdd_split(lit, bdd_negation_union(c2, u2), :bdd_bot, :bdd_bot)
 
           # this is (lit and c1) or u1 or (not lit and d1) \ lit
           # which is (u1 \ lit) or (not lit and d1)
           # which is (u1 and not lit) or (d1 and not lit)
           {:eq, {lit, _c1, u1, d1, _}, _} ->
             bdd_union(bdd_difference(u1, lit), bdd_difference(d1, lit))
-
-          # bdd_split(lit, :bdd_bot, :bdd_bot, bdd_union(d1, u1))
 
           {:eq, _, _} ->
             :bdd_bot
@@ -6094,80 +6083,78 @@ defmodule Module.Types.Descr do
     bdd_difference(bdd1, bdd2)
   end
 
-  def bdd_intersection(bdd, bdd), do: bdd
-
   def bdd_intersection(bdd1, bdd2) do
     bdd1 = bdd_normalize(bdd1)
     bdd2 = bdd_normalize(bdd2)
 
-    case {bdd1, bdd2} do
-      {:bdd_top, bdd} ->
-        bdd
+    if bdd_equal?(bdd1, bdd2) do
+      bdd1
+    else
+      case {bdd1, bdd2} do
+        {:bdd_top, bdd} ->
+          bdd
 
-      {bdd, :bdd_top} ->
-        bdd
+        {bdd, :bdd_top} ->
+          bdd
 
-      {:bdd_bot, _bdd} ->
-        :bdd_bot
+        {:bdd_bot, _bdd} ->
+          :bdd_bot
 
-      {_, :bdd_bot} ->
-        :bdd_bot
+        {_, :bdd_bot} ->
+          :bdd_bot
 
-      _ ->
-        case bdd_compare(bdd1, bdd2) do
-          {:lt, {lit1, c1, u1, d1, _}, bdd2} ->
-            bdd_split(
-              lit1,
-              bdd_intersection(c1, bdd2),
-              bdd_intersection(u1, bdd2),
-              bdd_intersection(d1, bdd2)
-            )
+        _ ->
+          case bdd_compare(bdd1, bdd2) do
+            {:lt, {lit1, c1, u1, d1, _}, bdd2} ->
+              bdd_split(
+                lit1,
+                bdd_intersection(c1, bdd2),
+                bdd_intersection(u1, bdd2),
+                bdd_intersection(d1, bdd2)
+              )
 
-          {:gt, bdd1, {lit2, c2, u2, d2, _}} ->
-            bdd_split(
-              lit2,
-              bdd_intersection(bdd1, c2),
-              bdd_intersection(bdd1, u2),
-              bdd_intersection(bdd1, d2)
-            )
+            {:gt, bdd1, {lit2, c2, u2, d2, _}} ->
+              bdd_split(
+                lit2,
+                bdd_intersection(bdd1, c2),
+                bdd_intersection(bdd1, u2),
+                bdd_intersection(bdd1, d2)
+              )
 
-          # Notice that (a, c1, u1, d1) and (a, c2, u2, d2) is described as:
-          #
-          #     {a, (C1 or U1) and (C2 or U2), :bdd_bot, (D1 or U1) and (D2 or U2)}
-          #
-          # However, if we distribute the intersection over the unions, we find a
-          # common term, U1 and U2, leading to:
-          #
-          #     {a1,
-          #      (C1 and (C2 or U2)) or (U1 and C2),
-          #      (U1 and U2),
-          #      (D1 and (D2 or U2)) or (U1 and D2)}
-          #
-          # This formula is longer, meaning more operations, but it does preserve
-          # unions in place whenever possible. This change has reduced the algorithmic
-          # complexity in the past, but perhaps it is rendered less useful now due to
-          # the eager literal intersections.
-          {:eq, {lit, c1, u1, d1, _}, {_, c2, u2, d2, _}} ->
-            bdd_split(
-              lit,
-              bdd_intersection_eq(c1, c2, u1, u2),
-              bdd_intersection(u1, u2),
-              bdd_intersection_eq(d1, d2, u1, u2)
-            )
+            # Notice that (a, c1, u1, d1) and (a, c2, u2, d2) is described as:
+            #
+            #     {a, (C1 or U1) and (C2 or U2), :bdd_bot, (D1 or U1) and (D2 or U2)}
+            #
+            # However, if we distribute the intersection over the unions, we find a
+            # common term, U1 and U2, leading to:
+            #
+            #     {a1,
+            #      (C1 and (C2 or U2)) or (U1 and C2),
+            #      (U1 and U2),
+            #      (D1 and (D2 or U2)) or (U1 and D2)}
+            #
+            # This formula is longer, meaning more operations, but it does preserve
+            # unions in place whenever possible. This change has reduced the algorithmic
+            # complexity in the past, but perhaps it is rendered less useful now due to
+            # the eager literal intersections.
+            {:eq, {lit, c1, u1, d1, _}, {_, c2, u2, d2, _}} ->
+              bdd_split(
+                lit,
+                bdd_intersection_eq(c1, c2, u1, u2),
+                bdd_intersection(u1, u2),
+                bdd_intersection_eq(d1, d2, u1, u2)
+              )
 
-          # Important! lit must be put into the union/assumptions, to give it a go a simplification
-          {:eq, {lit, c1, u1, _, _}, _} ->
-            # bdd_split(lit, :bdd_top, u1, d1}
-            bdd_union(c1, bdd_union(u1, lit))
+            {:eq, {lit, c1, u1, _, _}, _} ->
+              bdd_split(lit, bdd_union(c1, u1), :bdd_bot, :bdd_bot)
 
-          {:eq, _, {lit, c2, u2, _, _}} ->
-            bdd_union(c2, bdd_union(u2, lit))
+            {:eq, _, {lit, c2, u2, _, _}} ->
+              bdd_split(lit, bdd_union(c2, u2), :bdd_bot, :bdd_bot)
 
-          # bdd_split(lit, bdd_union(c2, u2), :bdd_bot, :bdd_bot)
-
-          {:eq, bdd, _} ->
-            bdd
-        end
+            {:eq, bdd, _} ->
+              bdd
+          end
+      end
     end
   end
 

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -5756,14 +5756,6 @@ defmodule Module.Types.Descr do
 
   ## BDD helpers
 
-  @compile {:inline,
-            bdd_leaf_new: 2,
-            bdd_node_new: 4,
-            bdd_normalize: 1,
-            bdd_hash: 1,
-            bdd_compute_hash: 4,
-            bdd_leaf_value: 1,
-            bdd_equal?: 2}
   defp bdd_leaf_new(arg1, arg2), do: {:erlang.phash2({arg1, arg2}), arg1, arg2}
 
   defp bdd_node_new(lit, c, u, d),

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -158,6 +158,11 @@ defmodule Module.Types.DescrTest do
 
       assert union(difference(list(term()), list(integer())), list(integer()))
              |> equal?(list(term()))
+
+      t1 = non_empty_list(integer())
+      t2 = non_empty_list(number())
+
+      assert union(difference(t2, t1), t1) == union(t1, t2)
     end
 
     test "fun" do
@@ -632,7 +637,7 @@ defmodule Module.Types.DescrTest do
                closed_map(__struct__: difference(atom(), atom_bar))
 
       # Explicitly assert we keep it as cascading differences
-      assert %{map: {{:closed, _}, :bdd_bot, :bdd_bot, _}} =
+      assert %{map: {{:closed, _, _}, :bdd_bot, :bdd_bot, _, _}} =
                difference(
                  difference(
                    open_map(value: term()),

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -162,7 +162,13 @@ defmodule Module.Types.DescrTest do
       t1 = non_empty_list(integer())
       t2 = non_empty_list(number())
 
-      assert union(difference(t2, t1), t1) == union(t1, t2)
+      assert difference(t2, t1) |> union(t1) == union(t1, t2)
+
+      t3 = non_empty_list(pid())
+
+      # (t3 \ t2 \ t1) \/ (t2 \ t1) \/ t1 is structurally the same as t1 \/ t2 \/ t3
+      assert difference(t3, t2) |> difference(t1) |> union(difference(t2, t1)) |> union(t1) ==
+               union(t1, t2) |> union(t3)
     end
 
     test "fun" do


### PR DESCRIPTION
## Summary

- hash-cons BDD leaves and nodes by storing precomputed hashes
- route list, map, and tuple unions/intersections/differences through the generic BDD operations and simplify split/negation paths instead of keeping the previous specialized optimizations
- add bdd simplifications that leverage hash-consing

Keeping hashes on the BDD structure and simplifying through the generic operations reduces repeated structural work and makes equivalent fragments cheaper to compare and reuse.

## Validation

- 109/123 tests passing, 14 assertions failing in `Module.Types.DescrTest` (leaving this as a draft PR)
