### PR TITLE
Fix Time.from_seconds_after_midnight/3 not validates microsecond and produce invalid Time

### DIFF
--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -467,8 +467,12 @@ defmodule Time do
           Calendar.microsecond(),
           Calendar.calendar()
         ) :: t
-  def from_seconds_after_midnight(seconds, microsecond \\ {0, 0}, calendar \\ Calendar.ISO)
-      when is_integer(seconds) do
+  def from_seconds_after_midnight(
+        seconds,
+        {microsecond, precision} \\ {0, 0},
+        calendar \\ Calendar.ISO
+      )
+      when is_integer(seconds) and microsecond in 0..999_999 and precision in 0..6 do
     seconds_in_day = Integer.mod(seconds, @seconds_per_day)
 
     {hour, minute, second, {_, _}} =
@@ -479,7 +483,7 @@ defmodule Time do
       hour: hour,
       minute: minute,
       second: second,
-      microsecond: microsecond
+      microsecond: {microsecond, precision}
     }
   end
 

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -180,4 +180,16 @@ defmodule TimeTest do
                  ~r/unsupported value 1 for :microsecond. Expected a tuple \{ms, precision\}/,
                  fn -> Time.shift(time, microsecond: 1) end
   end
+
+  test "from_seconds_after_midnight/3" do
+    assert Time.from_seconds_after_midnight(86399, {999_999, 6}) == ~T[23:59:59.999999]
+
+    assert_raise FunctionClauseError, fn ->
+      Time.from_seconds_after_midnight(0, {1_000_000, 6})
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Time.from_seconds_after_midnight(0, {999_999, 7})
+    end
+  end
 end


### PR DESCRIPTION
`Time.from_seconds_after_midnight/3` not validates microsecond and produce invalid Time struct,
which later can misbehave in `Time.diff/3`, `Time.compare/2` etc.


```elixir
iex> time = Time.from_seconds_after_midnight(0, {999_999_999, 6})
#Inspect.Error<
  got FunctionClauseError with message:

      """
      no function clause matching in Calendar.ISO.time_to_iodata/5
      """

  while inspecting:

      %{
        microsecond: {999999999, 6},
        second: 0,
        calendar: Calendar.ISO,
        __struct__: Time,
        minute: 0,
        hour: 0
      }
...

iex> time.microsecond
{999999999, 6}
```

Inspect error, but Time is constructed