### PR TITLE
Add missing `Of.reset_vars` call in receive/after `badtimeout` error path

### DIFF
--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -596,7 +596,8 @@ defmodule Module.Types.Expr do
             {opt_union(body_type, acc), Of.reset_vars(context, original)}
           else
             error = {:badtimeout, timeout_type, timeout, context}
-            {opt_union(body_type, acc), error(__MODULE__, error, meta, stack, context)}
+            context = error(__MODULE__, error, meta, stack, context)
+            {opt_union(body_type, acc), Of.reset_vars(context, original)}
           end
       end)
       |> dynamic_unless_static(stack)


### PR DESCRIPTION
Variable refinement should not leak outside after block

Assisted-by: Claude Opus 4.8