### PR TITLE
Optimize String.bag_distance/2 for equal strings

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -3176,7 +3176,7 @@ defmodule String do
   """
   @spec bag_distance(t, t) :: float
   @doc since: "1.8.0"
-  def bag_distance("", ""), do: 1.0
+  def bag_distance(string, string) when is_binary(string), do: 1.0
   def bag_distance(_string, ""), do: 0.0
   def bag_distance("", _string), do: 0.0
 


### PR DESCRIPTION
Return immediately when arguments are equal. Same way as it's done for `jaro_distance/2` below.
