### PR TITLE
Fix 'not in' as continuation operator in IEx

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -129,6 +129,8 @@ defmodule IEx.Evaluator do
     end
   end
 
+  # We use elem operations, instead of pattern matching,
+  # because "not in" tokenizer tuples have four elements.
   defp adjust_operator([token | _] = _tokens, line, column, _file, _opts, :match)
        when elem(token, 0) in @op_tokens,
        do:

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -129,18 +129,18 @@ defmodule IEx.Evaluator do
     end
   end
 
-  defp adjust_operator([{op_type, _, token} | _] = _tokens, line, column, _file, _opts, :match)
-       when op_type in @op_tokens,
+  defp adjust_operator([token | _] = _tokens, line, column, _file, _opts, :match)
+       when elem(token, 0) in @op_tokens,
        do:
          {:error,
           {[line: line, column: column],
            "pipe shorthand is not allowed immediately after a match expression in IEx. To make it work, surround the whole pipeline with parentheses ",
-           "'#{token}'"}}
+           "'#{elem(token, 2)}'"}}
 
-  defp adjust_operator([{op_type, _, _} | _] = tokens, line, column, file, opts, _last_op)
-       when op_type in @op_tokens do
+  defp adjust_operator([token | _] = tokens, line, column, file, opts, _last_op)
+       when elem(token, 0) in @op_tokens do
     {:ok, prefix, _warnings} = :elixir.string_to_tokens(~c"v(-1)", line, column, file, opts)
-    {:ok, prefix ++ tokens, op_type}
+    {:ok, prefix ++ tokens, elem(token, 0)}
   end
 
   defp adjust_operator(tokens, _line, _column, _file, _opts, _last_op), do: {:ok, tokens, nil}

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1339,6 +1339,7 @@ defmodule IEx.HelpersTest do
       assert capture_iex("42\n |> IO.inspect(label: \"foo\")") =~ "foo: 42"
       assert capture_iex("[42]\n++ [24]\n|> IO.inspect(label: \"foo\")") =~ "foo: [42, 24]"
       assert capture_iex("|> IO.puts()") =~ "(RuntimeError) v(-1) is out of bounds"
+      assert capture_iex("4\nnot in [1, 2]") == "4\ntrue"
     end
 
     test "raises if previous expression was a match" do
@@ -1350,6 +1351,9 @@ defmodule IEx.HelpersTest do
 
       assert capture_iex("%{x: x} = map = %{x: 42}\n|> IO.puts()") =~
                "surround the whole pipeline with parentheses '|>'"
+
+      assert capture_iex("x = 4\nnot in [1, 2]") =~
+               "surround the whole pipeline with parentheses 'not in'"
     end
   end
 


### PR DESCRIPTION
## Current

```elixir
iex> 4
iex> in [1, 2]
false

```elixir
iex> 4
iex> not in [1, 2]
** (SyntaxError) invalid syntax found on iex:4:1:
    error: syntax error before: {in_op,{4,1,nil},'not in',{4,5,nil}}
    │
  4 │ not in [1, 2]
    │ ^
    │
    └─ iex:4:1
    (iex 1.21.0-dev) lib/iex/server.ex:403: IEx.Server.__parse__/3
    (stdlib 8.0.2) io_lib.erl:1649: :io_lib.get_until/4
    (kernel 11.0.3) group.erl:407: :group.xterm/3
    (stdlib 8.0.2) gen_statem.erl:3741: :gen_statem.loop_state_callback/11
    (stdlib 8.0.2) proc_lib.erl:333: :proc_lib.init_p_do_apply/3
```

## Expected 

`true`, same as:

```elixir
iex> 4 not in [1, 2]
true
```

Tokenizer represents composite `not in` as four-element token, like: `{in_op,{4,1,nil},'not in',{4,5,nil}}`