### PR TITLE
Do not return `{:ok, _}` on maps with empty lines in `map_put_static_value`

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -3897,7 +3897,7 @@ defmodule Module.Types.Descr do
   defp map_put_static_value(descr, split_keys, type) do
     case :maps.take(:dynamic, descr) do
       :error ->
-        if descr_key?(descr, :map) and map_only?(descr) do
+        if non_empty_map_only?(descr) do
           {:ok, map_put_static(descr, split_keys, type)}
         else
           :badmap

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -3334,6 +3334,16 @@ defmodule Module.Types.DescrTest do
 
       assert map_put(map, atom([:k]), binary()) == {:ok, open_map(k: binary(), x: term())}
     end
+
+    test "verdict is stable across representations of an empty type" do
+      # An empty map component that survives syntactically (open_map(c: none())
+      # is a non-normalized empty, equal to none()) must report :badmap like
+      # none(), not {:ok, <inhabited>}.
+      a2 = open_map(c: none())
+      assert equal?(none(), a2)
+      assert map_put(none(), atom([:a]), integer()) == :badmap
+      assert map_put(a2, atom([:a]), integer()) == :badmap
+    end
   end
 
   describe "disjoint" do

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -3335,7 +3335,7 @@ defmodule Module.Types.DescrTest do
       assert map_put(map, atom([:k]), binary()) == {:ok, open_map(k: binary(), x: term())}
     end
 
-    test "verdict is stable across representations of an empty type" do
+    test "is consistent across representations of an empty type" do
       # An empty map component that survives syntactically (open_map(c: none())
       # is a non-normalized empty, equal to none()) must report :badmap like
       # none(), not {:ok, <inhabited>}.

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -3339,7 +3339,7 @@ defmodule Module.Types.DescrTest do
       # An empty map component that survives syntactically (open_map(c: none())
       # is a non-normalized empty, equal to none()) must report :badmap like
       # none(), not {:ok, <inhabited>}.
-      a2 = open_map(c: none())
+      a2 = open_map(c: {none(), false})
       assert equal?(none(), a2)
       assert map_put(none(), atom([:a]), integer()) == :badmap
       assert map_put(a2, atom([:a]), integer()) == :badmap


### PR DESCRIPTION
Addresses Repro 1 from #15594

Related to https://github.com/elixir-lang/elixir/pull/15593

Assisted-By: Claude Opus 4.8