### PR TITLE
Document :opening_delimiter option for Mix.Tasks.Format format/2

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -143,6 +143,9 @@ defmodule Mix.Tasks.Format do
 
     * `:modifiers` (charlist) - list of sigil modifiers.
 
+    * `:opening_delimiter` (string) - the opening delimiter of the sigil being
+      formatted, e.g. `[`, `"`, or `"""` for a heredoc.
+
     * `:extension` (string) - the extension of the file being formatted, e.g. `".md"`.
 
   Now any application can use your formatter as follows:


### PR DESCRIPTION
Sigil callbacks have received :opening_delimiter in their opts since v1.15.0, but it was never listed alongside :sigil and :modifiers. It lets a formatter distinguish, for example, a heredoc sigil from a regular one.