### PR TITLE
fix ===/2 arity in docs

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -965,7 +965,7 @@ defmodule Keyword do
       iex> Keyword.equal?([a: 1, b: 2, a: 3], [b: 2, a: 3, a: 1])
       true
 
-  Comparison between values is done with `===/3`,
+  Comparison between values is done with `===/2`,
   which means integers are not equivalent to floats:
 
       iex> Keyword.equal?([a: 1.0], [a: 1])

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1109,7 +1109,7 @@ defmodule Map do
       iex> Map.equal?(%{a: 1, b: 2}, %{b: 1, a: 2})
       false
 
-  Comparison between keys and values is done with `===/3`,
+  Comparison between keys and values is done with `===/2`,
   which means integers are not equivalent to floats:
 
       iex> Map.equal?(%{a: 1.0}, %{a: 1})


### PR DESCRIPTION
Just a friendly doc fix for a small error I noticed while working on a bidirectional map library 💜