### PR TITLE
Respect --raise when mix test --warnings-as-errors passes with warnings

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -712,7 +712,7 @@ defmodule Mix.Tasks.Test do
         cond do
           warnings_as_errors? and (warnings? or helper_warned? or warn_files != []) and
               failures == 0 ->
-            abort_due_to_warnings()
+            abort_due_to_warnings(shell, opts)
 
           failures > 0 and opts[:raise] ->
             raise_with_shell(shell, "\"mix test\" failed")
@@ -740,7 +740,7 @@ defmodule Mix.Tasks.Test do
       {:noop, _} ->
         cond do
           warnings_as_errors? and warn_files != [] ->
-            abort_due_to_warnings()
+            abort_due_to_warnings(shell, opts)
 
           opts[:stale] ->
             Mix.shell().info("No stale tests")
@@ -784,15 +784,22 @@ defmodule Mix.Tasks.Test do
     {files, directly_included}
   end
 
-  defp abort_due_to_warnings() do
-    message =
-      "\nERROR! Test suite aborted after successful execution due to warnings while using the --warnings-as-errors option"
+  defp abort_due_to_warnings(shell, opts) do
+    if opts[:raise] do
+      message =
+        "test suite aborted after successful execution due to warnings while using the --warnings-as-errors option"
 
-    IO.puts(:stderr, IO.ANSI.format([:red, message]))
+      raise_with_shell(shell, message)
+    else
+      message =
+        "\nERROR! Test suite aborted after successful execution due to warnings while using the --warnings-as-errors option"
 
-    System.at_exit(fn _ ->
-      exit({:shutdown, 1})
-    end)
+      IO.puts(:stderr, IO.ANSI.format([:red, message]))
+
+      System.at_exit(fn _ ->
+        exit({:shutdown, 1})
+      end)
+    end
   end
 
   defp raise_with_shell(shell, message) do

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -545,6 +545,37 @@ defmodule Mix.Tasks.TestTest do
       end)
     end
 
+    test "raise if warning in tests but tests pass and --raise is specified" do
+      in_fixture("test_stale", fn ->
+        msg =
+          "** (Mix) test suite aborted after successful execution due to warnings while using the --warnings-as-errors option"
+
+        refute mix(["test", "--warnings-as-errors", "--raise"]) =~ msg
+
+        File.write!("lib/warning.ex", """
+        unused_compile_var = 1
+        """)
+
+        File.write!("test/warning_test_stale.exs", """
+        defmodule WarningTest do
+          use ExUnit.Case
+
+          test "warning" do
+            unused_test_var = 1
+          end
+        end
+        """)
+
+        {output, exit_status} =
+          mix_code(["test", "--warnings-as-errors", "--raise", "test/warning_test_stale.exs"])
+
+        assert output =~ "variable \"unused_compile_var\" is unused"
+        assert output =~ "variable \"unused_test_var\" is unused"
+        assert output =~ msg
+        assert exit_status == 1
+      end)
+    end
+
     test "fail with --exit-status + 1 if warning in tests and tests fail" do
       in_fixture("test_stale", fn ->
         File.write!("test/warning_test_warnings_as_errors_and_failures.exs", """


### PR DESCRIPTION
Currently if `mix test --warnings-as-errors --raise` passes and there are test warnings, it only exits with status as usual, rather than raising. Note that `--raise` already applies not only to tests failing, but also when no tests match the given pattern, so it makes sense to apply it to warnings for consistency.