### PR TITLE
Honor --no-compile in mix format

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -78,6 +78,10 @@ defmodule Mix.Tasks.Format do
 
     * `--dry-run` - does not save files after formatting.
 
+    * `--no-compile` - does not compile, even if compilation is required
+      to load formatter plugins. If a plugin cannot be loaded, an error
+      is raised.
+
     * `--verbose` - prints the names of files that were formatted.
 
     * `--dot-formatter` - path to the file with formatter configuration.
@@ -152,7 +156,7 @@ defmodule Mix.Tasks.Format do
       ]
 
   Notice that, when running the formatter with plugins, your code will be
-  compiled first.
+  compiled first, unless the `--no-compile` flag is given.
 
   In addition, the order by which you input your plugins is the format order.
   So, in the above `.formatter.exs`, the `MixMarkdownFormatter` will format
@@ -316,7 +320,7 @@ defmodule Mix.Tasks.Format do
 
     plugins =
       if plugins != [] do
-        Keyword.get(opts, :plugin_loader, &plugin_loader/1).(plugins)
+        Keyword.get(opts, :plugin_loader, &plugin_loader(&1, opts)).(plugins)
       else
         []
       end
@@ -357,12 +361,12 @@ defmodule Mix.Tasks.Format do
      end)}
   end
 
-  defp plugin_loader(plugins) do
+  defp plugin_loader(plugins, opts) do
     if plugins != [] do
-      Mix.Task.run("loadpaths", [])
+      Mix.Task.run("loadpaths", if(opts[:no_compile], do: ["--no-compile"], else: []))
     end
 
-    if not Enum.all?(plugins, &Code.ensure_loaded?/1) do
+    if !opts[:no_compile] and not Enum.all?(plugins, &Code.ensure_loaded?/1) do
       Mix.Task.run("compile", [])
     end
 

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -597,6 +597,51 @@ defmodule Mix.Tasks.FormatTest do
     end)
   end
 
+  defmodule FormatWithPluginApp do
+    def project do
+      [app: :format_with_plugin, version: "0.1.0"]
+    end
+  end
+
+  test "doesn't compile plugins with --no-compile", context do
+    in_tmp(context.test, fn ->
+      Mix.Project.push(__MODULE__.FormatWithPluginApp)
+      on_exit(fn -> purge([UncompiledPlugin]) end)
+
+      File.write!(".formatter.exs", """
+      [
+        inputs: ["a.ex"],
+        plugins: [UncompiledPlugin]
+      ]
+      """)
+
+      File.mkdir_p!("lib")
+
+      File.write!("lib/uncompiled_plugin.ex", """
+      defmodule UncompiledPlugin do
+        @behaviour Mix.Tasks.Format
+
+        def features(_opts), do: [extensions: [".ex"]]
+        def format(contents, _opts), do: "# formatted\\n" <> contents
+      end
+      """)
+
+      File.write!("a.ex", """
+      foo bar
+      """)
+
+      assert_raise Mix.Error, "Formatter plugin UncompiledPlugin cannot be found", fn ->
+        Mix.Tasks.Format.run(["--no-compile"])
+      end
+
+      refute_received {:mix_shell, :info, ["Compiling" <> _]}
+
+      assert File.read!("a.ex") == """
+             foo bar
+             """
+    end)
+  end
+
   test "uses extension plugins with --stdin-filename", context do
     in_tmp(context.test, fn ->
       File.write!(".formatter.exs", """


### PR DESCRIPTION
7061c37b8 added a `--no-compile` switch to `mix format` to keep compilation
output away from stdout (#15256), but the parsed option is never consumed -
the default plugin loader runs `loadpaths`, and `compile` whenever a
configured plugin is not yet loaded, regardless of the flag. In a project
with a formatter plugin configured in `.formatter.exs`:

```console
$ mix --version
Mix 1.20.0 (compiled with Erlang/OTP 29)
$ rm -rf _build
$ echo 'defmodule T do end' | mix format --no-compile -
Compiling 1 file (.ex)
Generated my_app app
defmodule T do
end
```

With the option honored, a plugin that cannot be loaded without compiling
fails the run with the existing "Formatter plugin X cannot be found" error,
rather than compiling anyway.