### PR TITLE
Fix IEx completion crash on maps with non-atom keys

### DIFF
--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -386,7 +386,7 @@ defmodule IEx.Autocomplete do
       end)
 
     entries =
-      for key when key != :__struct__ <- Map.keys(pairs),
+      for key when is_atom(key) and key != :__struct__ <- Map.keys(pairs),
           name = Atom.to_string(key),
           if(hint == "",
             do: not String.starts_with?(name, "_"),

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -510,6 +510,11 @@ defmodule IEx.AutocompleteTest do
     assert {:no, [], []} = expand(~c"%{unknown | some: \"foo\", unkno")
   end
 
+  test "completion for mixed type map keys in update syntax" do
+    eval("map = %{\"another\" => \"qwe\", some: 1, other: :ok}")
+    assert {:yes, ~c"me: ", []} = expand(~c"%{map | so")
+  end
+
   test "completion for struct var keys" do
     eval("struct = %IEx.AutocompleteTest.MyStruct{}")
     assert expand(~c"struct.my") == {:yes, ~c"_val", []}


### PR DESCRIPTION
## Before
```
iex(1)> m = %{"hello" => "world", a: 1} # any map with non-atom key
iex(2)> %{m | # press <TAB> after |<SPACE>

20:04:54.883 [error] :gen_statem #PID<0.70.0> terminating
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not an atom
...
*** ERROR: Shell process terminated! (^G to start new job) ***
```

## After
```
iex(1)> m = %{"hello" => "world", a: 1, ab: 2}
iex(2)> %{m | a # <TAB> works
a:     ab:
```