### PR TITLE
doc: align List.to_unsafe_atom/1 the doc of String.to_unsafe_atom/1

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -1035,10 +1035,12 @@ defmodule List do
   Elixir supports conversions from charlists which contain any Unicode
   code point.
 
-  Warning: this function creates atoms dynamically and atoms are
-  not garbage-collected. Therefore, `charlist` should not be an
-  untrusted value, such as input received from a socket or during
-  a web request. Consider using `to_existing_atom/1` instead.
+  > #### Dynamic Atom Creation {: .warning}
+  >
+  > This function creates atoms dynamically and atoms are
+  > not garbage-collected. Therefore, `charlist` should not be an
+  > untrusted value, such as input received from a socket or during
+  > a web request. Consider using `to_existing_atom/1` instead.
 
   By default, the maximum number of atoms is `1_048_576`. This limit
   can be raised or lowered using the VM option `+t`.

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -1030,10 +1030,20 @@ defmodule List do
   end
 
   @doc """
-  Converts a charlist to an atom.
+  Converts a charlist to an existing atom or creates a new one.
 
   Elixir supports conversions from charlists which contain any Unicode
   code point.
+
+  Warning: this function creates atoms dynamically and atoms are
+  not garbage-collected. Therefore, `charlist` should not be an
+  untrusted value, such as input received from a socket or during
+  a web request. Consider using `to_existing_atom/1` instead.
+
+  By default, the maximum number of atoms is `1_048_576`. This limit
+  can be raised or lowered using the VM option `+t`.
+
+  The maximum atom size is 255 Unicode code points.
 
   Inlined by the compiler.
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2971,10 +2971,12 @@ defmodule String do
   @doc """
   Converts a string to an existing atom or creates a new one.
 
-  Warning: this function creates atoms dynamically and atoms are
-  not garbage-collected. Therefore, `string` should not be an
-  untrusted value, such as input received from a socket or during
-  a web request. Consider using `to_existing_atom/1` instead.
+  > #### Dynamic Atom Creation {: .warning}
+  >
+  > This function creates atoms dynamically and atoms are
+  > not garbage-collected. Therefore, `string` should not be an
+  > untrusted value, such as input received from a socket or during
+  > a web request. Consider using `to_existing_atom/1` instead.
 
   By default, the maximum number of atoms is `1_048_576`. This limit
   can be raised or lowered using the VM option `+t`.


### PR DESCRIPTION
Also, I propose adding (convert to) a `{: .warning}` admonition block here and in `String`.