### PR TITLE
Fix IEx.Helpers.r/1 fails reload modules defined in same file

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -507,6 +507,7 @@ defmodule IEx.Helpers do
             source
         end
       end)
+      |> Enum.uniq()
 
     {erlang, elixir} = Enum.split_with(sources, &String.ends_with?(&1, ".erl"))
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1544,6 +1544,31 @@ defmodule IEx.HelpersTest do
       cleanup_modules([Sample])
     end
 
+    test "reloads Elixir modules from same file" do
+      filename = "sample.ex"
+
+      contents = """
+      defmodule Foo do
+        def hello, do: :foo
+      end
+
+      defmodule Bar do
+        def hello, do: :bar
+      end
+      """
+
+      with_file(filename, contents, fn ->
+        assert Enum.sort(c(filename, ".")) == [Bar, Foo]
+
+        assert capture_io(:stderr, fn ->
+                 assert {:reloaded, modules} = r([Bar, Foo])
+                 assert Enum.sort(modules) == [Bar, Foo]
+               end) =~ "redefining module Foo"
+      end)
+    after
+      cleanup_modules([Bar, Foo])
+    end
+
     test "reloads Erlang modules" do
       assert_raise UndefinedFunctionError, ~r"function :sample.hello/0 is undefined", fn ->
         :sample.hello()


### PR DESCRIPTION
Two modules defined in one file:
```elixir
defmodule Foo do
    def hello, do: :foo
end

defmodule Bar do
    def hello, do: :bar
end
```
Trying to reload after compilation:
```
iex> r([Bar, Foo])

    ...
    
    error: cannot define module Foo because it is currently being defined in /tmp/reload.ex:1
    │
  1 │ defmodule Foo do
    │ ^^^^^^^^^^^^^^^^
    │
    └─ /tmp/reload.ex:1: Foo (module)


= Compilation error in file /tmp/reload.ex ==
** (CompileError) /tmp/reload.ex: cannot compile module Foo (errors have been logged)
    (stdlib 8.0.2) lists.erl:2465: :lists.foldl/3
    (elixir 1.21.0-dev) lib/kernel/parallel_compiler.ex:549: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/8
** (MatchError) no match of right hand side value:
```

Expected: `{:reloaded, [Bar, Foo]}`

## Changes:
 - add elixir sources dedup
 - tests