### PR TITLE
Colorize CLI error banner

### DIFF
--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -98,21 +98,26 @@ defmodule Kernel.CLI do
   @doc """
   Shared helper for error formatting on CLI tools.
   """
-  def format_error(kind, reason, stacktrace, ansi? \\ false) do
+  def format_error(kind, reason, stacktrace) do
+    {banner, rest} = format_error_parts(kind, reason, stacktrace)
+    [banner, rest]
+  end
+
+  defp format_error_parts(kind, reason, stacktrace) do
     {blamed, stacktrace} = Exception.blame(kind, reason, stacktrace)
 
-    iodata =
+    banner =
       case blamed do
         %FunctionClauseError{} ->
           formatted = Exception.format_banner(kind, reason, stacktrace)
           padded_blame = pad(FunctionClauseError.blame(blamed, &inspect/1, &blame_match/1))
-          [banner_ansi(formatted, ansi?), padded_blame]
+          [formatted, padded_blame]
 
         _ ->
-          Exception.format_banner(kind, blamed, stacktrace) |> banner_ansi(ansi?)
+          Exception.format_banner(kind, blamed, stacktrace)
       end
 
-    [iodata, ?\n, Exception.format_stacktrace(prune_stacktrace(stacktrace))]
+    {banner, [?\n, Exception.format_stacktrace(prune_stacktrace(stacktrace))]}
   end
 
   @doc """
@@ -179,13 +184,9 @@ defmodule Kernel.CLI do
   ## Error handling
 
   defp print_error(kind, reason, stacktrace) do
-    IO.write(:stderr, format_error(kind, reason, stacktrace, IO.ANSI.enabled?()))
+    {banner, rest} = format_error_parts(kind, reason, stacktrace)
+    IO.write(:stderr, [IO.ANSI.format([:red, banner]), rest])
   end
-
-  defp banner_ansi(banner, true),
-    do: IO.iodata_to_binary(IO.ANSI.format([:red, banner], true))
-
-  defp banner_ansi(banner, false), do: banner
 
   defp blame_match(%{match?: true, node: node}), do: blame_ansi(:normal, "+", node)
   defp blame_match(%{match?: false, node: node}), do: blame_ansi(:red, "-", node)

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -98,7 +98,7 @@ defmodule Kernel.CLI do
   @doc """
   Shared helper for error formatting on CLI tools.
   """
-  def format_error(kind, reason, stacktrace) do
+  def format_error(kind, reason, stacktrace, ansi? \\ false) do
     {blamed, stacktrace} = Exception.blame(kind, reason, stacktrace)
 
     iodata =
@@ -106,10 +106,10 @@ defmodule Kernel.CLI do
         %FunctionClauseError{} ->
           formatted = Exception.format_banner(kind, reason, stacktrace)
           padded_blame = pad(FunctionClauseError.blame(blamed, &inspect/1, &blame_match/1))
-          [formatted, padded_blame]
+          [banner_ansi(formatted, ansi?), padded_blame]
 
         _ ->
-          Exception.format_banner(kind, blamed, stacktrace)
+          Exception.format_banner(kind, blamed, stacktrace) |> banner_ansi(ansi?)
       end
 
     [iodata, ?\n, Exception.format_stacktrace(prune_stacktrace(stacktrace))]
@@ -179,8 +179,13 @@ defmodule Kernel.CLI do
   ## Error handling
 
   defp print_error(kind, reason, stacktrace) do
-    IO.write(:stderr, format_error(kind, reason, stacktrace))
+    IO.write(:stderr, format_error(kind, reason, stacktrace, IO.ANSI.enabled?()))
   end
+
+  defp banner_ansi(banner, true),
+    do: IO.iodata_to_binary(IO.ANSI.format([:red, banner], true))
+
+  defp banner_ansi(banner, false), do: banner
 
   defp blame_match(%{match?: true, node: node}), do: blame_ansi(:normal, "+", node)
   defp blame_match(%{match?: false, node: node}), do: blame_ansi(:red, "-", node)

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -197,6 +197,27 @@ defmodule Kernel.CLI.ExecutableTest do
     assert elixir(fixture_path("at_exit.exs") |> to_charlist()) ==
              "goodbye cruel world with status 1\n"
   end
+
+  describe "format_error/4" do
+    test "colors the banner in red when ansi? is true" do
+      formatted =
+        Kernel.CLI.format_error(:error, %ArgumentError{message: "boom"}, [], true)
+        |> IO.iodata_to_binary()
+
+      assert formatted =~ IO.ANSI.red()
+      assert formatted =~ IO.ANSI.reset()
+      assert formatted =~ "** (ArgumentError) boom"
+    end
+
+    test "leaves output plain by default" do
+      formatted =
+        Kernel.CLI.format_error(:error, %ArgumentError{message: "boom"}, [])
+        |> IO.iodata_to_binary()
+
+      refute formatted =~ "\e["
+      assert formatted =~ "** (ArgumentError) boom"
+    end
+  end
 end
 
 defmodule Kernel.CLI.RPCTest do

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -197,27 +197,6 @@ defmodule Kernel.CLI.ExecutableTest do
     assert elixir(fixture_path("at_exit.exs") |> to_charlist()) ==
              "goodbye cruel world with status 1\n"
   end
-
-  describe "format_error/4" do
-    test "colors the banner in red when ansi? is true" do
-      formatted =
-        Kernel.CLI.format_error(:error, %ArgumentError{message: "boom"}, [], true)
-        |> IO.iodata_to_binary()
-
-      assert formatted =~ IO.ANSI.red()
-      assert formatted =~ IO.ANSI.reset()
-      assert formatted =~ "** (ArgumentError) boom"
-    end
-
-    test "leaves output plain by default" do
-      formatted =
-        Kernel.CLI.format_error(:error, %ArgumentError{message: "boom"}, [])
-        |> IO.iodata_to_binary()
-
-      refute formatted =~ "\e["
-      assert formatted =~ "** (ArgumentError) boom"
-    end
-  end
 end
 
 defmodule Kernel.CLI.RPCTest do


### PR DESCRIPTION
I noticed that the error message from the cli output is not colored and thought it would improve readability, when more salient. Hope this improves the overall experience. It's gated behind the `--color` flag to not break existing output parsing.

Claude Opus was used to assist in this PR

Before:
<img width="724" height="87" alt="image" src="https://github.com/user-attachments/assets/a835d397-40dd-4fe8-beb1-4621c6de9d9d" />

After:
<img width="718" height="92" alt="image" src="https://github.com/user-attachments/assets/80460095-1924-4119-9ea4-48c4a259ea4d" />

