### PR TITLE
Consistently return path as binary in relative_to_cwd

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -485,7 +485,7 @@ defmodule Path do
   def relative_to_cwd(path, opts \\ []) when is_list(opts) do
     case :file.get_cwd() do
       {:ok, base} -> relative_to(path, IO.chardata_to_string(base), opts)
-      _ -> path
+      _ -> IO.chardata_to_string(path)
     end
   end
 

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -430,3 +430,27 @@ defmodule PathTest do
     defp strip_drive_letter_if_windows(path), do: path
   end
 end
+
+defmodule PathCwdFailureTest do
+  use ExUnit.Case, async: false
+
+  @tag :tmp_dir
+  @tag :unix
+  test "relative_to_cwd/2 returns a binary even when cwd cannot be retrieved", config do
+    {:ok, original} = :file.get_cwd()
+    tmp = Path.join(config.tmp_dir, "deleted")
+    File.mkdir_p!(tmp)
+
+    try do
+      File.cd!(tmp)
+      File.rm_rf!(tmp)
+      assert {:error, _} = :file.get_cwd()
+
+      assert Path.relative_to_cwd("foo/bar") == "foo/bar"
+      assert Path.relative_to_cwd(~c"foo/bar") == "foo/bar"
+      assert Path.relative_to_cwd(["foo", ?/, "bar"]) == "foo/bar"
+    after
+      :file.set_cwd(original)
+    end
+  end
+end

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -431,7 +431,7 @@ defmodule PathTest do
   end
 end
 
-defmodule PathCwdFailureTest do
+defmodule Path.SyncTest do
   use ExUnit.Case, async: false
 
   @tag :tmp_dir


### PR DESCRIPTION
Previously if path parameter was passed in as chardata it was returned as is on `:file.get_cwd` failure All `relative_to` and `join` code paths normalize to binary