### PR TITLE
Fix dynamic handling for none values in descr functions

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -407,6 +407,11 @@ defmodule Module.Types.Descr do
   defp pop_dynamic(:term), do: {:term, :term}
   defp pop_dynamic(descr), do: Map.pop(descr, :dynamic, descr)
 
+  @compile {:inline, put_dynamic: 2}
+  defp put_dynamic(_static, dynamic) when dynamic == @none, do: @none
+  defp put_dynamic(:term, :term), do: :term
+  defp put_dynamic(static, dynamic), do: Map.put(static, :dynamic, dynamic)
+
   @doc """
   Computes the union of two descrs.
   """
@@ -502,7 +507,7 @@ defmodule Module.Types.Descr do
       {right_dynamic, right_static} = pop_dynamic(right)
       dynamic_part = bare_difference_static(left_dynamic, right_static)
 
-      Map.put(bare_difference_static(left_static, right_dynamic), :dynamic, dynamic_part)
+      put_dynamic(bare_difference_static(left_static, right_dynamic), dynamic_part)
     else
       bare_difference_static(left, right)
     end
@@ -6131,7 +6136,7 @@ defmodule Module.Types.Descr do
       {right_dynamic, right_static} = pop_dynamic(right)
       dynamic_part = opt_difference_static(left_dynamic, right_static)
 
-      Map.put(opt_difference_static(left_static, right_dynamic), :dynamic, dynamic_part)
+      put_dynamic(opt_difference_static(left_static, right_dynamic), dynamic_part)
     else
       opt_difference_static(left, right)
     end

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -620,7 +620,12 @@ defmodule Module.Types.DescrTest do
       assert equal?(dynamic(), opt_difference(term(), dynamic()))
       assert empty?(opt_difference(dynamic(), term()))
       assert empty?(opt_difference(none(), dynamic()))
-      assert empty?(opt_difference(dynamic(integer()), integer()))
+      assert opt_difference(dynamic(integer()), integer()) == none()
+      assert opt_difference(dynamic(integer()), integer()) |> opt_negation() == term()
+      assert opt_negation(dynamic(none())) == term()
+      assert bare_difference(dynamic(integer()), integer()) == none()
+      assert bare_difference(dynamic(integer()), integer()) |> bare_negation() == term()
+      assert bare_negation(dynamic(none())) == term()
     end
 
     test "tuple" do


### PR DESCRIPTION
#15487 

Fix gradual difference handling so `dynamic(none())` is normalized to `none()` instead of leaking into later operations and crashing during negation.

Assisted-by: Codex GPT5.5 to validate ideas and assess potential impacts.

I hope these changes fit the description below:
> I think we should assume dynamic(none()) may appear in other places and fix its handling instead.