### PR TITLE
Ensure no double newlines in files generated by "mix new"

### DIFF
--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -20,11 +20,13 @@ defmodule Mix.Tasks.NewTest do
         assert file =~ "# HelloWorld\n"
         assert String.ends_with?(file, "\n")
         refute String.ends_with?(file, "\n\n")
+        refute file =~ "\n\n\n"
       end)
 
       assert_file("hello_world/.gitignore", fn file ->
         assert String.ends_with?(file, "\n")
         refute String.ends_with?(file, "\n\n")
+        refute file =~ "\n\n\n"
       end)
 
       assert_file("hello_world/lib/hello_world.ex", ~r/defmodule HelloWorld do/)
@@ -130,11 +132,13 @@ defmodule Mix.Tasks.NewTest do
         assert file =~ "# HelloWorld\n"
         assert String.ends_with?(file, "\n")
         refute String.ends_with?(file, "\n\n")
+        refute file =~ "\n\n\n"
       end)
 
       assert_file("hello_world/.gitignore", fn file ->
         assert String.ends_with?(file, "\n")
         refute String.ends_with?(file, "\n\n")
+        refute file =~ "\n\n\n"
       end)
 
       assert_received {:mix_shell, :info, ["* creating mix.exs"]}

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -16,18 +16,8 @@ defmodule Mix.Tasks.NewTest do
         assert file =~ "version: \"0.1.0\""
       end)
 
-      assert_file("hello_world/README.md", fn file ->
-        assert file =~ "# HelloWorld\n"
-        assert String.ends_with?(file, "\n")
-        refute String.ends_with?(file, "\n\n")
-        refute file =~ "\n\n\n"
-      end)
-
-      assert_file("hello_world/.gitignore", fn file ->
-        assert String.ends_with?(file, "\n")
-        refute String.ends_with?(file, "\n\n")
-        refute file =~ "\n\n\n"
-      end)
+      assert_file("hello_world/README.md", ~r/# HelloWorld\n/)
+      assert_file("hello_world/.gitignore")
 
       assert_file("hello_world/lib/hello_world.ex", ~r/defmodule HelloWorld do/)
       assert_file("hello_world/test/test_helper.exs", ~r/ExUnit.start()/)
@@ -128,18 +118,8 @@ defmodule Mix.Tasks.NewTest do
         assert file =~ "apps_path: \"apps\""
       end)
 
-      assert_file("hello_world/README.md", fn file ->
-        assert file =~ "# HelloWorld\n"
-        assert String.ends_with?(file, "\n")
-        refute String.ends_with?(file, "\n\n")
-        refute file =~ "\n\n\n"
-      end)
-
-      assert_file("hello_world/.gitignore", fn file ->
-        assert String.ends_with?(file, "\n")
-        refute String.ends_with?(file, "\n\n")
-        refute file =~ "\n\n\n"
-      end)
+      assert_file("hello_world/README.md", ~r/# HelloWorld\n/)
+      assert_file("hello_world/.gitignore")
 
       assert_received {:mix_shell, :info, ["* creating mix.exs"]}
 
@@ -264,6 +244,15 @@ defmodule Mix.Tasks.NewTest do
 
   defp assert_file(file) do
     assert File.regular?(file), "Expected #{file} to exist, but does not"
+    content = File.read!(file)
+
+    # \S\n\z matches non-whitespace followed by a single newline at EOF
+    assert content == "" or content =~ ~r/\S\n\z/,
+           "Expected #{file} to end with a single trailing newline"
+
+    refute content =~ "\n\n\n", "Expected #{file} to not contain consecutive blank lines"
+
+    content
   end
 
   defp assert_file(file, match) do
@@ -272,8 +261,8 @@ defmodule Mix.Tasks.NewTest do
         assert_file(file, &assert(&1 =~ match))
 
       is_function(match, 1) ->
-        assert_file(file)
-        match.(File.read!(file))
+        content = assert_file(file)
+        match.(content)
     end
   end
 end


### PR DESCRIPTION
Add assertions to Mix.Tasks.NewTest to refute consecutive empty lines ("\n\n\n") in generated README.md and .gitignore files for both standard and umbrella projects, preventing accidental regression of template formatting issues (such as fixed in 7a7d7d9565e8d2177573d2d43efbf99fd7795791).