### PR TITLE
avoid using Keyword.pop/2 in ExUnit.Diff.struct_module/2

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -765,16 +765,20 @@ defmodule ExUnit.Diff do
     end
   end
 
+  # if kw represents a struct, this returns the result of `struct.__info__(:struct)`, otherwise nil
   defp struct_module(kw) do
-    {struct, struct_kw} = Keyword.pop(kw, :__struct__)
+    case Enum.split_with(kw, fn {k, _} -> k == :__struct__ end) do
+      {[{_, struct} | _], struct_kw} when is_atom(struct) and struct != nil ->
+        info =
+          Code.ensure_loaded?(struct) and function_exported?(struct, :__info__, 1) and
+            struct.__info__(:struct)
 
-    info =
-      is_atom(struct) and struct != nil and
-        Code.ensure_loaded?(struct) and function_exported?(struct, :__info__, 1) and
-        struct.__info__(:struct)
+        if info && Enum.all?(struct_kw, fn {k, _} -> Enum.any?(info, &(&1.field == k)) end) do
+          struct
+        end
 
-    if info && Enum.all?(struct_kw, fn {k, _} -> Enum.any?(info, &(&1.field == k)) end) do
-      struct
+      _ ->
+        nil
     end
   end
 


### PR DESCRIPTION
In `ExUnit.Diff.struct_module/2` we call `Keyword.pop(kw, :__struct__)`  
but we don't actually know if `kw` is a Keyword here.

I stumbled on this while looking at what @josevalim said in https://github.com/elixir-lang/elixir/pull/15470#issuecomment-4707034100  
I wanted to see what actually broke if we guarded Keyword functions for keyword lists.

Only few tests blew up, and only in ExUnit, examples:

- https://github.com/elixir-lang/elixir/blob/1d599978f7d36ea6896b294b3d26d110212be7ab/lib/ex_unit/test/ex_unit/diff_test.exs#L527-L531
- https://github.com/elixir-lang/elixir/blob/1d599978f7d36ea6896b294b3d26d110212be7ab/lib/ex_unit/test/ex_unit/diff_test.exs#L563-L570

`ExUnit.Diff.struct_module/2` is being called for both structs and maps.  
(since https://github.com/elixir-lang/elixir/commit/bbf54bc00d0b2ed8b55dfb0ebdd19e751539cf9a, before this point we delegated to `diff_map` earlier)

`diff_quoted_struct` uses the return of `struct_module` to determine when to call `diff_quoted_struct` or `diff_map`, so at this point, we don't actually know if `kw` represents a Keyword or any other map pairs.

This fix seemed straight forward, just don't use `Keyword.pop/2` to get the `:__struct__` value out of `kw`.  
I've used `Enum.split_with` instead, to make sure that all occurrences of `:__struct__` is removed (just like `Keyword.pop/2` would have)

I considered using `:lists.keytake` instead of `Enum.split_with`, but that would return at the first occurrence.

