### PR TITLE
Provide optional test outcome information to on_exit callbacks.

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -188,17 +188,11 @@ defmodule ExUnit do
     It is received by formatters and contains the following fields:
 
       * `:file` - (since v1.11.0) the file of the test module
-
       * `:name` - the test module name
-
       * `:parameters` - (since v1.18.0) the test module parameters
-
       * `:setup_all?` - (since v1.18.0) if the test module requires a setup all
-
       * `:state` - the failed state of `setup_all` after it runs (see `t:ExUnit.state/0`)
-
       * `:tags` - all tags in this module
-
       * `:tests` - all tests in this module
 
     """

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -526,7 +526,12 @@ defmodule ExUnit.Callbacks do
   """
   @spec on_exit(term, on_exit_callback) :: :ok
   def on_exit(name_or_ref \\ make_ref(), callback)
-      when is_function(callback, 0) or is_function(callback, 1) do
+
+  def on_exit(name_or_ref, callback) when is_function(callback, 0) do
+    on_exit(name_or_ref, fn _ -> callback.() end)
+  end
+
+  def on_exit(name_or_ref, callback) when is_function(callback, 1) do
     case ExUnit.OnExitHandler.add(self(), name_or_ref, callback) do
       :ok ->
         :ok

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -171,6 +171,7 @@ defmodule ExUnit.Callbacks do
   """
 
   @type child_spec_overrides :: Supervisor.child_spec_overrides()
+  @type on_exit_callback :: (-> term) | (%ExUnit.TestModule{} | %ExUnit.Test{} -> term)
 
   @doc false
   def __register__(module) do
@@ -456,11 +457,10 @@ defmodule ExUnit.Callbacks do
   end
 
   @doc """
-  Registers a callback that runs once the test exits.
+  Registers a `callback` function that runs once the test exits.
 
-  `callback` is a function that receives no arguments and
-  runs in a separate process than the caller. Its return
-  value is irrelevant and is discarded.
+  The `callback` function runs in a separate process than
+  the caller. Its return value is irrelevant and is discarded.
 
   `on_exit/2` is usually called from `setup/1` and `setup_all/1`
   callbacks, often to undo the action performed during the setup.
@@ -471,6 +471,11 @@ defmodule ExUnit.Callbacks do
   `on_exit/2` handler: if you want to override a previous handler, for
   example, use the same `name_or_ref` across multiple `on_exit/2`
   calls.
+
+  The `callback` may optionally accept a single argument. If called inside
+  a `setup/1` callback or inside a test, it is provided an `ExUnit.Test` struct.
+  If called inside a `setup_all/1` callback then it is provided
+  an `ExUnit.TestModule` struct.
 
   If `on_exit/2` is called inside `setup/1` or inside a test, it's
   executed in a blocking fashion after the test exits and *before
@@ -501,13 +506,26 @@ defmodule ExUnit.Callbacks do
         on_exit(:drop_table, fn -> :ok end)
       end
 
+  You can accept an argument in the `callback` to perform conditional cleanup,
+  although (like any `on_exit/2` callback) there is no guarantee it will execute
+  if, for example, the test run is interrupted with `Ctrl`+`C`:
+
+      setup do
+        File.write!("keep_if_failed.json", "{}")
+        on_exit(fn
+          %ExUnit.Test{state: {:failed, _}} -> :ok
+          _ -> File.rm!("keep_if_failed.json")
+        end)
+      end
+
   Relying too much on overriding callbacks like this can lead to test
   cases that are hard to understand and with too many layers of
   indirection. However, it can be useful in some cases or for library
   authors, for example.
   """
-  @spec on_exit(term, (-> term)) :: :ok
-  def on_exit(name_or_ref \\ make_ref(), callback) when is_function(callback, 0) do
+  @spec on_exit(term, on_exit_callback) :: :ok
+  def on_exit(name_or_ref \\ make_ref(), callback)
+      when is_function(callback, 0) or is_function(callback, 1) do
     case ExUnit.OnExitHandler.add(self(), name_or_ref, callback) do
       :ok ->
         :ok

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -171,7 +171,8 @@ defmodule ExUnit.Callbacks do
   """
 
   @type child_spec_overrides :: Supervisor.child_spec_overrides()
-  @type on_exit_callback :: (-> term) | (%ExUnit.TestModule{} | %ExUnit.Test{} -> term)
+  @type on_exit_status :: :passed | :failed | module
+  @type on_exit_callback :: (-> term) | (on_exit_status -> term)
 
   @doc false
   def __register__(module) do
@@ -472,10 +473,10 @@ defmodule ExUnit.Callbacks do
   example, use the same `name_or_ref` across multiple `on_exit/2`
   calls.
 
-  The `callback` may optionally accept a single argument. If called inside
-  a `setup/1` callback or inside a test, it is provided an `ExUnit.Test` struct.
-  If called inside a `setup_all/1` callback then it is provided
-  an `ExUnit.TestModule` struct.
+  The `callback` may optionally accept a single `t:on_exit_status/0` parameter.
+  If `on_exit/2` is called inside a `setup/1` callback or inside a test,
+  this argument will be an atom representing the test's status.
+  If called inside a `setup_all/1` callback then it will be the test module name.
 
   If `on_exit/2` is called inside `setup/1` or inside a test, it's
   executed in a blocking fashion after the test exits and *before
@@ -514,7 +515,7 @@ defmodule ExUnit.Callbacks do
       setup do
         File.write!("keep_if_failed.json", "{}")
         on_exit(fn
-          %ExUnit.Test{state: {:failed, _}} -> :ok
+          :failed -> :ok
           _ -> File.rm!("keep_if_failed.json")
         end)
       end

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -486,6 +486,9 @@ defmodule ExUnit.Callbacks do
   called inside a `setup_all/1` callback then `callback` is executed
   after running *all tests* (see `setup_all/1` for more information).
 
+  There is no guarantee a `callback` provided to `on_exit/2` will execute,
+  as, for example, the test run can be interrupted with `Ctrl`+`C`.
+
   ## Examples
 
       setup do
@@ -506,9 +509,7 @@ defmodule ExUnit.Callbacks do
         on_exit(:drop_table, fn -> :ok end)
       end
 
-  You can accept an argument in the `callback` to perform conditional cleanup,
-  although (like any `on_exit/2` callback) there is no guarantee it will execute
-  if, for example, the test run is interrupted with `Ctrl`+`C`:
+  You can accept an argument in the `callback` to perform conditional cleanup:
 
       setup do
         File.write!("keep_if_failed.json", "{}")

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -336,8 +336,8 @@ defmodule ExUnit.Case do
        `ExUnit.Callbacks.setup/1` callbacks run, in the order they were defined. Then,
        the test itself is executed.
 
-    3. After the test exits, a new process is spawned to run all `ExUnit.Callbacks.on_exit/2`,
-       in the reverse order they were defined.
+    3. After the test exits, a new process is spawned to run all `ExUnit.Callbacks.on_exit/2`
+       callbacks, in the reverse order they were defined.
 
   """
 

--- a/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
+++ b/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
@@ -19,7 +19,8 @@ defmodule ExUnit.OnExitHandler do
   end
 
   @spec add(pid, term, (-> term)) :: :ok | :error
-  def add(pid, name_or_ref, callback) when is_pid(pid) and is_function(callback, 0) do
+  def add(pid, name_or_ref, callback)
+      when is_pid(pid) and (is_function(callback, 0) or is_function(callback, 1)) do
     try do
       :ets.lookup_element(@name, pid, @on_exit)
     rescue
@@ -49,11 +50,12 @@ defmodule ExUnit.OnExitHandler do
     end
   end
 
-  @spec run(pid, timeout) :: :ok | {Exception.kind(), term, Exception.stacktrace()}
-  def run(pid, timeout) when is_pid(pid) do
+  @spec run(pid, %ExUnit.Test{} | %ExUnit.TestModule{}, timeout) ::
+          :ok | {Exception.kind(), term, Exception.stacktrace()}
+  def run(pid, context, timeout) when is_pid(pid) do
     [{^pid, sup, callbacks}] = :ets.take(@name, pid)
     error = terminate_supervisor(sup, timeout)
-    exec_on_exit_callbacks(Enum.reverse(callbacks), timeout, error)
+    exec_on_exit_callbacks(Enum.reverse(callbacks), context, timeout, error)
   end
 
   defp terminate_supervisor(nil, _timeout), do: nil
@@ -69,9 +71,9 @@ defmodule ExUnit.OnExitHandler do
     end
   end
 
-  defp exec_on_exit_callbacks(callbacks, timeout, error) do
+  defp exec_on_exit_callbacks(callbacks, context, timeout, error) do
     {runner_pid, runner_monitor, error} =
-      Enum.reduce(callbacks, {nil, nil, error}, &exec_on_exit_callback(&1, timeout, &2))
+      Enum.reduce(callbacks, {nil, nil, error}, &exec_on_exit_callback(&1, context, timeout, &2))
 
     if is_pid(runner_pid) and Process.alive?(runner_pid) do
       Process.exit(runner_pid, :shutdown)
@@ -84,10 +86,10 @@ defmodule ExUnit.OnExitHandler do
     error || :ok
   end
 
-  defp exec_on_exit_callback({_name_or_ref, callback}, timeout, runner) do
+  defp exec_on_exit_callback({_name_or_ref, callback}, context, timeout, runner) do
     {runner_pid, runner_monitor, error} = runner
     {runner_pid, runner_monitor} = ensure_alive_callback_runner(runner_pid, runner_monitor)
-    send(runner_pid, {:run, self(), callback})
+    send(runner_pid, {:run, self(), callback, context})
     receive_runner_reply(runner_pid, runner_monitor, error, timeout)
   end
 
@@ -122,8 +124,8 @@ defmodule ExUnit.OnExitHandler do
   @doc false
   def on_exit_runner_loop do
     receive do
-      {:run, from, fun} ->
-        send(from, {self(), exec_callback(fun)})
+      {:run, from, callback, context} ->
+        send(from, {self(), exec_callback(callback, context)})
         on_exit_runner_loop()
     end
   end
@@ -136,11 +138,19 @@ defmodule ExUnit.OnExitHandler do
     {runner_pid, runner_monitor}
   end
 
-  defp exec_callback(callback) do
-    callback.()
+  defp exec_callback(callback, context) do
+    exec_callback_with_context(callback, context)
     nil
   catch
     kind, error ->
       {kind, error, __STACKTRACE__}
+  end
+
+  defp exec_callback_with_context(callback, _context) when is_function(callback, 0) do
+    callback.()
+  end
+
+  defp exec_callback_with_context(callback, context) when is_function(callback, 1) do
+    callback.(context)
   end
 end

--- a/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
+++ b/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
@@ -49,12 +49,12 @@ defmodule ExUnit.OnExitHandler do
     end
   end
 
-  @spec run(pid, %ExUnit.Test{} | %ExUnit.TestModule{}, timeout) ::
+  @spec run(pid, ExUnit.Callbacks.on_exit_status(), timeout) ::
           :ok | {Exception.kind(), term, Exception.stacktrace()}
-  def run(pid, context, timeout) when is_pid(pid) do
+  def run(pid, status, timeout) when is_pid(pid) do
     [{^pid, sup, callbacks}] = :ets.take(@name, pid)
     error = terminate_supervisor(sup, timeout)
-    exec_on_exit_callbacks(Enum.reverse(callbacks), context, timeout, error)
+    exec_on_exit_callbacks(Enum.reverse(callbacks), status, timeout, error)
   end
 
   defp terminate_supervisor(nil, _timeout), do: nil
@@ -70,9 +70,9 @@ defmodule ExUnit.OnExitHandler do
     end
   end
 
-  defp exec_on_exit_callbacks(callbacks, context, timeout, error) do
+  defp exec_on_exit_callbacks(callbacks, status, timeout, error) do
     {runner_pid, runner_monitor, error} =
-      Enum.reduce(callbacks, {nil, nil, error}, &exec_on_exit_callback(&1, context, timeout, &2))
+      Enum.reduce(callbacks, {nil, nil, error}, &exec_on_exit_callback(&1, status, timeout, &2))
 
     if is_pid(runner_pid) and Process.alive?(runner_pid) do
       Process.exit(runner_pid, :shutdown)
@@ -85,10 +85,10 @@ defmodule ExUnit.OnExitHandler do
     error || :ok
   end
 
-  defp exec_on_exit_callback({_name_or_ref, callback}, context, timeout, runner) do
+  defp exec_on_exit_callback({_name_or_ref, callback}, status, timeout, runner) do
     {runner_pid, runner_monitor, error} = runner
     {runner_pid, runner_monitor} = ensure_alive_callback_runner(runner_pid, runner_monitor)
-    send(runner_pid, {:run, self(), callback, context})
+    send(runner_pid, {:run, self(), callback, status})
     receive_runner_reply(runner_pid, runner_monitor, error, timeout)
   end
 
@@ -123,8 +123,8 @@ defmodule ExUnit.OnExitHandler do
   @doc false
   def on_exit_runner_loop do
     receive do
-      {:run, from, callback, context} ->
-        send(from, {self(), exec_callback(callback, context)})
+      {:run, from, callback, status} ->
+        send(from, {self(), exec_callback(callback, status)})
         on_exit_runner_loop()
     end
   end
@@ -137,8 +137,8 @@ defmodule ExUnit.OnExitHandler do
     {runner_pid, runner_monitor}
   end
 
-  defp exec_callback(callback, context) do
-    callback.(context)
+  defp exec_callback(callback, status) do
+    callback.(status)
     nil
   catch
     kind, error ->

--- a/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
+++ b/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
@@ -18,9 +18,8 @@ defmodule ExUnit.OnExitHandler do
     :ok
   end
 
-  @spec add(pid, term, ExUnit.Callbacks.on_exit_callback()) :: :ok | :error
-  def add(pid, name_or_ref, callback)
-      when is_pid(pid) and (is_function(callback, 0) or is_function(callback, 1)) do
+  @spec add(pid, term, (%ExUnit.TestModule{} | %ExUnit.Test{} -> term)) :: :ok | :error
+  def add(pid, name_or_ref, callback) when is_pid(pid) and is_function(callback, 1) do
     try do
       :ets.lookup_element(@name, pid, @on_exit)
     rescue
@@ -139,18 +138,10 @@ defmodule ExUnit.OnExitHandler do
   end
 
   defp exec_callback(callback, context) do
-    exec_callback_with_context(callback, context)
+    callback.(context)
     nil
   catch
     kind, error ->
       {kind, error, __STACKTRACE__}
-  end
-
-  defp exec_callback_with_context(callback, _context) when is_function(callback, 0) do
-    callback.()
-  end
-
-  defp exec_callback_with_context(callback, context) when is_function(callback, 1) do
-    callback.(context)
   end
 end

--- a/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
+++ b/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
@@ -18,7 +18,7 @@ defmodule ExUnit.OnExitHandler do
     :ok
   end
 
-  @spec add(pid, term, (-> term)) :: :ok | :error
+  @spec add(pid, term, ExUnit.Callbacks.on_exit_callback()) :: :ok | :error
   def add(pid, name_or_ref, callback)
       when is_pid(pid) and (is_function(callback, 0) or is_function(callback, 1)) do
     try do

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -562,7 +562,16 @@ defmodule ExUnit.Runner do
 
   # Any other ExUnit.state outcome (test was excluded, skipped, invalid) and
   # the runner shouldn't make it this far to ask the callback to be run anyways
-  defp run_exec_on_exit(_, pid, timeout) do
+
+  defp run_exec_on_exit(%ExUnit.Test{state: {:excluded, _}}, pid, timeout) do
+    :ok
+  end
+
+  defp run_exec_on_exit(%ExUnit.Test{state: {:skipped, _}}, pid, timeout) do
+    :ok
+  end
+
+  defp run_exec_on_exit(%ExUnit.Test{state: {:invalid, _}}, pid, timeout) do
     :ok
   end
 

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -537,14 +537,14 @@ defmodule ExUnit.Runner do
       %{test | state: failed(kind, error, prune_stacktrace(__STACKTRACE__))}
   end
 
-  defp exec_on_exit(test_or_case, pid, timeout) do
-    case ExUnit.OnExitHandler.run(pid, timeout) do
+  defp exec_on_exit(test_or_test_module, pid, timeout) do
+    case ExUnit.OnExitHandler.run(pid, test_or_test_module, timeout) do
       :ok ->
-        test_or_case
+        test_or_test_module
 
       {kind, reason, stack} ->
-        state = test_or_case.state || failed(kind, reason, prune_stacktrace(stack))
-        %{test_or_case | state: state}
+        state = test_or_test_module.state || failed(kind, reason, prune_stacktrace(stack))
+        %{test_or_test_module | state: state}
     end
   end
 

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -538,7 +538,7 @@ defmodule ExUnit.Runner do
   end
 
   defp exec_on_exit(test_or_test_module, pid, timeout) do
-    case ExUnit.OnExitHandler.run(pid, test_or_test_module, timeout) do
+    case run_exec_on_exit(test_or_test_module, pid, timeout) do
       :ok ->
         test_or_test_module
 
@@ -546,6 +546,24 @@ defmodule ExUnit.Runner do
         state = test_or_test_module.state || failed(kind, reason, prune_stacktrace(stack))
         %{test_or_test_module | state: state}
     end
+  end
+
+  defp run_exec_on_exit(%ExUnit.TestModule{name: module_name}, pid, timeout) do
+    ExUnit.OnExitHandler.run(pid, module_name, timeout)
+  end
+
+  defp run_exec_on_exit(%ExUnit.Test{state: nil}, pid, timeout) do
+    ExUnit.OnExitHandler.run(pid, :passed, timeout)
+  end
+
+  defp run_exec_on_exit(%ExUnit.Test{state: {:failed, _}}, pid, timeout) do
+    ExUnit.OnExitHandler.run(pid, :failed, timeout)
+  end
+
+  # Any other ExUnit.state outcome (test was excluded, skipped, invalid) and
+  # the runner shouldn't make it this far to ask the callback to be run anyways
+  defp run_exec_on_exit(_, pid, timeout) do
+    :ok
   end
 
   ## Helpers

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -358,44 +358,25 @@ defmodule ExUnit.CallbacksTest do
     defmodule OnExitOptionalContextTest do
       use ExUnit.Case
 
-      def format_context(%ExUnit.TestModule{name: name}), do: inspect(name)
-      def format_context(%ExUnit.Test{state: nil}), do: "passed"
-      def format_context(%ExUnit.Test{state: {:failed, _}}), do: "failed"
-      def format_context(%ExUnit.Test{state: {:excluded, _}}), do: "excluded"
-      def format_context(%ExUnit.Test{state: {:invalid, _}}), do: "invalid"
-      def format_context(%ExUnit.Test{state: {:skipped, _}}), do: "skipped"
-
       setup do
-        on_exit(fn ->
-          IO.puts("on_exit setup run no context")
-        end)
-
-        on_exit(fn context ->
-          IO.puts("on_exit setup run context: #{format_context(context)}")
+        on_exit(fn %ExUnit.Test{state: {:failed, _}} ->
+          IO.puts("on_exit setup run with context")
         end)
 
         :ok
       end
 
       setup_all do
-        on_exit(fn ->
-          IO.puts("on_exit setup_all run no context")
-        end)
-
-        on_exit(fn context ->
-          IO.puts("on_exit setup_all run context: #{format_context(context)}")
+        on_exit(fn %ExUnit.TestModule{name: ExUnit.CallbacksTest.OnExitOptionalContextTest} ->
+          IO.puts("on_exit setup_all run with context")
         end)
 
         :ok
       end
 
       test "ok" do
-        on_exit(fn ->
-          IO.puts("simple on_exit run no context")
-        end)
-
-        on_exit(fn context ->
-          IO.puts("simple on_exit run context: #{format_context(context)}")
+        on_exit(fn %ExUnit.Test{state: {:failed, _}} ->
+          IO.puts("simple on_exit run with context")
         end)
 
         flunk("oops")
@@ -406,12 +387,35 @@ defmodule ExUnit.CallbacksTest do
     output = capture_io(fn -> ExUnit.run() end)
 
     assert output =~ """
-           simple on_exit run context: failed
-           simple on_exit run no context
-           on_exit setup run context: failed
-           on_exit setup run no context
-           on_exit setup_all run context: ExUnit.CallbacksTest.OnExitOptionalContextTest
-           on_exit setup_all run no context
+           simple on_exit run with context
+           on_exit setup run with context
+           on_exit setup_all run with context
+           """
+  end
+
+  test "on_exit accepts mixed arities" do
+    defmodule OnExitMixedAritiesTest do
+      use ExUnit.Case
+
+      test "ok" do
+        on_exit(fn ->
+          IO.puts("simple on_exit setup run no context")
+        end)
+
+        on_exit(fn %ExUnit.Test{state: {:failed, _}} ->
+          IO.puts("simple on_exit setup run with context")
+        end)
+
+        flunk("oops")
+      end
+    end
+
+    no_formatters!()
+    output = capture_io(fn -> ExUnit.run() end)
+
+    assert output =~ """
+           simple on_exit setup run with context
+           simple on_exit setup run no context
            """
   end
 

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -354,6 +354,67 @@ defmodule ExUnit.CallbacksTest do
            """
   end
 
+  test "on_exit accepts optional context" do
+    defmodule OnExitOptionalContextTest do
+      use ExUnit.Case
+
+      def format_context(%ExUnit.TestModule{name: name}), do: inspect(name)
+      def format_context(%ExUnit.Test{state: nil}), do: "passed"
+      def format_context(%ExUnit.Test{state: {:failed, _}}), do: "failed"
+      def format_context(%ExUnit.Test{state: {:excluded, _}}), do: "excluded"
+      def format_context(%ExUnit.Test{state: {:invalid, _}}), do: "invalid"
+      def format_context(%ExUnit.Test{state: {:skipped, _}}), do: "skipped"
+
+      setup do
+        on_exit(fn ->
+          IO.puts("on_exit setup run no context")
+        end)
+
+        on_exit(fn context ->
+          IO.puts("on_exit setup run context: #{format_context(context)}")
+        end)
+
+        :ok
+      end
+
+      setup_all do
+        on_exit(fn ->
+          IO.puts("on_exit setup_all run no context")
+        end)
+
+        on_exit(fn context ->
+          IO.puts("on_exit setup_all run context: #{format_context(context)}")
+        end)
+
+        :ok
+      end
+
+      test "ok" do
+        on_exit(fn ->
+          IO.puts("simple on_exit run no context")
+        end)
+
+        on_exit(fn context ->
+          IO.puts("simple on_exit run context: #{format_context(context)}")
+        end)
+
+        flunk("oops")
+      end
+    end
+
+    no_formatters!()
+    output = capture_io(fn -> ExUnit.run() end)
+
+    assert output =~ """
+           simple on_exit run context: failed
+           simple on_exit run no context
+           on_exit setup run context: failed
+           on_exit setup run no context
+           on_exit setup_all run context: ExUnit.CallbacksTest.OnExitOptionalContextTest
+           on_exit setup_all run no context
+           """
+  end
+
   test "raises an error when using setup/2 with something other than a block" do
     message =
       "setup/2 requires a block as the second argument after the context, got: :start_counter"

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -13,6 +13,11 @@ defmodule ExUnit.CallbacksTest do
     [counter: []]
   end
 
+  defp no_formatters! do
+    ExUnit.configure(formatters: [])
+    on_exit(fn -> ExUnit.configure(formatters: [ExUnit.CLIFormatter]) end)
+  end
+
   test "callbacks run custom code with context" do
     defmodule CallbacksTest do
       use ExUnit.Case
@@ -212,11 +217,6 @@ defmodule ExUnit.CallbacksTest do
     assert capture_io(fn -> ExUnit.run() end) =~ "Failed: 2 tests"
   end
 
-  defp no_formatters! do
-    ExUnit.configure(formatters: [])
-    on_exit(fn -> ExUnit.configure(formatters: [ExUnit.CLIFormatter]) end)
-  end
-
   test "exits with shutdown reason" do
     defmodule OnExitAliveTest do
       use ExUnit.Case
@@ -354,32 +354,32 @@ defmodule ExUnit.CallbacksTest do
            """
   end
 
-  test "on_exit accepts optional context" do
-    defmodule OnExitOptionalContextTest do
+  test "on_exit callback accepts optional status" do
+    defmodule OnExitOptionalStatusTest do
       use ExUnit.Case
 
       setup do
-        on_exit(fn %ExUnit.Test{state: {:failed, _}} ->
-          IO.puts("on_exit setup run with context")
+        on_exit(fn _ ->
+          IO.puts("on_exit setup run with status")
         end)
 
         :ok
       end
 
       setup_all do
-        on_exit(fn %ExUnit.TestModule{name: ExUnit.CallbacksTest.OnExitOptionalContextTest} ->
-          IO.puts("on_exit setup_all run with context")
+        on_exit(fn _ ->
+          IO.puts("on_exit setup_all run with status")
         end)
 
         :ok
       end
 
       test "ok" do
-        on_exit(fn %ExUnit.Test{state: {:failed, _}} ->
-          IO.puts("simple on_exit run with context")
+        on_exit(fn _ ->
+          IO.puts("simple on_exit run with status")
         end)
 
-        flunk("oops")
+        assert true
       end
     end
 
@@ -387,26 +387,26 @@ defmodule ExUnit.CallbacksTest do
     output = capture_io(fn -> ExUnit.run() end)
 
     assert output =~ """
-           simple on_exit run with context
-           on_exit setup run with context
-           on_exit setup_all run with context
+           simple on_exit run with status
+           on_exit setup run with status
+           on_exit setup_all run with status
            """
   end
 
-  test "on_exit accepts mixed arities" do
+  test "on_exit callback accepts mixed arities" do
     defmodule OnExitMixedAritiesTest do
       use ExUnit.Case
 
       test "ok" do
         on_exit(fn ->
-          IO.puts("simple on_exit setup run no context")
+          IO.puts("simple on_exit setup run no status")
         end)
 
-        on_exit(fn %ExUnit.Test{state: {:failed, _}} ->
-          IO.puts("simple on_exit setup run with context")
+        on_exit(fn _ ->
+          IO.puts("simple on_exit setup run with status")
         end)
 
-        flunk("oops")
+        assert true
       end
     end
 
@@ -414,8 +414,113 @@ defmodule ExUnit.CallbacksTest do
     output = capture_io(fn -> ExUnit.run() end)
 
     assert output =~ """
-           simple on_exit setup run with context
-           simple on_exit setup run no context
+           simple on_exit setup run with status
+           simple on_exit setup run no status
+           """
+  end
+
+  test "on_exit callback for setup_all/2 receives module as status" do
+    defmodule OnExitSetupAllStatusTest do
+      use ExUnit.Case
+
+      setup_all do
+        on_exit(fn
+          ExUnit.CallbacksTest.OnExitSetupAllStatusTest ->
+            IO.puts("on_exit setup_all run with expected status")
+
+          _ ->
+            IO.puts("on_exit setup_all run with unexpected status")
+        end)
+
+        :ok
+      end
+
+      test "ok" do
+        assert true
+      end
+    end
+
+    no_formatters!()
+    output = capture_io(fn -> ExUnit.run() end)
+
+    assert output =~ """
+           on_exit setup_all run with expected status
+           """
+  end
+
+  test "on_exit callback for passing tests receives status" do
+    defmodule OnExitSetupPassedStatusTest do
+      use ExUnit.Case
+
+      setup do
+        on_exit(fn
+          :passed ->
+            IO.puts("on_exit setup run with expected status")
+
+          _ ->
+            IO.puts("on_exit setup run with unexpected status")
+        end)
+
+        :ok
+      end
+
+      test "ok" do
+        on_exit(fn
+          :passed ->
+            IO.puts("simple on_exit run with expected status")
+
+          _ ->
+            IO.puts("simple on_exit run with unexpected status")
+        end)
+
+        assert true
+      end
+    end
+
+    no_formatters!()
+    output = capture_io(fn -> ExUnit.run() end)
+
+    assert output =~ """
+           simple on_exit run with expected status
+           on_exit setup run with expected status
+           """
+  end
+
+  test "on_exit callback for failed tests receives status" do
+    defmodule OnExitSetupFailedStatusTest do
+      use ExUnit.Case
+
+      setup do
+        on_exit(fn
+          :failed ->
+            IO.puts("on_exit setup run with expected status")
+
+          _ ->
+            IO.puts("on_exit setup run with unexpected status")
+        end)
+
+        :ok
+      end
+
+      test "ok" do
+        on_exit(fn
+          :failed ->
+            IO.puts("simple on_exit run with expected status")
+
+          _ ->
+            IO.puts("simple on_exit run with unexpected status")
+        end)
+
+        assert false
+      end
+    end
+
+    no_formatters!()
+    output = capture_io(fn -> ExUnit.run() end)
+
+    assert output =~ """
+           simple on_exit run with expected status
+           on_exit setup run with expected status
            """
   end
 


### PR DESCRIPTION
Per [#elixir-lang-core discussion](https://groups.google.com/g/elixir-lang-core/c/ebdoMFGSgvw), this PR allows `ExUnit.Callbacks.on_exit/2` to be given a `callback` function that accepts an argument. This argument can be used to perform conditional cleanup based on test outcomes.

In the discussion I proposed that this argument be an `ExUnit.state()`. In this implementation, however, I decided to allow it to be the full `%ExUnit.Test{} | %ExUnit.TestModule{}` struct, under the reasoning that:

- What the `ExUnit.state()` is for an `%ExUnit.TestModule{}` is somewhat unclear
  - I think it's always `nil`, and when passed along to a callback it loses context as to if a `setup/1` test passed, or the callback was provided in `setup_all/1`
  - I considered instead passing either `test.state` or `test_module.name` along, and am still open to this approach
- This allows the callback author to decide how to handle the full context of `setup/1` vs `setup_all/1`
  - Including writing a single re-usable function that handles both structs and can be used in both
- Should these structs expose more context beyond `status` in the future, the conditional cleanup we can do becomes more powerful
  - As a contrived example, a test could now use `%ExUnit.Test{time: time_in_ms}` to change how it does cleanup
  - It is worth discussing if this is a good thing or not

---

Update based on discussion:

There is a concern that my initial choice of test outcome datastructures to be passed arounc could be heavy: containing all captured logs in the `setup/1` case and information about all module tests in the `setup_all/1` case. Even just an `ExUnit.state()` could be heavy since it contains structured information about where and how the test failed.

Since these outcomes would get copied over to all `on_exit` callbacks, it might cause noticeable performance degradation for all test suites. [Discussion here](https://github.com/elixir-lang/elixir/pull/15496#discussion_r34272647970).