### PR TITLE
Refine `List.keyfind!/3` return type to `tuple`

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -435,7 +435,7 @@ defmodule List do
 
   """
   @doc since: "1.13.0"
-  @spec keyfind!([tuple], any, non_neg_integer) :: any
+  @spec keyfind!([tuple], any, non_neg_integer) :: tuple
   def keyfind!(list, key, position) when is_integer(position) do
     :lists.keyfind(key, position + 1, list) ||
       raise KeyError,


### PR DESCRIPTION
`List.keyfind!/3` returns `:lists.keyfind(...) || raise KeyError`. `:lists.keyfind/3` returns the matching tuple or `false`; `false` is falsy and triggers the raise, while any tuple is truthy, so a normal return is always a tuple. The spec declared the broad `any`.

This aligns `keyfind!/3` with the module's own bang convention: `first!/1` and `last!/1` return the precise `elem` type, dropping the `any` that their defaulted non-bang siblings carry. `keyfind/4` keeps `any` because its `default` argument can be any term; `keyfind!/3`, having no default, was the lone bang function still specced `any`.

Assisted-by: Claude Code:claude-opus-4-8