### PR TITLE
Reject negative Duration in to_timeout

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -6421,12 +6421,20 @@ defmodule Kernel do
         {microsecond, _precision} = duration.microsecond
         millisecond = :erlang.convert_time_unit(microsecond, :microsecond, :millisecond)
 
-        duration.week * unquote(week_in_ms) +
-          duration.day * unquote(day_in_ms) +
-          duration.hour * unquote(hour_in_ms) +
-          duration.minute * 60_000 +
-          duration.second * 1000 +
-          millisecond
+        total =
+          duration.week * unquote(week_in_ms) +
+            duration.day * unquote(day_in_ms) +
+            duration.hour * unquote(hour_in_ms) +
+            duration.minute * 60_000 +
+            duration.second * 1000 +
+            millisecond
+
+        if total < 0 do
+          raise ArgumentError,
+                "duration must be positive, got: #{inspect(duration)}"
+        end
+
+        total
     end
   end
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1550,6 +1550,16 @@ defmodule KernelTest do
       end
     end
 
+    test "raises on durations that result in a negative timeout" do
+      assert_raise ArgumentError,
+                   ~r"duration must be positive",
+                   fn -> to_timeout(Duration.new!(second: -1)) end
+
+      assert_raise ArgumentError,
+                   ~r"duration must be positive",
+                   fn -> to_timeout(Duration.new!(hour: 1, minute: -61)) end
+    end
+
     test "works with timeouts" do
       assert to_timeout(1_000) == 1_000
       assert to_timeout(0) == 0


### PR DESCRIPTION
Previously a negative timeout value violating the spec was returned