### PR TITLE
Scope ExUnit diff width tests

### DIFF
--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -86,9 +86,13 @@ defmodule ExUnit.DiffTest do
     end
   end
 
-  defmacrop refute_diff(expr, expected_left, expected_right, pins \\ [])
+  # Use a finite width only for tests that exercise display layout. Most diff
+  # tests should keep the default :infinity width so generated inspected values,
+  # such as references, pids, and functions, do not affect line wrapping.
+  @terminal_width 80
+  defmacrop refute_diff(expr, expected_left, expected_right, pins \\ [], width \\ :infinity)
 
-  defmacrop refute_diff({:=, _, [left, right]}, expected_left, expected_right, pins) do
+  defmacrop refute_diff({:=, _, [left, right]}, expected_left, expected_right, pins, width) do
     left = Assertions.__expand_pattern__(left, __CALLER__) |> Macro.escape()
 
     quote do
@@ -97,12 +101,13 @@ defmodule ExUnit.DiffTest do
         unquote(right),
         unquote(expected_left),
         unquote(expected_right),
-        {:match, unquote(pins)}
+        {:match, unquote(pins)},
+        unquote(width)
       )
     end
   end
 
-  defmacrop refute_diff({op, _, [left, right]}, expected_left, expected_right, [])
+  defmacrop refute_diff({op, _, [left, right]}, expected_left, expected_right, [], width)
             when op in [:==, :===] do
     quote do
       refute_diff(
@@ -110,19 +115,20 @@ defmodule ExUnit.DiffTest do
         unquote(right),
         unquote(expected_left),
         unquote(expected_right),
-        unquote(op)
+        unquote(op),
+        unquote(width)
       )
     end
   end
 
-  defp refute_diff(left, right, expected_left, expected_right, context) do
+  defp refute_diff(left, right, expected_left, expected_right, context, width) do
     {diff, _env} = Diff.compute(left, right, context)
     assert diff.equivalent? == false
 
-    diff_left = to_diff(diff.left, "-")
+    diff_left = to_diff(diff.left, "-", width)
     assert diff_left =~ expected_left
 
-    diff_right = to_diff(diff.right, "+")
+    diff_right = to_diff(diff.right, "+", width)
     assert diff_right =~ expected_right
   end
 
@@ -134,11 +140,10 @@ defmodule ExUnit.DiffTest do
     assert env_binding == expected_binding
   end
 
-  @terminal_width 80
-  defp to_diff(side, sign) do
+  defp to_diff(side, sign, width) do
     side
     |> Diff.to_algebra(&diff_wrapper(&1, sign))
-    |> Algebra.format(@terminal_width)
+    |> Algebra.format(width)
     |> IO.iodata_to_binary()
   end
 
@@ -718,7 +723,9 @@ defmodule ExUnit.DiffTest do
         },
         name: nil
       }\
-      """
+      """,
+      [],
+      @terminal_width
     )
 
     refute_diff(
@@ -742,7 +749,9 @@ defmodule ExUnit.DiffTest do
         },
         name: nil
       }\
-      """
+      """,
+      [],
+      @terminal_width
     )
   end
 
@@ -917,7 +926,9 @@ defmodule ExUnit.DiffTest do
         }-
       ]\
       """,
-      "[]"
+      "[]",
+      [],
+      @terminal_width
     )
 
     refute_diff(
@@ -934,7 +945,9 @@ defmodule ExUnit.DiffTest do
           "notifications" => true
         }+
       ]\
-      """
+      """,
+      [],
+      @terminal_width
     )
 
     assert_diff([map] == [map], [])
@@ -967,7 +980,9 @@ defmodule ExUnit.DiffTest do
         }-
       ]\
       """,
-      "[]"
+      "[]",
+      [],
+      @terminal_width
     )
 
     refute_diff(
@@ -984,7 +999,9 @@ defmodule ExUnit.DiffTest do
           notifications: true
         }+
       ]\
-      """
+      """,
+      [],
+      @terminal_width
     )
 
     assert_diff([customer] == [customer], [])
@@ -1232,18 +1249,8 @@ defmodule ExUnit.DiffTest do
 
     refute_diff(
       {ref1, ref2} == {ref2, ref1},
-      """
-      {
-        -#{inspect_ref1}-,
-        -#{inspect_ref2}-
-      }\
-      """,
-      """
-      {
-        +#{inspect_ref2}+,
-        +#{inspect_ref1}+
-      }\
-      """
+      "{-#{inspect_ref1}-, -#{inspect_ref2}-}",
+      "{+#{inspect_ref2}+, +#{inspect_ref1}+}"
     )
 
     refute_diff(
@@ -1263,11 +1270,7 @@ defmodule ExUnit.DiffTest do
 
     refute_diff(
       %{ref1 => ref2} == :a,
-      """
-      -%{
-        #{inspect_ref1} => #{inspect_ref2}
-      }\
-      """,
+      "-%{#{inspect_ref1} => #{inspect_ref2}}",
       "+:a+"
     )
 
@@ -1313,11 +1316,7 @@ defmodule ExUnit.DiffTest do
 
     refute_diff(
       %{identity => identity} == :a,
-      """
-      -%{
-        #{inspect} => #{inspect}
-      }-\
-      """,
+      "-%{#{inspect} => #{inspect}}-",
       "+:a+"
     )
 


### PR DESCRIPTION
## Summary

- Make `ExUnit.DiffTest` use `:infinity` as the default diff formatting width.
- Add an explicit terminal-width override for tests that exercise display layout.
- Flatten generated-value expectations for refs and functions so VM-generated inspect strings do not control wrapping.

## Context

This follows up on #13954 which changed the test helper to format at 80 columns globally to force-test the inserted/deleted map-in-list formatting. However, this introduced a latent issue in diffs that involve PIDs or Refs that have variable lengths, and such tests may fail intermittently such as in https://github.com/elixir-lang/elixir/actions/runs/25930787536/job/76225550506:

```
1) test refs (ExUnit.DiffTest)
   test/ex_unit/diff_test.exs:1221
   Assertion with =~ failed
   code:  assert diff_left =~ expected_left
   left:  "{-#Reference<0.134765775.2.103458>-, -#Reference<0.134765775.2.103459>-}"
   right: "{\n  -#Reference<0.134765775.2.103458>-,\n  -#Reference<0.134765775.2.103459>-\n}"
   stacktrace:
     test/ex_unit/diff_test.exs:123: ExUnit.DiffTest.refute_diff/5
     test/ex_unit/diff_test.exs:1233: (test)
```

This PR keeps that finite-width coverage, but narrows it to deterministic layout assertions:
- structs with missing keys on match
- maps in lists
- structs in lists

Other diff tests default back to `:infinity`, which makes semantic checks independent from generated inspected values such as refs, pids, and functions.

## Tests

- `make test_ex_unit`
- `bin/mix format --check-formatted lib/ex_unit/test/ex_unit/diff_test.exs`
- `git diff --check`