### PR TITLE
Fix `IEx` missing evaluator continuation binary operator `**`

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -58,7 +58,7 @@ defmodule IEx.Evaluator do
   @break_trigger ~c"#iex:break\n"
 
   @op_tokens [:or_op, :and_op, :comp_op, :rel_op, :arrow_op, :in_op] ++
-               [:three_op, :concat_op, :mult_op]
+               [:three_op, :concat_op, :mult_op, :power_op]
 
   @doc """
   Default parsing implementation with support for pipes and #iex:break.


### PR DESCRIPTION
## Before
```elixir
iex(1)> 3
3
iex(2)> **2
** (SyntaxError) invalid syntax found on iex:2:1:
    error: syntax error before: '**'
    │
  2 │ **2
    │ ^
    │
    └─ iex:2:1
```

## After
```elixir
iex(1)> 3
3
iex(2)> **2
9
```