### PR TITLE
Fix `refute_in_delta` boundary logic and negative delta

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -913,7 +913,7 @@ defmodule ExUnit.Assertions do
   def assert_in_delta(value1, value2, delta, message \\ nil)
 
   def assert_in_delta(_, _, delta, _) when delta < 0 do
-    raise ArgumentError, "delta must always be a positive number, got: #{inspect(delta)}"
+    raise ArgumentError, "delta must be a non-negative number, got: #{inspect(delta)}"
   end
 
   def assert_in_delta(value1, value2, delta, message) do
@@ -1171,20 +1171,26 @@ defmodule ExUnit.Assertions do
       refute_in_delta 10, 11, 2
 
   """
-  def refute_in_delta(value1, value2, delta, message \\ nil) do
+  def refute_in_delta(value1, value2, delta, message \\ nil)
+
+  def refute_in_delta(_, _, delta, _) when delta < 0 do
+    raise ArgumentError, "delta must be a non-negative number, got: #{inspect(delta)}"
+  end
+
+  def refute_in_delta(value1, value2, delta, message) do
     diff = abs(value1 - value2)
 
     message =
       if message do
         message <>
           " (difference between #{inspect(value1)} " <>
-          "and #{inspect(value2)} is less than #{inspect(delta)})"
+          "and #{inspect(value2)} is less than or equal to #{inspect(delta)})"
       else
         "Expected the difference between #{inspect(value1)} and " <>
           "#{inspect(value2)} (#{inspect(diff)}) to be more than #{inspect(delta)}"
       end
 
-    refute diff < delta, message
+    refute diff <= delta, message
   end
 
   @doc """

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -1036,6 +1036,20 @@ defmodule ExUnit.AssertionsTest do
     false = refute_in_delta(1.1, 1.5, 0.2)
   end
 
+  test "refute in delta raises when passing a negative delta" do
+    assert_raise ArgumentError, fn ->
+      refute_in_delta(1.1, 1.2, -0.2)
+    end
+  end
+
+  test "refute in delta fails when the difference equals the delta" do
+    refute_in_delta(10, 15, 5)
+    flunk("This should never be tested")
+  rescue
+    error in [ExUnit.AssertionError] ->
+      "Expected the difference between 10 and 15 (5) to be more than 5" = error.message
+  end
+
   test "refute in delta error" do
     refute_in_delta(10, 11, 2)
     flunk("This should never be tested")
@@ -1049,7 +1063,7 @@ defmodule ExUnit.AssertionsTest do
     flunk("This should never be tested")
   rescue
     error in [ExUnit.AssertionError] ->
-      "test message (difference between 10 and 11 is less than 2)" = error.message
+      "test message (difference between 10 and 11 is less than or equal to 2)" = error.message
   end
 
   test "catch_throw with no throw" do


### PR DESCRIPTION
Current `refute_in_delta/4` impl is not consistent with `assert_in_delta/4` (does not acts as full opposite on boundary cases)

```elixir
iex> assert_in_delta(10, 15, 5)
iex> refute_in_delta(10, 15, 5)
false # expected ** (ExUnit.AssertionError) 
```

Changes
- fix boundary logic
- add missing negative delta guard
- assertion message in refute/assert_in_delta (positive -> non-negative)
- tests updated