### PR TITLE
Refine `Keyword.put/3`, `update/4` and `update!/3` return types

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -814,7 +814,7 @@ defmodule Keyword do
       [a: 3, b: 2]
 
   """
-  @spec put(t, key, value) :: t
+  @spec put(t, key, value) :: [{key, value}, ...]
   def put(keywords, key, value) when is_list(keywords) and is_atom(key) do
     [{key, value} | delete(keywords, key)]
   end
@@ -1174,7 +1174,7 @@ defmodule Keyword do
       ...
 
   """
-  @spec update!(t, key, (current_value :: value -> new_value :: value)) :: t
+  @spec update!(t, key, (current_value :: value -> new_value :: value)) :: [{key, value}, ...]
   def update!(keywords, key, fun)
       when is_list(keywords) and is_atom(key) and is_function(fun, 1) do
     update!(keywords, key, fun, keywords)
@@ -1212,7 +1212,7 @@ defmodule Keyword do
       [a: 1, b: 11]
 
   """
-  @spec update(t, key, default :: value, (existing_value :: value -> new_value :: value)) :: t
+  @spec update(t, key, default :: value, (existing_value :: value -> new_value :: value)) :: [{key, value}, ...]
   def update(keywords, key, default, fun)
       when is_list(keywords) and is_atom(key) and is_function(fun, 1) do
     update_guarded(keywords, key, default, fun)


### PR DESCRIPTION
These functions always return a non-empty keyword list: every return path conses at least one entry onto the result.

  * `put/3` returns `[{key, value} | delete(...)]`.
  * `update/4` conses in all three clauses, including the empty-input clause which returns `[{key, default}]`.
  * `update!/3` conses in both returning clauses; the remaining clause raises `KeyError`.

Narrow the specs from `t` to `[{key, value}, ...]`, matching the non-empty-list idiom already used elsewhere (e.g. `List.duplicate/2`, `List.keystore/4`). The input `t` is a proper list by definition, so `delete/2` yields a proper list and the result is a proper non-empty keyword list.

Assisted-by: Claude Code:claude-opus-4-8