### PR TITLE
Refine negative size guards as impossible to match

### DIFF
--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -397,6 +397,10 @@ defmodule Module.Types.Apply do
         result = if precise? and subtype?(actual, expected), do: return, else: boolean()
         {result, context}
 
+      {:impossible, arg, fun} ->
+        {_, context} = of_fun.(arg, sized_domain(fun), expr, stack, context)
+        {opposite_boolean(expected), context}
+
       :none ->
         {left_type, context} = of_fun.(left, term(), expr, stack, context)
         {right_type, context} = of_fun.(right, term(), expr, stack, context)
@@ -739,11 +743,24 @@ defmodule Module.Types.Apply do
   defp sized_order(name, fun, size, arg, return) do
     case expected_order(fun, name, size) do
       :none -> :none
+      :impossible -> {:impossible, arg, fun}
       {expected, precise?} -> {arg, expected, precise?, return}
     end
   end
 
-  defp expected_order(_, :<, 0), do: :none
+  defp sized_domain(:length), do: @list
+  defp sized_domain(:map_size), do: open_map()
+  defp sized_domain(:tuple_size), do: open_tuple([])
+
+  defp opposite_boolean(expected) do
+    case booleaness(expected) do
+      {true, _} -> @atom_false
+      {false, _} -> @atom_true
+      _ -> boolean()
+    end
+  end
+
+  defp expected_order(_, :<, 0), do: :impossible
 
   defp expected_order(:tuple_size, :<, size),
     do: {difference(open_tuple([]), open_tuple(List.duplicate(term(), size))), true}

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -1162,18 +1162,20 @@ defmodule Module.Types.PatternTest do
     end
 
     test "length ordered" do
-      assert typecheck!([x], length(x) < 0, x) == dynamic(list(term()))
+      assert typeerror!([x], length(x) < 0, x) =~ "this guard will never succeed"
+      assert typeerror!([x], 0 > length(x), x) =~ "this guard will never succeed"
+      assert typeerror!([x], not (length(x) >= 0), x) =~ "this guard will never succeed"
+      assert typeerror!([x], not (0 <= length(x)), x) =~ "this guard will never succeed"
+
       assert typecheck!([x], length(x) >= 0, x) == dynamic(list(term()))
       assert typecheck!([x], length(x) <= 0, x) == dynamic(empty_list())
 
       assert typecheck!([x], 0 <= length(x), x) == dynamic(list(term()))
       assert typecheck!([x], 0 >= length(x), x) == dynamic(empty_list())
       assert typecheck!([x], 0 < length(x), x) == dynamic(non_empty_list(term()))
-      assert typecheck!([x], 0 > length(x), x) == dynamic(list(term()))
 
       assert typecheck!([x], not (length(x) > 0), x) == dynamic(empty_list())
       assert typecheck!([x], not (length(x) < 0), x) == dynamic(list(term()))
-      assert typecheck!([x], not (length(x) >= 0), x) == dynamic(list(term()))
       assert typecheck!([x], not (length(x) <= 0), x) == dynamic(non_empty_list(term()))
 
       assert typecheck!([x], length(x) < 1, x) == dynamic(empty_list())
@@ -1209,19 +1211,21 @@ defmodule Module.Types.PatternTest do
     end
 
     test "map_size ordered" do
+      assert typeerror!([x], map_size(x) < 0, x) =~ "this guard will never succeed"
+      assert typeerror!([x], 0 > map_size(x), x) =~ "this guard will never succeed"
+      assert typeerror!([x], not (map_size(x) >= 0), x) =~ "this guard will never succeed"
+      assert typeerror!([x], not (0 <= map_size(x)), x) =~ "this guard will never succeed"
+
       assert typecheck!([x], map_size(x) > 0, x) == dynamic(@non_empty_map)
-      assert typecheck!([x], map_size(x) < 0, x) == dynamic(open_map())
       assert typecheck!([x], map_size(x) >= 0, x) == dynamic(open_map())
       assert typecheck!([x], map_size(x) <= 0, x) == dynamic(empty_map())
 
       assert typecheck!([x], 0 <= map_size(x), x) == dynamic(open_map())
       assert typecheck!([x], 0 >= map_size(x), x) == dynamic(empty_map())
       assert typecheck!([x], 0 < map_size(x), x) == dynamic(@non_empty_map)
-      assert typecheck!([x], 0 > map_size(x), x) == dynamic(open_map())
 
       assert typecheck!([x], not (map_size(x) > 0), x) == dynamic(empty_map())
       assert typecheck!([x], not (map_size(x) < 0), x) == dynamic(open_map())
-      assert typecheck!([x], not (map_size(x) >= 0), x) == dynamic(open_map())
       assert typecheck!([x], not (map_size(x) <= 0), x) == dynamic(@non_empty_map)
 
       assert typecheck!([x], map_size(x) < 1, x) == dynamic(empty_map())
@@ -1273,19 +1277,21 @@ defmodule Module.Types.PatternTest do
     end
 
     test "tuple_size ordered" do
+      assert typeerror!([x], tuple_size(x) < 0, x) =~ "this guard will never succeed"
+      assert typeerror!([x], 0 > tuple_size(x), x) =~ "this guard will never succeed"
+      assert typeerror!([x], not (tuple_size(x) >= 0), x) =~ "this guard will never succeed"
+      assert typeerror!([x], not (0 <= tuple_size(x)), x) =~ "this guard will never succeed"
+
       assert typecheck!([x], tuple_size(x) > 0, x) == dynamic(open_tuple([term()]))
-      assert typecheck!([x], tuple_size(x) < 0, x) == dynamic(open_tuple([]))
       assert typecheck!([x], tuple_size(x) >= 0, x) == dynamic(open_tuple([]))
       assert typecheck!([x], tuple_size(x) <= 0, x) == dynamic(tuple([]))
 
       assert typecheck!([x], 0 <= tuple_size(x), x) == dynamic(open_tuple([]))
       assert typecheck!([x], 0 >= tuple_size(x), x) == dynamic(tuple([]))
       assert typecheck!([x], 0 < tuple_size(x), x) == dynamic(open_tuple([term()]))
-      assert typecheck!([x], 0 > tuple_size(x), x) == dynamic(open_tuple([]))
 
       assert typecheck!([x], not (tuple_size(x) > 0), x) == dynamic(tuple([]))
       assert typecheck!([x], not (tuple_size(x) < 0), x) == dynamic(open_tuple([]))
-      assert typecheck!([x], not (tuple_size(x) >= 0), x) == dynamic(open_tuple([]))
       assert typecheck!([x], not (tuple_size(x) <= 0), x) == dynamic(open_tuple([term()]))
 
       assert typecheck!([x], tuple_size(x) > 2, x) == dynamic(@open_ternary_tuple)
@@ -1302,6 +1308,14 @@ defmodule Module.Types.PatternTest do
       assert typecheck!([x], not (tuple_size(x) < 2), x) == dynamic(@open_binary_tuple)
       assert typecheck!([x], not (tuple_size(x) >= 2), x) == dynamic(@non_open_binary_tuple)
       assert typecheck!([x], not (tuple_size(x) <= 2), x) == dynamic(@open_ternary_tuple)
+    end
+
+    test "impossible size order composes with boolean operators" do
+      assert typeerror!([x], is_list(x) and length(x) < 0, x) =~
+               "this guard will never succeed"
+
+      assert typecheck!([x], is_list(x) or length(x) < 0, x)
+             |> equal?(dynamic(union(empty_list(), non_empty_list(term(), term()))))
     end
   end
 


### PR DESCRIPTION
This PR explores if refining impossible guard size expressions is viable