### PR TITLE
doc: Inspect moduledoc add missing result marker

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -92,7 +92,7 @@ defprotocol Inspect do
       end
 
       inspect(%Point{x: 1})
-      %Point{x: 1, y: 0}
+      #=> %Point{x: 1, y: 0}
 
   ## Custom implementation
 


### PR DESCRIPTION
Adds `Inspect` moduledoc missing result marker