### PR TITLE
Fix invalid type inference on size compare in guards

### DIFF
--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -726,8 +726,8 @@ defmodule Module.Types.Apply do
 
       {size, {{:., _, [:erlang, fun]}, _, [arg]}} when is_data_size(fun, size) ->
         case booleaness(expected) do
-          {true, _} -> sized_order(invert_order(name), fun, size, arg, @atom_true)
-          {false, _} -> sized_order(name, fun, size, arg, @atom_false)
+          {true, _} -> sized_order(mirror_order(name), fun, size, arg, @atom_true)
+          {false, _} -> sized_order(invert_order(mirror_order(name)), fun, size, arg, @atom_false)
           _ -> :none
         end
 
@@ -778,6 +778,11 @@ defmodule Module.Types.Apply do
   defp invert_order(:"=<"), do: :>
   defp invert_order(:>), do: :"=<"
   defp invert_order(:<), do: :>=
+
+  defp mirror_order(:>=), do: :"=<"
+  defp mirror_order(:"=<"), do: :>=
+  defp mirror_order(:>), do: :<
+  defp mirror_order(:<), do: :>
 
   @doc """
   Returns the domain of an unknown module.

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -1166,10 +1166,10 @@ defmodule Module.Types.PatternTest do
       assert typecheck!([x], length(x) >= 0, x) == dynamic(list(term()))
       assert typecheck!([x], length(x) <= 0, x) == dynamic(empty_list())
 
-      assert typecheck!([x], 0 <= length(x), x) == dynamic(non_empty_list(term()))
-      assert typecheck!([x], 0 >= length(x), x) == dynamic(list(term()))
-      assert typecheck!([x], 0 < length(x), x) == dynamic(list(term()))
-      assert typecheck!([x], 0 > length(x), x) == dynamic(empty_list())
+      assert typecheck!([x], 0 <= length(x), x) == dynamic(list(term()))
+      assert typecheck!([x], 0 >= length(x), x) == dynamic(empty_list())
+      assert typecheck!([x], 0 < length(x), x) == dynamic(non_empty_list(term()))
+      assert typecheck!([x], 0 > length(x), x) == dynamic(list(term()))
 
       assert typecheck!([x], not (length(x) > 0), x) == dynamic(empty_list())
       assert typecheck!([x], not (length(x) < 0), x) == dynamic(list(term()))
@@ -1214,10 +1214,10 @@ defmodule Module.Types.PatternTest do
       assert typecheck!([x], map_size(x) >= 0, x) == dynamic(open_map())
       assert typecheck!([x], map_size(x) <= 0, x) == dynamic(empty_map())
 
-      assert typecheck!([x], 0 <= map_size(x), x) == dynamic(@non_empty_map)
-      assert typecheck!([x], 0 >= map_size(x), x) == dynamic(open_map())
-      assert typecheck!([x], 0 < map_size(x), x) == dynamic(open_map())
-      assert typecheck!([x], 0 > map_size(x), x) == dynamic(empty_map())
+      assert typecheck!([x], 0 <= map_size(x), x) == dynamic(open_map())
+      assert typecheck!([x], 0 >= map_size(x), x) == dynamic(empty_map())
+      assert typecheck!([x], 0 < map_size(x), x) == dynamic(@non_empty_map)
+      assert typecheck!([x], 0 > map_size(x), x) == dynamic(open_map())
 
       assert typecheck!([x], not (map_size(x) > 0), x) == dynamic(empty_map())
       assert typecheck!([x], not (map_size(x) < 0), x) == dynamic(open_map())
@@ -1278,10 +1278,10 @@ defmodule Module.Types.PatternTest do
       assert typecheck!([x], tuple_size(x) >= 0, x) == dynamic(open_tuple([]))
       assert typecheck!([x], tuple_size(x) <= 0, x) == dynamic(tuple([]))
 
-      assert typecheck!([x], 0 <= tuple_size(x), x) == dynamic(open_tuple([term()]))
-      assert typecheck!([x], 0 >= tuple_size(x), x) == dynamic(open_tuple([]))
-      assert typecheck!([x], 0 < tuple_size(x), x) == dynamic(open_tuple([]))
-      assert typecheck!([x], 0 > tuple_size(x), x) == dynamic(tuple([]))
+      assert typecheck!([x], 0 <= tuple_size(x), x) == dynamic(open_tuple([]))
+      assert typecheck!([x], 0 >= tuple_size(x), x) == dynamic(tuple([]))
+      assert typecheck!([x], 0 < tuple_size(x), x) == dynamic(open_tuple([term()]))
+      assert typecheck!([x], 0 > tuple_size(x), x) == dynamic(open_tuple([]))
 
       assert typecheck!([x], not (tuple_size(x) > 0), x) == dynamic(tuple([]))
       assert typecheck!([x], not (tuple_size(x) < 0), x) == dynamic(open_tuple([]))
@@ -1293,10 +1293,10 @@ defmodule Module.Types.PatternTest do
       assert typecheck!([x], tuple_size(x) >= 2, x) == dynamic(@open_binary_tuple)
       assert typecheck!([x], tuple_size(x) <= 2, x) == dynamic(@non_open_ternary_tuple)
 
-      assert typecheck!([x], 2 <= tuple_size(x), x) == dynamic(@open_ternary_tuple)
-      assert typecheck!([x], 2 >= tuple_size(x), x) == dynamic(@non_open_binary_tuple)
-      assert typecheck!([x], 2 < tuple_size(x), x) == dynamic(@open_binary_tuple)
-      assert typecheck!([x], 2 > tuple_size(x), x) == dynamic(@non_open_ternary_tuple)
+      assert typecheck!([x], 2 <= tuple_size(x), x) == dynamic(@open_binary_tuple)
+      assert typecheck!([x], 2 >= tuple_size(x), x) == dynamic(@non_open_ternary_tuple)
+      assert typecheck!([x], 2 < tuple_size(x), x) == dynamic(@open_ternary_tuple)
+      assert typecheck!([x], 2 > tuple_size(x), x) == dynamic(@non_open_binary_tuple)
 
       assert typecheck!([x], not (tuple_size(x) > 2), x) == dynamic(@non_open_ternary_tuple)
       assert typecheck!([x], not (tuple_size(x) < 2), x) == dynamic(@open_binary_tuple)


### PR DESCRIPTION
The PR is addressing invalid edge conditions on size comparisons in guards so equivalent mirrored expressions `tuple_size(x) >= 2` and `2 <=tuple_size(x)` typecheck correctly

The PR is not addressing
```
assert typecheck!([x], length(x) < 0, x) == dynamic(list(term()))
```
which I believe should be `none` type instead of list

Fixes https://github.com/elixir-lang/elixir/issues/15323

