### PR TITLE
Delete duplicate keys on `:pop` in `Keyword.get_and_update/3` and `get_and_update!/3`

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -517,7 +517,7 @@ defmodule Keyword do
         {get, :lists.reverse(acc, [{key, value} | delete(t, key)])}
 
       :pop ->
-        {current, :lists.reverse(acc, t)}
+        {current, :lists.reverse(acc, delete(t, key))}
 
       other ->
         raise "the given function must return a two-element tuple or :pop, got: #{inspect(other)}"
@@ -583,7 +583,7 @@ defmodule Keyword do
         {get, :lists.reverse(acc, [{key, value} | delete(t, key)])}
 
       :pop ->
-        {value, :lists.reverse(acc, t)}
+        {value, :lists.reverse(acc, delete(t, key))}
 
       other ->
         raise "the given function must return a two-element tuple or :pop, got: #{inspect(other)}"

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -31,6 +31,8 @@ defmodule KeywordTest do
   test "get_and_update/3 removes duplicates from the input keyword list" do
     assert Keyword.get_and_update([a: 1, b: 2, a: 3], :a, fn value -> {value, value + 10} end) ==
              {1, [a: 11, b: 2]}
+
+    assert Keyword.get_and_update([a: 1, b: 2, a: 3], :a, fn _ -> :pop end) == {1, [b: 2]}
   end
 
   test "get_and_update/3 raises on bad return value from the argument function" do
@@ -50,6 +52,8 @@ defmodule KeywordTest do
   test "get_and_update!/3 removes duplicates from the input keyword list" do
     assert Keyword.get_and_update!([a: 1, b: 2, a: 3], :a, fn value -> {value, value + 10} end) ==
              {1, [a: 11, b: 2]}
+
+    assert Keyword.get_and_update!([a: 1, b: 2, a: 3], :a, fn _ -> :pop end) == {1, [b: 2]}
   end
 
   test "get_and_update!/3 raises on bad return value from the argument function" do


### PR DESCRIPTION
Both functions document updating "in one pass, deleting duplicate keys", but the `:pop` branch left any later duplicates in place:

```elixir
iex> Keyword.get_and_update([a: 1, a: 2], :a, fn _ -> :pop end)
{1, [a: 2]}
```

> I am evaluating claude fable on code review tasks and this was one of the findings