### PR TITLE
Support acronym names in Mix tasks

### DIFF
--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -354,13 +354,61 @@ defmodule Mix.Task do
   end
 
   defp fetch(task) when is_binary(task) or is_atom(task) do
-    case Mix.Utils.command_to_module(to_string(task), Mix.Tasks) do
-      {:module, module} ->
-        if task?(module), do: {:ok, module}, else: {:error, :invalid}
+    task = to_string(task)
 
-      {:error, _} ->
+    case task_module(task) do
+      nil ->
         {:error, :not_found}
+
+      module ->
+        if task?(module), do: {:ok, module}, else: {:error, :invalid}
     end
+  end
+
+  defp task_module(task) do
+    expected = "Elixir.Mix.Tasks." <> Mix.Utils.command_to_module_name(task)
+
+    case available_task_module(task, expected) do
+      nil -> nil
+      ^expected -> String.to_atom(expected)
+      module -> String.to_atom(module)
+    end
+  end
+
+  defp available_task_module(task, expected) do
+    case find_available_task_module(available_modules(), task, expected) do
+      nil ->
+        :code.clear_cache()
+        find_available_task_module(available_modules(), task, expected)
+
+      module ->
+        module
+    end
+  end
+
+  defp available_modules do
+    Enum.map(:code.all_available(), fn {module, _file, _loaded?} -> List.to_string(module) end)
+  end
+
+  defp find_available_task_module(modules, task, expected) do
+    if expected in modules do
+      expected
+    else
+      case Enum.filter(modules, &(task_name_from_module(&1) == task)) do
+        [module] -> module
+        _ -> nil
+      end
+    end
+  end
+
+  defp task_name_from_module("Elixir.Mix.Tasks." <> rest) do
+    rest
+    |> String.split(".")
+    |> Enum.map_join(".", &Macro.underscore/1)
+  end
+
+  defp task_name_from_module(_module) do
+    nil
   end
 
   @doc """

--- a/lib/mix/test/mix/task_test.exs
+++ b/lib/mix/test/mix/task_test.exs
@@ -4,6 +4,19 @@
 
 Code.require_file("../test_helper.exs", __DIR__)
 
+defmodule Mix.Tasks.Casing.HTTP do
+  use Mix.Task
+  def run(_), do: "HTTP"
+end
+
+defmodule Mix.Tasks.Casing.Http do
+  use Mix.Task
+  def run(_), do: "Http"
+end
+
+defmodule Mix.Tasks.InvalidAcronym.XML do
+end
+
 defmodule Mix.TaskTest do
   use MixTest.Case
 
@@ -32,14 +45,19 @@ defmodule Mix.TaskTest do
       Mix.Task.run("invalid")
     end
 
-    message =
-      "The task \"acronym.http\" could not be found because the module is named " <>
-        "Mix.Tasks.Acronym.HTTP instead of Mix.Tasks.Acronym.Http as expected. " <>
-        "Please rename it and try again"
+    assert Mix.Task.run("acronym.http") == "An HTTP Task"
+  end
 
-    assert_raise Mix.NoTaskError, message, fn ->
-      Mix.Task.run("acronym.http")
-    end
+  test "run/2 prefers conventionally named tasks" do
+    assert Mix.Task.run("casing.http") == "Http"
+  end
+
+  test "run/2 raises on invalid acronym tasks" do
+    assert_raise Mix.InvalidTaskError,
+                 "The task \"invalid_acronym.xml\" does not export run/1",
+                 fn ->
+                   Mix.Task.run("invalid_acronym.xml")
+                 end
   end
 
   test "run/2 converts OptionParser.ParseError into Mix errors" do
@@ -97,11 +115,19 @@ defmodule Mix.TaskTest do
       end
       """)
 
+      File.write!("custom/raw_repo/lib/task_http.ex", """
+      defmodule Mix.Tasks.TaskHTTP do
+        use Mix.Task
+        def run(_), do: "Hello HTTP"
+      end
+      """)
+
       # Clean up the tasks and update task
       Mix.Task.clear()
 
       # Task was found from deps loadpaths
       assert Mix.Task.run("task_hello") == "Hello World v1"
+      assert Mix.Task.run("task_http") == "Hello HTTP"
 
       # The compile task should not have run yet
       assert Mix.Task.run("compile") != :noop
@@ -136,6 +162,22 @@ defmodule Mix.TaskTest do
 
       # Check if compile task have run
       refute Mix.TasksServer.run({:task, "compile", Mix.Project.get()})
+    end)
+  end
+
+  test "run/2 finds acronym tasks after compiling current project", context do
+    in_tmp(context.test, fn ->
+      Mix.Project.push(SampleProject, "sample")
+      File.mkdir_p!("lib/mix/tasks")
+
+      File.write!("lib/mix/tasks/xml.schema.ex", """
+      defmodule Mix.Tasks.XML.Schema do
+        use Mix.Task
+        def run(_), do: "XML schema"
+      end
+      """)
+
+      assert Mix.Task.run("xml.schema") == "XML schema"
     end)
   end
 


### PR DESCRIPTION
Mix task lookup reconstructs a module name from the command, so `mix xml.schema` looks for `Mix.Tasks.Xml.Schema`. This is lossy for acronym modules: `Mix.Task.task_name(Mix.Tasks.XML.Schema)` returns `"xml.schema"`, but that task cannot currently be invoked.

This is the acronym-task case from #4137 / #4148. The fix avoids the pitfalls discussed there: it does not try casing variants and does not speculatively load wrong-cased modules, which can produce `:badfile` loader errors on case-insensitive filesystems.

Instead, lookup now resolves from available `Mix.Tasks.*` modules using the same module-to-command mapping Mix already uses for task names. The conventional module still wins when present, so `Mix.Tasks.Xml` is preferred over `Mix.Tasks.XML`.

If only the acronym module exists, it can now be invoked:

```elixir
Mix.Tasks.XML.Schema -> mix xml.schema
```

If multiple non-conventional modules map to the same task name, Mix treats it as not found rather than selecting one based on code path order.

This uses `:code.all_available/0`, available since Erlang/OTP 23. Current Elixir main targets OTP 27-29 and already uses this API elsewhere, so no compatibility guard is needed.
