### PR TITLE
Make sure we never suggest back invalid characters

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1438,7 +1438,7 @@ suggest_simpler_unexpected_token_in_error(Wrong, Line, WrongColumn, Scope) ->
     {error, _Reason} ->
        ConfusableSkeleton = 'Elixir.String.Tokenizer.Security':confusable_skeleton(Wrong),
        case (Scope#elixir_tokenizer.identifier_tokenizer):tokenize(ConfusableSkeleton) of
-         {_, Simpler, _, _, _, _} ->
+         {_, Simpler, _, _, _, _} when Simpler =/= Wrong ->
            Message = suggest_change("Codepoint failed identifier tokenization, but a simpler form was found.",
                                     Wrong,
                                     "You could write the above in a similar way that is accepted by Elixir:",

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -1353,6 +1353,12 @@ defmodule Kernel.ParserTest do
       ]
 
       assert_syntax_error(message, ~c"fooی𝚳")
+
+      # regression test: ǜ (should not suggest back the wrong character)
+      assert_syntax_error(
+        ["nofile:1:4:", ~s/unexpected token: "#{"\u01DC"}" (column 4, code point U+01DC)/],
+        ~c":fooǜ"
+      )
     end
 
     test "keyword missing space" do


### PR DESCRIPTION
Tentative fix for https://github.com/elixir-lang/elixir/issues/15419

```erlang
Wrong: [476]
ConfusableSkeleton: [117,776,768]
Simpler: [476]
```

There's probably an issue with `confusable_skeleton` or tokenize here to be fixed as well, so it might not be the final fix, but either way I think it never makes sense to suggest back the same `Wrong` characters?

To be backported.

Note: this comes from https://github.com/elixir-lang/elixir/blob/23a431223bbbc156eb224c6aa55b68479393d3e5/lib/elixir/unicode/security.ex#L111:

```elixir
:unicode.characters_to_nfd_list([476])
[117, 776, 768]
```