### PR TITLE
Reject non-integer arguments in `Integer.extended_gcd/2` zero clauses

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -545,10 +545,10 @@ defmodule Integer do
   @doc since: "1.12.0"
   @spec extended_gcd(integer, integer) :: {non_neg_integer, integer, integer}
   def extended_gcd(0, 0), do: {0, 0, 0}
-  def extended_gcd(0, b) when b > 0, do: {b, 0, 1}
-  def extended_gcd(0, b) when b < 0, do: {-b, 0, -1}
-  def extended_gcd(a, 0) when a > 0, do: {a, 1, 0}
-  def extended_gcd(a, 0) when a < 0, do: {-a, -1, 0}
+  def extended_gcd(0, b) when is_integer(b) and b > 0, do: {b, 0, 1}
+  def extended_gcd(0, b) when is_integer(b) and b < 0, do: {-b, 0, -1}
+  def extended_gcd(a, 0) when is_integer(a) and a > 0, do: {a, 1, 0}
+  def extended_gcd(a, 0) when is_integer(a) and a < 0, do: {-a, -1, 0}
 
   def extended_gcd(integer1, integer2) when is_integer(integer1) and is_integer(integer2) do
     extended_gcd(integer2, integer1, 0, 1, 1, 0)


### PR DESCRIPTION
The zero base-case clauses guarded only on comparison with 0, so under Erlang term ordering non-integer arguments (floats, atoms) matched when the other argument was 0, e.g. `Integer.extended_gcd(2.5, 0)` returned `{2.5, 1, 0}` instead of raising, violating the spec and diverging from `Integer.gcd/2`.

```elixir
iex(1)> Integer.extended_gcd(:atom, 0)
{:atom, 1, 0}
iex(2)> Integer.extended_gcd(2.5, 0)
{2.5, 1, 0}
iex(3)> Integer.extended_gcd(-2.5, 0)
{-2.5, 1, 0}
iex(4)> Integer.extended_gcd(0, -1.2)
{-1.2, 0, 1}
```

> I am evaluating claude fable on code review tasks and this was one of the findings - more to follow