### PR TITLE
Fix `EEx.tokenize/2` missing comment token in result doc

### DIFF
--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -344,6 +344,7 @@ defmodule EEx do
 
   It returns `{:ok, [token]}` where a token is one of:
 
+    * `{:comment, content, %{column: column, line: line}}`
     * `{:text, content, %{column: column, line: line}}`
     * `{:expr, marker, content, %{column: column, line: line}}`
     * `{:start_expr, marker, content, %{column: column, line: line}}`


### PR DESCRIPTION
Fix `EEx.tokenize/2` missing comment token in result doc