### PR TITLE
Refine `String.slice/3` return type to `t`

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2410,7 +2410,7 @@ defmodule String do
       ""
 
   """
-  @spec slice(t, integer, non_neg_integer) :: grapheme
+  @spec slice(t, integer, non_neg_integer) :: t
 
   def slice(_, _, 0) do
     ""


### PR DESCRIPTION
`String.slice/3` returns a substring of arbitrary length: its docstring opens with "Returns a substring" and its examples yield "lix" (3 graphemes), "lixir" (5) and "" (0). The spec declared `grapheme` instead, whose typedoc is "Multiple code points that may be perceived as a single character" — a single grapheme, which the function never returns.

`grapheme` is defined as `@type grapheme :: t`, so this is identical to analysis tools; the change is reader-facing precision. It also aligns `slice/3` with the module convention: single-grapheme returners use `grapheme` (`first/1`, `last/1`, `at/2`) while substring returners use `t` (`slice/2`, `byte_slice/3`, `split_at/2`). `slice/3` was the lone anomaly.

Assisted-by: Claude Code:claude-opus-4-8