### PR TITLE
Correctly render list with negative leaves

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -2505,7 +2505,7 @@ defmodule Module.Types.Descr do
                   [to_quoted(ty, opts), to_quoted(lst, opts)]
                 end
 
-              {name, [], args}
+              {:non_empty_list, [], args}
             end)
             |> Kernel.then(
               &[

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -3405,6 +3405,12 @@ defmodule Module.Types.DescrTest do
       assert list(term()) |> opt_difference(list(integer())) |> to_quoted_string() ==
                "non_empty_list(term()) and not non_empty_list(integer())"
 
+      keeps_empty = opt_difference(list(term()), non_empty_list(integer()))
+      assert subtype?(empty_list(), keeps_empty)
+
+      assert to_quoted_string(keeps_empty) ==
+               "list(term()) and not non_empty_list(integer())"
+
       assert list(term())
              |> opt_difference(list(integer()))
              |> opt_difference(list(atom()))

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -3405,10 +3405,7 @@ defmodule Module.Types.DescrTest do
       assert list(term()) |> opt_difference(list(integer())) |> to_quoted_string() ==
                "non_empty_list(term()) and not non_empty_list(integer())"
 
-      keeps_empty = opt_difference(list(term()), non_empty_list(integer()))
-      assert subtype?(empty_list(), keeps_empty)
-
-      assert to_quoted_string(keeps_empty) ==
+      assert to_quoted_string(opt_difference(list(term()), non_empty_list(integer()))) ==
                "list(term()) and not non_empty_list(integer())"
 
       assert list(term())

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -3405,7 +3405,7 @@ defmodule Module.Types.DescrTest do
       assert list(term()) |> opt_difference(list(integer())) |> to_quoted_string() ==
                "non_empty_list(term()) and not non_empty_list(integer())"
 
-      assert to_quoted_string(opt_difference(list(term()), non_empty_list(integer()))) ==
+      assert opt_difference(list(term()), non_empty_list(integer())) |> to_quoted_string() ==
                "list(term()) and not non_empty_list(integer())"
 
       assert list(term())


### PR DESCRIPTION
BDD leaves represent non empty lists
Fixes #15513
Assisted-by: Claude Opus 4.8 & GPT 5.5