### PR TITLE
Properly reset variables between cond clauses

### DIFF
--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -347,9 +347,9 @@ defmodule Module.Types.Expr do
     cache_result(meta, stack, context, fn ->
       {body_type, acc_context} =
         reduce_non_empty(clauses, {none(), context}, fn
-          {:->, meta, [[head], body]}, {acc, context}, last? ->
+          {:->, meta, [[head], body]}, {acc, initial_context}, last? ->
             {head_type, context} =
-              of_expr(head, term(), head, %{stack | reverse_arrow: :cache}, context)
+              of_expr(head, term(), head, %{stack | reverse_arrow: :cache}, initial_context)
 
             context =
               maybe_always_or_never_match_cond(head_type, head, meta, stack, context, last?)
@@ -360,9 +360,8 @@ defmodule Module.Types.Expr do
             # Keep the context except the warnings, and compute the body
             truthy_context = reset_warnings(truthy_context, context)
             {body_type, body_context} = of_expr(body, expected, expr, stack, truthy_context)
-
             # Reset the context vars to the head definition to compute the falsy type
-            context = Of.reset_vars(body_context, context)
+            context = Of.reset_vars(body_context, initial_context)
 
             context =
               if last? do

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -3450,5 +3450,17 @@ defmodule Module.Types.ExprTest do
                )
              ) == dynamic() or binary()
     end
+
+    defguard is_pair(x) when is_tuple(x) and tuple_size(x) == 2
+
+    test "cond with custom guard" do
+      assert typecheck!(
+               [x],
+               cond do
+                 is_pair(x) -> :pair
+                 is_atom(x) -> :atom
+               end
+             ) == atom([:pair, :atom])
+    end
   end
 end


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/15450 (tentative fix)

Explanation:

In `initial_context`, we just have `x`. But the guard expands to:

```elixir
{arg1} = {x}
:erlang.andalso(:erlang.is_tuple(arg1), :erlang.==(:erlang.tuple_size(arg1), 2))
```

So after `of_expr`, we added `arg1` to the context which doesn't get reset by `reset_vars`.
Not sure yet why it actually influences `x` though, still investigating.

To be backported.