### PR TITLE
Fix `IO.read/2` docs: integer count is in characters, not bytes

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -152,9 +152,8 @@ defmodule IO do
 
   The `device` is iterated as specified by the `line_or_chars` argument:
 
-    * if `line_or_chars` is an integer, it represents a number of bytes. The device is
-      iterated by that number of bytes. This should be the preferred mode for reading
-      non-textual inputs.
+    * if `line_or_chars` is an integer, it represents a number of characters. The device
+      is iterated by that number of characters.
 
     * if `line_or_chars` is `:line`, the device is iterated line by line.
       CRLF newlines  ("\r\n") are automatically normalized to "\n".


### PR DESCRIPTION
`IO.read/2` is the Unicode-safe reader and delegates an integer count to `:io.get_chars/3`, which counts characters, not bytes. The docs were copied from `IO.binread/2` (the byte-oriented, Unicode-unsafe reader), so they incorrectly described the integer argument as a number of bytes and carried binread/2's "preferred mode for reading non-textual inputs" note. This also contradicted read/2's own return description, which already documents the result as "the output characters".

Assisted-by: Claude Code:claude-opus-4-8