### PR TITLE
Accept chardata paths in Mix.Release.make_boot_script/4

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -609,6 +609,8 @@ defmodule Mix.Release do
   @spec make_boot_script(t, Path.t(), [{application(), mode()}], [String.t()]) ::
           :ok | {:error, String.t()}
   def make_boot_script(release, path, modes, prepend_paths \\ []) do
+    path = IO.chardata_to_string(path)
+
     with {:ok, rel_spec} <- build_release_spec(release, modes) do
       File.write!(path <> ".rel", consultable(rel_spec))
 


### PR DESCRIPTION
Found by re-running the type checker over stdlib function bodies with spec-derived argument domains (the spec-domain body check from #15559): the `path` argument is spec'd `Path.t()` (chardata), but the body applies `<>` and `String.to_charlist/1` to it, so a charlist path — valid per the spec — raises `ArgumentError`. Normalize with `IO.chardata_to_string/1` first, as the `Path` module functions do.

Assisted-By: Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)