### PR TITLE
Fix spec of ex_unit capture_log options

### DIFF
--- a/lib/ex_unit/lib/ex_unit/capture_log.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_log.ex
@@ -45,7 +45,7 @@ defmodule ExUnit.CaptureLog do
 
   @type capture_log_opts :: [
           {:level, Logger.level() | nil}
-          | {:formatter, {module(), term()} | nil}
+          | {:formatter, {module(), term()}}
         ]
 
   @doc """


### PR DESCRIPTION
Passing `formatter: nil` was never supported and would crash in https://github.com/elixir-lang/elixir/blob/274dbb6e10ab6e47cf93cc5d576c9a22180b1d2c/lib/ex_unit/lib/ex_unit/capture_server.ex#L79