### PR TITLE
Add `Enum.natural_join/3` to join `[1, 2, 3]` into `"1, 2 and 3"`

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1719,23 +1719,15 @@ defmodule Enum do
   @spec natural_join(Enumerable.t(), binary(), binary()) :: binary()
   def natural_join(enumerable, joiner \\ ", ", final_joiner \\ " and ")
       when is_binary(joiner) and is_binary(final_joiner) do
-    natural_join(to_list(enumerable), joiner, final_joiner, [])
-  end
-
-  # done; reverse and finalize
-  defp natural_join([], _, _, result), do: result |> :lists.reverse() |> IO.iodata_to_binary()
-
-  # single element; short circuit
-  defp natural_join([head | []], _, _, []), do: entry_to_string(head)
-
-  # final element; replace interspersed joiner with final joiner, recurse to finalize
-  defp natural_join([head | [] = tail], joiner, final_joiner, [joiner | result_tail]) do
-    natural_join(tail, joiner, final_joiner, [entry_to_string(head), final_joiner | result_tail])
-  end
-
-  # other element; intersperse joiner and recurse
-  defp natural_join([head | tail], joiner, final_joiner, result) do
-    natural_join(tail, joiner, final_joiner, [joiner, entry_to_string(head) | result])
+    case reduce(enumerable, :empty, fn
+           elem, :empty -> {:one, entry_to_string(elem)}
+           elem, {:one, prev} -> {:many, prev, entry_to_string(elem)}
+           elem, {:many, acc, prev} -> {:many, [acc, joiner | prev], entry_to_string(elem)}
+         end) do
+      :empty -> ""
+      {:one, str} -> IO.iodata_to_binary(str)
+      {:many, acc, last} -> IO.iodata_to_binary([acc, final_joiner | last])
+    end
   end
 
   @doc """

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1704,6 +1704,41 @@ defmodule Enum do
   end
 
   @doc """
+  Similar to `Enum.join/2` but takes a final joiner as the third argument,
+  used for the last element, to create joined strings like "1, 2 and 3".
+
+  ## Examples
+
+      iex> Enum.natural_join([1, 2, 3])
+      "1, 2 and 3"
+      iex> Enum.natural_join([1, 2])
+      "1 and 2"
+      iex> Enum.natural_join([1])
+      "1"
+  """
+  @spec natural_join(Enumerable.t(), binary(), binary()) :: binary()
+  def natural_join(enumerable, joiner \\ ", ", final_joiner \\ " and ")
+      when is_binary(joiner) and is_binary(final_joiner) do
+    natural_join(to_list(enumerable), joiner, final_joiner, [])
+  end
+
+  # done; reverse and finalize
+  defp natural_join([], _, _, result), do: result |> :lists.reverse() |> IO.iodata_to_binary()
+
+  # single element; short circuit
+  defp natural_join([head | []], _, _, []), do: entry_to_string(head)
+
+  # final element; replace interspersed joiner with final joiner, recurse to finalize
+  defp natural_join([head | [] = tail], joiner, final_joiner, [joiner | result_tail]) do
+    natural_join(tail, joiner, final_joiner, [entry_to_string(head), final_joiner | result_tail])
+  end
+
+  # other element; intersperse joiner and recurse
+  defp natural_join([head | tail], joiner, final_joiner, result) do
+    natural_join(tail, joiner, final_joiner, [joiner, entry_to_string(head) | result])
+  end
+
+  @doc """
   Returns a list where each element is the result of invoking
   `fun` on each corresponding element of `enumerable`.
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -514,6 +514,24 @@ defmodule EnumTest do
     assert Enum.join(fn acc, _ -> acc end, ".") == ""
   end
 
+  test "natural_join/2" do
+    assert Enum.natural_join([], " = ") == ""
+    assert Enum.natural_join([1], " = ") == "1"
+    assert Enum.natural_join([1, 2], " = ") == "1 and 2"
+    assert Enum.natural_join([1, 2, 3], " = ") == "1 = 2 and 3"
+    assert Enum.natural_join([1, "2", 3], " = ") == "1 = 2 and 3"
+    assert Enum.natural_join([1, 2, 3]) == "1, 2 and 3"
+    assert Enum.natural_join([1, 2, 3], ", ", " or ") == "1, 2 or 3"
+    assert Enum.natural_join(["", "", 1, 2, "", 3, "", "\n"], ";") == ";;1;2;;3; and \n"
+
+    assert Enum.natural_join([["a", "b"], ["c", "d", "e", ["f", "g"]], "h", "i"], " ") ==
+             "ab cdefg h and i"
+
+    assert Enum.natural_join([""]) == ""
+
+    assert Enum.natural_join(fn acc, _ -> acc end, ".") == ""
+  end
+
   test "map/2" do
     assert Enum.map([], fn x -> x * 2 end) == []
     assert Enum.map([1, 2, 3], fn x -> x * 2 end) == [2, 4, 6]
@@ -2039,6 +2057,14 @@ defmodule EnumTest.Range do
     assert Enum.join(1..0//-1, " = ") == "1 = 0"
     assert Enum.join(1..3, " = ") == "1 = 2 = 3"
     assert Enum.join(1..3) == "123"
+  end
+
+  test "natural_join/2" do
+    assert Enum.natural_join(1..0//-1, " = ", " + ") == "1 + 0"
+    assert Enum.natural_join(1..0//-1, " = ", "") == "10"
+    assert Enum.natural_join(1..0//-1, " = ") == "1 and 0"
+    assert Enum.natural_join(1..3, " = ") == "1 = 2 and 3"
+    assert Enum.natural_join(1..3) == "1, 2 and 3"
   end
 
   test "map/2" do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -521,7 +521,7 @@ defmodule EnumTest do
     assert Enum.natural_join([1, 2, 3], " = ") == "1 = 2 and 3"
     assert Enum.natural_join([1, "2", 3], " = ") == "1 = 2 and 3"
     assert Enum.natural_join([1, 2, 3]) == "1, 2 and 3"
-    assert Enum.natural_join([1, 2, 3], ", ", " or ") == "1, 2 or 3"
+    assert Enum.natural_join([1, 2, 3, 4], ", ", " or ") == "1, 2, 3 or 4"
     assert Enum.natural_join(["", "", 1, 2, "", 3, "", "\n"], ";") == ";;1;2;;3; and \n"
 
     assert Enum.natural_join([["a", "b"], ["c", "d", "e", ["f", "g"]], "h", "i"], " ") ==


### PR DESCRIPTION
Hi! Thought I'd open a little PR to propose adding a function to the standard lib. It's only a very small thing so I figured I would do the proposing and the implementation in one go :)

**Problem**

Joining a list into a human-readable string with a different final separator (e.g. `"1, 2 and 3"`) is a common formatting need that cannot be correctly implemented as a single-pass composition of existing `Enum` functions. The closest approach requires two traversals and manual edge-case handling:

```elixir
{init, [last]} = Enum.split(list, -1)   # two traversals
Enum.join(init, ", ") <> " and " <> to_string(last)
# crashes on [], wrong on [x], doesn't handle nested iodata
```

**Proposed addition: `Enum.natural_join/3`**

```elixir
Enum.natural_join(enumerable, joiner \\ ", ", final_joiner \\ " and ")
```

Joins an enumerable into a string like `Enum.join/2`, but uses `final_joiner` before the last element instead of `joiner`. Defaults produce English natural-language list strings out of the box. Other languages can easily be supported by callers by passing in a `gettext(" and ")`, and of course something like " or " can also be passed in for different semantics.

**Approach**

- Uses a reduction like other join-family functions to process in a single pass regardless of the type of enumerable
- Handles all edge cases correctly in the same pass: empty enumerable returns `""`, single-element skips both joiners, two-element uses only `final_joiner`.
- Consistent with `join/2`: accepts `Enumerable.t()`, requires `joiner` and `final_joiner` to be binaries, delegates element stringification to `entry_to_string/1` (handles nested iodata).

**Why a new function rather than extending `join/3`**

Adding a third argument to `join/2` would require a `nil` default to preserve backwards compatibility, polluting the type signature (`binary() | nil`) and adding a special-case clause. A separate function seems like it's cleaner and more discoverable.