### PR TITLE
Document that mix test --dry-run was introduced in 1.20.0

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -121,7 +121,7 @@ defmodule Mix.Tasks.Test do
 
     * `--cover` - runs coverage tool. See "Coverage" section below
 
-    * `--dry-run` *(since v1.19.0)* - prints which tests would be run based on current options,
+    * `--dry-run` *(since v1.20.0)* - prints which tests would be run based on current options,
       but does not actually run any tests. This combines with all other options
       like `--stale`, `--only`, `--exclude`, and so on.
 


### PR DESCRIPTION
I saw @Nezteb's [post on Elixir Forum](https://elixirforum.com/t/elixir-v1-20-0-released/75566/31?u=zachallaun) and went to check out the docs. Noticed that it said "since 1.19.0" but I don't believe it actually landed until 1.20.0.