### PR TITLE
Remove redundant abs call from Date.Range

### DIFF
--- a/lib/elixir/lib/calendar/date_range.ex
+++ b/lib/elixir/lib/calendar/date_range.ex
@@ -185,7 +185,7 @@ defmodule Date.Range do
            last_in_iso_days: last_days,
            step: step
          }),
-         do: abs(div(last_days - first_days, step)) + 1
+         do: div(last_days - first_days, step) + 1
 
     # TODO: Remove me on v2.0
     defp size(


### PR DESCRIPTION
Assisted-by: GPT 5.6 Sol : Codex CLI

The preceding clauses handle steps that point away from the last date. 
 `last_days - first_days` and `step` have the same sign, so `div/2` is already non-negative.
