### PR TITLE
Fix ExUnit.RunnerStats.increment_failure_counter/2 spec

### DIFF
--- a/lib/ex_unit/lib/ex_unit/runner_stats.ex
+++ b/lib/ex_unit/lib/ex_unit/runner_stats.ex
@@ -25,7 +25,7 @@ defmodule ExUnit.RunnerStats do
     GenServer.call(sup, :get_failure_counter)
   end
 
-  @spec increment_failure_counter(pid) :: pos_integer
+  @spec increment_failure_counter(pid, pos_integer) :: non_neg_integer
   def increment_failure_counter(sup, increment \\ 1)
       when is_pid(sup) and is_integer(increment) and increment >= 1 do
     GenServer.call(sup, {:increment_failure_counter, increment})


### PR DESCRIPTION
Fix `ExUnit.RunnerStats.increment_failure_counter/2` spec