### PR TITLE
Allow float keywords in to_timeout/1.

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -6360,12 +6360,13 @@ defmodule Kernel do
   `year` and `month` fields set to `0`, since those cannot be reliably converted to
   milliseconds (due to the varying number of days in a month and year).
 
-  Microseconds in durations are converted to milliseconds (through `System.convert_time_unit/3`).
+  Microseconds in durations are converted to milliseconds
+  (rounded via the floor function, through `System.convert_time_unit/3`).
 
   ### Passing components
 
   The `duration` argument can also be keyword list which can contain the following
-  keys, each appearing at most once with a non-negative integer value:
+  keys, each appearing at most once with a non-negative numeric value:
 
     * `:week` - the number of weeks (a week is always 7 days)
     * `:day` - the number of days (a day is always 24 hours)
@@ -6387,6 +6388,8 @@ defmodule Kernel do
   With a keyword list:
 
       iex> to_timeout(hour: 1, minute: 30)
+      5400000
+      iex> to_timeout(hour: 1.5)
       5400000
 
   With a duration:
@@ -6443,7 +6446,7 @@ defmodule Kernel do
 
   def to_timeout(components) when is_list(components) do
     reducer = fn
-      {key, value}, {acc, seen_keys} when is_integer(value) and value >= 0 ->
+      {key, value}, {acc, seen_keys} when is_number(value) and value >= 0 ->
         case :lists.member(key, seen_keys) do
           true ->
             raise ArgumentError, "timeout component #{inspect(key)} is duplicated"
@@ -6484,7 +6487,7 @@ defmodule Kernel do
       {key, value}, {_acc, _seen_keys} ->
         raise ArgumentError,
               "timeout component #{inspect(key)} must be a non-negative " <>
-                "integer, got: #{inspect(value)}"
+                "number, got: #{inspect(value)}"
     end
 
     elem(:lists.foldl(reducer, {0, _seen_keys = []}, components), 0)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -6360,8 +6360,7 @@ defmodule Kernel do
   `year` and `month` fields set to `0`, since those cannot be reliably converted to
   milliseconds (due to the varying number of days in a month and year).
 
-  Microseconds in durations are converted to milliseconds
-  (rounded via the floor function, through `System.convert_time_unit/3`).
+  Microseconds in durations are converted to milliseconds (through `System.convert_time_unit/3`).
 
   ### Passing components
 
@@ -6376,7 +6375,8 @@ defmodule Kernel do
     * `:millisecond` - the number of milliseconds
 
   The timeout is calculated as the sum of the components, each multiplied by
-  the corresponding factor.
+  the corresponding factor. Fractional milliseconds are rounded upwards with
+  `ceil/1` to ensure the timeout exceeds the requested value.
 
   ### Passing timeouts
 
@@ -6490,7 +6490,7 @@ defmodule Kernel do
                 "number, got: #{inspect(value)}"
     end
 
-    elem(:lists.foldl(reducer, {0, _seen_keys = []}, components), 0)
+    ceil(elem(:lists.foldl(reducer, {0, _seen_keys = []}, components), 0))
   end
 
   ## Sigils

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1494,9 +1494,11 @@ defmodule KernelTest do
       assert to_timeout(minute: 74) == 1000 * 60 * 74
       assert to_timeout(second: 1293) == 1_293_000
       assert to_timeout(millisecond: 1_234_123) == 1_234_123
+      assert to_timeout(millisecond: 1.25) == 2
+      assert to_timeout(millisecond: 1.75) == 2
 
       assert to_timeout(hour: 2, minute: 30) == 1000 * 60 * 60 * 2 + 1000 * 60 * 30
-      assert to_timeout(hour: 2.5) == 1000 * 60 * 60 * 2.5
+      assert to_timeout(hour: 2.5, second: 1.3) == 1000 * 60 * 60 * 2.5 + 1000 * 1.3
       assert to_timeout(minute: 30, hour: 2) == 1000 * 60 * 60 * 2 + 1000 * 60 * 30
       assert to_timeout(minute: 74, second: 30) == 1000 * 60 * 74 + 1000 * 30
     end

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1496,15 +1496,16 @@ defmodule KernelTest do
       assert to_timeout(millisecond: 1_234_123) == 1_234_123
 
       assert to_timeout(hour: 2, minute: 30) == 1000 * 60 * 60 * 2 + 1000 * 60 * 30
+      assert to_timeout(hour: 2.5) == 1000 * 60 * 60 * 2.5
       assert to_timeout(minute: 30, hour: 2) == 1000 * 60 * 60 * 2 + 1000 * 60 * 30
       assert to_timeout(minute: 74, second: 30) == 1000 * 60 * 74 + 1000 * 30
     end
 
     test "raises on invalid values with keyword lists" do
       for unit <- [:hour, :minute, :second, :millisecond],
-          value <- [-1, 1.0, :not_an_int] do
+          value <- [-1, :not_a_number] do
         message =
-          "timeout component #{inspect(unit)} must be a non-negative integer, " <>
+          "timeout component #{inspect(unit)} must be a non-negative number, " <>
             "got: #{inspect(value)}"
 
         assert_raise ArgumentError, message, fn -> to_timeout([{unit, value}]) end

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1494,8 +1494,10 @@ defmodule KernelTest do
       assert to_timeout(minute: 74) == 1000 * 60 * 74
       assert to_timeout(second: 1293) == 1_293_000
       assert to_timeout(millisecond: 1_234_123) == 1_234_123
-      assert to_timeout(millisecond: 1.25) == 2
-      assert to_timeout(millisecond: 1.75) == 2
+
+      assert to_timeout(millisecond: 3.25) == 4
+      assert to_timeout(millisecond: 3.75) == 4
+      assert to_timeout(hour: 0.000001) == 4
 
       assert to_timeout(hour: 2, minute: 30) == 1000 * 60 * 60 * 2 + 1000 * 60 * 30
       assert to_timeout(hour: 2.5, second: 1.3) == 1000 * 60 * 60 * 2.5 + 1000 * 1.3


### PR DESCRIPTION
Per [core discussion](https://groups.google.com/g/elixir-lang-core/c/DkWUrBY7iqU), I ran into another situation with a dynamically-calculated rate limit from an API response (in fractional minutes), and thought I would proffer an implementation.

While floats are not allowed in `Duration`s, it makes sense to me that since the purpose of `to_timeout/1` is not to construct a `Duration`, a general-purpose `Kernel` function should be made more flexible. Duration and simple numeric arguments still require integers, to encourage thinking of timeouts on millisecond timescales.

I understand the mailing list discussion did not end with a _[👍 PRs welcome]_, so feel free to close if the argument for this form is not sufficiently persuasive.