### PR TITLE
Clarify `:allow_pre` does not affect `<` and `<=` in Version docs

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -81,8 +81,10 @@ defmodule Version do
   allowing us to express `~> 2.1` or `~> 2.1-dev`, something that wouldn't be allowed
   when using the common comparison operators.
 
-  When the `:allow_pre` option is set `false` in `Version.match?/3`, the requirement
-  will not match a pre-release version unless the operand is a pre-release version.
+  When the `:allow_pre` option is set `false` in `Version.match?/3`, a pre-release
+  version will not match the `~>`, `>`, and `>=` operators unless the operand is
+  itself a pre-release version. The `<` and `<=` operators are not affected by
+  `:allow_pre` and always match according to precedence.
   The default is to always allow pre-releases but note that in
   Hex `:allow_pre` is set to `false`. See the table below for examples.
 
@@ -99,6 +101,7 @@ defmodule Version do
   `>= 2.1.0`     | `2.2.0-dev` | `true`            | `true`
   `>= 2.1.0`     | `2.2.0-dev` | `false`           | `false`
   `>= 2.1.0-dev` | `2.2.6-dev` | `true` or `false` | `true`
+  `< 2.2.0`      | `2.1.0-dev` | `true` or `false` | `true`
 
   """
 
@@ -282,8 +285,9 @@ defmodule Version do
 
   ## Options
 
-    * `:allow_pre` (boolean) - when `false`, pre-release versions will not match
-      unless the operand is a pre-release version. Defaults to `true`.
+    * `:allow_pre` (boolean) - when `false`, pre-release versions will not match the
+      `~>`, `>`, and `>=` operators unless the operand is a pre-release version;
+      the `<` and `<=` operators are not affected. Defaults to `true`.
       For examples, please refer to the table above under the "Requirements" section.
 
   ## Examples


### PR DESCRIPTION
The `Version` moduledoc and `Version.match?/3` documentation stated unconditionally that, with `allow_pre: false`, a pre-release version would not match unless the operand was itself a pre-release. This holds for the `~>`, `>`, and `>=` operators, which carry the `allow_pre` guard, but not for `<` and `<=`, which have no such guard and match pre-releases according to precedence regardless of the option:

    Version.match?("1.9.0-rc", ">= 1.0.0", allow_pre: false)  # => false
    Version.match?("1.9.0-rc", "< 2.0.0",  allow_pre: false)  # => true

Reword both doc locations to scope the `allow_pre` behavior to the `~>`, `>`, and `>=` operators and note that `<`/`<=` are unaffected, and add an illustrative row to the examples table.

Assisted-by: Claude Code:claude-opus-4-8