### PR TITLE
Optimize Map JSON encoding using :maps.to_list

### DIFF
--- a/lib/elixir/lib/json.ex
+++ b/lib/elixir/lib/json.ex
@@ -154,23 +154,21 @@ end
 
 defimpl JSON.Encoder, for: Map do
   def encode(value, encoder) do
-    case :maps.next(:maps.iterator(value)) do
-      :none ->
+    case :maps.to_list(value) do
+      [] ->
         "{}"
 
-      {key, value, iterator} ->
-        [?{, key(key, encoder), ?:, encoder.(value, encoder) | next(iterator, encoder)]
+      [{key, value} | rest] ->
+        [?{, key(key, encoder), ?:, encoder.(value, encoder) | next(rest, encoder)]
     end
   end
 
-  defp next(iterator, encoder) do
-    case :maps.next(iterator) do
-      :none ->
-        "}"
+  defp next([], _encoder) do
+    "}"
+  end
 
-      {key, value, iterator} ->
-        [?,, key(key, encoder), ?:, encoder.(value, encoder) | next(iterator, encoder)]
-    end
+  defp next([{key, value} | rest], encoder) do
+    [?,, key(key, encoder), ?:, encoder.(value, encoder) | next(rest, encoder)]
   end
 
   # Erlang supports only numbers, binaries, and atoms as keys,


### PR DESCRIPTION
Assisted-by: Antigravity CLI Gemini Flash 3.5

It seems like the upfront `:maps.to_list` version is ~10% faster than the `:maps.iterator` one.

Bench:
```elixir
Mix.install([
  {:benchee, "~> 1.3"}
])

# Old Map Encoder using :maps.iterator and :maps.next
defmodule OldMapEncoder do
  def encode(value, encoder) do
    case :maps.next(:maps.iterator(value)) do
      :none ->
        "{}"

      {key, value, iterator} ->
        [?{, key(key, encoder), ?:, encoder.(value, encoder) | next(iterator, encoder)]
    end
  end

  defp next(iterator, encoder) do
    case :maps.next(iterator) do
      :none ->
        "}"

      {key, value, iterator} ->
        [?,, key(key, encoder), ?:, encoder.(value, encoder) | next(iterator, encoder)]
    end
  end

  defp key(key, encoder) when is_atom(key), do: encoder.(Atom.to_string(key), encoder)
  defp key(key, encoder) when is_binary(key), do: encoder.(key, encoder)
  defp key(key, encoder), do: encoder.(String.Chars.to_string(key), encoder)
end

# New Map Encoder using :maps.to_list
defmodule NewMapEncoder do
  def encode(value, encoder) do
    case :maps.to_list(value) do
      [] ->
        "{}"

      [{key, value} | rest] ->
        [?{, key(key, encoder), ?:, encoder.(value, encoder) | next(rest, encoder)]
    end
  end

  defp next([], _encoder) do
    "}"
  end

  defp next([{key, value} | rest], encoder) do
    [?,, key(key, encoder), ?:, encoder.(value, encoder) | next(rest, encoder)]
  end

  defp key(key, encoder) when is_atom(key), do: encoder.(Atom.to_string(key), encoder)
  defp key(key, encoder) when is_binary(key), do: encoder.(key, encoder)
  defp key(key, encoder), do: encoder.(String.Chars.to_string(key), encoder)
end

# Old full encoder dispatcher mimicking JSON.protocol_encode/2
defmodule OldEncoder do
  def encode(value, encoder) when is_atom(value) do
    case value do
      nil -> "null"
      true -> "true"
      false -> "false"
      _ -> encoder.(Atom.to_string(value), encoder)
    end
  end

  def encode(value, _encoder) when is_binary(value),
    do: :json.encode_binary(value)

  def encode(value, _encoder) when is_integer(value),
    do: :json.encode_integer(value)

  def encode(value, _encoder) when is_float(value),
    do: :json.encode_float(value)

  def encode(value, encoder) when is_list(value),
    do: :json.encode_list(value, encoder)

  def encode(%{} = value, encoder) when not is_map_key(value, :__struct__),
    do: OldMapEncoder.encode(value, encoder)

  def encode(value, encoder),
    do: JSON.Encoder.encode(value, encoder)
end

# New full encoder dispatcher mimicking JSON.protocol_encode/2
defmodule NewEncoder do
  def encode(value, encoder) when is_atom(value) do
    case value do
      nil -> "null"
      true -> "true"
      false -> "false"
      _ -> encoder.(Atom.to_string(value), encoder)
    end
  end

  def encode(value, _encoder) when is_binary(value),
    do: :json.encode_binary(value)

  def encode(value, _encoder) when is_integer(value),
    do: :json.encode_integer(value)

  def encode(value, _encoder) when is_float(value),
    do: :json.encode_float(value)

  def encode(value, encoder) when is_list(value),
    do: :json.encode_list(value, encoder)

  def encode(%{} = value, encoder) when not is_map_key(value, :__struct__),
    do: NewMapEncoder.encode(value, encoder)

  def encode(value, encoder),
    do: JSON.Encoder.encode(value, encoder)
end

# Benchmark inputs covering small, medium, large, and nested map structures.
inputs = %{
  "Small Map (5 Atom Keys)" => Map.new(1..5, fn i -> {String.to_atom("key_#{i}"), i} end),
  "Medium Map (100 Atom Keys)" => Map.new(1..100, fn i -> {String.to_atom("key_#{i}"), i} end),
  "Large Map (10,000 Atom Keys)" => Map.new(1..10000, fn i -> {String.to_atom("key_#{i}"), i} end),

  "Small Map (5 String Keys)" => Map.new(1..5, fn i -> {"key_#{i}", i} end),
  "Medium Map (100 String Keys)" => Map.new(1..100, fn i -> {"key_#{i}", i} end),
  "Large Map (10,000 String Keys)" => Map.new(1..10000, fn i -> {"key_#{i}", i} end),

  "Nested Map" => %{a: 1, b: %{c: 2, d: %{e: 3, f: %{g: 4}}}}
}

Benchee.run(
  %{
    "Old (:maps.iterator)" => fn input ->
      IO.iodata_to_binary(OldEncoder.encode(input, &OldEncoder.encode/2))
    end,
    "New (:maps.to_list)" => fn input ->
      IO.iodata_to_binary(NewEncoder.encode(input, &NewEncoder.encode/2))
    end
  },
  inputs: inputs,
  time: 2,
  memory_time: 2
)
```

Bench results (noisy system, heat throttling mini pc):

```txt
Operating System: Linux
CPU Information: AMD Ryzen 7 8845HS w
Number of Available Cores: 16
Available memory: 54.72 GB
Elixir 1.20.0
Erlang 29.0.1
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 2 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: Large Map (10,000 Atom Keys), Large Map (10,000 String Keys), Medium Map (100 Atom Keys), Medium Map (100 String Keys), Nested Map, Small Map (5 Atom Keys), Small Map (5 String Keys)
Estimated total run time: 1 min 24 s
Excluding outliers: false

Benchmarking New (:maps.to_list) with input Large Map (10,000 Atom Keys) ...
Benchmarking New (:maps.to_list) with input Large Map (10,000 String Keys) ...
Benchmarking New (:maps.to_list) with input Medium Map (100 Atom Keys) ...
Benchmarking New (:maps.to_list) with input Medium Map (100 String Keys) ...
Benchmarking New (:maps.to_list) with input Nested Map ...
Benchmarking New (:maps.to_list) with input Small Map (5 Atom Keys) ...
Benchmarking New (:maps.to_list) with input Small Map (5 String Keys) ...
Benchmarking Old (:maps.iterator) with input Large Map (10,000 Atom Keys) ...
Benchmarking Old (:maps.iterator) with input Large Map (10,000 String Keys) ...
Benchmarking Old (:maps.iterator) with input Medium Map (100 Atom Keys) ...
Benchmarking Old (:maps.iterator) with input Medium Map (100 String Keys) ...
Benchmarking Old (:maps.iterator) with input Nested Map ...
Benchmarking Old (:maps.iterator) with input Small Map (5 Atom Keys) ...
Benchmarking Old (:maps.iterator) with input Small Map (5 String Keys) ...
Calculating statistics...
Formatting results...

##### With input Large Map (10,000 Atom Keys) #####
Name                           ips        average  deviation         median         99th %
New (:maps.to_list)         975.72        1.02 ms    ±11.73%        1.01 ms        1.60 ms
Old (:maps.iterator)        743.18        1.35 ms    ±17.25%        1.27 ms        2.48 ms

Comparison:
New (:maps.to_list)         975.72
Old (:maps.iterator)        743.18 - 1.31x slower +0.32 ms

Memory usage statistics:

Name                    Memory usage
New (:maps.to_list)          1.83 MB
Old (:maps.iterator)         1.81 MB - 0.99x memory usage -0.02509 MB

**All measurements for memory usage were the same**

##### With input Large Map (10,000 String Keys) #####
Name                           ips        average  deviation         median         99th %
New (:maps.to_list)         1.25 K        0.80 ms     ±8.33%        0.79 ms        0.98 ms
Old (:maps.iterator)        0.91 K        1.10 ms    ±10.31%        1.08 ms        1.58 ms

Comparison:
New (:maps.to_list)         1.25 K
Old (:maps.iterator)        0.91 K - 1.37x slower +0.30 ms

Memory usage statistics:

Name                    Memory usage
New (:maps.to_list)          1.83 MB
Old (:maps.iterator)         1.81 MB - 0.99x memory usage -0.02109 MB

**All measurements for memory usage were the same**

##### With input Medium Map (100 Atom Keys) #####
Name                           ips        average  deviation         median         99th %
New (:maps.to_list)       125.05 K        8.00 μs    ±29.14%        7.69 μs       11.67 μs
Old (:maps.iterator)      105.79 K        9.45 μs    ±24.70%        9.16 μs       13.14 μs

Comparison:
New (:maps.to_list)       125.05 K
Old (:maps.iterator)      105.79 K - 1.18x slower +1.46 μs

Memory usage statistics:

Name                    Memory usage
New (:maps.to_list)         16.95 KB
Old (:maps.iterator)        16.72 KB - 0.99x memory usage -0.22656 KB

**All measurements for memory usage were the same**

##### With input Medium Map (100 String Keys) #####
Name                           ips        average  deviation         median         99th %
New (:maps.to_list)       141.51 K        7.07 μs    ±39.51%        6.84 μs       11.05 μs
Old (:maps.iterator)      117.21 K        8.53 μs    ±24.72%        8.28 μs       11.99 μs

Comparison:
New (:maps.to_list)       141.51 K
Old (:maps.iterator)      117.21 K - 1.21x slower +1.46 μs

Memory usage statistics:

Name                    Memory usage
New (:maps.to_list)         16.97 KB
Old (:maps.iterator)        18.82 KB - 1.11x memory usage +1.85 KB

**All measurements for memory usage were the same**

##### With input Nested Map #####
Name                           ips        average  deviation         median         99th %
New (:maps.to_list)         1.90 M      525.59 ns  ±1003.06%         491 ns         731 ns
Old (:maps.iterator)        1.46 M      685.97 ns   ±872.83%         641 ns         922 ns

Comparison:
New (:maps.to_list)         1.90 M
Old (:maps.iterator)        1.46 M - 1.31x slower +160.38 ns

Memory usage statistics:

Name                    Memory usage
New (:maps.to_list)          1.36 KB
Old (:maps.iterator)         1.37 KB - 1.01x memory usage +0.00781 KB

**All measurements for memory usage were the same**

##### With input Small Map (5 Atom Keys) #####
Name                           ips        average  deviation         median         99th %
New (:maps.to_list)         2.19 M      456.76 ns  ±1893.76%         410 ns         621 ns
Old (:maps.iterator)        1.91 M      522.26 ns  ±1662.34%         451 ns         792 ns

Comparison:
New (:maps.to_list)         2.19 M
Old (:maps.iterator)        1.91 M - 1.14x slower +65.50 ns

Memory usage statistics:

Name                    Memory usage
New (:maps.to_list)          1.05 KB
Old (:maps.iterator)         1.02 KB - 0.98x memory usage -0.02344 KB

**All measurements for memory usage were the same**

##### With input Small Map (5 String Keys) #####
Name                           ips        average  deviation         median         99th %
New (:maps.to_list)         2.29 M      436.88 ns  ±2107.81%         381 ns         721 ns
Old (:maps.iterator)        2.05 M      486.63 ns  ±1807.10%         431 ns         681 ns

Comparison:
New (:maps.to_list)         2.29 M
Old (:maps.iterator)        2.05 M - 1.11x slower +49.75 ns

Memory usage statistics:

Name                    Memory usage
New (:maps.to_list)          1.05 KB
Old (:maps.iterator)         1.02 KB - 0.98x memory usage -0.02344 KB

**All measurements for memory usage were the same**
```