### PR TITLE
Fix map difference union optimization

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -3062,7 +3062,8 @@ defmodule Module.Types.Descr do
   #
   # Outside of this particular scenario, the `a_int` optimization has been useful,
   # but we haven't measured benefits for `a_union`.
-  defp map_leaf_difference(bdd_leaf(tag, fields), bdd_leaf(:open, [{key, v2}]), type) do
+  defp map_leaf_difference(bdd_leaf(tag, fields), bdd_leaf(:open, [{key, v2}]), type)
+       when type != :union do
     {found?, v1} =
       case fields_find(key, fields) do
         {:ok, value} -> {true, value}

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -608,6 +608,12 @@ defmodule Module.Types.DescrTest do
       assert difference(closed_map(a: integer()), open_map(b: if_set(integer()))) == none()
     end
 
+    test "map double negation with redundant empty map" do
+      type = closed_map(a: atom()) |> union(open_map(a: if_set(integer()))) |> union(empty_map())
+
+      assert negation(negation(type)) |> equal?(type)
+    end
+
     test "map (struct optimizations)" do
       # We do direct assertions because we want to check how it works underneath
       atom_foo = atom([:foo])


### PR DESCRIPTION
This disables the :union case of the single-key open-map difference optimization.

The optimization could build an invalid union literal and make double negation leave extra maps. A regression covers the redundant empty_map case.
