### PR TITLE
Drop empty map lines in map_fetch_key_static

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -3139,7 +3139,7 @@ defmodule Module.Types.Descr do
   end
 
   defp map_fetch_key_static(%{map: bdd}, key) do
-    bdd |> map_bdd_to_dnf_with_empty() |> map_dnf_fetch_static(key)
+    bdd |> map_bdd_to_dnf_remove_empty() |> map_dnf_fetch_static(key)
   end
 
   defp map_fetch_key_static(%{}, _key), do: {false, none()}

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -2458,6 +2458,14 @@ defmodule Module.Types.DescrTest do
              |> opt_difference(open_map(a: atom([:foo, :bar])))
              |> opt_difference(open_map(a: atom([:foo, :baz])))
              |> map_fetch_key(:a) == {false, integer()}
+
+      t = closed_map(a: term())
+      knife = open_map(c: none())
+      cover = opt_union(t, knife)
+      t2 = opt_difference(cover, opt_difference(cover, t))
+      assert equal?(t, t2)
+      assert map_fetch_key(t, :a) == {false, term()}
+      assert map_fetch_key(t2, :a) == map_fetch_key(t, :a)
     end
 
     # Times out without a projection-only map_fetch_key path


### PR DESCRIPTION
no maps inhabit required key with `none()`. It should not contribute to the fetched value type

Assisted-By: Claude Opus 4.8

Fixes #15592