### PR TITLE
Fix parse_error input spec

### DIFF
--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -317,7 +317,7 @@ compile_error(Meta, File, Message) when is_list(Message) ->
 %% Tokenization parsing/errors.
 
 -spec parse_error(elixir:keyword(), binary() | {binary(), binary()},
-                  binary(), binary(), {unicode:charlist(), integer(), integer()}) -> no_return().
+                  binary(), binary(), {unicode:charlist(), integer(), integer(), non_neg_integer()}) -> no_return().
 parse_error(Location, File, Error, <<>>, Input) ->
   Message = case Error of
     <<"syntax error before: ">> -> <<"syntax error: expression is incomplete">>;


### PR DESCRIPTION
`elixir_errors:parse_error/5` receives the original parser input as a 4-tuple that includes indentation. Both parser call sites pass `{String, StartLine, StartColumn, Indentation}`, and `cut_snippet/3` already pattern matches that shape.

This updates the spec to match the existing runtime contract.

## Verification

- `git diff --check`
- `make compile`