### PR TITLE
Fix System.cmd/3 unit test that fails on Ubuntu 26.04

### DIFF
--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -210,18 +210,18 @@ defmodule SystemTest do
     test "cmd/3 with absolute and relative paths", config do
       echo = Path.join(config.tmp_dir, @echo)
       File.mkdir_p!(Path.dirname(echo))
-      File.ln_s!(System.find_executable("echo"), echo)
+      File.ln_s!(System.find_executable("sh"), echo)
 
       File.cd!(Path.dirname(echo), fn ->
         # There is a bug in OTP where find_executable is finding
         # entries on the current directory. If this is the case,
         # we should avoid the assertion below.
         if !System.find_executable(@echo) do
-          assert :enoent = catch_error(System.cmd(@echo, ["hello"]))
+          assert :enoent = catch_error(System.cmd(@echo, ["-c", "echo hello"]))
         end
 
         assert {"hello\n", 0} =
-                 System.cmd(Path.join(File.cwd!(), @echo), ["hello"], [{:arg0, "echo"}])
+                 System.cmd(Path.join(File.cwd!(), @echo), ["-c", "echo hello"], [{:arg0, "sh"}])
       end)
     end
 


### PR DESCRIPTION
This test runs `System.cmd/3` against a symlink to the `echo` command. This works when `echo` is its own binary and when it's in a multicall binary that's dispatched using `argv[0]`. It doesn't work for the new Rust/uutils coreutils which doesn't dispatch via `argv[0]`. In this case, intended call to echo produces no output:

```
  1) test Unix cmd/3 with absolute and relative paths (SystemTest)
     test/elixir/system_test.exs:210
     match (=) failed
     code:  assert {"hello\n", 0} = System.cmd(Path.join(File.cwd!(), @echo), ["hello"], arg0: "echo")
     left:  {"hello\n", 0}
     right: {"", 0}
     stacktrace:
       test/elixir/system_test.exs:223: anonymous fn/0 in SystemTest."test Unix cmd/3 with absolute and relative paths"/1
       (elixir 1.21.0-dev) lib/file.ex:2100: File.cd!/2
       test/elixir/system_test.exs:215: (test)
```

This fix switches the binary used for the test over to `sh` which fixes the issue on Ubuntu 26.04. This was also verified on Ubuntu 24.04, Ubuntu 22.04, Alpine Linux 3.24, macOS Tahoe (26.5.1) and MacOS Sequoia (15.3.2).