### PR TITLE
Fix Kernel.SpecialForms references in Macro.Env docs

### DIFF
--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -345,7 +345,7 @@ defmodule Macro.Env do
 
   ## Additional options
 
-  It accepts the same options as `Kernel.SpecialForm.require/2` plus:
+  It accepts the same options as `Kernel.SpecialForms.require/2` plus:
 
     * #{trace_option}
 
@@ -386,7 +386,7 @@ defmodule Macro.Env do
 
   ## Additional options
 
-  It accepts the same options as `Kernel.SpecialForm.import/2` plus:
+  It accepts the same options as `Kernel.SpecialForms.import/2` plus:
 
     * `:emit_warnings` - emit warnings found when defining imports
 
@@ -406,7 +406,7 @@ defmodule Macro.Env do
       iex> Macro.Env.lookup_import(env, {:flatten, 1})
       [{:function, List}]
 
-  It accepts the same options as `Kernel.SpecialForm.import/2`:
+  It accepts the same options as `Kernel.SpecialForms.import/2`:
 
       iex> env = __ENV__
       iex> Macro.Env.lookup_import(env, {:is_odd, 1})
@@ -448,7 +448,7 @@ defmodule Macro.Env do
 
   ## Additional options
 
-  It accepts the same options as `Kernel.SpecialForm.alias/2` plus:
+  It accepts the same options as `Kernel.SpecialForms.alias/2` plus:
 
     * #{trace_option}
 


### PR DESCRIPTION
The docs for `Macro.Env.define_require/4`, `Macro.Env.define_import/4`, and
`Macro.Env.define_alias/4` refer to `Kernel.SpecialForm.require/2`,
`Kernel.SpecialForm.import/2` (twice), and `Kernel.SpecialForm.alias/2` — the
module name is missing the trailing "s". Since the module is called
`Kernel.SpecialForms`, ExDoc cannot resolve these references, so they render as
plain code spans instead of links (see e.g. the current
[`define_import/4` docs](https://hexdocs.pm/elixir/main/Macro.Env.html#define_import/4)).

This fixes the four occurrences in `lib/elixir/lib/macro/env.ex`.

Found by mechanically verifying that every `Mod.fun/arity` reference in the
docs resolves to an existing function, macro, callback, or type.
