### PR TITLE
Fix Date.range/3 raises wrong exception for invalid step

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -160,7 +160,7 @@ defmodule Date do
       ) do
     raise ArgumentError,
           "both dates must have matching calendar and the step must be a " <>
-            "non-zero integer, got: #{inspect(first)}, #{inspect(last)}, #{step}"
+            "non-zero integer, got: #{inspect(first)}, #{inspect(last)}, #{inspect(step)}"
   end
 
   defp range(first, first_days, last, last_days, calendar, step) do

--- a/lib/elixir/test/elixir/calendar/date_range_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_range_test.exs
@@ -162,11 +162,8 @@ defmodule Date.RangeTest do
       Date.range(~D[2000-01-01], ~D[2000-01-31], step)
     end
 
-    step = {1}
-    message = ~r/got: ~D\[2000-01-01\], ~D\[2000-02-01\], \{1\}/
-
-    assert_raise ArgumentError, message, fn ->
-      Date.range(~D[2000-01-01], ~D[2000-02-01], step)
+    assert_raise ArgumentError, ~r/got: ~D\[2000-01-01\], ~D\[2000-02-01\], \{1\}/, fn ->
+      Date.range(~D[2000-01-01], ~D[2000-02-01], {1})
     end
   end
 

--- a/lib/elixir/test/elixir/calendar/date_range_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_range_test.exs
@@ -161,6 +161,13 @@ defmodule Date.RangeTest do
     assert_raise ArgumentError, message, fn ->
       Date.range(~D[2000-01-01], ~D[2000-01-31], step)
     end
+
+    step = {1}
+    message = ~r/got: ~D\[2000-01-01\], ~D\[2000-02-01\], \{1\}/
+
+    assert_raise ArgumentError, message, fn ->
+      Date.range(~D[2000-01-01], ~D[2000-02-01], step)
+    end
   end
 
   describe "old date ranges" do


### PR DESCRIPTION
Fixes `Date.range/3` raises wrong exception for non-printable (does not implements String.Chars protocol) `step`

## Current

```elixir
iex> Date.range(~D[2001-01-01], ~D[2002-01-01], {1})
** (Protocol.UndefinedError) protocol String.Chars not implemented for Tuple

Got value:

    {1}
...
```

## Expected

```elixir
** (ArgumentError) both dates must have matching calendar and the step must be a non-zero integer, got: ~D[2001-01-01], ~D[2002-01-01], {1}
```