### PR TITLE
In EEX Compiler, flatten expr list only once, not on every iteration

### DIFF
--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -303,7 +303,7 @@ defmodule EEx.Compiler do
       file: file,
       source: source,
       line: line,
-      quoted: [],
+      quoted: %{},
       parser_options: [indentation: indentation] ++ parser_options,
       indentation: indentation
     }
@@ -366,7 +366,7 @@ defmodule EEx.Compiler do
         rest,
         state.engine.handle_begin(buffer),
         [{contents, start_line, start_column} | scope],
-        %{state | quoted: [], line: line}
+        %{state | quoted: %{}, line: line}
       )
 
     if mark == ~c"" and not match?({:=, _, [_, _]}, contents) do
@@ -443,10 +443,10 @@ defmodule EEx.Compiler do
 
   defp wrap_expr(current, line, buffer, chars, state) do
     new_lines = List.duplicate(?\n, line - state.line)
-    key = length(state.quoted)
+    key = map_size(state.quoted)
     placeholder = [~c"__EEX__(", Integer.to_charlist(key), ~c");"]
     count = [current, placeholder, new_lines, chars]
-    new_state = %{state | quoted: [{key, state.engine.handle_end(buffer)} | state.quoted]}
+    new_state = %{state | quoted: Map.put(state.quoted, key, state.engine.handle_end(buffer))}
 
     {count, new_state}
   end
@@ -479,8 +479,7 @@ defmodule EEx.Compiler do
   # Changes placeholder to real expression
 
   defp insert_quoted({:__EEX__, _, [key]}, quoted) do
-    {^key, value} = List.keyfind(quoted, key, 0)
-    value
+    Map.get(quoted, key)
   end
 
   defp insert_quoted({left, line, right}, quoted) do

--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -479,7 +479,7 @@ defmodule EEx.Compiler do
   # Changes placeholder to real expression
 
   defp insert_quoted({:__EEX__, _, [key]}, quoted) do
-    Map.get(quoted, key)
+    Map.fetch!(quoted, key)
   end
 
   defp insert_quoted({left, line, right}, quoted) do

--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -410,7 +410,7 @@ defmodule EEx.Compiler do
        ) do
     {wrapped, state} = wrap_expr(current, meta.line, buffer, chars, state)
     options = [file: state.file, line: line, column: column] ++ state.parser_options
-    tuples = Code.string_to_quoted!(wrapped, options)
+    tuples = Code.string_to_quoted!(:lists.flatten(wrapped), options)
     buffer = insert_quoted(tuples, state.quoted)
     {buffer, rest}
   end
@@ -426,7 +426,7 @@ defmodule EEx.Compiler do
 
   defp generate_buffer([{:eof, _meta}], _buffer, [{content, line, column} | _scope], state) do
     message = "expected a closing '<% end %>' for block expression in EEx"
-    expr_meta = non_whitespace_meta(content, line, column, state)
+    expr_meta = non_whitespace_meta(:lists.flatten(content), line, column, state)
     syntax_error!(message, expr_meta, state)
   end
 
@@ -444,8 +444,8 @@ defmodule EEx.Compiler do
   defp wrap_expr(current, line, buffer, chars, state) do
     new_lines = List.duplicate(?\n, line - state.line)
     key = length(state.quoted)
-    placeholder = ~c"__EEX__(" ++ Integer.to_charlist(key) ++ ~c");"
-    count = current ++ placeholder ++ new_lines ++ chars
+    placeholder = [~c"__EEX__(", Integer.to_charlist(key), ~c");"]
+    count = [current, placeholder, new_lines, chars]
     new_state = %{state | quoted: [{key, state.engine.handle_end(buffer)} | state.quoted]}
 
     {count, new_state}


### PR DESCRIPTION
> Disclosure: I found and fixed the following performance improvement using Opus 4.7, but I made damn sure to understand what the problem is and how the fix works. I also wrote the description below myself to make sure I know what I'm proposing here.

### Problem

This PR fixes a performance issue in `/lib/eex/lib/eex/compiler.ex:444-452` -> `wrap_expr/5` which computes `count = current ++ placeholder ++ new_lines ++ chars` for every middle block and the end block of an expression. The `current` is the aggregator of the expression and because `++` is used, the compiler walks every character in that charlist before it appends the placeholder, new_lines, and chars. So, the longer the `current` becomes, the longer the compiler needs to walk the charlist until it finally appends the new block to the aggregator. This is roughly `O(N^2)`.

### Fix

With the help of Opus, I created a fix which builds a nested list of expressions and then flattens the list into a single charlist once the end block is reached, so flattening the list only once instead of after every middle block. 

I also fixed another small issue which was that the `quoted` expressions were stored as Keyword list but retrieved like a Map (i.e. "find the expression for a given key") in `insert_quoted/2`. I refactored `quoted` to be a map which took care of the quadratic performance with large numbers of case arms. You can see it at the `N = 1600` case in the benchmarks where the average iteration takes 4.4x longer if N doubles (from 800 -> 1600).

### Benchmarks

Here are the before/after benchmarks:

I built a very long `case x do ... end` expression with `N` case arms like `1, `2`, ... N as cases.

| N    | Before   | After   | Speedup | Before μs/N | μs/N² | After μs/N | μs/N²
|------|----------|---------|---------|--------|----------|----------|----------|
| 100  | 0.47 ms  | 0.27 ms | 1.7×    |   4.71 |   0.0471 | 2.72 |   0.0272 |
| 200  | 1.51 ms  | 0.49 ms | 2.6×    |   7.56 |   0.0378 | 2.44 |   0.0122 |
| 400  | 5.49 ms  | 1.06 ms | 4.6×    |  13.72 |   0.0343 | 2.66 |   0.0066 |
| 800  | 23.3 ms  | 2.13 ms | 8.1×    |  29.12 |   0.0364 | 2.67 |   0.0033 |
| 1600 | 102.8 ms | 4.61 ms | 22.3×    |  64.22 |   0.0401 | 2.88 |   0.0018 |

