### PR TITLE
fix: ANSI.Docs rendering

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -673,7 +673,7 @@ defmodule IO.ANSI.Docs do
 
   # Characters that can mark the beginning or the end of a word.
   # Only support the most common ones at this moment.
-  @delimiters [?\s, ?', ?", ?!, ?@, ?#, ?$, ?%, ?^, ?&] ++
+  @delimiters [?\s, ?', ?", ?!, ??, ?,, ?:, ?;, ?/, ?@, ?#, ?$, ?%, ?^, ?&] ++
                 [?-, ?+, ?(, ?), ?[, ?], ?{, ?}, ?<, ?>, ?.]
 
   ### Inline start

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -317,6 +317,23 @@ defmodule IO.ANSI.DocsTest do
       assert result == "\e[36mhello world\e[0m\n\e[0m"
     end
 
+    test "star/underscore works before punctuation" do
+      result = format_markdown("**hello world**,")
+      assert result == "\e[1mhello world\e[0m,\n\e[0m"
+
+      result = format_markdown("*hello world*;")
+      assert result == "\e[4mhello world\e[0m;\n\e[0m"
+
+      result = format_markdown("__hello world__:")
+      assert result == "\e[1mhello world\e[0m:\n\e[0m"
+
+      result = format_markdown("_hello world_?")
+      assert result == "\e[4mhello world\e[0m?\n\e[0m"
+
+      result = format_markdown("*hello world*/")
+      assert result == "\e[4mhello world\e[0m/\n\e[0m"
+    end
+
     test "star/underscore/backtick works across words with ansi disabled" do
       result = format_markdown("*hello world*", enabled: false)
       assert result == "*hello world*"


### PR DESCRIPTION
## Current behavior

Invalid rendering when closing marker is followed by common punctuation (`,`, `:`, `;`, `?` etc.)

<img width="565" height="170" alt="Monosnap e8c0a21ef0e0f5101a0d9e590435203ca7bf96af 2026-07-09 17-23-05" src="https://github.com/user-attachments/assets/2d0f14ed-f7a6-432d-90e5-884ba11d7b67" />

## Expected
<img width="573" height="182" alt="Monosnap e8c0a21ef0e0f5101a0d9e590435203ca7bf96af 2026-07-09 17-22-42" src="https://github.com/user-attachments/assets/cb9693d2-ef12-4ef4-90cc-c3af427f0401" />

## Changes
- most common delims upd
- tests

PR fixes ~30 cases already present in Elixir docs.