### PR TITLE
Fix `GenServer.call/3` timeout doc: non-negative, not greater than zero

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -1158,7 +1158,7 @@ defmodule GenServer do
 
   ## Timeouts
 
-  `timeout` is an integer greater than zero which specifies how many
+  `timeout` is a non-negative integer which specifies how many
   milliseconds to wait for a reply, or the atom `:infinity` to wait
   indefinitely. The default value is `5000`. If no reply is received within
   the specified time, the function call fails and the caller exits. If the


### PR DESCRIPTION
The docs said `timeout` "is an integer greater than zero", but both the colocated guard (`is_integer(timeout) and timeout >= 0`) and the `timeout` typespec (`:infinity | non_neg_integer()`) accept `0` — `GenServer.call(pid, msg, 0)` is a legal call (time out immediately unless a reply is already waiting). The prose was the only place excluding zero; align it with the guard and the typespec.

Assisted-by: Claude Code:claude-opus-4-8