### PR TITLE
Add more docs to System.otp_release/0

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -1379,11 +1379,10 @@ defmodule System do
   @doc """
   Returns the Erlang/OTP release number.
 
-  The version is a single number, the major version of OTP. There is
-  no way to get the *exact* OTP version. This is because the exact
-  OTP version in the general case is difficult to determine.
-  For more information, see the [*Versions* page](https://www.erlang.org/doc/system/versions.html)
-  in the Erlang documentation.
+  The version is a single number, the major version of OTP.
+  Erlang/OTP does not provide an API to fetch the exact
+  patch version, see the [*Versions* page](https://www.erlang.org/doc/system/versions.html)
+  in the Erlang documentation for more information.
 
   ## Examples
 

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -1386,8 +1386,8 @@ defmodule System do
 
   ## Examples
 
-      System.otp_release()
-      #=> "29"
+      iex> System.otp_release()
+      "#{:erlang.system_info(:otp_release)}"
 
   """
   @spec otp_release :: String.t()

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -1378,6 +1378,18 @@ defmodule System do
 
   @doc """
   Returns the Erlang/OTP release number.
+
+  The version is a single number, the major version of OTP. There is
+  no way to get the *exact* OTP version. This is because the exact
+  OTP version in the general case is difficult to determine.
+  For more information, see the [*Versions* page](https://www.erlang.org/doc/system/versions.html)
+  in the Erlang documentation.
+
+  ## Examples
+
+      System.otp_release()
+      #=> "29"
+
   """
   @spec otp_release :: String.t()
   @doc since: "1.3.0"


### PR DESCRIPTION
I'm aware that using a specific version in the example could be confusing, especially the more time passes and versions of OTP advance, but I think an example is helpful nonetheless. 