### PR TITLE
Reject invalid config shapes in Config.validate!/2

### DIFF
--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -377,21 +377,27 @@ defmodule Config do
     end
   end
 
-  defp validate!(config, file) do
-    Enum.all?(config, fn
+  defp validate!(config, file) when is_list(config) do
+    Enum.each(config, fn
       {app, value} when is_atom(app) ->
-        if Keyword.keyword?(value) do
-          true
-        else
+        if not Keyword.keyword?(value) do
           raise ArgumentError,
                 "expected config for app #{inspect(app)} in #{Path.relative_to_cwd(file)} " <>
                   "to return keyword list, got: #{inspect(value)}"
         end
 
-      _ ->
-        false
+      other ->
+        raise ArgumentError,
+              "expected config in #{Path.relative_to_cwd(file)} to be a keyword list " <>
+                "of {atom, keyword} pairs, got entry: #{inspect(other)}"
     end)
 
     config
+  end
+
+  defp validate!(config, file) do
+    raise ArgumentError,
+          "expected config in #{Path.relative_to_cwd(file)} to be a keyword list " <>
+            "of {atom, keyword} pairs, got: #{inspect(config)}"
   end
 end

--- a/lib/elixir/test/elixir/config/reader_test.exs
+++ b/lib/elixir/test/elixir/config/reader_test.exs
@@ -52,6 +52,19 @@ defmodule Config.ReaderTest do
                  ~r"expected config for app :sample in .*/bad_app.exs to return keyword list",
                  fn -> Config.Reader.read!(fixture_path("configs/bad_app.exs")) end
 
+    assert_raise ArgumentError,
+                 ~r"expected config .* to be a keyword list of {atom, keyword} pairs",
+                 fn ->
+                   Config.Reader.eval!(
+                     "nofile",
+                     ~s([{"not_atom", [key: :val]}, {:valid, [k: :v]}])
+                   )
+                 end
+
+    assert_raise ArgumentError,
+                 ~r"expected config .* to be a keyword list of {atom, keyword} pairs",
+                 fn -> Config.Reader.eval!("nofile", "[:not_a_pair]") end
+
     assert_raise RuntimeError, "no :env key was given to this configuration file", fn ->
       Config.Reader.read!(fixture_path("configs/env.exs"))
     end


### PR DESCRIPTION
Previous code used `Enum.all?` and silently skipped invalid pairs