### PR TITLE
use tail recursion in tuple aggregates

### DIFF
--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -132,10 +132,10 @@ defmodule Tuple do
   """
   @doc since: "1.12.0"
   @spec sum(tuple) :: number()
-  def sum(tuple), do: sum(tuple, tuple_size(tuple))
+  def sum(tuple), do: sum(tuple, 1, tuple_size(tuple) + 1, 0)
 
-  defp sum(_tuple, 0), do: 0
-  defp sum(tuple, index), do: :erlang.element(index, tuple) + sum(tuple, index - 1)
+  defp sum(_tuple, top, top, acc), do: acc
+  defp sum(tuple, index, top, acc), do: sum(tuple, index + 1, top, acc + :erlang.element(index, tuple))
 
   @doc """
   Computes a product of tuple elements.
@@ -151,10 +151,12 @@ defmodule Tuple do
   """
   @doc since: "1.12.0"
   @spec product(tuple) :: number()
-  def product(tuple), do: product(tuple, tuple_size(tuple))
+  def product(tuple), do: product(tuple, 1, tuple_size(tuple) + 1, 1)
 
-  defp product(_tuple, 0), do: 1
-  defp product(tuple, index), do: :erlang.element(index, tuple) * product(tuple, index - 1)
+  defp product(_tuple, top, top, acc), do: acc
+
+  defp product(tuple, index, top, acc),
+    do: product(tuple, index + 1, top, acc * :erlang.element(index, tuple))
 
   @doc """
   Converts a tuple to a list.

--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -135,7 +135,9 @@ defmodule Tuple do
   def sum(tuple), do: sum(tuple, 1, tuple_size(tuple) + 1, 0)
 
   defp sum(_tuple, top, top, acc), do: acc
-  defp sum(tuple, index, top, acc), do: sum(tuple, index + 1, top, acc + :erlang.element(index, tuple))
+
+  defp sum(tuple, index, top, acc),
+    do: sum(tuple, index + 1, top, acc + :erlang.element(index, tuple))
 
   @doc """
   Computes a product of tuple elements.


### PR DESCRIPTION
Currently this code builds up all the intermediate values on the stack and aggregates them as the recursion unwinds.

This change aggregates as it goes, without those allocations.
It can be made even faster by aggregating backwards `({1, 2, 3} => 3 + 2 + 1)`, but that can return slightly different values for floats, so I kept the original order `({1, 2, 3} => 1 + 2 + 3)`
  Benchee results below are for both versions, on tuples from 1..x. This PR implements sum/product.

product on 1000 elements is faster in the forward run because the reverse version operates on bignums earlier (1000 * 999 * ... * 1 vs 1 * 2 * ... * 1000).
  ```
  ############ tuple size = 10 ############

Name                             ips        average  deviation         median         99th %
sum_reverse (tail-rec)       24.02 M       41.63 ns   ±164.63%          40 ns          70 ns
sum (tail-rec)               23.53 M       42.50 ns   ±165.87%          40 ns          70 ns
old_sum (body-rec)           11.27 M       88.72 ns ±13611.72%          40 ns          90 ns

Comparison:
sum_reverse (tail-rec)       24.02 M
sum (tail-rec)               23.53 M - 1.02x slower +0.88 ns
old_sum (body-rec)           11.27 M - 2.13x slower +47.09 ns

############ tuple size = 1000 ############

Name                             ips        average  deviation         median         99th %
sum_reverse (tail-rec)      421.98 K        2.37 μs    ±37.49%        2.32 μs        2.52 μs
sum (tail-rec)              389.85 K        2.57 μs    ±31.04%        2.50 μs        2.73 μs
old_sum (body-rec)          271.84 K        3.68 μs    ±81.97%        3.03 μs        6.84 μs

Comparison:
sum_reverse (tail-rec)      421.98 K
sum (tail-rec)              389.85 K - 1.08x slower +0.195 μs
old_sum (body-rec)          271.84 K - 1.55x slower +1.31 μs

############ tuple size = 10 ############

Name                                 ips        average  deviation         median         99th %
product_reverse (tail-rec)       24.70 M       40.49 ns    ±65.12%          40 ns          60 ns
product (tail-rec)               23.40 M       42.73 ns    ±69.79%          40 ns          70 ns
old_product (body-rec)           12.58 M       79.50 ns ±10612.54%          50 ns          90 ns

Comparison:
product_reverse (tail-rec)       24.70 M
product (tail-rec)               23.40 M - 1.06x slower +2.24 ns
old_product (body-rec)           12.58 M - 1.96x slower +39.01 ns

############ tuple size = 1000 ############

Name                                 ips        average  deviation         median         99th %
product (tail-rec)               17.06 K       58.63 μs    ±16.24%       57.23 μs       71.33 μs
product_reverse (tail-rec)       15.49 K       64.54 μs    ±19.81%       63.93 μs       72.97 μs
old_product (body-rec)           12.76 K       78.38 μs    ±26.18%       76.59 μs      103.03 μs

Comparison:
product (tail-rec)               17.06 K
product_reverse (tail-rec)       15.49 K - 1.10x slower +5.92 μs
old_product (body-rec)           12.76 K - 1.34x slower +19.76 μs
```