### PR TITLE
Fix IEx.Helpers.process_info/1 heap and stack memory calculation

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -893,7 +893,9 @@ defmodule IEx.Helpers do
   def process_info(pid) do
     with pid when is_pid(pid) <- GenServer.whereis(pid),
          info when is_list(info) <-
-           :erpc.call(node(pid), :erlang, :process_info, [pid, @process_info_keys]) do
+           :erpc.call(node(pid), :erlang, :process_info, [pid, @process_info_keys]),
+         word_size when is_integer(word_size) <-
+           :erpc.call(node(pid), :erlang, :system_info, [:wordsize]) do
       info = Map.new(info)
 
       IO.puts(IEx.color(:eval_result, ["\n# Process ", inspect(pid)]))
@@ -901,7 +903,7 @@ defmodule IEx.Helpers do
       print_process_overview(info)
       print_process_links(info[:links])
       print_process_monitors(info[:monitors])
-      print_process_memory(info)
+      print_process_memory(info, word_size)
       print_process_stacktrace(info[:current_stacktrace])
     else
       _ ->
@@ -957,11 +959,14 @@ defmodule IEx.Helpers do
     end
   end
 
-  defp print_process_memory(info) do
+  defp print_process_memory(info, word_size) do
     print_pane("Memory")
 
-    for key <- [:memory, :total_heap_size, :heap_size, :stack_size] do
-      print_entry(@process_info_label_mapping[key], format_bytes(info[key]))
+    print_entry(@process_info_label_mapping[:memory], format_bytes(info[:memory]))
+
+    # InfoTuple's word-sized items
+    for key <- [:total_heap_size, :heap_size, :stack_size] do
+      print_entry(@process_info_label_mapping[key], format_bytes(info[key] * word_size))
     end
   end
 


### PR DESCRIPTION
Fix `:total_heap_size`, `:heap_size`, `:stack_size` displayed in wrong units, `:erlang.process_info/2` returns it
in VM's word size.

```elixir
iex> pid = spawn(fn -> receive do after :infinity -> nil end end)
iex> process_info(pid)

# Process #PID<0.110.0>

...

## Memory 

Memory               2 KB
Total heap size      233 B
Heap size            233 B
Stack size           9 B
```

Here 233, 233, and 9 are words

References
https://www.erlang.org/doc/apps/erts/erlang.html#process_info/2
https://www.erlang.org/doc/apps/erts/garbagecollection.html#sizing-the-heap