### PR TITLE
Remove stale :three_op operator from IEx.Evaluator

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -58,7 +58,7 @@ defmodule IEx.Evaluator do
   @break_trigger ~c"#iex:break\n"
 
   @op_tokens [:or_op, :and_op, :comp_op, :rel_op, :arrow_op, :in_op] ++
-               [:three_op, :concat_op, :mult_op, :power_op]
+               [:concat_op, :mult_op, :power_op]
 
   @doc """
   Default parsing implementation with support for pipes and #iex:break.


### PR DESCRIPTION
Tokenizer does not emits this token type (deprecated `^^^`)