### PR TITLE
Refine `Time.to_seconds_after_midnight/1` return type

### DIFF
--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -496,7 +496,7 @@ defmodule Time do
 
   """
   @doc since: "1.11.0"
-  @spec to_seconds_after_midnight(Calendar.time()) :: {integer(), non_neg_integer()}
+  @spec to_seconds_after_midnight(Calendar.time()) :: {non_neg_integer(), non_neg_integer()}
   def to_seconds_after_midnight(%{microsecond: {microsecond, _precision}} = time) do
     iso_days = {0, to_day_fraction(time)}
     {Calendar.ISO.iso_days_to_unit(iso_days, :second), microsecond}


### PR DESCRIPTION
The first tuple element is the number of seconds after midnight, which is always in `[0, 86400)`: the implementation builds `iso_days = {0, ...}` with the day count hardcoded to `0`, so `Calendar.ISO.iso_days_to_unit/2` returns only the (non-negative) fraction-of-day part. The spec declared the first element as the broad `integer()`; narrow it to `non_neg_integer()` to match — the name and docstring ("seconds after midnight") already imply a non-negative value.

Unlike `NaiveDateTime.to_gregorian_seconds/1`, which shares the same tuple shape but whose first element is genuinely negative for pre-epoch instants, here negatives are structurally impossible.

Assisted-by: Claude Code:claude-opus-4-8