### PR TITLE
Investigating crash when typing cond

### DIFF
--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -308,7 +308,7 @@ defmodule Module.Types.Expr do
         of_expr(pos_head, term(), pos_head, %{stack | reverse_arrow: :cache}, acc_context)
 
       # Reset the context vars, keep warnings, as we will infer with expected truthy
-      context = Of.reset_vars(context, acc_context)
+      # context = Of.reset_vars(context, acc_context)
 
       context =
         maybe_always_or_never_match_cond(pos_head_type, pos_head, pos_meta, stack, context, false)
@@ -355,7 +355,7 @@ defmodule Module.Types.Expr do
               of_expr(head, term(), head, %{stack | reverse_arrow: :cache}, acc_context)
 
             # Reset the context vars, keep warnings, as we will infer with expected truthy
-            context = Of.reset_vars(context, acc_context)
+            # context = Of.reset_vars(context, acc_context)
 
             context =
               maybe_always_or_never_match_cond(head_type, head, meta, stack, context, last?)

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -3261,5 +3261,18 @@ defmodule Module.Types.ExprTest do
                )
              ) == dynamic() or binary()
     end
+
+    test "case nested in cond" do
+      assert typecheck!(
+               [value],
+               cond do
+                 (case float? = is_float(value) do
+                    false -> is_integer(value)
+                    true -> true
+                  end) ->
+                   float?
+               end
+             ) == boolean()
+    end
   end
 end


### PR DESCRIPTION
Not a fix, just a branch to troubleshoot https://github.com/elixir-lang/elixir/issues/15402.

It seems the reset of context before checking  is causing the variable `1` to be missing?