### PR TITLE
Optimize URI form and RFC 3986 query encoding with SWAR

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -168,8 +168,8 @@ defmodule URI do
   end
 
   defp encode_kv_pair({key, value}, :rfc3986) do
-    encode(Kernel.to_string(key), &char_unreserved?/1) <>
-      "=" <> encode(Kernel.to_string(value), &char_unreserved?/1)
+    encode_unreserved(Kernel.to_string(key), :percent) <>
+      "=" <> encode_unreserved(Kernel.to_string(value), :percent)
   end
 
   defp encode_kv_pair({key, value}, :www_form) do
@@ -340,6 +340,10 @@ defmodule URI do
     character in @reserved_characters
   end
 
+  defguardp unreserved_char?(character)
+            when character in ?0..?9 or character in ?a..?z or character in ?A..?Z or
+                   character in ~c"~_-."
+
   @doc """
   Checks if `character` is an unreserved one in a URI.
 
@@ -357,8 +361,51 @@ defmodule URI do
   """
   @spec char_unreserved?(byte) :: boolean
   def char_unreserved?(character) do
-    character in ?0..?9 or character in ?a..?z or character in ?A..?Z or character in ~c"~_-."
+    unreserved_char?(character)
   end
+
+  # A 56-bit word remains a small integer on 64-bit BEAM; using 64 bits would
+  # allocate a bignum for the range arithmetic below.
+  @swar_ones 0x01010101010101
+  @swar_mask80 0x80808080808080
+  @swar_threshold 7
+  @compile {:inline, encode_unreserved_byte: 2, hex: 1}
+
+  defmacrop swar_range(word, first, last) do
+    ge = @swar_ones * (0x80 - first)
+    gt = @swar_ones * (0x7F - last)
+
+    quote do
+      bxor(unquote(word) + unquote(ge), unquote(word) + unquote(gt))
+    end
+  end
+
+  # For a range [lo, hi], the high bit of
+  # `bxor(word + (0x80 - lo), word + (0x7F - hi))` is set in exactly the
+  # lanes inside the range. The ASCII check prevents carries between lanes.
+  # Punctuation uses ranges too, avoiding false positives from subtraction-
+  # based zero-byte detectors when a borrow crosses lanes.
+  defguardp unreserved_word?(word)
+            when band(word, @swar_mask80) == 0 and
+                   band(
+                     bor(
+                       bor(
+                         bor(
+                           swar_range(word, ?0, ?9),
+                           swar_range(word, ?A, ?Z)
+                         ),
+                         swar_range(word, ?a, ?z)
+                       ),
+                       bor(
+                         swar_range(word, ?-, ?.),
+                         bor(
+                           swar_range(word, ?_, ?_),
+                           swar_range(word, ?~, ?~)
+                         )
+                       )
+                     ),
+                     @swar_mask80
+                   ) == @swar_mask80
 
   @doc """
   Checks if `character` is allowed unescaped in a URI.
@@ -433,12 +480,132 @@ defmodule URI do
   """
   @spec encode_www_form(binary) :: binary
   def encode_www_form(string) when is_binary(string) do
-    for <<byte <- string>>, into: "" do
-      case percent(byte, &char_unreserved?/1) do
-        "%20" -> "+"
-        percent -> percent
-      end
+    encode_unreserved(string, :www_form)
+  end
+
+  defp encode_unreserved(string, mode) when byte_size(string) < @swar_threshold do
+    case string do
+      <<>> -> string
+      _ -> encode_unreserved_small(string, "", mode)
     end
+  end
+
+  defp encode_unreserved(string, mode), do: encode_unreserved(string, "", mode)
+
+  defp encode_unreserved_small(<<?\s, rest::binary>>, acc, :www_form) do
+    encode_unreserved_small(rest, <<acc::binary, ?+>>, :www_form)
+  end
+
+  defp encode_unreserved_small(<<byte, rest::binary>>, acc, mode)
+       when not unreserved_char?(byte) do
+    encode_unreserved_small(
+      rest,
+      <<acc::binary, ?%, hex(bsr(byte, 4)), hex(band(byte, 15))>>,
+      mode
+    )
+  end
+
+  defp encode_unreserved_small(<<byte, rest::binary>>, acc, mode) do
+    encode_unreserved_small(rest, <<acc::binary, byte>>, mode)
+  end
+
+  defp encode_unreserved_small(<<>>, acc, _mode), do: acc
+
+  defp encode_unreserved(<<?\s, rest::binary>>, acc, :www_form) do
+    encode_unreserved(rest, <<acc::binary, ?+>>, :www_form)
+  end
+
+  # Avoid the word guard when its first byte already makes failure certain.
+  defp encode_unreserved(<<byte, rest::binary>>, acc, mode)
+       when not unreserved_char?(byte) do
+    encode_unreserved(
+      rest,
+      <<acc::binary, ?%, hex(bsr(byte, 4)), hex(band(byte, 15))>>,
+      mode
+    )
+  end
+
+  # Seven bytes are checked with SWAR in each stride.
+  defp encode_unreserved(<<word::56, rest::binary>>, acc, mode)
+       when unreserved_word?(word) do
+    encode_unreserved(rest, <<acc::binary, word::56>>, mode)
+  end
+
+  defp encode_unreserved(<<_::56, _::binary>> = string, acc, mode) do
+    encode_unreserved_fallback(string, acc, mode)
+  end
+
+  defp encode_unreserved(<<>>, acc, _mode), do: acc
+
+  defp encode_unreserved(rest, acc, mode) do
+    encode_unreserved_small(rest, acc, mode)
+  end
+
+  # Consume through the first disallowed byte instead of checking overlapping words.
+  defp encode_unreserved_fallback(<<byte1, byte2, rest::binary>>, acc, mode)
+       when byte_size(rest) >= 5 and not unreserved_char?(byte2) do
+    encoded = encode_unreserved_byte(byte2, mode)
+    encode_unreserved(rest, <<acc::binary, byte1, encoded::binary>>, mode)
+  end
+
+  defp encode_unreserved_fallback(<<byte1, byte2, byte3, rest::binary>>, acc, mode)
+       when byte_size(rest) >= 4 and not unreserved_char?(byte3) do
+    encode_unreserved(
+      rest,
+      <<acc::binary, byte1, byte2, encode_unreserved_byte(byte3, mode)::binary>>,
+      mode
+    )
+  end
+
+  defp encode_unreserved_fallback(<<byte1, byte2, byte3, byte4, rest::binary>>, acc, mode)
+       when byte_size(rest) >= 3 and not unreserved_char?(byte4) do
+    encode_unreserved(
+      rest,
+      <<acc::binary, byte1, byte2, byte3, encode_unreserved_byte(byte4, mode)::binary>>,
+      mode
+    )
+  end
+
+  defp encode_unreserved_fallback(<<byte1, byte2, byte3, byte4, byte5, rest::binary>>, acc, mode)
+       when byte_size(rest) >= 2 and not unreserved_char?(byte5) do
+    encode_unreserved(
+      rest,
+      <<acc::binary, byte1, byte2, byte3, byte4, encode_unreserved_byte(byte5, mode)::binary>>,
+      mode
+    )
+  end
+
+  defp encode_unreserved_fallback(
+         <<byte1, byte2, byte3, byte4, byte5, byte6, rest::binary>>,
+         acc,
+         mode
+       )
+       when byte_size(rest) >= 1 and not unreserved_char?(byte6) do
+    encode_unreserved(
+      rest,
+      <<acc::binary, byte1, byte2, byte3, byte4, byte5,
+        encode_unreserved_byte(byte6, mode)::binary>>,
+      mode
+    )
+  end
+
+  defp encode_unreserved_fallback(
+         <<byte1, byte2, byte3, byte4, byte5, byte6, byte7, rest::binary>>,
+         acc,
+         mode
+       ) do
+    encode_unreserved(
+      rest,
+      <<acc::binary, byte1, byte2, byte3, byte4, byte5, byte6,
+        encode_unreserved_byte(byte7, mode)::binary>>,
+      mode
+    )
+  end
+
+  defp encode_unreserved_byte(?\s, :www_form), do: <<?+>>
+
+  defp encode_unreserved_byte(byte, _mode) do
+    <<?%, hex(bsr(byte, 4)), hex(band(byte, 15))>>
   end
 
   defp percent(char, predicate) do

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -20,6 +20,46 @@ defmodule URITest do
     assert URI.encode_www_form("4test ~1.x") == "4test+~1.x"
     assert URI.encode_www_form("poll:146%") == "poll%3A146%25"
     assert URI.encode_www_form("/\n+/ゆ") == "%2F%0A%2B%2F%E3%82%86"
+
+    boundary_input = :binary.copy("a /%+~_", 10)
+
+    for length <- [0, 1, 2, 3, 4, 5, 6, 7, 8, 62, 63, 64, 65] do
+      input = binary_part(boundary_input, 0, length)
+      assert URI.encode_www_form(input) == encode_www_form_reference(input)
+    end
+
+    safe_prefix = :binary.copy("a", 63)
+    safe = :binary.copy("a", 14)
+
+    for position <- 0..6, byte <- 0..255 do
+      <<prefix::binary-size(^position), _replaced, suffix::binary>> = safe
+      input = <<safe_prefix::binary, prefix::binary, byte, suffix::binary>>
+      assert URI.encode_www_form(input) == encode_www_form_reference(input)
+    end
+  end
+
+  defp encode_unreserved_reference(input) do
+    for <<byte <- input>>, into: "" do
+      if unreserved_reference?(byte) do
+        <<byte>>
+      else
+        "%" <> Base.encode16(<<byte>>)
+      end
+    end
+  end
+
+  defp encode_www_form_reference(input) do
+    for <<byte <- input>>, into: "" do
+      cond do
+        byte == ?\s -> "+"
+        unreserved_reference?(byte) -> <<byte>>
+        true -> "%" <> Base.encode16(<<byte>>)
+      end
+    end
+  end
+
+  defp unreserved_reference?(byte) do
+    byte in ?0..?9 or byte in ?a..?z or byte in ?A..?Z or byte in [?~, ?_, ?-, ?.]
   end
 
   test "encode_query/1,2" do
@@ -38,6 +78,25 @@ defmodule URITest do
 
     assert URI.encode_query([{"foo[]", "+=/?&# Ñ"}], :www_form) ==
              "foo%5B%5D=%2B%3D%2F%3F%26%23+%C3%91"
+
+    boundary_input = :binary.copy("a /%+~_", 10)
+
+    for length <- [0, 1, 2, 3, 4, 5, 6, 7, 8, 62, 63, 64, 65] do
+      input = binary_part(boundary_input, 0, length)
+      expected = encode_unreserved_reference(input)
+      assert URI.encode_query([{input, input}], :rfc3986) == expected <> "=" <> expected
+    end
+
+    safe_prefix = :binary.copy("a", 63)
+    word = :binary.copy("a", 7)
+
+    for position <- 0..6, byte <- 0..255 do
+      <<word_prefix::binary-size(^position), _replaced, word_suffix::binary>> = word
+      input = <<safe_prefix::binary, word_prefix::binary, byte, word_suffix::binary>>
+
+      assert URI.encode_query([{input, ""}], :rfc3986) ==
+               encode_unreserved_reference(input) <> "="
+    end
 
     assert_raise ArgumentError, fn ->
       URI.encode_query([{"foo", ~c"bar"}])


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT-5.6 Sol

Use a guarded 56-bit fast path with compact scalar tail handling and an isolated fallback scanner. Fast-path empty inputs before allocating the binary builder, and cover SWAR lane and length boundaries with focused differential tests.

@NelsonVides it would be great if you would review it.

Elixir Forum discussion: https://elixirforum.com/t/help-swar-optimize-uri-encode-www-form-1/76227

Benchmark:

```elixir
# Run this file from an Elixir checkout on both branches:
#
#     git switch main
#     bin/elixirc lib/elixir/lib/uri.ex -o lib/elixir/ebin
#     bin/elixir --erl "+S 1:1" bench.exs
#     git switch optimize-uri-unreserved-swar
#     bin/elixirc lib/elixir/lib/uri.ex -o lib/elixir/ebin
#     bin/elixir --erl "+S 1:1" bench.exs

Mix.install([{:benchee, "~> 1.5"}])

safe_70 = String.duplicate("abcdefg", 10)
mixed_70 = String.duplicate("abc /?~", 10)
safe_700 = String.duplicate(safe_70, 10)
mixed_700 = String.duplicate(mixed_70, 10)

inputs = %{
  "empty" => "",
  "safe, 6 bytes" => "abcdef",
  "safe, 7 bytes" => "abcdefg",
  "safe, 70 bytes" => safe_70,
  "mixed, 70 bytes" => mixed_70,
  "safe, 700 bytes" => safe_700,
  "mixed, 700 bytes" => mixed_700
}

{revision, 0} = System.cmd("git", ["rev-parse", "--short", "HEAD"])

IO.puts("""
Revision:     #{String.trim(revision)}
Elixir:       #{System.version()}
OTP:          #{:erlang.system_info(:otp_release)}
Architecture: #{:erlang.system_info(:system_architecture)}
Word size:    #{:erlang.system_info(:wordsize) * 8}-bit
""")

options = [
  inputs: inputs,
  time: 2,
  warmup: 1,
  memory_time: 1,
  reduction_time: 1,
  print: [fast_warning: false]
]

Benchee.run(
  %{"URI.encode_www_form/1" => &URI.encode_www_form/1},
  options
)

query_inputs =
  Map.new(inputs, fn {name, value} ->
    {name, [{"key", value}]}
  end)

Benchee.run(
  %{
    "URI.encode_query/2 (:rfc3986)" => fn query -> URI.encode_query(query, :rfc3986) end
  },
  Keyword.put(options, :inputs, query_inputs)
)
```

Average of medians from two alternating runs:
```txt
   Input                         Main     Branch    Speedup
  ━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━  ━━━━━━━━━  ━━━━━━━━━
   WWW empty                    60 ns      30 ns      2.00×
  ────────────────────────  ──────────  ─────────  ─────────
   WWW safe, 6 B               156 ns     100 ns      1.56×
  ────────────────────────  ──────────  ─────────  ─────────
   WWW safe, 7 B               171 ns      80 ns      2.13×
  ────────────────────────  ──────────  ─────────  ─────────
   WWW safe, 70 B             1.24 µs     201 ns      6.17×
  ────────────────────────  ──────────  ─────────  ─────────
   WWW mixed, 70 B            1.44 µs     521 ns      2.75×
  ────────────────────────  ──────────  ─────────  ─────────
   WWW safe, 700 B           12.52 µs    1.52 µs      8.26×
  ────────────────────────  ──────────  ─────────  ─────────
   WWW mixed, 700 B          14.48 µs    4.72 µs      3.07×
  ────────────────────────  ──────────  ─────────  ─────────
   RFC query empty             206 ns     120 ns      1.72×
  ────────────────────────  ──────────  ─────────  ─────────
   RFC query safe, 6 B         311 ns     211 ns      1.47×
  ────────────────────────  ──────────  ─────────  ─────────
   RFC query safe, 7 B         331 ns     191 ns      1.73×
  ────────────────────────  ──────────  ─────────  ─────────
   RFC query safe, 70 B       1.41 µs     316 ns      4.47×
  ────────────────────────  ──────────  ─────────  ─────────
   RFC query mixed, 70 B      1.47 µs     687 ns      2.14×
  ────────────────────────  ──────────  ─────────  ─────────
   RFC query safe, 700 B     12.77 µs    1.72 µs      7.44×
  ────────────────────────  ──────────  ─────────  ─────────
   RFC query mixed, 700 B    13.53 µs    5.44 µs      2.49×

  Allocation and reduction improvements are also substantial:

  - WWW safe 700 B: 16.51 KB → 104 B, 3.51K → 103 reductions.
  - WWW mixed 700 B: 16.51 KB → 104 B, 4.71K → 406 reductions.
  - RFC safe 700 B: 16.74 KB → 312 B, 3.54K → 121 reductions.
  ``` 
