### PR TITLE
Fix `Duration` specs to allow negative microsecond values

### DIFF
--- a/lib/elixir/lib/calendar/duration.ex
+++ b/lib/elixir/lib/calendar/duration.ex
@@ -130,6 +130,16 @@ defmodule Duration do
             microsecond: {0, 0}
 
   @typedoc """
+  The microsecond component of a duration.
+
+  Unlike `t:Calendar.microsecond/0`, the value may be negative, as
+  durations may represent negative amounts of time. The precision is
+  an integer from 0 to 6 holding the number of significant digits,
+  as in the calendar types.
+  """
+  @type microsecond :: {value :: integer, precision :: 0..6}
+
+  @typedoc """
   The duration struct type.
   """
   @type t :: %Duration{
@@ -140,7 +150,7 @@ defmodule Duration do
           hour: integer,
           minute: integer,
           second: integer,
-          microsecond: Calendar.microsecond()
+          microsecond: microsecond()
         }
 
   @typedoc """
@@ -154,7 +164,7 @@ defmodule Duration do
           | {:hour, integer}
           | {:minute, integer}
           | {:second, integer}
-          | {:microsecond, Calendar.microsecond()}
+          | {:microsecond, microsecond()}
 
   @typedoc """
   The duration type specifies a `%Duration{}` struct or a keyword list of valid duration unit pairs.


### PR DESCRIPTION
`Duration.t` and `Duration.unit_pair` referenced `Calendar.microsecond()`, whose value is a `non_neg_integer`. However, durations may represent negative amounts of time, negative microsecond values are advertised by the module documentation, produced by parsing, and returned by the module's own doctests:

    Duration.from_iso8601!("PT-0.5S")
    #=> %Duration{microsecond: {-500000, 1}}

Introduce a dedicated `Duration.microsecond()` type whose value is an integer and whose precision is 0..6, matching what `new!/1` validates.

Assisted-By: Claude Opus