### PR TITLE
Fix Calendar.strftime negative year as 2-digits formatting

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -914,20 +914,25 @@ defmodule Calendar do
 
   # Year as 2-digits
   defp format_modifiers("y" <> rest, width, pad, datetime, format_options, acc) do
-    result = datetime.year |> rem(100) |> Integer.to_string() |> pad_leading(width, pad)
+    result =
+      if datetime.year < 0 do
+        [?- | -datetime.year |> rem(100) |> Integer.to_string() |> pad_leading(width, pad)]
+      else
+        datetime.year |> rem(100) |> Integer.to_string() |> pad_leading(width, pad)
+      end
+
     parse(rest, datetime, format_options, [result | acc])
   end
 
   # Year
   defp format_modifiers("Y" <> rest, width, pad, datetime, format_options, acc) do
-    {sign, year} =
+    result =
       if datetime.year < 0 do
-        {?-, -datetime.year}
+        [?- | -datetime.year |> Integer.to_string() |> pad_leading(width, pad)]
       else
-        {[], datetime.year}
+        datetime.year |> Integer.to_string() |> pad_leading(width, pad)
       end
 
-    result = [sign | year |> Integer.to_string() |> pad_leading(width, pad)]
     parse(rest, datetime, format_options, [result | acc])
   end
 

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -472,5 +472,12 @@ defmodule CalendarTest do
       assert Calendar.strftime(Date.new!(-111, 1, 1), "%Y") == "-0111"
       assert Calendar.strftime(Date.new!(-1111, 1, 1), "%Y") == "-1111"
     end
+
+    test "zero padding for negative year as 2-digits" do
+      assert Calendar.strftime(Date.new!(-1, 1, 1), "%y") == "-01"
+      assert Calendar.strftime(Date.new!(-11, 1, 1), "%y") == "-11"
+      assert Calendar.strftime(Date.new!(-100, 1, 1), "%y") == "-00"
+      assert Calendar.strftime(Date.new!(-101, 1, 1), "%y") == "-01"
+    end
   end
 end


### PR DESCRIPTION
Fix `Calendar.strftime/3` negative year as 2-digits formatting

```elixir
iex> Calendar.strftime(Date.new!(-1, 1, 1), "%y")
"-1" # expected "-01"
```

