### PR TITLE
Fix System.stacktrace arity in the table of deprecations

### DIFF
--- a/lib/elixir/pages/references/compatibility-and-deprecations.md
+++ b/lib/elixir/pages/references/compatibility-and-deprecations.md
@@ -140,7 +140,7 @@ Version | Deprecated feature                                  | Replaced by (ava
 [v1.11] | `Mix.Project.compile/2`                             | `Mix.Task.run("compile", args)` (v1.0)
 [v1.11] | `Supervisor.Spec.worker/3` and `Supervisor.Spec.supervisor/3` | The new child specs outlined in `Supervisor` (v1.5)
 [v1.11] | `Supervisor.start_child/2` and `Supervisor.terminate_child/2` | `DynamicSupervisor` (v1.6)
-[v1.11] | `System.stacktrace/1`                               | `__STACKTRACE__` in `try/catch/rescue` (v1.7)
+[v1.11] | `System.stacktrace/0`                               | `__STACKTRACE__` in `try/catch/rescue` (v1.7)
 [v1.10] | `Code.ensure_compiled?/1`                           | `Code.ensure_compiled/1` (v1.0)
 [v1.10] | `Code.load_file/2`                                  | `Code.require_file/2` (v1.0) or `Code.compile_file/2` (v1.7)
 [v1.10] | `Code.loaded_files/0`                               | `Code.required_files/0` (v1.7)


### PR DESCRIPTION
The table of deprecations in
`lib/elixir/pages/references/compatibility-and-deprecations.md` lists:

```
[v1.11] | `System.stacktrace/1` | `__STACKTRACE__` in `try/catch/rescue` (v1.7)
```

The deprecated function is `System.stacktrace/0` — it never took any arguments
(its implementation was `apply(:erlang, :get_stacktrace, [])`, and the
deprecation commit 42d5f9c21 is titled "Deprecate System.stacktrace/0 across
the language"). Since `System.stacktrace/1` never existed, the reference in
the table cannot be resolved; with the correct arity it links to the
still-present deprecated function.

Found by cross-checking every row of the table against the `:deprecated`
metadata in the compiled modules (`Code.fetch_docs/1`), as a follow-up to
#15712.
