### PR TITLE
Compact inferred functions

### DIFF
--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -122,7 +122,16 @@ defmodule Module.Types do
           end
       end)
 
-    {Map.new(types), unreachable}
+    types =
+      Map.new(types, fn {fun_arity, inferred} ->
+        {fun_arity, compress_exported_inferred(inferred)}
+      end)
+
+    {types, unreachable}
+  end
+
+  defp compress_exported_inferred({:infer, domain, clauses}) do
+    {:infer, domain, Descr.group_clauses_by_return(clauses)}
   end
 
   defp infer_mode(kind, infer_signatures?) do

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -179,11 +179,95 @@ defmodule Module.Types.Descr do
   @doc """
   Creates a function from non-overlapping function clauses.
   """
-  def fun_from_non_overlapping_clauses([{args, return} | clauses]) do
+  def fun_from_non_overlapping_clauses(clauses) do
+    clauses
+    |> group_clauses_by_return()
+    |> fun_from_clauses()
+  end
+
+  defp fun_from_clauses([{args, return} | clauses]) do
     Enum.reduce(clauses, fun(args, return), fn {args, return}, acc ->
       intersection(acc, fun(args, return))
     end)
   end
+
+  # Compact clauses that have the same return and differ in exactly one
+  # argument by unioning that argument. For example:
+  #
+  #   (integer(), atom() -> boolean()) and (float(), atom() -> boolean())
+  #
+  # becomes:
+  #
+  #   (number(), atom() -> boolean())
+  #
+  # Arity-zero clauses have no argument position to widen.
+  def group_clauses_by_return([{[], _} | _] = clauses), do: clauses
+
+  def group_clauses_by_return([{args, _} | _] = clauses) do
+    arity = length(args)
+
+    if Enum.all?(clauses, &(elem(&1, 0) |> length() == arity)) do
+      do_group_clauses_by_return(clauses)
+    else
+      clauses
+    end
+  end
+
+  def group_clauses_by_return(clauses), do: clauses
+
+  defp do_group_clauses_by_return(clauses) do
+    {clauses, merged?} =
+      Enum.reduce(clauses, {[], false}, fn {args, return}, {acc, merged?} ->
+        case merge_clause_by_return(acc, args, return) do
+          {:ok, acc} -> {acc, true}
+          :error -> {[{args, return} | acc], merged?}
+        end
+      end)
+
+    clauses = Enum.reverse(clauses)
+
+    # Keep going until no pair can be compacted. One merge can expose
+    # another, such as a|b with c later becoming a|b|c.
+    if merged? do
+      do_group_clauses_by_return(clauses)
+    else
+      clauses
+    end
+  end
+
+  defp merge_clause_by_return([{existing_args, return} | tail], args, return) do
+    case merge_args(existing_args, args, [], false) do
+      {:ok, args} ->
+        {:ok, [{args, return} | tail]}
+
+      :error ->
+        with {:ok, tail} <- merge_clause_by_return(tail, args, return) do
+          {:ok, [{existing_args, return} | tail]}
+        end
+    end
+  end
+
+  defp merge_clause_by_return([head | tail], args, return) do
+    with {:ok, tail} <- merge_clause_by_return(tail, args, return) do
+      {:ok, [head | tail]}
+    end
+  end
+
+  defp merge_clause_by_return([], _args, _return), do: :error
+
+  defp merge_args([arg | existing], [arg | args], acc, changed?) do
+    merge_args(existing, args, [arg | acc], changed?)
+  end
+
+  # Allow exactly one differing argument. That one position is widened
+  # with union/2; a second difference means the clauses must stay separate.
+  defp merge_args([existing_arg | existing], [arg | args], acc, false) do
+    merge_args(existing, args, [union(existing_arg, arg) | acc], true)
+  end
+
+  defp merge_args([_ | _], [_ | _], _acc, true), do: :error
+  defp merge_args([], [], acc, true), do: {:ok, Enum.reverse(acc)}
+  defp merge_args([], [], _acc, false), do: :error
 
   @doc """
   Creates a function from overlapping function clauses.

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -1109,6 +1109,44 @@ defmodule Module.Types.DescrTest do
     test "fun_from_non_overlapping_clauses" do
       assert fun_from_non_overlapping_clauses([{[integer()], atom()}, {[float()], binary()}]) ==
                intersection(fun([integer()], atom()), fun([float()], binary()))
+
+      assert fun_from_non_overlapping_clauses([
+               {[integer()], atom()},
+               {[float()], binary()},
+               {[pid()], atom()}
+             ]) ==
+               intersection(fun([union(integer(), pid())], atom()), fun([float()], binary()))
+
+      assert fun_from_non_overlapping_clauses([
+               {[integer(), atom()], binary()},
+               {[float(), atom()], binary()}
+             ]) ==
+               fun([number(), atom()], binary())
+    end
+
+    test "group_clauses_by_return compacts any single differing argument" do
+      assert group_clauses_by_return([
+               {[integer(), atom(), binary()], boolean()},
+               {[float(), atom(), binary()], boolean()},
+               {[atom(), integer(), binary()], atom()},
+               {[atom(), float(), binary()], atom()},
+               {[atom(), binary(), integer()], pid()},
+               {[atom(), binary(), float()], pid()}
+             ]) == [
+               {[number(), atom(), binary()], boolean()},
+               {[atom(), number(), binary()], atom()},
+               {[atom(), binary(), number()], pid()}
+             ]
+    end
+
+    test "group_clauses_by_return repeats until no more clauses can be compacted" do
+      assert group_clauses_by_return([
+               {[number(), binary()], boolean()},
+               {[integer(), atom()], boolean()},
+               {[float(), atom()], boolean()}
+             ]) == [
+               {[number(), union(binary(), atom())], boolean()}
+             ]
     end
 
     test "fun_from_inferred_clauses" do

--- a/lib/elixir/test/elixir/module/types/infer_test.exs
+++ b/lib/elixir/test/elixir/module/types/infer_test.exs
@@ -122,6 +122,33 @@ defmodule Module.Types.InferTest do
               [{[term()], dynamic(union(atom([:error]), tuple([integer(), binary()])))}]}
   end
 
+  test "infers Credo-style operator predicate clauses", config do
+    types =
+      infer config do
+        def operator?({:comp_op, _, _}), do: true
+        def operator?({:comp_op2, _, _}), do: true
+        def operator?({:dual_op, _, _}), do: true
+        def operator?({:mult_op, _, _}), do: true
+        def operator?({:two_op, _, _}), do: true
+        def operator?({:concat_op, _, _}), do: true
+        def operator?({:ternary_op, _, _}), do: true
+        def operator?({:rel_op, _, _}), do: true
+        def operator?({:rel_op2, _, _}), do: true
+        def operator?({:and_op, _, _}), do: true
+        def operator?({:or_op, _, _}), do: true
+        def operator?({:match_op, _, _}), do: true
+        def operator?({:in_match_op, _, _}), do: true
+        def operator?({:stab_op, _, _}), do: true
+        def operator?({:pipe_op, _, _}), do: true
+        def operator?({:arrow_op, _, _}), do: false
+        def operator?(_), do: false
+      end
+
+    assert {:infer, [domain], clauses} = types[{:operator?, 1}]
+    assert domain |> equal?(term())
+    assert length(clauses) == 2
+  end
+
   test "from private functions", config do
     types =
       infer config do


### PR DESCRIPTION
If we infer an intersection of function types using clauses, we compact the clauses which have the same return type (if possible, that is, if the domain can be unioned). 

A domain can be unioned if:
1. it's of arity 1 
2. it's of arity n > 2, and all the arguments are the same but one which differs (this one gets unioned then).

PS: those two cases are in the added tests.