### PR TITLE
Align `Access.filter/1` spec with its truthy semantics

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -934,7 +934,7 @@ defmodule Access do
 
   """
   @doc since: "1.6.0"
-  @spec filter((term -> boolean)) :: access_fun(data :: list, current_value :: list)
+  @spec filter((term -> as_boolean(term))) :: access_fun(data :: list, current_value :: list)
   def filter(func) when is_function(func) do
     fn op, data, next -> filter(op, data, func, next) end
   end


### PR DESCRIPTION
`Access.filter/1` treats the predicate's return value as truthy/falsy, not strictly boolean: the `:get` path uses it as a comprehension filter (`for elem <- data, func.(elem)`) and the `:get_and_update` path uses `if func.(head)`. The spec `(term -> boolean)` was therefore narrower than what the code accepts. Every sibling accessor already uses `as_boolean(term)` — `Access.find/1`, `Map.filter/2`, `Keyword.filter/2`, `MapSet.filter/2` — so this aligns `Access.filter/1` with that convention.

Assisted-by: Claude Code:claude-opus-4-8