### PR TITLE
Add Path.safe_join/2

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -699,6 +699,32 @@ defmodule Path do
     end
   end
 
+  @doc """
+  Safely joins two paths.
+
+  Returns `{:ok, path}` if `right` is safe to append to `left`, or `:error`
+  otherwise. See `safe_relative/2` for the exact safety rules applied to `right`.
+
+  ## Examples
+
+      iex> Path.safe_join("foo", "bar")
+      {:ok, "foo/bar"}
+
+      iex> Path.safe_join("foo", "../bar")
+      :error
+
+      iex> Path.safe_join("foo", "/bar")
+      :error
+
+  """
+  @doc since: "1.21.0"
+  @spec safe_join(t, t) :: {:ok, t} | :error
+  def safe_join(left, right) do
+    with {:ok, right} <- safe_relative(right, left) do
+      {:ok, join(left, right)}
+    end
+  end
+
   @doc ~S"""
   Splits the path into a list at the path separator.
 

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -416,6 +416,14 @@ defmodule PathTest do
     assert Path.join(["/foo", "bar"], ["fiz", "buz"]) == "/foobar/fizbuz"
   end
 
+  test "safe_join/2" do
+    assert {:ok, "foo/bar"} = Path.safe_join("foo", "bar")
+    assert {:ok, "foo"} = Path.safe_join("foo", ".")
+
+    assert :error = Path.safe_join("foo", "../bar")
+    assert :error = Path.safe_join("foo", "/bar")
+  end
+
   test "split/1" do
     assert Path.split("") == []
     assert Path.split("foo") == ["foo"]


### PR DESCRIPTION
Path traversal via unsafe path composition is a well-known class of bug ([CWE-22](https://cwe.mitre.org/data/definitions/22.html), and part of [OWASP Top 10 A01:2025 Broken Access Control](https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control)). It typically occurs when a trusted root is combined with an externally-supplied segment that is assumed to be a safe relative path.

`Path.safe_relative/2` already exists to validate such segments, but pairing it with `join/2` at every call site is boilerplate that is easy to omit.

`Path.safe_join/2` makes the safe pattern a one-liner. It validates right via `safe_relative/2` and joins it to left.

Only a /2 version is provided. A list-based /1 variant was considered and rejected because it has no clear trust boundary. With `[root, a, b, c]` it is ambiguous which segments are trusted and which need validation. Callers who need to compose a trusted prefix should do so explicitly.