### PR TITLE
Add missing calendar key to Calendar.time() and fix NaiveDateTime.truncate/2 spec

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -106,6 +106,7 @@ defmodule Calendar do
   @typedoc "Any map or struct that contains the time fields."
   @type time :: %{
           optional(any) => any,
+          calendar: calendar,
           hour: hour,
           minute: minute,
           second: second,

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -672,7 +672,7 @@ defmodule NaiveDateTime do
 
   """
   @doc since: "1.6.0"
-  @spec truncate(t(), :microsecond | :millisecond | :second) :: t()
+  @spec truncate(Calendar.naive_datetime(), :microsecond | :millisecond | :second) :: t()
   def truncate(%NaiveDateTime{microsecond: microsecond} = naive_datetime, precision) do
     %{naive_datetime | microsecond: Calendar.truncate(microsecond, precision)}
   end


### PR DESCRIPTION
Found by re-running the type checker over stdlib function bodies with spec-derived argument domains (the spec-domain body check from #15559):

- `Calendar.time()` is the only calendar-family type without a `calendar:` field (`date`, `naive_datetime` and `datetime` all declare it), yet virtually every `Time` function taking `Calendar.time()` destructures the field in its head (`to_string/1`, `to_iso8601/2`, `add/3`, `compare/2`, `shift/2`, `diff/3`). A map conforming to the declared type raises `FunctionClauseError` today: `Time.to_string(%{hour: 1, minute: 2, second: 3, microsecond: {0, 0}})`. Declare `calendar: calendar` like the sibling types.
- `NaiveDateTime.truncate/2`'s second clause deliberately accepts any naive-datetime-compatible map (e.g. a `DateTime`), the same convention as `add/3`, `to_date/1` and `compare/2` — but its spec said `t()`, making that clause unreachable per the spec. Now `Calendar.naive_datetime()` like its siblings.

The full stdlib recompiles with no new type-checker warnings under the tightened `time()` type, and all calendar test suites pass.

Assisted-By: Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)