### PR TITLE
docs: improve docstrings and typespecs

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -10,8 +10,8 @@ defmodule Access do
   keys of any type in a data structure via the `data[key]` syntax.
 
   `Access` supports keyword lists (`Keyword`) and maps (`Map`) out
-  of the box. Keywords supports only atoms keys, keys for maps can
-  be of any type. Both return `nil` if the key does not exist:
+  of the box. Keyword lists support only atom keys, while keys for maps
+  can be of any type. Both return `nil` if the key does not exist:
 
       iex> keywords = [a: 1, b: 2]
       iex> keywords[:a]
@@ -33,7 +33,7 @@ defmodule Access do
       iex> keywords[:c][:unknown]
       nil
 
-  This works because accessing anything on a `nil` value, returns
+  This works because accessing anything on a `nil` value returns
   `nil` itself:
 
       iex> nil[:a]
@@ -917,7 +917,7 @@ defmodule Access do
       iex> pop_in(list, [Access.filter(&(&1.salary >= 20)), :name])
       {["francine"], [%{name: "john", salary: 10}, %{salary: 30}]}
 
-  When no match is found, an empty list is returned and the update function is never called
+  When no match is found, an empty list is returned and the update function is never called:
 
       iex> list = [%{name: "john", salary: 10}, %{name: "francine", salary: 30}]
       iex> get_in(list, [Access.filter(&(&1.salary >= 50)), :name])
@@ -1198,7 +1198,7 @@ defmodule Access do
       iex> pop_in(list, [Access.find(&(&1.salary <= 40))])
       {%{name: "john", salary: 10}, [%{name: "francine", salary: 30}]}
 
-  When no match is found, nil is returned and the update function is never called
+  When no match is found, nil is returned and the update function is never called:
 
       iex> list = [%{name: "john", salary: 10}, %{name: "francine", salary: 30}]
       iex> get_in(list, [Access.find(&(&1.salary >= 50)), :name])

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -996,7 +996,7 @@ defmodule Application do
   end
 
   @doc """
-  Gets the directory for app.
+  Gets the directory for `app`.
 
   This information is returned based on the code path. Here is an
   example:
@@ -1077,7 +1077,7 @@ defmodule Application do
   @doc """
   Formats the error reason returned by `start/2`,
   `ensure_started/2`, `stop/1`, `load/1` and `unload/1`,
-  returns a string.
+  and returns a string.
   """
   @spec format_error(any) :: String.t()
   def format_error(reason) do

--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -1388,7 +1388,7 @@ defmodule Base do
 
   The values for `:case` can be:
 
-    * `:upper` - only allows  upper case characters (default)
+    * `:upper` - only allows upper case characters (default)
     * `:lower` - only allows lower case characters
     * `:mixed` - allows mixed case characters
 

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -295,7 +295,7 @@ defmodule Calendar do
   @callback time_from_day_fraction(day_fraction) :: {hour, minute, second, microsecond}
 
   @doc """
-  Define the rollover moment for the calendar.
+  Defines the rollover moment for the calendar.
 
   This is the moment, in your calendar, when the current day ends
   and the next day starts.
@@ -381,13 +381,13 @@ defmodule Calendar do
   @callback iso_days_to_end_of_day(iso_days) :: iso_days
 
   @doc """
-  Shifts date by given duration according to its calendar.
+  Shifts date by the given duration according to its calendar.
   """
   @doc since: "1.17.0"
   @callback shift_date(year, month, day, Duration.t()) :: {year, month, day}
 
   @doc """
-  Shifts naive datetime by given duration according to its calendar.
+  Shifts naive datetime by the given duration according to its calendar.
   """
   @doc since: "1.17.0"
   @callback shift_naive_datetime(
@@ -402,7 +402,7 @@ defmodule Calendar do
             ) :: {year, month, day, hour, minute, second, microsecond}
 
   @doc """
-  Shifts time by given duration according to its calendar.
+  Shifts time by the given duration according to its calendar.
   """
   @doc since: "1.17.0"
   @callback shift_time(hour, minute, second, microsecond, Duration.t()) ::

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -1047,7 +1047,7 @@ defmodule Date do
   @doc """
   Calculates the quarter of the year of a given `date`.
 
-  Returns the day of the year as an integer. For the ISO 8601
+  Returns the quarter of the year as an integer. For the ISO 8601
   calendar (the default), it is an integer from 1 to 4.
 
   ## Examples

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -180,7 +180,7 @@ defmodule DateTime do
   since v1.15.0.
 
   The default unit if none gets passed is `:native`,
-  which results on a default resolution of microseconds.
+  which results in a default resolution of microseconds.
 
   ## Examples
 
@@ -1296,9 +1296,9 @@ defmodule DateTime do
   end
 
   @doc """
-  Converts a number of gregorian seconds to a `DateTime` struct.
+  Converts a number of Gregorian seconds to a `DateTime` struct.
 
-  The returned `DateTime` will have `UTC` timezone, if you want other timezone, please use
+  The returned `DateTime` will have `UTC` timezone, if you want another timezone, please use
   `DateTime.shift_zone/3`.
 
   ## Examples
@@ -1341,7 +1341,7 @@ defmodule DateTime do
   end
 
   @doc """
-  Converts a `DateTime` struct to a number of gregorian seconds and microseconds.
+  Converts a `DateTime` struct to a number of Gregorian seconds and microseconds.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -72,7 +72,7 @@ defmodule Duration do
 
   However, once again, it is important to remember that shifting a duration is not
   arithmetic, so you may want to use the functions in this module depending on what
-  you to achieve. Compare the results of both examples below:
+  you want to achieve. Compare the results of both examples below:
 
       # Adding one month after the other
       iex> date = ~D[2016-01-31]

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -683,7 +683,7 @@ defmodule Calendar.ISO do
   end
 
   @doc """
-  Parses an ISO 8601 formatted duration string to a list of `Duration` compabitble unit pairs.
+  Parses an ISO 8601 formatted duration string to a list of `Duration` compatible unit pairs.
 
   See `Duration.from_iso8601/1`.
   """

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -164,7 +164,7 @@ defmodule NaiveDateTime do
   Returns the "local time" for the machine the Elixir program is running on.
 
   WARNING: This function can cause insidious bugs. It depends on the time zone
-  configuration at run time. This can changed and be set to a time zone that has
+  configuration at run time. This can change and be set to a time zone that has
   daylight saving jumps (spring forward or fall back).
 
   This function can be used to display what the time is right now for the time

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -62,7 +62,7 @@ defmodule Time do
 
   You can pass a time unit to automatically truncate the resulting time.
 
-  The default unit if none gets passed is `:native` which results on a default resolution of microseconds.
+  The default unit if none gets passed is `:native` which results in a default resolution of microseconds.
 
   ## Examples
 
@@ -689,7 +689,7 @@ defmodule Time do
   @doc """
   Compares two time structs.
 
-  Returns `:gt` if first time is later than the second
+  Returns `:gt` if the first time is later than the second
   and `:lt` for vice versa. If the two times are equal
   `:eq` is returned.
 

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1297,9 +1297,9 @@ defmodule Code do
     * `:literal_encoder` (since v1.10.0) - how to encode literals in the AST.
       It must be a function that receives two arguments, the literal and its
       metadata, and it must return `{:ok, ast :: Macro.t}` or
-      `{:error, reason :: binary}`. If you return anything than the literal
+      `{:error, reason :: binary}`. If you return anything other than the literal
       itself as the `term`, then the AST is no longer valid. This option
-      may still useful for textual analysis of the source code.
+      may still be useful for textual analysis of the source code.
 
     * `:static_atoms_encoder` - the static atom encoder function, see
       "The `:static_atoms_encoder` function" section below. Note this
@@ -1678,7 +1678,7 @@ defmodule Code do
   @doc """
   Stores all given compilation options.
 
-  Changing the compilation options affect all processes
+  Changing the compilation options affects all processes
   running in a given Erlang VM node. To store individual
   options and for a description of all options, see
   `put_compiler_option/2`.
@@ -1742,7 +1742,7 @@ defmodule Code do
   @doc """
   Stores a compilation option.
 
-  Changing the compilation options affect all processes running in a
+  Changing the compilation options affects all processes running in a
   given Erlang VM node.
 
   Available options are:
@@ -1758,7 +1758,7 @@ defmodule Code do
       remove the `:debug_info` while deploying, tools like `mix release`
       already do such by default.
 
-      Other environments, such as `mix test`, automatically disables this
+      Other environments, such as `mix test`, automatically disable this
       via the `:test_elixirc_options` project configuration, as there is
       typically no need to store debug chunks for test files.
 
@@ -1776,13 +1776,13 @@ defmodule Code do
     * `:ignore_module_conflict` - when `true`, does not warn when a module has
       already been defined. Defaults to `false`.
 
-    * `:infer_signatures` (since v1.18.0) - a list of applications of which modules
-      should be using during type inference. When `false`, it disables module-local
+    * `:infer_signatures` (since v1.18.0) - a list of applications whose modules
+      should be used during type inference. When `false`, it disables module-local
       signature inference used when type checking remote calls to the compiled
       module. Type checking will be executed regardless of the value of this option.
       Mix projects will set this option to your dependencies list in dev/prod, and
       it will disable this option during test (as there is typically no need to infer
-      signature for test files). Outside of Mix projects, it defaults to `[:elixir]`.
+      signatures for test files). Outside of Mix projects, it defaults to `[:elixir]`.
 
     * `:module_definition` (since v1.20.0) - stores if the module definition should
       be `:compiled` (the default) or `:interpreted`. Note this does not affect the
@@ -1805,7 +1805,7 @@ defmodule Code do
 
     * `:on_undefined_variable` (since v1.15.0) - either `:raise` or `:warn`.
       When `:raise` (the default), undefined variables will trigger a compilation
-      error. You may be set it to `:warn` if you want undefined variables to
+      error. You may set it to `:warn` if you want undefined variables to
       emit a warning and expand as to a local call to the zero-arity function
       of the same name (for example, `node` would be expanded as `node()`).
       This `:warn` behavior only exists for compatibility reasons when working

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -35,7 +35,7 @@ defmodule Code.Fragment do
   Returns the list of lines in the given string, preserving their line endings.
 
   Only the line endings recognized by the Elixir compiler are
-  considered, namely `\r\n` and `\n`. If you would like the retrieve
+  considered, namely `\r\n` and `\n`. If you would like to retrieve
   lines without their line endings, use `String.split(string, ["\r\n", "\n"])`.
 
   ## Examples
@@ -51,6 +51,7 @@ defmodule Code.Fragment do
 
   """
   @doc since: "1.19.0"
+  @spec lines(String.t()) :: [String.t()]
   def lines(string) do
     lines(string, <<>>)
   end
@@ -657,7 +658,7 @@ defmodule Code.Fragment do
       iex> Code.Fragment.surround_context("foo", {1, 1})
       %{begin: {1, 1}, context: {:local_or_var, ~c"foo"}, end: {1, 4}}
 
-  ## Differences to `cursor_context/2`
+  ## Differences from `cursor_context/2`
 
   Because `surround_context/3` attempts to capture complex expressions,
   it has some differences to `cursor_context/2`:
@@ -671,7 +672,7 @@ defmodule Code.Fragment do
       be a local or variable
 
     * `@` when not followed by any identifier is returned as `{:operator, ~c"@"}`
-      (in contrast to `{:module_attribute, ~c""}` in `cursor_context/2`
+      (in contrast to `{:module_attribute, ~c""}` in `cursor_context/2`)
 
     * This function never returns empty sigils `{:sigil, ~c""}` or empty structs
       `{:struct, ~c""}` as context

--- a/lib/elixir/lib/code/typespec.ex
+++ b/lib/elixir/lib/code/typespec.ex
@@ -117,7 +117,7 @@ defmodule Code.Typespec do
   element is spec name and arity and the second is the spec.
 
   The module must have a corresponding BEAM file which can be
-  located by the runtime system. The types will be in the Erlang
+  located by the runtime system. The specs will be in the Erlang
   Abstract Format.
   """
   @spec fetch_specs(module | binary) :: {:ok, [tuple]} | :error
@@ -135,10 +135,10 @@ defmodule Code.Typespec do
   Returns all callbacks available from the module's BEAM code.
 
   The result is returned as a list of tuples where the first
-  element is spec name and arity and the second is the spec.
+  element is the callback name and arity and the second is the callback.
 
   The module must have a corresponding BEAM file
-  which can be located by the runtime system. The types will be
+  which can be located by the runtime system. The callbacks will be
   in the Erlang Abstract Format.
   """
   @spec fetch_callbacks(module | binary) :: {:ok, [tuple]} | :error

--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -233,7 +233,7 @@ defmodule Config do
   Returns the environment this configuration file is executed on.
 
   In Mix projects this function returns the environment this configuration
-  file is executed on. 
+  file is executed on.
   In releases, returns the `MIX_ENV` specified when running `mix release`.
 
   This is most often used to execute conditional code:
@@ -284,8 +284,8 @@ defmodule Config do
 
   In case the file doesn't exist, an error is raised.
 
-  If file is a relative, it will be expanded relatively to the
-  directory the current configuration file is in.
+  If the file is relative, it will be expanded relative to the
+  directory of the current configuration file.
 
   ## Examples
 

--- a/lib/elixir/lib/config/provider.ex
+++ b/lib/elixir/lib/config/provider.ex
@@ -25,7 +25,7 @@ defmodule Config.Provider do
   For example, imagine you want to list some basic configuration
   on Mix's built-in `config/runtime.exs` file, but you also want
   to support additional configuration files. To do so, you can add
-  this inside the `def project` portion of  your `mix.exs`:
+  this inside the `def project` portion of your `mix.exs`:
 
       releases: [
         demo: [

--- a/lib/elixir/lib/config/reader.ex
+++ b/lib/elixir/lib/config/reader.ex
@@ -16,7 +16,7 @@ defmodule Config.Reader do
 
   For example, if you expect the target system to have a config file
   in an absolute path, you can add this inside the `def project` portion
-  of  your `mix.exs`:
+  of your `mix.exs`:
 
       releases: [
         demo: [

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -2376,7 +2376,7 @@ defmodule File.Error do
   @moduledoc """
   An exception that is raised when a file operation fails.
 
-  For example, this exception is raised, when trying to read a non existent file:
+  For example, this exception is raised, when trying to read a nonexistent file:
 
       iex> File.read!("nonexistent_file.txt")
       ** (File.Error) could not read file "nonexistent_file.txt": no such file or directory
@@ -2409,7 +2409,7 @@ defmodule File.CopyError do
   @moduledoc """
   An exception that is raised when copying a file fails.
 
-  For example, this exception is raised when trying to copy to file or directory that isn't present:
+  For example, this exception is raised when trying to copy to a file or directory that isn't present:
 
       iex> File.cp_r!("non_existent", "source_dir/subdir")
       ** (File.CopyError) could not copy recursively from "non_existent" to "source_dir/subdir". non_existent: no such file or directory
@@ -2477,7 +2477,7 @@ defmodule File.LinkError do
   @moduledoc """
   An exception that is raised when linking a file fails.
 
-  For example, this exception is raised when trying to link to file that isn't present:
+  For example, this exception is raised when trying to link to a file that isn't present:
 
       iex> File.ln!("existing.txt", "link.txt")
       ** (File.LinkError) could not create hard link from "link.txt" to "existing.txt": no such file or directory

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -2221,7 +2221,7 @@ defmodule File do
   type. If you pass, for example, `[encoding: :utf8]` or
   `[encoding: {:utf16, :little}]` in the modes parameter, the underlying stream
   will use `IO.write/2` and the `String.Chars` protocol to convert the data.
-  See `IO.binwrite/2` and `IO.write/2` .
+  See `IO.binwrite/2` and `IO.write/2`.
 
   One may also consider passing the `:delayed_write` option if the stream
   is meant to be written to under a tight loop.

--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -25,7 +25,7 @@ defmodule Float do
   and arithmetic due to the fact most decimal fractions cannot be
   represented by a floating-point binary and most operations are not exact,
   but operate on approximations. Those issues are not specific
-  to Elixir, they are a property of floating point representation itself.
+  to Elixir, they are a property of floating-point representation itself.
 
   For example, the numbers 0.1 and 0.01 are two of them, what means the result
   of squaring 0.1 does not give 0.01 neither the closest representable. Here is
@@ -253,7 +253,7 @@ defmodule Float do
   @doc """
   Rounds a float to the smallest float greater than or equal to `number`.
 
-  `ceil/2` also accepts a precision to round a floating-point value down
+  `ceil/2` also accepts a precision to round a floating-point value up
   to an arbitrary number of fractional digits (between 0 and 15).
 
   The operation is performed on the binary floating point, without a
@@ -322,7 +322,7 @@ defmodule Float do
   and therefore the number above is internally represented as 5.567499999,
   which explains the behavior above. If you want exact rounding for decimals,
   you must use a decimal library. The behavior above is also in accordance
-  to reference implementations, such as "Correctly Rounded Binary-Decimal and
+  with reference implementations, such as "Correctly Rounded Binary-Decimal and
   Decimal-Binary Conversions" by David M. Gay.
 
   ## Examples

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -108,7 +108,7 @@ defmodule Integer do
   defguard is_even(integer) when is_integer(integer) and (integer &&& 1) == 0
 
   @doc """
-  Computes `base` raised to power of `exponent`.
+  Computes `base` raised to the power of `exponent`.
 
   Both `base` and `exponent` must be integers.
   The exponent must be zero or positive.

--- a/lib/elixir/lib/kernel/lexical_tracker.ex
+++ b/lib/elixir/lib/kernel/lexical_tracker.ex
@@ -23,7 +23,7 @@ defmodule Kernel.LexicalTracker do
 
   @doc """
   Invoked during module expansion to annotate a require
-  must be warned if unused.
+  that must be warned if unused.
   """
   def warn_require(pid, meta, module, alias) do
     :gen_server.cast(pid, {:warn_require, module, meta, alias})
@@ -32,7 +32,7 @@ defmodule Kernel.LexicalTracker do
 
   @doc """
   Invoked during module expansion to annotate an alias
-  must be warned if unused.
+  that must be warned if unused.
   """
   def warn_alias(pid, meta, alias, module) do
     :gen_server.cast(pid, {:warn_alias, alias, meta})
@@ -41,7 +41,7 @@ defmodule Kernel.LexicalTracker do
 
   @doc """
   Invoked during module expansion to annotate an import
-  must be warned if unused.
+  that must be warned if unused.
   """
   def warn_import(pid, module) do
     :gen_server.cast(pid, {:warn_import, module})

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -520,8 +520,8 @@ defmodule List do
 
   As in `Enum.sort/2`, avoid using the default sorting function to sort
   structs, as by default it performs structural comparison instead of a
-  semantic one. In such cases, you shall pass a sorting function as third
-  element or any module that implements a `compare/2` function. For example,
+  semantic one. In such cases, you shall pass a sorting function as the third
+  argument or any module that implements a `compare/2` function. For example,
   if you have tuples with user names and their birthday, and you want to
   sort on their birthday, in both ascending and descending order, you should
   do:
@@ -661,7 +661,7 @@ defmodule List do
   end
 
   @doc """
-  Wraps `term` in a list if this is not list.
+  Wraps `term` in a list if it is not a list.
 
   If `term` is already a list, it returns the list.
   If `term` is `nil`, it returns an empty list.

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -166,7 +166,7 @@ defmodule Macro do
       of a `__block__` or the right side of `->`. The last expression of the
       block does not have metadata if it is not followed by an end of line
       character (either a newline or `;`). This entry may appear multiple times
-      in the same metadata if the expression is surround by parens
+      in the same metadata if the expression is surrounded by parens
 
     * `:format` - set to `:keyword` when an atom is defined as a keyword.
       It may also be set to `:atom` to distinguish `nil`, `false`, and `true`
@@ -732,7 +732,7 @@ defmodule Macro do
   end
 
   @doc """
-  This functions behaves like `prewalk/3`, but performs a depth-first,
+  This function behaves like `prewalk/3`, but performs a depth-first,
   post-order traversal of quoted expressions using an accumulator.
   """
   @spec postwalk(t, any, (t, any -> {t, any})) :: {t, any}
@@ -940,7 +940,7 @@ defmodule Macro do
 
   This is useful when a struct needs to be expanded at
   compilation time and the struct being expanded may or may
-  not have been compiled (including structs in the defined
+  not have been compiled (including structs defined
   under the module being compiled). For compiled modules,
   it will invoke `module.__info__(:struct)`.
 
@@ -1034,7 +1034,7 @@ defmodule Macro do
   defp find_invalid(other), do: {:error, other}
 
   @doc """
-  Returns an enumerable that traverses the  `ast` in depth-first,
+  Returns an enumerable that traverses the `ast` in depth-first,
   pre-order traversal.
 
   ## Examples
@@ -1092,7 +1092,7 @@ defmodule Macro do
   end
 
   @doc """
-  Returns an enumerable that traverses the  `ast` in depth-first,
+  Returns an enumerable that traverses the `ast` in depth-first,
   post-order traversal.
 
   ## Examples
@@ -2500,7 +2500,7 @@ defmodule Macro do
 
   ### As a remote call
 
-  Inspect an atom the function name of a remote call.
+  Inspect an atom as the function name of a remote call.
 
       iex> Macro.inspect_atom(:remote_call, :foo)
       "foo"

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -234,7 +234,7 @@ defmodule Macro.Env do
   > This function does not emit compiler tracing events,
   > which may block the compiler from correctly tracking
   > dependencies. Use this function for reflection purposes
-  > but to do not use it to expand imports into qualified
+  > but do not use it to expand imports into qualified
   > calls. Instead, use `expand_import/5`.
 
   ## Examples
@@ -394,7 +394,7 @@ defmodule Macro.Env do
 
     * `:info_callback` - a function to use instead of `c:Module.__info__/1`.
       The function will be invoked with `:functions` or `:macros` argument.
-      It has to return a list of `{function, arity}` key value pairs.
+      It has to return a list of `{function, arity}` key-value pairs.
       If it fails, it defaults to using module metadata based on `module_info/1`.
 
   ## Examples

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -201,7 +201,7 @@ defmodule MapSet do
   Checks if two sets are equal.
 
   The comparison between elements is done using `===/2`,
-  which a set with `1` is not equivalent to a set with
+  which means a set with `1` is not equivalent to a set with
   `1.0`.
 
   ## Examples
@@ -340,7 +340,7 @@ defmodule MapSet do
   > If you find yourself doing multiple calls to `MapSet.filter/2`
   > and `MapSet.reject/2` in a pipeline, it is likely more efficient
   > to use `Enum.map/2` and `Enum.filter/2` instead and convert to
-  > a map at the end using `MapSet.new/1`.
+  > a set at the end using `MapSet.new/1`.
 
   ## Examples
 
@@ -404,7 +404,7 @@ defmodule MapSet do
 
   """
   @doc since: "1.15.0"
-  @spec split_with(MapSet.t(), (term() -> as_boolean(term))) :: {MapSet.t(), MapSet.t()}
+  @spec split_with(t(a), (a -> as_boolean(term))) :: {t(a), t(a)} when a: value
   def split_with(%MapSet{map: map}, fun) when is_function(fun, 1) do
     {while_true, while_false} = Map.split_with(map, fn {key, _} -> fun.(key) end)
     {%MapSet{map: while_true}, %MapSet{map: while_false}}

--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -232,7 +232,7 @@ defmodule Module.Types do
 
     context =
       Enum.reduce(defs, context(), fn {fun_arity, _kind, meta, _clauses} = def, context ->
-        # Optimized version of finder, since we already the definition
+        # Optimized version of finder, since we already have the definition
         finder = fn _ -> default_domain(:dynamic, def, fun_arity, impl) end
         {_kind, _inferred, context} = local_handler(meta, fun_arity, stack, context, finder)
         context

--- a/lib/elixir/lib/node.ex
+++ b/lib/elixir/lib/node.ex
@@ -39,7 +39,7 @@ defmodule Node do
   Currently supported options are:
 
   * `:name_domain` - determines the host name part of the node name. If `:longnames`,
-    fully qualified domain names will be   used which also is the default.
+    fully qualified domain names will be used, which is also the default.
     If `:shortnames`, only the short name of the host will be used.
 
   * `:net_ticktime` - The tick time to use in seconds. Defaults to the value of the
@@ -47,7 +47,7 @@ defmodule Node do
     See [the `kernel` documentation](https://www.erlang.org/doc/apps/kernel/kernel_app.html)
     for more information.
 
-  * `net_tickintensity` - The tick intensity to use. Defaults to the value of the
+  * `:net_tickintensity` - The tick intensity to use. Defaults to the value of the
     `net_tickintensity` configuration under Erlang's `kernel` application.
     See [the `kernel` documentation](https://www.erlang.org/doc/apps/kernel/kernel_app.html)
     for more information.

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -43,7 +43,7 @@ defmodule OptionParser do
 
   defmodule ParseError do
     @moduledoc """
-    An exception raised when parsing option fails.
+    An exception raised when parsing an option fails.
 
     For example, see `OptionParser.parse!/2`.
     """
@@ -387,7 +387,7 @@ defmodule OptionParser do
         do_parse(rest, config, new_opts, args, invalid, all?)
 
       {:invalid, option, value, rest} ->
-        # the option exist but it has wrong value
+        # the option exists but it has wrong value
         do_parse(rest, config, opts, args, [{option, value} | invalid], all?)
 
       {:undefined, option, _value, rest} ->

--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -61,7 +61,7 @@ defmodule Port do
     * `{pid, {:connect, new_pid}}` - sets the `new_pid` as the new owner of
       the port. Once a port is opened, the port is linked and connected to the
       caller process and communication to the port only happens through the
-      connected process. This message makes `new_pid` the new connected processes.
+      connected process. This message makes `new_pid` the new connected process.
       Unless the port is dead, the port will reply to the old owner with
       `{port, :connected}`. See `connect/2`.
 
@@ -156,7 +156,7 @@ defmodule Port do
 
   We do not always have control over how third-party software terminates.
   If necessary, one workaround is to wrap the child application in a script that
-  checks whether stdin has been closed.  Here is such a script that has been
+  checks whether stdin has been closed. Here is such a script that has been
   verified to work on bash shells:
 
       #!/usr/bin/env bash

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -226,7 +226,7 @@ defmodule Process do
   >
   > The functions `Kernel.exit/1` and `Process.exit/2` are
   > named similarly but provide very different functionalities. The
-  > `Kernel:exit/1` function should be used when the intent is to stop the current
+  > `Kernel.exit/1` function should be used when the intent is to stop the current
   > process while `Process.exit/2` should be used when the intent is to send an
   > exit signal to another process. Note also that `Kernel.exit/1` can be caught
   > with `try/1` while `Process.exit/2` can only be handled by trapping exits and
@@ -1002,7 +1002,7 @@ defmodule Process do
   end
 
   @doc """
-  Add a descriptive term to the current process.
+  Adds a descriptive term to the current process.
 
   The term does not need to be unique, and will be shown in Observer and in
   crash logs.

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -215,7 +215,7 @@ defmodule Protocol do
         ...
       end
 
-  If you are using `Mix.install/2`, you can do by passing the `consolidate_protocols`
+  If you are using `Mix.install/2`, you can do so by passing the `consolidate_protocols`
   option:
 
       Mix.install(

--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -340,7 +340,7 @@ defmodule Record do
     fields
   end
 
-  # Normalizes of record fields to have default values.
+  # Normalizes record fields to have default values.
   defp fields(kind, fields) do
     normalizer_fun = fn
       {key, value} when is_atom(key) ->

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1082,7 +1082,7 @@ defmodule String do
   end
 
   @doc """
-  Replaces all leading occurrences of `match` by `replacement` of `match` in `string`.
+  Replaces all leading occurrences of `match` by `replacement` in `string`.
 
   Returns the string untouched if there are no occurrences.
 
@@ -2979,7 +2979,7 @@ defmodule String do
   By default, the maximum number of atoms is `1_048_576`. This limit
   can be raised or lowered using the VM option `+t`.
 
-  The maximum atom size is of 255 Unicode code points.
+  The maximum atom size is 255 Unicode code points.
 
   Inlined by the compiler.
 
@@ -3001,7 +3001,7 @@ defmodule String do
 
   If the list of expected atoms is known upfront, prefer `to_existing_atom/2`.
 
-  The maximum atom size is of 255 Unicode code points.
+  The maximum atom size is 255 Unicode code points.
   Raises an `ArgumentError` if the atom does not exist.
 
   Inlined by the compiler.


### PR DESCRIPTION
This PR focuses on improving documentation clarity and correcting grammatical errors.

# Changes

- documentation refinements: fixed numerous typos, grammatical inconsistencies, and phrasing issues in module documentation (Access, Calendar, Code, File, MapSet)
- typespecs: added missing typespecs (`Code.Fragment.lines/1`) and improved existing ones to better reflect actual implementation logic (`MapSet.split_with/2`)
- clarification: improved technical explanations for better readability and fix `ceil/2` description
- consistency: standardized punctuation and formatting within docstrings to align with project style
