### PR TITLE
Fix Calendar.strftime/3 width calculations

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -998,14 +998,14 @@ defmodule Calendar do
     raise ArgumentError, "invalid strftime format: %#{next}"
   end
 
-  defp pad_preferred(result, width, pad) when length(result) < width do
-    pad_preferred([pad | result], width, pad)
+  defp pad_preferred(result, width, pad) do
+    result
+    |> IO.iodata_to_binary()
+    |> pad_leading(width, pad)
   end
 
-  defp pad_preferred(result, _width, _pad), do: result
-
   defp pad_leading(string, count, padding) do
-    to_pad = count - byte_size(string)
+    to_pad = count - String.length(string)
     if to_pad > 0, do: do_pad_leading(to_pad, padding, string), else: string
   end
 

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -340,6 +340,16 @@ defmodule CalendarTest do
       assert Calendar.strftime(~N[2019-08-15 17:07:57], "%010A") == "00Thursday"
     end
 
+    test "measures padding width in graphemes" do
+      assert Calendar.strftime(%{month: 9}, "%10B", month_names: fn _month -> "вересень" end) ==
+               "  вересень"
+    end
+
+    test "measures preferred format padding width" do
+      assert Calendar.strftime(~N[2019-08-15 17:07:57], "%20c") ==
+               "02019-08-15 17:07:57"
+    end
+
     test "limits width to at most 1024 characters" do
       assert Calendar.strftime(~D[2019-08-15], "%1024d") |> byte_size() == 1024
 


### PR DESCRIPTION
Preferred formats measured by their iodata element count instead of rendered length
```elixir
iex> Calendar.strftime(~N[2019-08-15 17:07:57], "%20c")
"0000000002019-08-15 17:07:57" # expected: "02019-08-15 17:07:57"
```

Unicode values measured in bytes, must in graphemes

```elixir
iex> Calendar.strftime(%{month: 9}, "%10B", month_names: fn _ -> "вересень" end)
"вересень" # expected: "  вересень"
```