### PR TITLE
Pass `:sigils` to mix format plugins invoked for a sigil

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -354,19 +354,7 @@ defmodule Mix.Tasks.Format do
           sigil <- find_sigils_from_plugins(plugin, formatter_opts),
           do: {sigil, plugin}
 
-    sigils =
-      sigils
-      |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
-      |> Enum.map(fn {sigil, plugins} ->
-        {sigil,
-         fn input, opts ->
-           Enum.reduce(plugins, input, fn plugin, input ->
-             plugin.format(input, opts ++ formatter_opts)
-           end)
-         end}
-      end)
-
-    {Keyword.put(formatter_opts, :sigils, sigils),
+    {Keyword.put(formatter_opts, :sigils, sigil_formatters(sigils, formatter_opts)),
      Enum.map(subs, fn {path, formatter_opts_and_subs} ->
        {path, load_plugins(formatter_opts_and_subs, opts)}
      end)}
@@ -382,6 +370,24 @@ defmodule Mix.Tasks.Format do
     end
 
     plugins
+  end
+
+  # A sigil formatter must receive :sigils itself, so a plugin can format sigils
+  # nested inside the sigil it was given. The list is rebuilt on each invocation.
+  defp sigil_formatters(sigil_plugins, formatter_opts) do
+    sigil_plugins
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+    |> Enum.map(fn {sigil, plugins} ->
+      {sigil,
+       fn input, opts ->
+         formatter_opts =
+           Keyword.put(formatter_opts, :sigils, sigil_formatters(sigil_plugins, formatter_opts))
+
+         Enum.reduce(plugins, input, fn plugin, input ->
+           plugin.format(input, opts ++ formatter_opts)
+         end)
+       end}
+    end)
   end
 
   @typedoc """

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -381,7 +381,7 @@ defmodule Mix.Tasks.Format do
   # nested inside the sigil it was given. The list is rebuilt on each invocation.
   defp prepend_sigils(grouped_sigils, formatter_opts_without_sigils) do
     sigils =
-      Enum.map(sigil_groups, fn {sigil, plugins} ->
+      Enum.map(grouped_sigils, fn {sigil, plugins} ->
         {sigil,
          fn input, opts ->
            formatter_opts = prepend_sigils(grouped_sigils, formatter_opts_without_sigils)

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -349,12 +349,17 @@ defmodule Mix.Tasks.Format do
       end
     end
 
-    sigils =
+    flatten_sigils =
       for plugin <- plugins,
           sigil <- find_sigils_from_plugins(plugin, formatter_opts),
           do: {sigil, plugin}
 
-    {Keyword.put(formatter_opts, :sigils, sigil_formatters(sigils, formatter_opts)),
+    formatter_opts =
+      flatten_sigils
+      |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+      |> prepend_sigils(Keyword.delete(formatter_opts, :sigils))
+
+    {formatter_opts,
      Enum.map(subs, fn {path, formatter_opts_and_subs} ->
        {path, load_plugins(formatter_opts_and_subs, opts)}
      end)}
@@ -374,20 +379,20 @@ defmodule Mix.Tasks.Format do
 
   # A sigil formatter must receive :sigils itself, so a plugin can format sigils
   # nested inside the sigil it was given. The list is rebuilt on each invocation.
-  defp sigil_formatters(sigil_plugins, formatter_opts) do
-    sigil_plugins
-    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
-    |> Enum.map(fn {sigil, plugins} ->
-      {sigil,
-       fn input, opts ->
-         formatter_opts =
-           Keyword.put(formatter_opts, :sigils, sigil_formatters(sigil_plugins, formatter_opts))
+  defp prepend_sigils(grouped_sigils, formatter_opts_without_sigils) do
+    sigils =
+      Enum.map(sigil_groups, fn {sigil, plugins} ->
+        {sigil,
+         fn input, opts ->
+           formatter_opts = prepend_sigils(grouped_sigils, formatter_opts_without_sigils)
+  
+           Enum.reduce(plugins, input, fn plugin, input ->
+             plugin.format(input, opts ++ formatter_opts)
+           end)
+         end}
+      end)
 
-         Enum.reduce(plugins, input, fn plugin, input ->
-           plugin.format(input, opts ++ formatter_opts)
-         end)
-       end}
-    end)
+    [sigils: sigils] ++ formatter_opts_without_sigils
   end
 
   @typedoc """

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -385,6 +385,7 @@ defmodule Mix.Tasks.Format do
         {sigil,
          fn input, opts ->
            formatter_opts = prepend_sigils(grouped_sigils, formatter_opts_without_sigils)
+
            Enum.reduce(plugins, input, fn plugin, input ->
              plugin.format(input, opts ++ formatter_opts)
            end)

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -385,7 +385,6 @@ defmodule Mix.Tasks.Format do
         {sigil,
          fn input, opts ->
            formatter_opts = prepend_sigils(grouped_sigils, formatter_opts_without_sigils)
-  
            Enum.reduce(plugins, input, fn plugin, input ->
              plugin.format(input, opts ++ formatter_opts)
            end)

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -572,6 +572,66 @@ defmodule Mix.Tasks.FormatTest do
     end)
   end
 
+  defmodule Elixir.SigilOuterPlugin do
+    @behaviour Mix.Tasks.Format
+
+    def features(opts) do
+      assert opts[:from_formatter_exs] == :yes
+      [sigils: [:O]]
+    end
+
+    def format(contents, opts) do
+      assert opts[:from_formatter_exs] == :yes
+      assert opts[:sigil] == :O
+      [Code.format_string!(contents, opts), ?\n]
+    end
+  end
+
+  defmodule Elixir.SigilInnerPlugin do
+    @behaviour Mix.Tasks.Format
+
+    def features(opts) do
+      assert opts[:from_formatter_exs] == :yes
+      [sigils: [:I]]
+    end
+
+    def format(contents, opts) do
+      assert opts[:from_formatter_exs] == :yes
+      assert opts[:sigil] == :I
+      String.upcase(contents)
+    end
+  end
+
+  test "uses sigil plugins for sigils nested inside sigils", context do
+    in_tmp(context.test, fn ->
+      File.write!(".formatter.exs", """
+      [
+        inputs: ["a.ex"],
+        plugins: [SigilOuterPlugin, SigilInnerPlugin],
+        from_formatter_exs: :yes
+      ]
+      """)
+
+      File.write!("a.ex", """
+      def nested_sigil_test do
+        ~O'''
+        inner(~I"foo bar")
+        '''
+      end
+      """)
+
+      Mix.Tasks.Format.run([])
+
+      assert File.read!("a.ex") == """
+             def nested_sigil_test do
+               ~O'''
+               inner(~I"FOO BAR")
+               '''
+             end
+             """
+    end)
+  end
+
   test "customizes plugin loading", context do
     in_tmp(context.test, fn ->
       File.write!(".formatter.exs", """


### PR DESCRIPTION
`mix format` passes the `:sigils` option to a plugin invoked for a file extension, but not to a plugin invoked for a sigil.

The plugin docs say `format/2` receives "all the formatting options". The sigil formatter closure captures `formatter_opts` before `:sigils` is put into it, so a plugin invoked for a sigil is the one caller that does not get it; the extension path passes the options `load_plugins/2` returned, which do carry it.

The consequence is that a plugin cannot dispatch a sigil nested inside the sigil it is formatting by passing on the options it received. `Phoenix.LiveView.HTMLFormatter` formats `{...}` attribute expressions by handing its own options to `Code.quoted_to_algebra/2`, so a custom sigil inside an attribute is formatted by its plugin in a `.heex` file but is left alone in an `~H` sigil. Nothing about this is HEEx specific: it applies to any plugin that formats embedded Elixir code.

The included test fails before the change.

With `:sigils` present, a plugin sigil nested inside itself now dispatches to the plugin again. A plugin that formats its contents once recurses as deep as the source nests, which is finite, and the extension path already allows this today.

I checked this against `Phoenix.LiveView.HTMLFormatter` plus a custom sigil plugin: every sigil in the file now formats the same way whether it sits at the top level, inside `~H`, or in a `.heex` file, and the result is idempotent.
