### PR TITLE
Fix `Calendar.ISO.valid_time?/4` doc: it validates a time, not a date

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1685,7 +1685,7 @@ defmodule Calendar.ISO do
   end
 
   @doc """
-  Determines if the date given is valid according to the proleptic Gregorian calendar.
+  Determines if the time given is valid.
 
   Leap seconds are not supported by the built-in Calendar.ISO.
 


### PR DESCRIPTION
The docstring was a verbatim copy of `valid_date?/3`'s ("Determines if the date given is valid according to the proleptic Gregorian calendar"), but `valid_time?/4` validates a time of day (hour, minute, second, microsecond) via `is_hour`/`is_minute`/`is_second`/`is_microsecond`. Time validity is calendar-independent, so the "proleptic Gregorian calendar" qualifier does not apply either; the very next line ("Leap seconds are not supported") already confirms the subject is a time.

Assisted-by: Claude Code:claude-opus-4-8