### PR TITLE
Fix `Date.range/2` doc: step is `range/3`'s third argument

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -81,7 +81,7 @@ defmodule Date do
 
   Ranges of dates can be increasing (`first <= last`) and are
   always inclusive. For a decreasing range, use `range/3` with
-  a step of -1 as first argument.
+  a step of -1 as third argument.
 
   ## Examples
 


### PR DESCRIPTION
The docstring told readers to use `range/3` "with a step of -1 as first argument", but `range/3` is `range(first, last, step)` — the step is the third argument (spec: `range(Calendar.date(), Calendar.date(), step :: pos_integer | neg_integer)`). Following the text literally would put -1 where the first date belongs.

Assisted-by: Claude Code:claude-opus-4-8