### PR TITLE
Inline in empty list in erlang pass

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4703,10 +4703,8 @@ defmodule Kernel do
         false
 
       [] ->
-        quote do
-          _ = unquote(left)
-          false
-        end
+        # inlined as false in erlang pass
+        quote(do: :lists.member(unquote(left), []))
 
       [head | tail] = list ->
         case in_body? do

--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -242,7 +242,11 @@ defmodule Module.Types.Apply do
         {Kernel, :put_elem, [{[open_tuple([]), integer(), term()], dynamic(open_tuple([]))}]},
 
         ## Lists
-        {:lists, :member, [{[term(), list(term())], boolean()}]},
+        {:lists, :member,
+         [
+           {[term(), empty_list()], atom([false])},
+           {[term(), non_empty_list(term())], boolean()}
+         ]},
 
         ## Map
         {Map, :delete, [{[open_map(), term()], open_map()}]},

--- a/lib/elixir/lib/module/types/helpers.ex
+++ b/lib/elixir/lib/module/types/helpers.ex
@@ -329,7 +329,7 @@ defmodule Module.Types.Helpers do
             end
         end
 
-      {{:., _, [:lists, :member]}, meta, [expr, [_ | _] = args]} = call ->
+      {{:., _, [:lists, :member]}, meta, [expr, args]} = call when is_list(args) ->
         if Enum.any?(args, &match?({:|, _, [_, _]}, &1)) do
           call
         else

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -576,9 +576,14 @@ translate_remote('Elixir.String.Chars', to_string, Meta, [Arg], S) ->
     {clause, Generated, [Var], [[Guard]], [Fast]},
     {clause, Generated, [Var], [], [Slow]}
   ]}, VS};
-translate_remote(lists, member, Meta, [_Expr, []], S) ->
+translate_remote(lists, member, Meta, [Expr, []], S) ->
   Ann = ?ann(Meta),
-  {{atom, Ann, false}, S};
+  {TExpr, S1} = translate(Expr, Ann, S),
+  {VarName, S2} = elixir_erl_var:build('_', S1),
+  Generated = erl_anno:set_generated(true, Ann),
+  Var = {var, Generated, VarName},
+  Block = {block, Generated, [{match, Generated, Var, TExpr}, {atom, Ann, false}]},
+  {Block, S2};
 translate_remote(lists, member, Meta, [Expr, [Head | Tail] = List], S) ->
   Ann = ?ann(Meta),
 

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -576,6 +576,9 @@ translate_remote('Elixir.String.Chars', to_string, Meta, [Arg], S) ->
     {clause, Generated, [Var], [[Guard]], [Fast]},
     {clause, Generated, [Var], [], [Slow]}
   ]}, VS};
+translate_remote(lists, member, Meta, [_Expr, []], S) ->
+  Ann = ?ann(Meta),
+  {{atom, Ann, false}, S};
 translate_remote(lists, member, Meta, [Expr, [Head | Tail] = List], S) ->
   Ann = ?ann(Meta),
 

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -579,11 +579,7 @@ translate_remote('Elixir.String.Chars', to_string, Meta, [Arg], S) ->
 translate_remote(lists, member, Meta, [Expr, []], S) ->
   Ann = ?ann(Meta),
   {TExpr, S1} = translate(Expr, Ann, S),
-  {VarName, S2} = elixir_erl_var:build('_', S1),
-  Generated = erl_anno:set_generated(true, Ann),
-  Var = {var, Generated, VarName},
-  Block = {block, Generated, [{match, Generated, Var, TExpr}, {atom, Ann, false}]},
-  {Block, S2};
+  {{block, Ann, [{match, Ann, {var, Ann, '_'}, TExpr}, {atom, Ann, false}]}, S1};
 translate_remote(lists, member, Meta, [Expr, [Head | Tail] = List], S) ->
   Ann = ?ann(Meta),
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -461,6 +461,11 @@ defmodule KernelTest do
       refute 2 in []
       refute false in []
       refute true in []
+
+      # make sure optimization still evaluates the left-hand side
+      # (do not use assert/refute which handle in/2 differently)
+      send(self(), :foo) in []
+      assert_received :foo
     end
 
     test "with expressions on right side" do

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -697,7 +697,7 @@ defmodule KernelTest do
              """
 
       # Empty list
-      assert expand_to_string(quote(do: :x in [])) =~ "_ = :x\nfalse"
+      assert expand_to_string(quote(do: :x in [])) =~ ":lists.member(:x, [])"
       assert expand_to_string(quote(do: :x in []), :guard) == "false"
 
       # Lists

--- a/lib/elixir/test/elixir/macro/env_test.exs
+++ b/lib/elixir/test/elixir/macro/env_test.exs
@@ -75,7 +75,7 @@ defmodule Macro.EnvTest do
   test "to_match/1" do
     quote = quote(do: x in [])
 
-    assert {:__block__, [], [{:=, [], [{:_, [], Kernel}, {:x, [], Macro.EnvTest}]}, false]} =
+    assert {{:., [], [:lists, :member]}, [], [{:x, [], Macro.EnvTest}, []]} =
              Macro.expand_once(quote, __ENV__)
 
     assert Macro.expand_once(quote, Macro.Env.to_match(__ENV__)) == false

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -1820,6 +1820,11 @@ defmodule Module.Types.ExprTest do
     test "Kernel.in/2" do
       assert typecheck!(
                [x],
+               x in []
+             ) == boolean()
+
+      assert typecheck!(
+               [x],
                (
                  true = x in [:foo, 1, :bar, 2.0, :baz]
                  x

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -1821,7 +1821,7 @@ defmodule Module.Types.ExprTest do
       assert typecheck!(
                [x],
                x in []
-             ) == boolean()
+             ) == atom([false])
 
       assert typecheck!(
                [x],

--- a/lib/elixir/test/elixir/module/types/helpers_test.exs
+++ b/lib/elixir/test/elixir/module/types/helpers_test.exs
@@ -20,6 +20,8 @@ defmodule Module.Types.HelpersTest do
       assert expr_to_string(quote(do: :erlang.list_to_atom(a))) == "List.to_atom(a)"
       assert expr_to_string(quote(do: :erlang.element(1, a))) == "elem(a, 0)"
       assert expr_to_string(quote(do: :erlang.element(:erlang.+(a, 1), b))) == "elem(b, a)"
+      assert expr_to_string(quote(do: :lists.member(a, []))) == "a in []"
+      assert expr_to_string(quote(do: :lists.member(a, [:foo, :bar]))) == "a in [:foo, :bar]"
     end
 
     test "Kernel macros" do

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -60,6 +60,23 @@ optimized_or_test() ->
      {clause, _, [{atom, _, true}], [], [{atom, _, true}]}]
   } = to_erl("is_list([]) or :done").
 
+optimized_in_test() ->
+  {'block', _,
+    [{match,_,
+      {var, _, '_1'},
+      {call, _, {remote, _, {atom, _, 'Elixir.IO'}, {atom, _, puts}}, [{atom, _, hi}]}},
+    {atom, _, false}]
+  } = to_erl("IO.puts(:hi) in []"),
+  {'block', _,
+    [{match,_,
+      {var, _, '_1'},
+      {call, _, {remote, _, {atom, _, 'Elixir.IO'}, {atom, _, puts}}, [{atom, _, hi}]}},
+    {op, _, 'orelse',
+      {op, _, '=:=', {var, _ , '_1'}, {integer, _, 1}},
+      {op, _, '=:=', {var, _ , '_1'}, {integer, _, 2}}
+      }]
+  } = to_erl("IO.puts(:hi) in [1, 2]").
+
 no_after_in_try_test() ->
   {'try', _, [_], [], [_], []} = to_erl("try do :foo.bar() catch _ -> :ok end").
 

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -63,7 +63,7 @@ optimized_or_test() ->
 optimized_in_test() ->
   {'block', _,
     [{match,_,
-      {var, _, '_1'},
+      {var, _, '_'},
       {call, _, {remote, _, {atom, _, 'Elixir.IO'}, {atom, _, puts}}, [{atom, _, hi}]}},
     {atom, _, false}]
   } = to_erl("IO.puts(:hi) in []"),


### PR DESCRIPTION
- `x in []` is expanded at `:lists.member(x, [])`
- then later the erlang pass inlines it as `false`

Same approach as 34a50002f9b3634ed8185efd6a2c65faf21f2c01

Closes https://github.com/elixir-lang/elixir/issues/15411