### PR TITLE
Fix `String.reverse/1` grapheme ordering around invalid utf8 bytes

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1784,7 +1784,7 @@ defmodule String do
     do: :unicode.characters_to_binary(acc)
 
   defp do_reverse({:error, <<byte, rest::bits>>}, acc),
-    do: :unicode.characters_to_binary(acc) <> <<byte>> <> do_reverse(:unicode_util.gc(rest), [])
+    do: do_reverse(:unicode_util.gc(rest), []) <> <<byte>> <> :unicode.characters_to_binary(acc)
 
   @doc """
   Returns a string `subject` repeated `n` times.

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -444,6 +444,7 @@ defmodule StringTest do
     assert String.reverse("Hello World") == "dlroW olleH"
     assert String.reverse("Hello ∂og") == "go∂ olleH"
     assert String.reverse("Ā̀stute") == "etutsĀ̀"
+    assert String.reverse("ab" <> <<254, 255>> <> "cd") == "dc" <> <<255, 254>> <> "ba"
     assert String.reverse(String.reverse("Hello World")) == "Hello World"
     assert String.reverse(String.reverse("Hello \r\n World")) == "Hello \r\n World"
   end


### PR DESCRIPTION
## Before

```elixir
iex> "ab" <> <<255>> <> "cd"
<<97, 98, 255, 99, 100>>

iex> String.reverse("ab" <> <<255>> <> "cd")
<<98, 97, 255, 100, 99>> # "ba" <> <<255>> <> "dc"
```

## After

```elixir
iex> String.reverse("ab" <> <<255>> <> "cd")
<<100, 99, 255, 98, 97>> # "dc" <> <<255>> <> "ba"
```