### PR TITLE
Remove redundant min from Enum.drop/2

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -903,7 +903,7 @@ defmodule Enum do
 
   def drop(enumerable, amount) when is_integer(amount) and amount < 0 do
     {count, fun} = slice_count_and_fun(enumerable, 1)
-    amount = Kernel.min(amount + count, count)
+    amount = amount + count
 
     if amount > 0 do
       fun.(0, amount, 1)


### PR DESCRIPTION
Assisted-by: GPT-5.6 Sol : Codex CLI

The negative amount guard guarantees amount + count is always less than count.


