### PR TITLE
Fix ExUnit.EventManager calling Supervisor on DynamicSupervisor

### DIFF
--- a/lib/ex_unit/lib/ex_unit/event_manager.ex
+++ b/lib/ex_unit/lib/ex_unit/event_manager.ex
@@ -87,7 +87,7 @@ defmodule ExUnit.EventManager do
   defp notify({sup, event}, msg) do
     :gen_event.notify(event, msg)
 
-    for {_, pid, _, _} <- Supervisor.which_children(sup) do
+    for {_, pid, _, _} <- DynamicSupervisor.which_children(sup) do
       GenServer.cast(pid, msg)
     end
 


### PR DESCRIPTION
Will such cases be caught in the future as the type system evolves?