### PR TITLE
Fix ExUnit StringIO processes leak when named device capture failed

### DIFF
--- a/lib/ex_unit/lib/ex_unit/capture_server.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_server.ex
@@ -155,6 +155,7 @@ defmodule ExUnit.CaptureServer do
       Process.register(pid, name)
     rescue
       ArgumentError ->
+        close_string_io(pid)
         {:reply, {:error, :no_device}, config}
     else
       _ ->

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -477,6 +477,17 @@ defmodule ExUnit.CaptureIOTest do
       end
     end
 
+    test "does not leak StringIO when named device does not exist" do
+      capture_server = Process.whereis(ExUnit.CaptureServer)
+      {:monitored_by, monitored_by} = Process.info(capture_server, :monitored_by)
+
+      assert_raise RuntimeError, "could not find IO device registered at :unknown_device", fn ->
+        capture_io(:unknown_device, fn -> :ok end)
+      end
+
+      assert Process.info(capture_server, :monitored_by) == {:monitored_by, monitored_by}
+    end
+
     test "no leakage on failures" do
       parent = self()
 


### PR DESCRIPTION
Fix ExUnit StringIO processes leak when named device capture failed

Not sure, is there more elegant way to test.