### PR TITLE
doc: correct :as_list typo to :as_lists in inspect examples

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -102,7 +102,7 @@ defmodule List do
   Even though the representation changed, the raw data does remain a list of
   integers, which can be handled as such:
 
-      iex> inspect(~c"abc", charlists: :as_list)
+      iex> inspect(~c"abc", charlists: :as_lists)
       "[97, 98, 99]"
       iex> Enum.map(~c"abc", fn num -> 1000 + num end)
       [1097, 1098, 1099]

--- a/lib/elixir/pages/getting-started/binaries-strings-and-charlists.md
+++ b/lib/elixir/pages/getting-started/binaries-strings-and-charlists.md
@@ -269,7 +269,7 @@ iex> heartbeats_per_minute = [99, 97, 116]
 You can always force charlists to be printed in their list representation by calling the `inspect/2` function:
 
 ```elixir
-iex> inspect(heartbeats_per_minute, charlists: :as_list)
+iex> inspect(heartbeats_per_minute, charlists: :as_lists)
 "[99, 97, 116]"
 ```
 


### PR DESCRIPTION
Fixes occurrences where `:as_list` was used instead of `:as_lists` for the `:charlists` option.