### PR TITLE
Fix gradual list handling in to_existing_atom/2

### DIFF
--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -1426,9 +1426,13 @@ defmodule Module.Types.Apply do
     # binary(), non_empty_list(a) -> a when a: atom()
 
     case remote_apply(info, args_types, stack) do
-      {:ok, _} ->
-        {false, refined_atom} = list_of(list)
-        {:ok, refined_atom}
+      {:ok, return_type} ->
+        refined_list = opt_intersection(list, non_empty_list(atom()))
+
+        case list_of(refined_list) do
+          {false, refined_atom} -> {:ok, refined_atom}
+          _ -> {:ok, return_type}
+        end
 
       other ->
         other

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -1918,6 +1918,26 @@ defmodule Module.Types.ExprTest do
                String.to_existing_atom(x, values)
              ) == dynamic(atom())
 
+      assert typecheck!(
+               [value],
+               String.to_existing_atom("foo", Enum.map(value, & &1))
+             ) == dynamic(atom())
+
+      assert typecheck!(
+               [value],
+               String.to_existing_atom("foo", List.wrap(value))
+             ) == dynamic(atom())
+
+      assert typecheck!(
+               [value],
+               String.to_existing_atom("foo", Keyword.keys(value))
+             ) == dynamic(atom())
+
+      assert typecheck!(
+               [value],
+               String.to_existing_atom("foo", [value] ++ [])
+             ) == dynamic(atom())
+
       assert typeerror!(
                [x],
                String.to_existing_atom(:not_a_string, x)
@@ -1951,6 +1971,26 @@ defmodule Module.Types.ExprTest do
       assert typecheck!(
                [x, values],
                List.to_existing_atom(x, values)
+             ) == dynamic(atom())
+
+      assert typecheck!(
+               [value],
+               List.to_existing_atom(~c"foo", Enum.map(value, & &1))
+             ) == dynamic(atom())
+
+      assert typecheck!(
+               [value],
+               List.to_existing_atom(~c"foo", List.wrap(value))
+             ) == dynamic(atom())
+
+      assert typecheck!(
+               [value],
+               List.to_existing_atom(~c"foo", Keyword.keys(value))
+             ) == dynamic(atom())
+
+      assert typecheck!(
+               [value],
+               List.to_existing_atom(~c"foo", [value] ++ [])
              ) == dynamic(atom())
 
       assert typeerror!(


### PR DESCRIPTION
Fixes #15588 

Not sure how redundant tests are or whether infer tests are needed.

I’d appreciate feedback, even if this isn’t what you expected.
