### PR TITLE
Faster Base decoding

### DIFF
--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -152,7 +152,10 @@ defmodule Base do
   defp remove_ignored(string, nil), do: string
 
   defp remove_ignored(string, :whitespace) do
-    for <<char::8 <- string>>, char not in ~c"\s\t\r\n", into: <<>>, do: <<char::8>>
+    case :binary.match(string, [<<?\s>>, <<?\t>>, <<?\r>>, <<?\n>>]) do
+      :nomatch -> string
+      _ -> for <<char::8 <- string>>, char not in ~c"\s\t\r\n", into: <<>>, do: <<char::8>>
+    end
   end
 
   @doc """
@@ -376,6 +379,26 @@ defmodule Base do
 
     defp unquote(validate_name)(<<>>), do: true
 
+    defp unquote(validate_name)(<<c1, c2, c3, c4, c5, c6, c7, c8, rest::binary>>) do
+      unquote(valid_char_name)(c1) and
+        unquote(valid_char_name)(c2) and
+        unquote(valid_char_name)(c3) and
+        unquote(valid_char_name)(c4) and
+        unquote(valid_char_name)(c5) and
+        unquote(valid_char_name)(c6) and
+        unquote(valid_char_name)(c7) and
+        unquote(valid_char_name)(c8) and
+        unquote(validate_name)(rest)
+    end
+
+    defp unquote(validate_name)(<<c1, c2, c3, c4, rest::binary>>) do
+      unquote(valid_char_name)(c1) and
+        unquote(valid_char_name)(c2) and
+        unquote(valid_char_name)(c3) and
+        unquote(valid_char_name)(c4) and
+        unquote(validate_name)(rest)
+    end
+
     defp unquote(validate_name)(<<c1, c2, rest::binary>>) do
       unquote(valid_char_name)(c1) and
         unquote(valid_char_name)(c2) and
@@ -391,6 +414,7 @@ defmodule Base do
 
     defp unquote(valid_char_name)(_char), do: false
 
+    @compile {:inline, [{decode_name, 1}]}
     defp unquote(decode_name)(char) do
       index = char - unquote(min)
 
@@ -870,6 +894,7 @@ defmodule Base do
 
     defp unquote(valid_char_name)(_char), do: false
 
+    @compile {:inline, [{decode_name, 1}]}
     defp unquote(decode_name)(char) do
       index = char - unquote(min)
 
@@ -1526,6 +1551,7 @@ defmodule Base do
 
     defp unquote(valid_char_name)(_char), do: false
 
+    @compile {:inline, [{decode_name, 1}]}
     defp unquote(decode_name)(char) do
       index = char - unquote(min)
 

--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -152,10 +152,7 @@ defmodule Base do
   defp remove_ignored(string, nil), do: string
 
   defp remove_ignored(string, :whitespace) do
-    case :binary.match(string, [<<?\s>>, <<?\t>>, <<?\r>>, <<?\n>>]) do
-      :nomatch -> string
-      _ -> for <<char::8 <- string>>, char not in ~c"\s\t\r\n", into: <<>>, do: <<char::8>>
-    end
+    for <<char::8 <- string>>, char not in ~c"\s\t\r\n", into: <<>>, do: <<char::8>>
   end
 
   @doc """
@@ -414,7 +411,6 @@ defmodule Base do
 
     defp unquote(valid_char_name)(_char), do: false
 
-    @compile {:inline, [{decode_name, 1}]}
     defp unquote(decode_name)(char) do
       index = char - unquote(min)
 
@@ -894,7 +890,6 @@ defmodule Base do
 
     defp unquote(valid_char_name)(_char), do: false
 
-    @compile {:inline, [{decode_name, 1}]}
     defp unquote(decode_name)(char) do
       index = char - unquote(min)
 
@@ -1551,7 +1546,6 @@ defmodule Base do
 
     defp unquote(valid_char_name)(_char), do: false
 
-    @compile {:inline, [{decode_name, 1}]}
     defp unquote(decode_name)(char) do
       index = char - unquote(min)
 


### PR DESCRIPTION
> Disclosure: I used Opus 4.7 to identify and fix these small performance improvements. I tested and benchmarked them myself and wrote the description below.

### Changes

1. Inline `decode_name/1` for all three compile-time blocks (base 16/32/64) since it seems that was missing. All other functions (e.g. `validate_char_name`) were already inlined.
2. Loop unroll `validate16(upper|lower|mixed)` for 4 and 8 bytes. It had previously only one function head for 2 bytes. Other functions (e.g. `decode_name/1`) have all 2/4/8 function heads. This allows for larger chunks when iterating through the byte list (I think).
3. In `remove_ignored(string, :whitespace)`, check whether the string contains whitespaces first before building a new binary. This will walk the string twice, but runs the costly path of building a new binary only if necessary.

### Benchmarks

I generated 64 random kilobytes and encoded them in the formats 16/32/64 + 64 (URL) for `Base.url_decode64!/1`. I used Benchee to measure one iteration of each `Base.decodeX` function on the random 64 kbs. The times below are the median iteration time.

I tested the `:lower, :mixed, :upper` cases and `ignore: :whitespaces` with (dirty) and without (clean) whitespaces in the random string.

(Benchee, 1s warmup, 3s measurement; M2 Pro, 64 KiB random input)

| Name                            |     before | deviation |     after  | deviation  | speedup        |
| --------------------------------|------------|-----------|------------|------------|----------------|
| decode16! lower 64KiB           |  307.79 μs |    ±4.23% |  202.04 μs |    ±5.34%  | 1.52×          |
| decode16! mixed 64KiB           |  307.79 μs |    ±4.98% |  200.25 μs |    ±5.79%  | 1.54×          |
| decode16! upper 64KiB           |  308.08 μs |    ±4.84% |  200.42 μs |    ±4.27%  | 1.54×          |
| decode32! 64KiB                 |  231.92 μs |    ±5.36% |  143.42 μs |    ±3.16%  | 1.62×          |
| decode64! 64KiB                 |  190.13 μs |    ±5.34% |  119.46 μs |    ±4.13%  | 1.59×          |
| decode64! ignore:ws CLEAN 64KiB | 1015.44 μs |    ±3.69% |  198.67 μs |    ±7.05%  | 5.11×          |
| decode64! ignore:ws DIRTY 64KiB | 1043.58 μs |    ±2.97% |  966.71 μs |    ±8.33%  | 1.08×          |
| url_decode64! 64KiB             |  192.92 μs |    ±5.68% |  119.58 μs |    ±3.07%  | 1.61×          |
| valid16? lower 64KiB            |  299.79 μs |    ±7.03% |  119.13 μs |    ±4.00%  | 2.52×          |
| valid16? upper 64KiB            |  292.83 μs |    ±5.76% |  119.17 μs |    ±3.46%  | 2.46×          |
| valid32? 64KiB                  |   69.71 μs |    ±7.01% |   71.33 μs |    ±3.68%  | within noise   |
| valid64? 64KiB                  |   57.79 μs |    ±6.81% |   59.42 μs |    ±2.68%  | within noise   |
| valid64? ignore:ws CLEAN 64KiB  |  889.40 μs |    ±3.42% |  137.54 μs |    ±2.72%  | 6.47×          |