### PR TITLE
Fix IEx.configure_opts() dot_iex typespec and add missing IEx.Server doc option

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -450,7 +450,7 @@ defmodule IEx do
           alive_prompt: String.t(),
           colors: colors_opts(),
           default_prompt: String.t(),
-          dot_iex: String.t() | nil,
+          dot_iex: String.t(),
           history_size: integer(),
           inspect: inspect_opts(),
           parser: {module(), atom(), [any()]},

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -38,6 +38,7 @@ defmodule IEx.Server do
     * `:prefix` - the IEx prefix
     * `:env` - the `Macro.Env` used for the evaluator
     * `:binding` - an initial set of variables for the evaluator
+    * `:dot_iex` - the path to the `.iex.exs` file to load; an empty string skips loading one
     * `:on_eof` - if it should `:stop_evaluator` (default) or `:halt` the system
     * `:register` - if this shell should be registered in the broker (default is `true`)
 


### PR DESCRIPTION
Fix IEx.configure_opts() `dot_iex` typespec and add missing IEx.Server doc option