### PR TITLE
Reject integer 0 in `Float.round/2`

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -346,7 +346,7 @@ defmodule Float do
   @spec round(float, precision_range) :: float
   def round(float, precision \\ 0)
 
-  def round(float, 0) when float == 0.0, do: float
+  def round(float, 0) when float === 0.0 or float === -0.0, do: float
 
   def round(float, 0) when is_float(float) do
     case :erlang.round(float) * 1.0 do


### PR DESCRIPTION
The zero shortcut clause guarded only on `float == 0.0`, and `0 == 0.0` is true under ==, so `Float.round(0)` and `Float.round(0, 0)` returned the integer 0 instead of raising, contradicting both the spec and the doc statement that the function only accepts floats and always returns a float. `Float.round(1)` and every other `Float` function already raised.

```elixir
iex(5)> Float.round(0)
0
iex(6)> Float.round(1)
** (FunctionClauseError) no function clause matching in Float.round/2

    The following arguments were given to Float.round/2:

        # 1
        1

        # 2
        0
```

> I am evaluating claude fable on code review tasks and this was one of the findings - more to follow