### PR TITLE
add Access.pop/3 to support a specific default value

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -482,6 +482,40 @@ defmodule Access do
     raise ArgumentError, "could not pop key #{inspect(key)} on a nil value"
   end
 
+  @doc """
+  Removes the entry with a given key from a container (a map, keyword
+  list, or struct that implements the `Access` behaviour).
+
+  Returns a tuple containing the value associated with the key and the
+  updated container. `default` is returned for the value if the key isn't
+  in the container.
+
+  Same as `pop/2` but takes a default value to be returned when the key is not found.
+  """
+  @spec pop(data, key, default) :: {value | default, data} when data: container, default: var
+  def pop(%module{} = container, key, default) do
+    module.pop(container, key, default)
+  rescue
+    exception in UndefinedFunctionError ->
+      raise_undefined_behaviour(
+        exception,
+        module,
+        {^module, :pop, [^container, ^key, ^default], _}
+      )
+  end
+
+  def pop(map, key, default) when is_map(map) do
+    Map.pop(map, key, default)
+  end
+
+  def pop(list, key, default) when is_list(list) do
+    Keyword.pop(list, key, default)
+  end
+
+  def pop(nil, key, _default) do
+    raise ArgumentError, "could not pop key #{inspect(key)} on a nil value"
+  end
+
   ## Accessors
 
   @doc """

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -55,6 +55,9 @@ defmodule AccessTest do
 
     assert Access.pop([foo: :bar], :foo) == {:bar, []}
     assert Access.pop([], :foo) == {nil, []}
+
+    assert Access.pop([foo: :bar], :foo, :default) == {:bar, []}
+    assert Access.pop([], :foo, :default) == {:default, []}
   end
 
   test "for maps" do
@@ -74,6 +77,9 @@ defmodule AccessTest do
 
     assert Access.pop(%{foo: :bar}, :foo) == {:bar, %{}}
     assert Access.pop(%{}, :foo) == {nil, %{}}
+
+    assert Access.pop(%{foo: :bar}, :foo, :default) == {:bar, %{}}
+    assert Access.pop(%{}, :foo, :default) == {:default, %{}}
   end
 
   test "for struct" do
@@ -100,6 +106,13 @@ defmodule AccessTest do
 
     assert_raise UndefinedFunctionError, message, fn ->
       Access.pop(struct(Sample, []), :name)
+    end
+
+    message =
+      ~r"function AccessTest.Sample.pop/3 is undefined \(AccessTest.Sample does not implement the Access behaviour"
+
+    assert_raise UndefinedFunctionError, message, fn ->
+      Access.pop(struct(Sample, []), :name, :default)
     end
   end
 


### PR DESCRIPTION
Adds `Access.pop/3` which allows specifying a default value for pop (like `Map.pop/3` and `Keyword.pop/3`)

Currently I've implemented it completely separate from `Access.pop/2`,
to avoid compatibility issues with `pop/2`.

So the underlying container must also implement `Access.pop/3` for this to work.
For supporting containers, they'd probably just implement a

```elixir
def pop(container, key, default \\ nil)
```

which would take care of `pop/2` and `pop/3`.

But I'm wondering if there might be a better way to handle this such that `pop/2` is just an inlined `pop(container, key, nil)`.
