### PR TITLE
Add missing String.count/2 clause for empty pattern list

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -745,7 +745,15 @@ defmodule String do
       iex> String.count("hello world", "")
       12
 
-  The `pattern` can also be a compiled pattern:
+  The `pattern` can also be a list:
+
+      iex> String.count("hello world", ["e", "o"])
+      3
+
+      iex> String.count("hello world", [])
+      0
+
+  Or a compiled pattern:
 
       iex> pattern = :binary.compile_pattern([" ", "!"])
       iex> String.count("foo bar baz!!", pattern)

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -756,6 +756,8 @@ defmodule String do
   @doc since: "1.19.0"
   def count(string, <<>>), do: length(string) + 1
 
+  def count(_string, []), do: 0
+
   def count(string, pattern) when is_struct(pattern, Regex) do
     Kernel.length(Regex.scan(pattern, string, return: :index))
   end


### PR DESCRIPTION
Pattern is defined as:
```
  @typedoc """
  Pattern used in functions like `replace/4` and `split/3`.

  It must be one of:

    * a string
    * an empty list
    * a list containing non-empty strings
    * a compiled search pattern created by `:binary.compile_pattern/1`

  """
  @type pattern ::
          t()
          | [nonempty_binary]
          | (compiled_search_pattern :: :binary.cp())
```
other functions like split/3, replace/4, contains?/2 have special cases for empty list