### PR TITLE
Document `--failed` interaction with `--partitions` in `mix test`

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -444,6 +444,14 @@ defmodule Mix.Tasks.Test do
   the results of all partitions inside `cover/`, you can run `mix test.coverage` to
   get the unified report.
 
+  Avoid passing `--partitions` when retrying failures with `--failed` if each
+  partition runs in its own workspace or on a separate machine, and therefore only
+  records its own failures. Because `--partitions` splits the failed files across
+  partitions, most partitions end up with nothing to run and silently print
+  "There are no tests to run". Instead, run `mix test --failed` on its own so each
+  partition re-runs everything it recorded. This does not apply when all partitions
+  share the same list of failures.
+
   ## The --stale option
 
   The `--stale` command line option attempts to run only the test files which


### PR DESCRIPTION
Hello Elixir team!

I got into a rough edge because I didn't know about this one. 

I was using `mix test --failed` to retry failures in a CI setup that started using `--partitions`, each running on a separate machine. The retry fallback also used `--partitions`, that was the problem. A test that had genuinely failed merged green, the retry just printed "There are no tests to run" and exited 0.

After digging in, then I understood `--partitions` with `--failed` was my mistake there. The failed test wasn't picked because we were running on partition 3, and the test would only run if I used partition 1 or no `--partitions` on the retry.

I think the behavior is by design, but worth noting in the docs.

Thanks!