### PR TITLE
Fix missed optimization of `Kernel.put_elem/3`

### DIFF
--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -717,7 +717,7 @@ rewrite_strategy(Left, Right, Args) ->
 ).
 
 ?reorder('Elixir.Kernel', elem, 2, [Tuple, Index], erlang, element, [increment(Ann, Index), Tuple]);
-?reorder('Elixir.Kernel', put_elem, 2, [Tuple, Index, Term], erlang, element, [increment(Ann, Index), Tuple, Term]);
+?reorder('Elixir.Kernel', put_elem, 3, [Tuple, Index, Term], erlang, setelement, [increment(Ann, Index), Tuple, Term]);
 ?reorder('Elixir.Kernel', is_map_key, 2, [Map, Key], erlang, is_map_key, [Key, Map]);
 ?reorder('Elixir.Map', delete, 2, [Map, Key], maps, remove, [Key, Map]);
 ?reorder('Elixir.Map', fetch, 2, [Map, Key], maps, find, [Key, Map]);


### PR DESCRIPTION
`?reorder` macro added in 87582af54 used wrong arity and wrong erlang call. No impact besides missed optimization 