### PR TITLE
Fix typespecs for scoped macro counters

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -518,7 +518,7 @@ defmodule Macro do
   @doc since: "1.11.3"
   @spec generate_unique_arguments(0, context :: atom) :: []
   @spec generate_unique_arguments(pos_integer, context) ::
-          [{atom, [counter: integer | {module, integer}], context}, ...]
+          [{atom, [counter: integer | {context, pos_integer()}], context}, ...]
         when context: atom
   def generate_unique_arguments(amount, context),
     do: generate_arguments(amount, context, &unique_var/2)
@@ -576,7 +576,7 @@ defmodule Macro do
 
   """
   @doc since: "1.11.3"
-  @spec unique_var(var, context) :: {var, [counter: integer | {module, integer}], context}
+  @spec unique_var(var, context) :: {var, [counter: integer | {context, pos_integer()}], context}
         when var: atom, context: atom
   def unique_var(var, context) when is_atom(var) and is_atom(context) do
     {var, [counter: :elixir_module.next_counter(context)], context}

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -518,7 +518,7 @@ defmodule Macro do
   @doc since: "1.11.3"
   @spec generate_unique_arguments(0, context :: atom) :: []
   @spec generate_unique_arguments(pos_integer, context) ::
-          [{atom, [counter: integer], context}, ...]
+          [{atom, [counter: integer | {module, integer}], context}, ...]
         when context: atom
   def generate_unique_arguments(amount, context),
     do: generate_arguments(amount, context, &unique_var/2)
@@ -576,7 +576,7 @@ defmodule Macro do
 
   """
   @doc since: "1.11.3"
-  @spec unique_var(var, context) :: {var, [counter: integer], context}
+  @spec unique_var(var, context) :: {var, [counter: integer | {module, integer}], context}
         when var: atom, context: atom
   def unique_var(var, context) when is_atom(var) and is_atom(context) do
     {var, [counter: :elixir_module.next_counter(context)], context}

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -518,7 +518,7 @@ defmodule Macro do
   @doc since: "1.11.3"
   @spec generate_unique_arguments(0, context :: atom) :: []
   @spec generate_unique_arguments(pos_integer, context) ::
-          [{atom, [counter: integer | {context, pos_integer()}], context}, ...]
+          [{atom, metadata(), context}, ...]
         when context: atom
   def generate_unique_arguments(amount, context),
     do: generate_arguments(amount, context, &unique_var/2)
@@ -576,7 +576,7 @@ defmodule Macro do
 
   """
   @doc since: "1.11.3"
-  @spec unique_var(var, context) :: {var, [counter: integer | {context, pos_integer()}], context}
+  @spec unique_var(var, context) :: {var, metadata(), context}
         when var: atom, context: atom
   def unique_var(var, context) when is_atom(var) and is_atom(context) do
     {var, [counter: :elixir_module.next_counter(context)], context}


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT-5.6 Sol

Macro variable counters may be integers or module-scoped tuples. Reflect both representations in the unique variable typespecs.

```elixir
  iex> defmodule CounterDemo do
  ...>   IO.inspect(Macro.unique_var(:x, __MODULE__))
  ...> end
  {:x, [counter: {CounterDemo, 1}], CounterDemo}
```

```elixir
  iex> Macro.unique_var(:x, CounterDemo)
  {:x, [counter: -576460752303423000], CounterDemo}
```
