### PR TITLE
Refine static predicate branches

### DIFF
--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -136,6 +136,23 @@ defmodule Module.Types.Of do
             {old_type, context}
         end
 
+      _ when stack.reverse_arrow == :use ->
+        new_type = intersection(old_type, type)
+
+        case empty?(new_type) do
+          false when new_type != old_type ->
+            data = %{
+              data
+              | type: new_type,
+                off_traces: new_trace(expr, new_type, stack, off_traces)
+            }
+
+            {new_type, %{context | vars: %{vars | version => data}}}
+
+          _ ->
+            {old_type, context}
+        end
+
       _ ->
         case gradual?(old_type) and compatible_intersection(old_type, type) do
           {:ok, new_type} when new_type != old_type ->

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -2241,6 +2241,61 @@ defmodule Module.Types.ExprTest do
                )
     end
 
+    test "refines static expression type from predicates" do
+      assert typecheck!(
+               [bin?],
+               (
+                 x =
+                   if bin? do
+                     "foo"
+                   else
+                     1
+                   end
+
+                 if is_binary(x) do
+                   String.length(x)
+                 else
+                   x + 1
+                 end
+               )
+             )
+             |> equal?(union(dynamic(), integer()))
+
+      message =
+        typeerror!(
+          [bin?, int?, bool?],
+          (
+            x =
+              if bin? do
+                "foo"
+              else
+                if int? do
+                  1
+                else
+                  if bool? do
+                    true
+                  else
+                    false
+                  end
+                end
+              end
+
+            if is_binary(x) do
+              String.length(x)
+            else
+              x + 1
+            end
+          )
+        )
+        |> strip_ansi()
+
+      assert message =~ "incompatible types given to Kernel.+/2"
+      assert message =~ "boolean() or integer(), integer()"
+      assert message =~ "# type: binary() or boolean() or integer()"
+      assert message =~ "# type: boolean() or integer()"
+      refute message =~ "dynamic("
+    end
+
     test "refines nested expression type" do
       assert typecheck!(
                case (if x = System.get_env("HELLO") do


### PR DESCRIPTION
Enable the reverse arrows to refine static types. Necessary for annotating functions, since the input is a static type. 

The examples showcase this by building an artificial static type union using literals.
