### PR TITLE
Fix trapped signal documentation

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -541,7 +541,7 @@ defmodule System do
   By default, the Erlang VM register traps to the three
   signals:
 
-    * `:sigstop` - gracefully shuts down the VM with `stop/0`
+    * `:sigterm` - gracefully shuts down the VM with `stop/0`
     * `:sigquit` - halts the VM via `halt/0`
     * `:sigusr1` - halts the VM via status code of 1
 


### PR DESCRIPTION
`sigstop` is untrappable on POSIX
`erl_signal_handler` implementation confirms that `sigterm` is trapped https://github.com/erlang/otp/blob/bf6adb8744a589c89eb79c8ae9c49ca348f325fd/lib/kernel/src/erl_signal_handler.erl#L39