### PR TITLE
Clarify ExUnit --slowest-modules switch header

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -335,7 +335,7 @@ defmodule ExUnit.CLIFormatter do
     percentage = Float.round(slowest_us / run_us * 100, 1)
 
     [
-      "\nTop #{slowest} slowest (#{slowest_time}s), #{percentage}% of total time:\n\n"
+      "\nTop #{slowest} slowest modules (#{slowest_time}s), #{percentage}% of total time:\n\n"
       | Enum.map(slowest_tests, &format_slow_module/1)
     ]
   end

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -268,7 +268,7 @@ defmodule ExUnitTest do
     configure_and_reload_on_exit(slowest_modules: 2)
 
     output = capture_io(fn -> ExUnit.run() end)
-    assert output =~ ~r"Top 2 slowest \(\d+\.\d+s\), \d+.\d% of total time:"
+    assert output =~ ~r"Top 2 slowest modules \(\d+\.\d+s\), \d+.\d% of total time:"
     assert output =~ ~r"SlowestTestModule \(.+ms\)"
     assert output =~ ~r"SlowerTestModule \(.+ms\)"
   end


### PR DESCRIPTION
`--slowest-modules` switch header was identical to `--slowest`, which was slightly confusing when both options used together