### PR TITLE
Improve Keyword performance

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1090,31 +1090,62 @@ defmodule Keyword do
   @spec merge(t, t, (key, value, value -> value)) :: t
   def merge(keywords1, keywords2, fun)
       when is_list(keywords1) and is_list(keywords2) and is_function(fun, 3) do
-    if keyword?(keywords1) do
-      do_merge(keywords2, [], keywords1, keywords1, fun, keywords2)
-    else
+    if not keyword?(keywords1) do
       raise ArgumentError,
             "expected a keyword list as the first argument, got: #{inspect(keywords1)}"
     end
+
+    keys2 = collect_keys!(keywords2)
+
+    {non_matching_rev, keys2, duplicate_keys} =
+      partition_left(keywords1, [], keys2, MapSet.new())
+
+    keys2 =
+      Enum.reduce(duplicate_keys, keys2, fn key, acc ->
+        Map.update!(acc, key, &:lists.reverse/1)
+      end)
+
+    emitted_rev = emit_right(keywords2, [], keys2, fun)
+    :lists.reverse(non_matching_rev) ++ :lists.reverse(emitted_rev)
   end
 
-  defp do_merge([{key, value2} | tail], acc, rest, original, fun, keywords2) when is_atom(key) do
-    case :lists.keyfind(key, 1, original) do
-      {^key, value1} ->
-        acc = [{key, fun.(key, value1, value2)} | acc]
-        original = :lists.keydelete(key, 1, original)
-        do_merge(tail, acc, delete(rest, key), original, fun, keywords2)
+  defp partition_left([{key, value} | rest], non_matching, keys2, duplicate_keys) do
+    case keys2 do
+      %{^key => []} ->
+        partition_left(rest, non_matching, Map.put(keys2, key, [value]), duplicate_keys)
 
-      false ->
-        do_merge(tail, [{key, value2} | acc], rest, original, fun, keywords2)
+      %{^key => current} ->
+        partition_left(
+          rest,
+          non_matching,
+          Map.put(keys2, key, [value | current]),
+          MapSet.put(duplicate_keys, key)
+        )
+
+      _ ->
+        partition_left(rest, [{key, value} | non_matching], keys2, duplicate_keys)
     end
   end
 
-  defp do_merge([], acc, rest, _original, _fun, _keywords2) do
-    rest ++ :lists.reverse(acc)
+  defp partition_left([], non_matching, keys2, duplicate_keys),
+    do: {non_matching, keys2, duplicate_keys}
+
+  defp emit_right([{key, value2} | rest], emitted, keys2, fun) do
+    case keys2 do
+      %{^key => [value1 | remaining]} ->
+        emit_right(
+          rest,
+          [{key, fun.(key, value1, value2)} | emitted],
+          Map.put(keys2, key, remaining),
+          fun
+        )
+
+      _ ->
+        emit_right(rest, [{key, value2} | emitted], keys2, fun)
+    end
   end
 
-  defp emit_right([], emitted, _queue_map, _fun), do: emitted
+  defp emit_right([], emitted, _keys2, _fun), do: emitted
 
   # Validates a keyword list while collecting its keys into a `%{key => []}`
   # lookup map. Raises with the full original list if a non-keyword element

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1391,11 +1391,17 @@ defmodule Keyword do
   """
   @spec pop(t, key, default) :: {value | default, t}
   def pop(keywords, key, default \\ nil) when is_list(keywords) and is_atom(key) do
-    case fetch(keywords, key) do
-      {:ok, value} -> {value, delete(keywords, key)}
-      :error -> {default, keywords}
-    end
+    do_pop(keywords, key, default, [])
   end
+
+  defp do_pop([{key, value} | tail], key, _default, acc),
+    do: {value, :lists.reverse(acc, delete_key(tail, key))}
+
+  defp do_pop([{_, _} = pair | tail], key, default, acc),
+    do: do_pop(tail, key, default, [pair | acc])
+
+  defp do_pop([], _key, default, acc),
+    do: {default, :lists.reverse(acc)}
 
   @doc """
   Returns the first value for `key` and removes all associated entries in the keyword list,

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -193,6 +193,15 @@ defmodule Keyword do
       iex> Keyword.new([{:a, 1}, {:a, 2}, {:a, 3}])
       [a: 3]
 
+      iex> Keyword.new([{:a, 1}, {:b, 2}, {:a, 3}])
+      [b: 2, a: 3]
+
+      iex> Keyword.new([{:a, 1}, {:b, 2}, {:a, 3}, {:c, 4}, {:b, 5}, {:a, 6}])
+      [c: 4, b: 5, a: 6]
+
+      iex> Keyword.new([])
+      []
+
   """
   @spec new(Enumerable.t()) :: t
   def new(pairs) do

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1156,9 +1156,6 @@ defmodule Keyword do
 
   defp emit_right([], emitted, _keys2, _fun), do: emitted
 
-  # Validates a keyword list while collecting its keys into a `%{key => []}`
-  # lookup map. Raises with the full original list if a non-keyword element
-  # is encountered. Used by merge/2 and merge/3.
   defp collect_keys!(list), do: collect_keys!(list, %{}, list)
 
   defp collect_keys!([{key, _} | rest], acc, original) when is_atom(key),

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1273,16 +1273,19 @@ defmodule Keyword do
   """
   @spec split(t, [key]) :: {t, t}
   def split(keywords, keys) when is_list(keywords) and is_list(keys) do
-    fun = fn {k, v}, {take, drop} ->
-      case k in keys do
-        true -> {[{k, v} | take], drop}
-        false -> {take, [{k, v} | drop]}
-      end
+    predicate = in_keys_check(keys)
+
+    fun = fn pair, {take, drop} ->
+      if predicate.(pair), do: {[pair | take], drop}, else: {take, [pair | drop]}
     end
 
-    acc = {[], []}
-    {take, drop} = :lists.foldl(fun, acc, keywords)
+    {take, drop} = :lists.foldl(fun, {[], []}, keywords)
     {:lists.reverse(take), :lists.reverse(drop)}
+  end
+
+  defp in_keys_check(keys) do
+    keys_set = MapSet.new(keys)
+    fn {key, _} -> MapSet.member?(keys_set, key) end
   end
 
   @doc """
@@ -1340,7 +1343,7 @@ defmodule Keyword do
   """
   @spec take(t, [key]) :: t
   def take(keywords, keys) when is_list(keywords) and is_list(keys) do
-    :lists.filter(fn {k, _} -> :lists.member(k, keys) end, keywords)
+    :lists.filter(in_keys_check(keys), keywords)
   end
 
   @doc """
@@ -1360,7 +1363,8 @@ defmodule Keyword do
   """
   @spec drop(t, [key]) :: t
   def drop(keywords, keys) when is_list(keywords) and is_list(keys) do
-    :lists.filter(fn {k, _} -> k not in keys end, keywords)
+    predicate = in_keys_check(keys)
+    :lists.filter(fn pair -> not predicate.(pair) end, keywords)
   end
 
   @doc """

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1107,10 +1107,10 @@ defmodule Keyword do
     keys2 = collect_keys!(keywords2)
 
     {non_matching_rev, keys2, duplicate_keys} =
-      partition_left(keywords1, [], keys2, MapSet.new())
+      partition_left(keywords1, [], keys2, %{})
 
     keys2 =
-      Enum.reduce(duplicate_keys, keys2, fn key, acc ->
+      Enum.reduce(duplicate_keys, keys2, fn {key, _true}, acc ->
         Map.update!(acc, key, &:lists.reverse/1)
       end)
 
@@ -1128,7 +1128,7 @@ defmodule Keyword do
           rest,
           non_matching,
           Map.put(keys2, key, [value | current]),
-          MapSet.put(duplicate_keys, key)
+          Map.put(duplicate_keys, key, true)
         )
 
       _ ->
@@ -1290,8 +1290,8 @@ defmodule Keyword do
   end
 
   defp in_keys_check(keys) do
-    keys_set = MapSet.new(keys)
-    fn {key, _} -> MapSet.member?(keys_set, key) end
+    keys_set = :lists.foldl(fn key, acc -> Map.put(acc, key, true) end, %{}, keys)
+    fn {key, _} -> Map.has_key?(keys_set, key) end
   end
 
   @doc """

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -214,12 +214,17 @@ defmodule Keyword do
   """
   @spec new(Enumerable.t(), (term -> {key, value})) :: t
   def new(pairs, transform) when is_function(transform, 1) do
-    fun = fn el, acc ->
-      {k, v} = transform.(el)
-      put_new(acc, k, v)
+    fun = fn element, {acc, seen} ->
+      {key, value} = transform.(element)
+
+      case seen do
+        %{^key => _} -> {acc, seen}
+        _ -> {[{key, value} | acc], Map.put(seen, key, true)}
+      end
     end
 
-    :lists.foldl(fun, [], Enum.reverse(pairs))
+    {result, _seen} = :lists.foldl(fun, {[], %{}}, Enum.reverse(pairs))
+    result
   end
 
   @doc """

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1039,21 +1039,18 @@ defmodule Keyword do
   def merge([], keywords2) when is_list(keywords2), do: keywords2
 
   def merge(keywords1, keywords2) when is_list(keywords1) and is_list(keywords2) do
-    if keyword?(keywords2) do
-      fun = fn
-        {key, _value} when is_atom(key) ->
-          not has_key?(keywords2, key)
+    keys2 = collect_keys!(keywords2)
 
-        _ ->
-          raise ArgumentError,
-                "expected a keyword list as the first argument, got: #{inspect(keywords1)}"
-      end
+    fun = fn
+      {key, _value} when is_atom(key) ->
+        not Map.has_key?(keys2, key)
 
-      :lists.filter(fun, keywords1) ++ keywords2
-    else
-      raise ArgumentError,
-            "expected a keyword list as the second argument, got: #{inspect(keywords2)}"
+      _ ->
+        raise ArgumentError,
+              "expected a keyword list as the first argument, got: #{inspect(keywords1)}"
     end
+
+    :lists.filter(fun, keywords1) ++ keywords2
   end
 
   @doc """
@@ -1117,9 +1114,21 @@ defmodule Keyword do
     rest ++ :lists.reverse(acc)
   end
 
-  defp do_merge(_other, _acc, _rest, _original, _fun, keywords2) do
+  defp emit_right([], emitted, _queue_map, _fun), do: emitted
+
+  # Validates a keyword list while collecting its keys into a `%{key => []}`
+  # lookup map. Raises with the full original list if a non-keyword element
+  # is encountered. Used by merge/2 and merge/3.
+  defp collect_keys!(list), do: collect_keys!(list, %{}, list)
+
+  defp collect_keys!([{key, _} | rest], acc, original) when is_atom(key),
+    do: collect_keys!(rest, Map.put(acc, key, []), original)
+
+  defp collect_keys!([], acc, _original), do: acc
+
+  defp collect_keys!(_other, _acc, original) do
     raise ArgumentError,
-          "expected a keyword list as the second argument, got: #{inspect(keywords2)}"
+          "expected a keyword list as the second argument, got: #{inspect(original)}"
   end
 
   @doc """


### PR DESCRIPTION
> Disclosure: I found, benchmarked, and refactored the performance improvements here with Claude Opus 4.7 but I rewrote most of Claude's code by hand and I understand the proposed changes, benchmarks, and results. I wrote the description below myself as well.

I refactored some functions in `Keyword` and achieved the following speed-ups over the baseline. `n` is the number of items in the input list(s). Time is the **average** iteration time of the optimized code. The speed-up multiplier is the best-case result (e.g. 50% of duplicate keys in the input of `Keyword.merge/2`)

The values at `n=5` and `n=10` seem slower than the baseline, but given their nanosecond execution times, variations here are mostly due to noise, but I think some regressions are real, for example for `merge/3 with `n=10`, so caution is advised.

| Function | n=5 | n=10 | n=100 | n=1000 |
|---|---|---:|---:|---:|
| `new/2`  | -  | 1.10x · 395 ns | 1.11x · 6.05 µs | **3.88x** · 76.03 µs |
| `merge/2` | -  | 0.90x · 208 ns | 1.62x · 4.42 µs | **7.13x** · 88.80 µs |
| `merge/3` | -  | 0.68x · 394 ns | 3.32x · 8.49 µs | **16.01x** · 200 µs |
| `pop/3`  | -  | 2.22x · 30 ns  | **3.03x** · 291 ns | **2.20x** · 3.97 µs |
| `take/2` | 0.80x  · 42ns  | 0.98x · 87  ns | 1.13x · 2.98 µs | **8.17x** · 44.55 µs |
| `drop/2` | 1.32x · 51ns  | 0.88x · 109 ns | 1.05x · 3.34 µs | **7.22x** · 50.53 µs |
| `split/2` |  0.87x · 83ns | 0.88x · 138 ns | 1.10x · 3.17 µs | **6.43x** · 58.22 µs |

An overview of the changes I've applied to the functions:

### `new/2`
The original code would call `put_new/3` on every key-value pair which runs `:lists.keyfind(key, 1, acc)` under the hood to check whether a key is already present. As the accumulator grows, the `:lists.keyfind/3` would walk the growing accumulator for every item.

The new code builds a `seen` map of keys and pattern-matches against new keys to check for duplicates. I also considered using `Map.get(seen, k)` here but my assumption was that the pattern-match found be slightly faster.

### `merge/2`
The original code would first call `keyword?(keywords2)` which walks the entire `keywords2` list to confirm it's a keyword list. It then called `has_key?(keywords2, key)` on every key-value pair which calls `:lists.keymember(key, 1, keywords)` under the hood, again walking the entire accumulator for every new item. 

The new code first collects all keys in `keywords2` and validates that the keyword list is valid in a single pass. It then uses `Map.has_key?(keys2, key)` to check for duplicates.

### `merge/3`
The original code would walk `keywords2` only once, but then walk `keywords1` three times for every entry. First, it would walk it as `original` with `:lists.keyfind(key, 1, original)` to check for duplication. If a duplication exists, it would walk it again with `:lists.keydelete(key, 1, original)` and once more with `delete(rest, key)`. The `:lists.keydelete/3` would remove only the first occurrence of the duplicate key from `original` but remove **all** duplicates from `rest`. If a `keywords1` had two occurrences of the same key, the original code would call `:lists.keydelete(key, 1, original)` again but it would be noop for `delete(rest, key)`.

The new code does three linear passes. First, it walks `keywords2` to collect all keys into a map with an empty list for each key. It also validates the keys. Second, `partition_left/4` walks `keywords1` once. It groups the values of keys also occurring in `keywords2`, builds an array of keys that don't occur in `keywords2`, and tracks the duplicate keys in a MapSet. If `keywords1` has any duplicate keys, it reverses the values of the duplicate keys to make sure their values are back in order.

Third, `emit_right` walks `keywords2` once more and joins the values of `keywords2` of keys that also appeared in `keywords1` left-to-right. It then adds the key-value pairs that didn't have a duplicate key in `keywords1`. Lastly, we concatenate the key-value pair from `keywords1` whose key did not occur in `keywords2` with the values from `keywords2` that did or did not have duplicate keys in `kewords1`.

### `split/2` - `take/2` - `drop/2`
All three of these functions would run `k in keys` for every entry of the keyword list. This would be fine for a small list of `keys` but if that lists grows to e.g. 50% of the keyword list, it would slow down these functions significantly.

The new code builds a MapSet from the keys and uses `MapSet.member?/2` for every entry. **I'm not sure whether this is "safe" though**. Can we assume that all `keys` are always valid MapSet entries? The `key in keys` check previously only checked for equality and didn't assume any validity of the keys.

### `pop/2`
The original code would walk the `keywords` list three times: Once to check whether the list contains the `key` with `fetch(keywords, key)`, then a  second time inside `delete(keywords. key)` which checks again that the key exists with `:lists.keymember(key, 1, keywords)`, and then `delete_key/2` would walk the `keywords` list a third time to remove the key from the list.

The new code walks the `keywords` list only once. If it finds the key, it runs `delete_key(tail, key)` to remove it from the tail and reverses the now clean new list. If it doesn't find the key, it reverses the `keywords` list once. This logic is very similar to `replace/3`.

I will add the benchmark and results in separate comments below.






