### PR TITLE
Fix Code.Typespec.spec_to_quoted/2 incomplete variable type collection

### DIFF
--- a/lib/elixir/lib/code/typespec.ex
+++ b/lib/elixir/lib/code/typespec.ex
@@ -193,8 +193,8 @@ defmodule Code.Typespec do
 
   ## To AST conversion
 
-  defp collect_vars({:ann_type, _anno, args}) when is_list(args) do
-    []
+  defp collect_vars({:ann_type, _anno, [_var, type]}) do
+    collect_vars(type)
   end
 
   defp collect_vars({:type, _anno, _kind, args}) when is_list(args) do

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -1313,6 +1313,19 @@ defmodule TypespecTest do
       end)
     end
 
+    test "spec_to_quoted collects nested type vars" do
+      bytecode =
+        test_module do
+          @spec foo(arg1 :: [t], arg2 :: [t]) :: atom() when t: var
+          def foo(_, _), do: :ok
+        end
+
+      [{{:foo, 2}, [spec]}] = specs(bytecode)
+
+      assert Macro.to_string(Code.Typespec.spec_to_quoted(:foo, spec)) ==
+               "foo(arg1 :: [t], arg2 :: [t]) :: atom() when t: var"
+    end
+
     test "spec_to_quoted preserves line metadata for elixir remote types" do
       bytecode =
         test_module do


### PR DESCRIPTION
`Code.Typespec.spec_to_quoted/2` skips type vars nested in annotated spec arguments

Erlang stdlib array

```elixir
iex> h :array.default/1
...
  @spec default(array :: array(type)) :: value :: type
```

Expected

```elixir
@spec default(array :: array(type)) :: value :: type when type: var
```
  

Elixir module

```elixir
defmodule Repro do
  @spec foo(arg1 :: [t], arg2 :: [t]) :: atom() when t: var
  def foo(_, _), do: :ok
end
```
  

```elixir
iex>  h Repro.foo/2
...    
    @spec foo(arg1 :: [t], arg2 :: [t]) :: atom()
```

Expected

```elixir
@spec foo(arg1 :: [t], arg2 :: [t]) :: atom() when t: var`
```

`when TYPE_VAR: var` part is missing because `:ann_type` node is ignored