### PR TITLE
Fix `Base.decode16!/2` doc: base 16 has no padding

### DIFF
--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -536,7 +536,7 @@ defmodule Base do
     * `:lower` - only allows lower case characters
     * `:mixed` - allows mixed case characters
 
-  An `ArgumentError` exception is raised if the padding is incorrect or
+  An `ArgumentError` exception is raised if the string has an odd length or
   a non-alphabet character is present in the string.
 
   ## Examples


### PR DESCRIPTION
The docstring said an `ArgumentError` is raised "if the padding is incorrect", but base 16 has no padding: `decode16!/2` accepts only the `:case` option (unlike `decode32!`/`decode64!`, which take `:padding`), and its two reachable error paths are an odd-length string ("wrong length. An even number of bytes was expected") and a non-alphabet character. The "padding is incorrect" wording is copied from the padded base 32/64 variants; state the real trigger (odd length) instead.

Assisted-by: Claude Code:claude-opus-4-8