### PR TITLE
Only use do-end blocks when every trailing keyword is a block keyword

### DIFF
--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -4,6 +4,8 @@
 defmodule Code.Normalizer do
   @moduledoc false
 
+  @do_end_keywords [:rescue, :catch, :else, :after]
+
   defguard is_literal(x)
            when is_integer(x) or
                   is_float(x) or
@@ -347,18 +349,20 @@ defmodule Code.Normalizer do
         args = normalize_args(args, %{state | parent_meta: meta})
         {form, meta, args}
 
-      Keyword.has_key?(meta, :do) ->
+      Keyword.has_key?(meta, :do) and kw_blocks?(last) ->
         # def foo do :ok end
         # def foo, do: :ok
         normalize_kw_blocks(form, meta, args, state)
 
-      match?([{:do, _} | _], last) and Keyword.keyword?(last) ->
+      match?([{:do, _} | _], last) and kw_blocks?(last) ->
         # Non normalized kw blocks
         line = state.parent_meta[:line] || meta[:line]
         meta = meta ++ [do: [line: line], end: [line: line]]
         normalize_kw_blocks(form, meta, args, state)
 
       true ->
+        # The formatter renders do-end blocks from the meta alone
+        meta = Keyword.drop(meta, [:do, :end])
         args = normalize_args(args, %{state | parent_meta: meta})
         {last_arg, leading_args} = List.pop_at(args, -1, [])
 
@@ -396,6 +400,17 @@ defmodule Code.Normalizer do
 
   defp block_keyword?([]), do: true
   defp block_keyword?(_), do: false
+
+  # Anything after the do block that is not a block keyword makes it a keyword list
+  defp kw_blocks?([{:do, _} | rest] = kw) do
+    Keyword.keyword?(kw) and Enum.all?(rest, &match?({key, _} when key in @do_end_keywords, &1))
+  end
+
+  defp kw_blocks?([{{:__block__, _, [:do]}, _} | rest]) do
+    Enum.all?(rest, &match?({{:__block__, _, [key]}, _} when key in @do_end_keywords, &1))
+  end
+
+  defp kw_blocks?(_), do: false
 
   defp allow_keyword?(:when, 2), do: true
   defp allow_keyword?(:{}, _), do: false

--- a/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
@@ -639,20 +639,13 @@ defmodule Code.Normalizer.QuotedASTTest do
     test "keyword args that start with do:" do
       assert quoted_to_string(quote(do: foo(do: a, bar: b))) == "foo(do: a, bar: b)"
       assert quoted_to_string(quote(do: foo(x, do: a, bar: b))) == "foo(x, do: a, bar: b)"
-      assert quoted_to_string(quote(do: Foo.bar(do: a, baz: b))) == "Foo.bar(do: a, baz: b)"
-
-      assert quoted_to_string(quote(do: for(x <- y, do: x, into: ""))) ==
-               ~S|for x <- y, do: x, into: ""|
+      assert quoted_to_string(quote(do: foo(bar: b, do: a))) == "foo(bar: b, do: a)"
 
       assert quoted_to_string({:foo, [], [[do: 1, do: 2]]}) == "foo(do: 1, do: 2)"
-      assert quoted_to_string(quote(do: foo(bar: b, do: a))) == "foo(bar: b, do: a)"
       assert quoted_to_string({:foo, [], [[rescue: 1]]}) == "foo(rescue: 1)"
 
       assert quoted_to_string({:foo, [], [[do: {:__block__, [], [1, 2]}, bar: 3]]}) ==
                "foo(\n  do:\n    (\n      1\n      2\n    ),\n  bar: 3\n)"
-
-      assert quoted_to_string({:case, [], [{:x, [], nil}, [do: [{:->, [], [[1], 2]}], other: 9]]}) ==
-               "case x, do: (1 -> 2), other: 9"
 
       assert quoted_to_string(quote(do: foo(do: a))) == "foo do\n  a\nend"
       assert quoted_to_string(quote(do: foo(do: a, else: b))) == "foo do\n  a\nelse\n  b\nend"
@@ -661,6 +654,9 @@ defmodule Code.Normalizer.QuotedASTTest do
 
       assert quoted_to_string(quote(do: foo(do: a, rescue: b, after: c))) ==
                "foo do\n  a\nrescue\n  b\nafter\n  c\nend"
+
+      assert quoted_to_string({:case, [], [{:x, [], nil}, [do: [{:->, [], [[1], 2]}], other: 9]]}) ==
+               "case x, do: (1 -> 2), other: 9"
 
       assert quoted_to_string(quote(do: receive(do: (x -> x), after: (100 -> nil)))) ==
                "receive do\n  x -> x\nafter\n  100 -> nil\nend"

--- a/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
@@ -636,6 +636,66 @@ defmodule Code.Normalizer.QuotedASTTest do
       assert quoted_to_string(quote(do: foo |> [bar: :baz])) == "foo |> [bar: :baz]"
     end
 
+    test "keyword args that start with do:" do
+      assert quoted_to_string(quote(do: foo(do: a, bar: b))) == "foo(do: a, bar: b)"
+      assert quoted_to_string(quote(do: foo(x, do: a, bar: b))) == "foo(x, do: a, bar: b)"
+      assert quoted_to_string(quote(do: Foo.bar(do: a, baz: b))) == "Foo.bar(do: a, baz: b)"
+
+      assert quoted_to_string(quote(do: for(x <- y, do: x, into: ""))) ==
+               ~S|for x <- y, do: x, into: ""|
+
+      assert quoted_to_string({:foo, [], [[do: 1, do: 2]]}) == "foo(do: 1, do: 2)"
+      assert quoted_to_string(quote(do: foo(bar: b, do: a))) == "foo(bar: b, do: a)"
+      assert quoted_to_string({:foo, [], [[rescue: 1]]}) == "foo(rescue: 1)"
+
+      assert quoted_to_string({:foo, [], [[do: {:__block__, [], [1, 2]}, bar: 3]]}) ==
+               "foo(\n  do:\n    (\n      1\n      2\n    ),\n  bar: 3\n)"
+
+      assert quoted_to_string({:case, [], [{:x, [], nil}, [do: [{:->, [], [[1], 2]}], other: 9]]}) ==
+               "case x, do: (1 -> 2), other: 9"
+
+      assert quoted_to_string(quote(do: foo(do: a))) == "foo do\n  a\nend"
+      assert quoted_to_string(quote(do: foo(do: a, else: b))) == "foo do\n  a\nelse\n  b\nend"
+      assert quoted_to_string(quote(do: foo(do: a, catch: b))) == "foo do\n  a\ncatch\n  b\nend"
+      assert quoted_to_string(quote(do: foo(do: a, after: b))) == "foo do\n  a\nafter\n  b\nend"
+
+      assert quoted_to_string(quote(do: foo(do: a, rescue: b, after: c))) ==
+               "foo do\n  a\nrescue\n  b\nafter\n  c\nend"
+
+      assert quoted_to_string(quote(do: receive(do: (x -> x), after: (100 -> nil)))) ==
+               "receive do\n  x -> x\nafter\n  100 -> nil\nend"
+    end
+
+    test "keyword args that start with do: with do/end in the metadata" do
+      meta = [do: [line: 1], end: [line: 1]]
+
+      assert quoted_to_string({:foo, meta, [[do: 1, bar: 2]]}) == "foo(do: 1, bar: 2)"
+      assert quoted_to_string({:foo, meta, [[do: 1, else: 2]]}) == "foo do\n  1\nelse\n  2\nend"
+    end
+
+    test "keyword args that start with do: are not forced into do-end blocks" do
+      assert quoted_to_string({:foo, [], [[do: 1, bar: 2]]}, force_do_end_blocks: true) ==
+               "foo(do: 1, bar: 2)"
+
+      assert quoted_to_string({:foo, [], [[do: 1, else: 2]]}, force_do_end_blocks: true) ==
+               "foo do\n  1\nelse\n  2\nend"
+    end
+
+    test "keyword args that start with do: round-trip through the parser" do
+      asts = [
+        quote(do: foo(do: a, bar: b)),
+        quote(do: for(x <- y, do: x, into: "")),
+        quote(do: foo(do: a, else: b)),
+        {:foo, [], [[do: 1, do: 2]]},
+        {:foo, [do: [line: 1], end: [line: 1]], [[do: 1, bar: 2]]}
+      ]
+
+      for ast <- asts do
+        string = quoted_to_string(ast)
+        assert string |> Code.string_to_quoted!() |> quoted_to_string() == string
+      end
+    end
+
     test "keyword arg with cursor" do
       input = "def foo, do: :bar, __cursor__()"
       expected = "def foo, [{:do, :bar}, __cursor__()]"


### PR DESCRIPTION
Closes #15724

`Macro.to_string/1` renders a trailing keyword list as do-end blocks as soon as its
first key is `do:`, regardless of what the remaining keys are. The output parses, but
it no longer means the same thing:

```elixir
Macro.to_string(quote do: for(cp <- gc, do: <<cp::utf8>>, into: ""))
```

```elixir
for cp <- gc do
  <<cp::utf8>>
into
  ""
end
```

`into` is parsed back as a bare variable, so the comprehension stops collecting into a
binary and the code does not compile.

The pre-`Code.Normalizer` implementation guarded on two conditions — the list starts
with `do:` **and** every key is a block keyword. It is still there, in the deprecated
`Macro.to_string/2` (`lib/elixir/lib/macro.ex:1534-1541`), and it still gets this
right:

```elixir
defp kw_blocks?([{:do, _} | _] = kw) do
  Enum.all?(kw, &match?({x, _} when x in unquote(kw_keywords), &1))
end
```

Only the first condition was carried over into `Code.Normalizer`. This restores the
second one under the same name, and applies it to **both** paths into
`normalize_kw_blocks/4`:

- the `Keyword.has_key?(meta, :do)` branch, reached when the AST already carries
  `do`/`end` metadata (what `Code.string_to_quoted(token_metadata: true)` produces, so
  tools that parse code and then add an option to a call hit it);
- the branch for keyword lists that are not yet normalized.

The metadata has to be dropped along with it. The formatter decides on do-end from
`meta?(meta, :do)` alone (`code/formatter.ex:1353`), so leaving `:do`/`:end` in place
would keep producing blocks no matter what the normalizer decided.

`@do_end_keywords` is the same list `Code.Formatter` uses for
`can_force_do_end_blocks?/2` (`code/formatter.ex:156`), and `macro.ex:1535` has a third
copy. **Should these be shared, or is the duplication fine?** `elixir_compiler.erl:237`
compiles `code/formatter.ex` before `code/normalizer.ex` and the normalizer already
depends on `Code.Formatter`, so sharing is possible — I did not want to add a public
function without asking.

## Verification

- New and extended tests in `code_normalizer/quoted_ast_test.exs` cover both
  directions and both paths: keyword lists with a non-block key stay keyword lists
  (including when `do`/`end` are in the metadata), and lists of only block keywords
  still render as do-end. They fail without the change.
- Full suite green: `make test` — elixir 7503, ex_unit 465, logger 165, eex 118,
  iex 289, mix 941.
- Running every `.ex`/`.exs` file under `lib/*/{lib,test}` (467 files, excluding mix test fixtures) through
  `parse |> Macro.to_string |> parse` and comparing ASTs: **63 files failed before,
  56 after**. The 7 fixed are `lib/elixir/lib/string.ex` and six Mix internals
  (`mix/state.ex`, `mix/project.ex`, `mix/dep.ex`, `mix/tasks/xref.ex`,
  `mix/compilers/protocol.ex`, `mix/compilers/test.ex`). One further file,
  `kernel/expansion_test.exs`, goes from unparseable to parseable. **No file
  regressed.** The remaining 56 are unrelated round-trip differences.

## Notes

- `mix format` is unaffected — `Code.format_string!/2` does not go through
  `Code.Normalizer`. The blast radius is `Macro.to_string/1` and
  `Code.quoted_to_algebra/2`.
- There is no regression in the other direction. `elixir_tokenizer.erl:1681-1684`
  tokenizes exactly `after`/`else`/`catch`/`rescue` as block keywords, so a list that
  should render as do-end cannot fall through to the keyword-list form.
- The output is not reordered: `for x <- y, do: x, into: ""` keeps the original key
  order even though `into:` before `do:` is the more idiomatic spelling. Reordering
  keys is out of scope here.
- With a multi-statement `do` body and a non-block key, the keyword-list form is
  verbose:
  ```elixir
  foo(
    do:
      (
        a()
        b()
      ),
    bar: 1
  )
  ```
  It is still better than the previous output, which did not parse back to the same AST.
- `code.ex:759-764` documents `:force_do_end_blocks` as converting "all keywords" into
  do-end blocks. That was already inaccurate for `Code.format_string!/2`; after this
  change it is also inaccurate for `Code.quoted_to_algebra/2`
  (`Code.quoted_to_algebra({:foo, [], [[do: 1, bar: 2]]}, force_do_end_blocks: true)`
  stays a keyword list). Happy to fix the doc here or in a separate PR.
- No CHANGELOG entry: the five previous normalizer fixes that changed
  `Macro.to_string/1` output (`09d43562e` #13924, `bc50d9494` #13250, `673fe4a89`
  #13905, `e54b87c18` #13960, `5b8b8e358` #15355) all shipped without one, and the old
  output here does not parse, so nothing could have depended on it.

Assisted-by: Claude Code:claude-opus-5
