### PR TITLE
Fix Calendar.ISO.parse_time negative zero offsets in basic format

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -2064,7 +2064,6 @@ defmodule Calendar.ISO do
 
   defp parse_offset(""), do: {nil, ""}
   defp parse_offset("Z"), do: {0, ""}
-  defp parse_offset("-00:00"), do: :error
 
   defp parse_offset(<<?+, h1, h2, ?:, m1, m2, rest::binary>>),
     do: parse_offset(1, h1, h2, m1, m2, rest)
@@ -2087,7 +2086,8 @@ defmodule Calendar.ISO do
          true <- m1 in ?0..?5 and m2 in ?0..?9,
          hour = (h1 - ?0) * 10 + h2 - ?0,
          min = (m1 - ?0) * 10 + m2 - ?0,
-         true <- hour < 24 do
+         true <- hour < 24,
+         true <- sign == 1 or hour != 0 or min != 0 do
       {(hour * 60 + min) * 60 * sign, rest}
     else
       _ -> :error

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -154,9 +154,12 @@ defmodule Calendar.ISOTest do
       assert Calendar.ISO.parse_time("23:50:07Z") == {:ok, {23, 50, 7, {0, 0}}}
       assert Calendar.ISO.parse_time("23:50:07+01:00") == {:ok, {23, 50, 7, {0, 0}}}
 
-      assert Calendar.ISO.parse_time("2015-01-23 23:50-00:00") == {:error, :invalid_format}
-      assert Calendar.ISO.parse_time("2015-01-23 23:50-00:60") == {:error, :invalid_format}
-      assert Calendar.ISO.parse_time("2015-01-23 23:50-24:00") == {:error, :invalid_format}
+      assert Calendar.ISO.parse_time("23:50:07-00:00") == {:error, :invalid_format}
+      assert Calendar.ISO.parse_time("23:50:07-0000") == {:error, :invalid_format}
+      assert Calendar.ISO.parse_time("23:50:07-00") == {:error, :invalid_format}
+
+      assert Calendar.ISO.parse_time("23:50:07-00:60") == {:error, :invalid_format}
+      assert Calendar.ISO.parse_time("23:50:07-24:00") == {:error, :invalid_format}
     end
 
     test "supports either comma or period millisecond delimiters" do
@@ -244,6 +247,12 @@ defmodule Calendar.ISOTest do
       assert Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123-00:00") ==
                {:error, :invalid_format}
 
+      assert Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123-0000") ==
+               {:error, :invalid_format}
+
+      assert Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123-00") ==
+               {:error, :invalid_format}
+
       assert Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123-00:60") ==
                {:error, :invalid_format}
 
@@ -319,6 +328,12 @@ defmodule Calendar.ISOTest do
                {:ok, {2015, 1, 24, 2, 20, 7, {123_000, 3}}, -9000}
 
       assert Calendar.ISO.parse_utc_datetime("2015-01-23T23:50:07.123-00:00") ==
+               {:error, :invalid_format}
+
+      assert Calendar.ISO.parse_utc_datetime("2015-01-23T23:50:07.123-0000") ==
+               {:error, :invalid_format}
+
+      assert Calendar.ISO.parse_utc_datetime("2015-01-23T23:50:07.123-00") ==
                {:error, :invalid_format}
 
       assert Calendar.ISO.parse_utc_datetime("2015-01-23T23:50:07.123-00:60") ==


### PR DESCRIPTION
`Calendar.ISO.parse_time` (and functions that use it) rejects only negative zero offset in extended format (-00:00), allowing basic (-0000, -00).

```elixir
iex> Calendar.ISO.parse_time("23:50:07-00:00")
{:error, :invalid_format}

iex> Calendar.ISO.parse_time("23:50:07-0000")
{:ok, {23, 50, 7, {0, 0}}} # expected {:error, :invalid_format}

iex> Calendar.ISO.parse_time("23:50:07-00")
{:ok, {23, 50, 7, {0, 0}}} # expected {:error, :invalid_format}

iex> Calendar.ISO.parse_utc_datetime("2015-01-23 23:50:07-00:00")
{:error, :invalid_format}

iex> Calendar.ISO.parse_utc_datetime("2015-01-23 23:50:07-0000")
{:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}, 0} # expected: {:error, :invalid_format}
```

existing offset test cases fixed because they are rejecting on invalid time, not offset (were checking the wrong thing)