### PR TITLE
Return 1.0 from `String.bag_distance/2` with empty strings

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -3170,10 +3170,13 @@ defmodule String do
       0.75
       iex> String.bag_distance("abcd", "abcd")
       1.0
+      iex> String.bag_distance("", "")
+      1.0
 
   """
   @spec bag_distance(t, t) :: float
   @doc since: "1.8.0"
+  def bag_distance("", ""), do: 1.0
   def bag_distance(_string, ""), do: 0.0
   def bag_distance("", _string), do: 0.0
 


### PR DESCRIPTION
Both `String.jaro_distance/2` and the general bag distance algorithm return 1.0 for equal strings; the empty pair was the only exception.


```
iex(5)> String.bag_distance("", "")
0.0
```