### PR TITLE
Mark vars in AST of ||, &&, if, and unless as generated

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1999,6 +1999,12 @@ defmodule Kernel do
     {:case, extra ++ meta, args}
   end
 
+  defp x_var do
+    quote generated: true do
+      x
+    end
+  end
+
   defp x_is_false_or_nil do
     quote generated: true do
       :erlang.orelse(:erlang."=:="(x, false), :erlang."=:="(x, nil))
@@ -2112,7 +2118,7 @@ defmodule Kernel do
       [optimize_boolean: true, type_check: {:case, :!}],
       quote do
         case unquote(value) do
-          x when unquote(x_is_false_or_nil()) -> false
+          unquote(x_var()) when unquote(x_is_false_or_nil()) -> false
           _ -> true
         end
       end
@@ -2126,7 +2132,7 @@ defmodule Kernel do
       [optimize_boolean: true, type_check: {:case, :!}],
       quote do
         case unquote(value) do
-          x when unquote(x_is_false_or_nil()) -> true
+          unquote(x_var()) when unquote(x_is_false_or_nil()) -> true
           _ -> false
         end
       end
@@ -4055,7 +4061,7 @@ defmodule Kernel do
       [optimize_boolean: true, type_check: {:case, :if}],
       quote do
         case unquote(condition) do
-          x when unquote(x_is_false_or_nil()) -> unquote(else_clause)
+          unquote(x_var()) when unquote(x_is_false_or_nil()) -> unquote(else_clause)
           _ -> unquote(do_clause)
         end
       end
@@ -4107,7 +4113,7 @@ defmodule Kernel do
       [optimize_boolean: true, type_check: {:case, :unless}],
       quote do
         case unquote(condition) do
-          x when unquote(x_is_false_or_nil()) -> unquote(do_clause)
+          unquote(x_var()) when unquote(x_is_false_or_nil()) -> unquote(do_clause)
           _ -> unquote(else_clause)
         end
       end
@@ -4382,8 +4388,8 @@ defmodule Kernel do
       [type_check: {:case, :&&}],
       quote do
         case unquote(left) do
-          x when unquote(x_is_false_or_nil()) ->
-            x
+          unquote(x_var()) when unquote(x_is_false_or_nil()) ->
+            unquote(x_var())
 
           _ ->
             unquote(right)
@@ -4425,11 +4431,11 @@ defmodule Kernel do
       [type_check: {:case, :||}],
       quote do
         case unquote(left) do
-          x when unquote(x_is_false_or_nil()) ->
+          unquote(x_var()) when unquote(x_is_false_or_nil()) ->
             unquote(right)
 
-          x ->
-            x
+          unquote(x_var()) ->
+            unquote(x_var())
         end
       end
     )


### PR DESCRIPTION
Commit 19c628ae23b474d09557f95c2b199a96e2349fb6 introduced a private AST helper `Kernel.x_is_false_or_nil/0` to add `generated: true` to a generated variable `x` in generated guards for of ||, &&, if, and unless ([diff](https://github.com/elixir-lang/elixir/commit/19c628ae23b474d09557f95c2b199a96e2349fb6#diff-43a76a6112c9082ee3ddb63acc2419db8764edd039cb52e29e436734b414574b)).

However, the variable `x`, on which the guards refer to, is not marked as `generated: true`, and thus has a different AST signature.

For reference, see [this diff](https://github.com/elixir-dx/dx/commit/b1dc67876f5d153851bd1f53bea0ebf5eb9aea07#diff-58077bdfa180e972234a4764a4d4ec1988bb4090537ad7e15af2de703a9f8469R1070-R1135) (expand to see lines 1070-1135).

This PR fixes this by adding another private AST helper `Kernel.x_var/0` to add `generated: true` to the generated variables `x` as well.