### PR TITLE
Fix `MapSet.split_with/2` doctest predicate arity

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -396,11 +396,11 @@ defmodule MapSet do
       iex> while_false
       MapSet.new([1, 3])
 
-      iex> {while_true, while_false} = MapSet.split_with(MapSet.new(), fn {_k, v} -> v > 50 end)
+      iex> {while_true, while_false} = MapSet.split_with(MapSet.new([10, 20, 60, 70]), fn v -> v > 50 end)
       iex> while_true
-      MapSet.new([])
+      MapSet.new([60, 70])
       iex> while_false
-      MapSet.new([])
+      MapSet.new([10, 20])
 
   """
   @doc since: "1.15.0"


### PR DESCRIPTION
The second doctest passed a two-element tuple pattern (`fn {_k, v} -> ... end`) to `MapSet.split_with/2`, but the predicate receives each set element as its only argument — as the docstring states and the first doctest and implementation (`fun.(key)`) confirm. The wrong form was a copy of `Map.split_with/2` and only went unnoticed because the example uses an empty set, so the predicate is never called. Aligns it with the documented arity.

Assisted-by: Claude Code:claude-opus-4-8