### PR TITLE
Refine `Enum.chunk_while/4` return type to `[chunk]`

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -618,7 +618,7 @@ defmodule Enum do
           acc,
           (element, acc -> {:cont, chunk, acc} | {:cont, acc} | {:halt, acc}),
           (acc -> {:cont, chunk, acc} | {:cont, acc})
-        ) :: Enumerable.t()
+        ) :: [chunk]
         when chunk: any
   def chunk_while(enumerable, acc, chunk_fun, after_fun) do
     {_, {res, acc}} =


### PR DESCRIPTION
`Enum.chunk_while/4` always returns a proper list of the emitted chunks: every terminal branch is `:lists.reverse(res)` or `:lists.reverse([chunk | res])`, and the docstring says "Returns a list of emitted chunks". The spec declared the broad `Enumerable.t()` instead.

Unlike `chunk_by/2` and `chunk_every/2,4` (which always chunk into sublists and are typed `[list]`), `chunk_while/4` lets the reducer emit an arbitrary term as a chunk (`{:cont, chunk, acc}`, with `chunk: any`), so `[chunk]` is the precise return type — narrower and better shaped than `Enumerable.t()`, without wrongly assuming each chunk is a list.

Assisted-by: Claude Code:claude-opus-4-8