### PR TITLE
Fix Mix.Dep.Lock.write/2 ignoring :file option when comparing changes

### DIFF
--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -42,7 +42,7 @@ defmodule Mix.Dep.Lock do
   def write(map, opts \\ []) do
     lockfile = opts[:file] || lockfile()
 
-    if map != read() do
+    if map != read(lockfile) do
       if Keyword.get(opts, :check_locked, false) do
         Mix.raise(
           "Your #{lockfile} is out of date and must be updated without the --check-locked flag"

--- a/lib/mix/test/mix/dep/lock_test.exs
+++ b/lib/mix/test/mix/dep/lock_test.exs
@@ -46,6 +46,17 @@ defmodule Mix.Dep.LockTest do
     end)
   end
 
+  test "does not raise with check_locked when custom lockfile is unchanged", context do
+    in_tmp(context.test, fn ->
+      custom_lockfile = Path.expand("custom.lock")
+
+      Mix.Dep.Lock.write(%{foo: :bar})
+      Mix.Dep.Lock.write(%{bar: :baz}, file: custom_lockfile)
+
+      Mix.Dep.Lock.write(%{bar: :baz}, file: custom_lockfile, check_locked: true)
+    end)
+  end
+
   test "raises a proper error if check_locked opt is true and there are changes", context do
     in_tmp(context.test, fn ->
       Mix.Dep.Lock.write(%{foo: :bar})


### PR DESCRIPTION
`Mix.Dep.Lock.write/2` accepts a `:file` option to write to a custom lockfile path. However, when checking whether the lock has changed, it called `read/0` without arguments, comparing the new lock against the default `mix.lock` rather than the target file.

For example, given:

```elixir
# mix.lock contains:    %{foo: {:hex, :foo, "0.1.0"}}
# vendor.lock contains: %{bar: {:hex, :bar, "0.1.0"}}

Mix.Dep.Lock.write(
  %{bar: {:hex, :bar, "0.1.0"}},
  file: "vendor.lock",
  check_locked: true
)
```

`vendor.lock` is already up to date, so this should be a no-op. Instead, the new map is compared against `mix.lock`, the values differ, and `Mix.Error` is raised:

```
** (Mix.Error) Your vendor.lock is out of date and must be updated without the --check-locked flag
```

Without `check_locked`, the same mismatch causes a spurious rewrite of the up-to-date file and an unnecessary `Mix.Task.run("will_recompile")`.

The fix passes the resolved `lockfile` path to `read/1` so the comparison and the write target the same file. A regression test for the `check_locked: true` case is added.
