### PR TITLE
fix: Duration.from_iso8601/1 not rejecting duplicate S (secs) when dup is fractional

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -731,19 +731,19 @@ defmodule Calendar.ISO do
   defp parse_duration_time(string, acc, allowed) do
     case Integer.parse(string) do
       {second, <<delimiter, _::binary>> = rest} when delimiter in [?., ?,] ->
-        case parse_microsecond(rest) do
-          {{ms, precision}, "S"} ->
-            ms =
-              case string do
-                "-" <> _ ->
-                  -ms
+        with {:second, _allowed} <- find_unit(allowed, ?S),
+             {{ms, precision}, "S"} <- parse_microsecond(rest) do
+          ms =
+            case string do
+              "-" <> _ ->
+                -ms
 
-                _ ->
-                  ms
-              end
+              _ ->
+                ms
+            end
 
-            {:ok, [second: second, microsecond: {ms, precision}] ++ acc}
-
+          {:ok, [second: second, microsecond: {ms, precision}] ++ acc}
+        else
           _ ->
             {:error, :invalid_time_component}
         end

--- a/lib/elixir/test/elixir/calendar/duration_test.exs
+++ b/lib/elixir/test/elixir/calendar/duration_test.exs
@@ -242,6 +242,7 @@ defmodule DurationTest do
     assert Duration.from_iso8601("P5H3HT4M") == {:error, :invalid_date_component}
     assert Duration.from_iso8601("P0.5Y") == {:error, :invalid_date_component}
     assert Duration.from_iso8601("PT1D") == {:error, :invalid_time_component}
+    assert Duration.from_iso8601("PT1S2.5S") == {:error, :invalid_time_component}
     assert Duration.from_iso8601("PT.6S") == {:error, :invalid_time_component}
     assert Duration.from_iso8601("PT0.5H") == {:error, :invalid_time_component}
     assert Duration.from_iso8601("invalid") == {:error, :invalid_duration}


### PR DESCRIPTION
## Current behavior

Duplicate seconds accepted when duplicate S has a fractional part

```elixir
iex> Duration.from_iso8601("PT1S2.5S")
{:ok, %Duration{second: 1, microsecond: {500000, 1}}}
```

## Expected

Should return an error `:invalid_time_component`, like dup secs without a fractional

```elixir
iex> Duration.from_iso8601("PT1S2S")
{:error, :invalid_time_component}

iex> Duration.from_iso8601("PT1S2.5S")
{:error, :invalid_time_component}
```

## Changes
- fix `Calendar.ISO.parse_duration/1`
- update tests