### PR TITLE
Disallow use of unquote when quote is used in pattern

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -3,9 +3,6 @@
 %% SPDX-FileCopyrightText: 2012 Plataformatec
 
 -module(elixir_expand).
-
--feature(maybe_expr, enable).
-
 -export([expand/3, expand_args/3, expand_arg/3, format_error/1]).
 -import(elixir_errors, [file_error/4, module_error/4, function_error/4]).
 -include("elixir.hrl").
@@ -269,12 +266,8 @@ expand({quote, Meta, [Opts, Do]}, S, E) when is_list(Do) ->
   Unquote = proplists:get_value(unquote, EOpts, DefaultUnquote),
   Generated = proplists:get_value(generated, EOpts, false),
 
-  maybe
-    true ?= map_get(context, E) /= nil,
-    true ?= Unquote,
-    true ?= elixir_quote:has_unquotes(Exprs),
-    file_error(Meta, E, ?MODULE, quote_in_pattern_with_unquote)
-  end,
+  (map_get(context, E) /= nil) andalso Unquote andalso elixir_quote:has_unquotes(Exprs) andalso
+    file_error(Meta, E, ?MODULE, quote_in_pattern_with_unquote),
 
   {Q, QContext, QPrelude} = elixir_quote:build(Meta, Line, File, Context, Unquote, Generated, ET),
   {EPrelude, SP, EP} = expand(QPrelude, ST, ET),

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -3,6 +3,9 @@
 %% SPDX-FileCopyrightText: 2012 Plataformatec
 
 -module(elixir_expand).
+
+-feature(maybe_expr, enable).
+
 -export([expand/3, expand_args/3, expand_arg/3, format_error/1]).
 -import(elixir_errors, [file_error/4, module_error/4, function_error/4]).
 -include("elixir.hrl").
@@ -263,13 +266,15 @@ expand({quote, Meta, [Opts, Do]}, S, E) when is_list(Do) ->
       {[], true}
   end,
 
-  Unquote = case E of
-    #{context := nil} -> proplists:get_value(unquote, EOpts, DefaultUnquote);
-    % unquote=raise when quote/1 is called in a guard or pattern
-    _ -> raise
-  end,
-
+  Unquote = proplists:get_value(unquote, EOpts, DefaultUnquote),
   Generated = proplists:get_value(generated, EOpts, false),
+
+  maybe
+    true ?= map_get(context, E) /= nil,
+    true ?= Unquote,
+    true ?= elixir_quote:has_unquotes(Exprs),
+    file_error(Meta, E, ?MODULE, quote_in_pattern_with_unquote)
+  end,
 
   {Q, QContext, QPrelude} = elixir_quote:build(Meta, Line, File, Context, Unquote, Generated, ET),
   {EPrelude, SP, EP} = expand(QPrelude, ST, ET),
@@ -1221,6 +1226,8 @@ format_error({expected_compile_time_module, Kind, GivenTerm}) ->
 format_error({unquote_outside_quote, Unquote}) ->
   %% Unquote can be "unquote" or "unquote_splicing".
   io_lib:format("~p called outside quote", [Unquote]);
+format_error(quote_in_pattern_with_unquote) ->
+  "unquote is not allowed when quote is used inside a pattern or guard";
 format_error({invalid_bind_quoted_for_quote, BQ}) ->
   io_lib:format("invalid :bind_quoted for quote, expected a keyword list of variable names, got: ~ts",
                 ['Elixir.Macro':to_string(BQ)]);

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -263,7 +263,12 @@ expand({quote, Meta, [Opts, Do]}, S, E) when is_list(Do) ->
       {[], true}
   end,
 
-  Unquote = proplists:get_value(unquote, EOpts, DefaultUnquote),
+  Unquote = case E of
+    #{context := nil} -> proplists:get_value(unquote, EOpts, DefaultUnquote);
+    % unquote=raise when quote/1 is called in a guard or pattern
+    _ -> raise
+  end,
+
   Generated = proplists:get_value(generated, EOpts, false),
 
   {Q, QContext, QPrelude} = elixir_quote:build(Meta, Line, File, Context, Unquote, Generated, ET),

--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -315,7 +315,7 @@ is_valid(line, Line) -> is_integer(Line);
 is_valid(file, File) -> is_binary(File);
 is_valid(context, Context) -> is_atom(Context) andalso (Context /= nil);
 is_valid(generated, Generated) -> is_boolean(Generated);
-is_valid(unquote, Unquote) -> is_boolean(Unquote).
+is_valid(unquote, Unquote) -> is_boolean(Unquote) orelse Unquote == raise.
 
 quote({unquote_splicing, _, [_]}, #elixir_quote{unquote=true}) ->
   argument_error(<<"unquote_splicing only works inside arguments and block contexts, "
@@ -324,6 +324,12 @@ quote(Expr, Q) ->
   do_quote(Expr, Q).
 
 %% quote/unquote
+
+do_quote({unquote, _, [_]}, #elixir_quote{unquote=raise}) ->
+  argument_error(<<"unquote/1 is not allowed when quote/1 is used inside a pattern or guard">>);
+
+do_quote({unquote_splicing, _, [_]}, #elixir_quote{unquote=raise}) ->
+  argument_error(<<"unquote_splicing/1 is not allowed when quote/1 is used inside a pattern or guard">>);
 
 do_quote({quote, Meta, [Arg]}, Q) when is_list(Meta) ->
   TArg = do_quote(Arg, Q#elixir_quote{unquote=false}),

--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -315,7 +315,7 @@ is_valid(line, Line) -> is_integer(Line);
 is_valid(file, File) -> is_binary(File);
 is_valid(context, Context) -> is_atom(Context) andalso (Context /= nil);
 is_valid(generated, Generated) -> is_boolean(Generated);
-is_valid(unquote, Unquote) -> is_boolean(Unquote) orelse Unquote == raise.
+is_valid(unquote, Unquote) -> is_boolean(Unquote).
 
 quote({unquote_splicing, _, [_]}, #elixir_quote{unquote=true}) ->
   argument_error(<<"unquote_splicing only works inside arguments and block contexts, "
@@ -324,12 +324,6 @@ quote(Expr, Q) ->
   do_quote(Expr, Q).
 
 %% quote/unquote
-
-do_quote({unquote, _, [_]}, #elixir_quote{unquote=raise}) ->
-  argument_error(<<"unquote/1 is not allowed when quote/1 is used inside a pattern or guard">>);
-
-do_quote({unquote_splicing, _, [_]}, #elixir_quote{unquote=raise}) ->
-  argument_error(<<"unquote_splicing/1 is not allowed when quote/1 is used inside a pattern or guard">>);
 
 do_quote({quote, Meta, [Arg]}, Q) when is_list(Meta) ->
   TArg = do_quote(Arg, Q#elixir_quote{unquote=false}),

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -456,6 +456,66 @@ defmodule Kernel.ErrorsTest do
                       """
   end
 
+  test "invalid unquote when quote/1 is in a pattern" do
+    assert_eval_raise ArgumentError,
+                      ["unquote/1 is not allowed when quote/1 is used inside a pattern or guard"],
+                      ~c"""
+                      defmodule Kernel.ErrorsTest.InvalidUnquoteInQuotePattern do
+                        def my_fun(ast) do
+                          case ast do
+                            quote(do: foo(unquote(x))) -> x
+                          end
+                        end
+                      end
+                      """
+  end
+
+  test "invalid unquote when quote/1 is in a guard" do
+    assert_eval_raise ArgumentError,
+                      ["unquote/1 is not allowed when quote/1 is used inside a pattern or guard"],
+                      ~c"""
+                      defmodule Kernel.ErrorsTest.InvalidUnquoteInQuoteGuard do
+                        def my_fun(ast, x) do
+                          case ast do
+                            ast when ast == quote(do: foo(unquote(x))) -> x
+                          end
+                        end
+                      end
+                      """
+  end
+
+  test "invalid unquote_splicing when quote/1 is in a pattern" do
+    assert_eval_raise ArgumentError,
+                      [
+                        "unquote_splicing/1 is not allowed when quote/1 is used inside a pattern or guard"
+                      ],
+                      ~c"""
+                      defmodule Kernel.ErrorsTest.InvalidUnquoteSplicingInQuotePattern do
+                        def my_fun(ast) do
+                          case ast do
+                            quote(do: foo(unquote_splicing(x))) -> x
+                          end
+                        end
+                      end
+                      """
+  end
+
+  test "invalid unquote_splicing when quote/1 is in a guard" do
+    assert_eval_raise ArgumentError,
+                      [
+                        "unquote_splicing/1 is not allowed when quote/1 is used inside a pattern or guard"
+                      ],
+                      ~c"""
+                      defmodule Kernel.ErrorsTest.InvalidUnquoteSplicingInQuoteGuard do
+                        def my_fun(ast, x) do
+                          case ast do
+                            ast when ast == quote(do: foo(unquote_splicing(x))) -> x
+                          end
+                        end
+                      end
+                      """
+  end
+
   test "invalid attribute" do
     msg = ~r"cannot inject attribute @foo into function/macro because cannot escape "
 

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -457,63 +457,18 @@ defmodule Kernel.ErrorsTest do
   end
 
   test "invalid unquote when quote/1 is in a pattern" do
-    assert_eval_raise ArgumentError,
-                      ["unquote/1 is not allowed when quote/1 is used inside a pattern or guard"],
-                      ~c"""
-                      defmodule Kernel.ErrorsTest.InvalidUnquoteInQuotePattern do
-                        def my_fun(ast) do
-                          case ast do
-                            quote(do: foo(unquote(x))) -> x
-                          end
-                        end
-                      end
-                      """
-  end
-
-  test "invalid unquote when quote/1 is in a guard" do
-    assert_eval_raise ArgumentError,
-                      ["unquote/1 is not allowed when quote/1 is used inside a pattern or guard"],
-                      ~c"""
-                      defmodule Kernel.ErrorsTest.InvalidUnquoteInQuoteGuard do
-                        def my_fun(ast, x) do
-                          case ast do
-                            ast when ast == quote(do: foo(unquote(x))) -> x
-                          end
-                        end
-                      end
-                      """
-  end
-
-  test "invalid unquote_splicing when quote/1 is in a pattern" do
-    assert_eval_raise ArgumentError,
-                      [
-                        "unquote_splicing/1 is not allowed when quote/1 is used inside a pattern or guard"
-                      ],
-                      ~c"""
-                      defmodule Kernel.ErrorsTest.InvalidUnquoteSplicingInQuotePattern do
-                        def my_fun(ast) do
-                          case ast do
-                            quote(do: foo(unquote_splicing(x))) -> x
-                          end
-                        end
-                      end
-                      """
-  end
-
-  test "invalid unquote_splicing when quote/1 is in a guard" do
-    assert_eval_raise ArgumentError,
-                      [
-                        "unquote_splicing/1 is not allowed when quote/1 is used inside a pattern or guard"
-                      ],
-                      ~c"""
-                      defmodule Kernel.ErrorsTest.InvalidUnquoteSplicingInQuoteGuard do
-                        def my_fun(ast, x) do
-                          case ast do
-                            ast when ast == quote(do: foo(unquote_splicing(x))) -> x
-                          end
-                        end
-                      end
-                      """
+    assert_compile_error(
+      ["unquote is not allowed when quote is used inside a pattern or guard"],
+      ~c"""
+      defmodule Kernel.ErrorsTest.InvalidUnquoteInQuotePattern do
+        def my_fun(ast) do
+          case ast do
+            quote(do: foo(unquote(x))) -> x
+          end
+        end
+      end
+      """
+    )
   end
 
   test "invalid attribute" do


### PR DESCRIPTION
Better error message for: https://github.com/elixir-lang/elixir/issues/15461

The only thing I don't love is that `unquote` comes from the public option, and this is an internal-only mechanism, but I think it's probably fine?