### PR TITLE
Escape C1 control characters with Unicode escapes

### DIFF
--- a/lib/elixir/lib/code/identifier.ex
+++ b/lib/elixir/lib/code/identifier.ex
@@ -150,9 +150,14 @@ defmodule Code.Identifier do
     <<acc::binary, char::utf8>>
   end
 
-  defp escape_char(char, acc) when char < 0x100 do
+  defp escape_char(char, acc) when char < 0x80 do
     <<a::4, b::4>> = <<char::8>>
     <<acc::binary, ?\\, ?x, to_hex(a), to_hex(b)>>
+  end
+
+  defp escape_char(char, acc) when char < 0x100 do
+    <<a::4, b::4>> = <<char::8>>
+    <<acc::binary, ?\\, ?u, ?0, ?0, to_hex(a), to_hex(b)>>
   end
 
   defp escape_char(char, acc) when char < 0x10000 do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -1081,6 +1081,14 @@ defmodule MacroTest do
       end
     end
 
+    test "escapes C1 control characters without changing their encoding" do
+      for codepoint <- 0x80..0x9F do
+        string = <<codepoint::utf8>>
+        source = Macro.to_string(string)
+        assert {^string, []} = Code.eval_string(source)
+      end
+    end
+
     test "converts invalid AST with inspect" do
       assert Macro.to_string(1..3) == "1..3"
     end


### PR DESCRIPTION
C1 control characters (U+0080–U+009F) were escaped using `\xNN`.
Because `\xNN` represents a raw byte, converting valid UTF-8 strings with
`Macro.to_string/1` could change their encoding.

For example, U+0090 (`<<0xC2, 0x90>>`) was rendered as `"\x90"` and evaluated
back to the invalid UTF-8 byte `<<0x90>>`.

This change uses `\u00NN` for C1 control characters while retaining `\xNN`
for ASCII control bytes. It also adds a regression test covering the complete
U+0080–U+009F range.

Tests:
- `make format`
- `bin/elixir lib/elixir/test/elixir/macro_test.exs`
- `make test_stdlib`
- `bin/elixir lib/elixir/test/elixir/system_test.exs`

Assisted-by: Codex:GPT-5
