### PR TITLE
Fix wrong intersection with union of dynamic()

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -448,8 +448,6 @@ defmodule Module.Types.Descr do
   """
   def intersection(:term, other), do: remove_optional(other)
   def intersection(other, :term), do: remove_optional(other)
-  def intersection(%{dynamic: :term}, other), do: dynamic(remove_optional(other))
-  def intersection(other, %{dynamic: :term}), do: dynamic(remove_optional(other))
 
   def intersection(left, right) do
     is_gradual_left = gradual?(left)

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -1500,6 +1500,11 @@ defmodule Module.Types.DescrTest do
         assert truthiness(dynamic(type)) == :always_false
       end
 
+      assert equal?(
+               intersection(union(atom(), dynamic()), union(atom(), dynamic())),
+               union(atom(), dynamic())
+             )
+
       for type <-
             [negation(atom()), atom([true]), negation(atom([false, nil])), atom([:ok]), integer()] do
         assert truthiness(type) == :always_true

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -1425,6 +1425,20 @@ defmodule Module.Types.ExprTest do
       assert typecheck!([x = 123, y = 456.0], x == y) == boolean()
     end
 
+    test "preserves static components across gradual self-intersections" do
+      assert typecheck!(
+               [x],
+               (
+                 # y :: :foo or dynamic()
+                 y = if :rand.uniform() > 0.5, do: :foo, else: x
+                 # y's type intersected with itself
+                 y = y
+
+                 y
+               )
+             ) == union(atom([:foo]), dynamic())
+    end
+
     test "in dynamic mode" do
       assert typedyn!([x = 123, y = 456.0], x < y) == dynamic(boolean())
       assert typedyn!([x = 123, y = 456.0], x == y) == dynamic(boolean())


### PR DESCRIPTION
This fixes a nasty error on intersection which makes it drop the static part systematically when intersecting a type that has `%{dynamic: :term}` (meaning it's `dynamic() or some_static`). These special cases do not seem necessary to me (they are handled by the general path). The typechecking example uses matching with self (`y = y`) to test intersection!