### PR TITLE
fix: DateRange invalid slice step computation when step != 1

### DIFF
--- a/lib/elixir/lib/calendar/date_range.ex
+++ b/lib/elixir/lib/calendar/date_range.ex
@@ -88,7 +88,7 @@ defmodule Date.Range do
             step: step
           } = range
         ) do
-      {:ok, size(range), &slice(first + &1 * step, step + &3 - 1, &2, calendar)}
+      {:ok, size(range), &slice(first + &1 * step, step * &3, &2, calendar)}
     end
 
     # TODO: Remove me on v2.0

--- a/lib/elixir/test/elixir/calendar/date_range_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_range_test.exs
@@ -65,6 +65,9 @@ defmodule Date.RangeTest do
 
       assert Enum.slice(@asc_range_2, 3, 3) == [~D[2000-01-07], ~D[2000-01-09], ~D[2000-01-11]]
       assert Enum.slice(@asc_range_2, -3, 3) == [~D[2000-12-28], ~D[2000-12-30], ~D[2001-01-01]]
+
+      assert Enum.slice(@asc_range_2, 0..4//2) == [~D[2000-01-01], ~D[2000-01-05], ~D[2000-01-09]]
+      assert Enum.slice(@asc_range_2, 1..4//2) == [~D[2000-01-03], ~D[2000-01-07]]
     end
 
     test "for descending range" do
@@ -73,6 +76,14 @@ defmodule Date.RangeTest do
 
       assert Enum.slice(@desc_range_2, 3, 3) == [~D[2000-12-26], ~D[2000-12-24], ~D[2000-12-22]]
       assert Enum.slice(@desc_range_2, -3, 3) == [~D[2000-01-05], ~D[2000-01-03], ~D[2000-01-01]]
+
+      assert Enum.slice(@desc_range_2, 0..4//2) == [
+               ~D[2001-01-01],
+               ~D[2000-12-28],
+               ~D[2000-12-24]
+             ]
+
+      assert Enum.slice(@desc_range_2, 1..4//2) == [~D[2000-12-30], ~D[2000-12-26]]
     end
 
     test "for empty range" do


### PR DESCRIPTION
## Current behavior

```elixir
Enum.slice(Date.range(~D[2001-01-01], ~D[2001-01-10], 2), 0..2//2)
#=> [~D[2001-01-01], ~D[2001-01-04]]
```

`~D[2001-01-04] `- is not at range at all

## Expected
```elixir
Enum.slice(Date.range(~D[2001-01-01], ~D[2001-01-10], 2), 0..2//2)
#=> [~D[2001-01-01], ~D[2001-01-05]]
```

## Changes
- fix slice step computation
- tests updated