### PR TITLE
Tighten IO typespecs

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -128,7 +128,7 @@ defmodule IO do
   @type nodata :: {:error, term} | :eof
   @type chardata :: String.t() | maybe_improper_list(char | chardata, String.t() | [])
 
-  @type inspect_opts :: [Inspect.Opts.new_opt() | {:label, term}]
+  @type inspect_opts :: [Inspect.Opts.new_opt() | {:label, String.Chars.t()}]
 
   @typedoc """
   Stacktrace information as keyword options for `warn/2`.

--- a/lib/elixir/lib/io/stream.ex
+++ b/lib/elixir/lib/io/stream.ex
@@ -31,7 +31,7 @@ defmodule IO.Stream do
   @type t :: %__MODULE__{
           device: IO.device(),
           raw: boolean(),
-          line_or_bytes: :line | non_neg_integer()
+          line_or_bytes: :line | pos_integer()
         }
 
   @doc false


### PR DESCRIPTION
Changes

- IO.inspect/2 label opt cannot be any term value, it must implement `String.Chars` 
- IO.Stream.t/0  `line_or_bytes` can be positive int or `:line`