### PR TITLE
Fix struct key malformed error message

### DIFF
--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -299,7 +299,7 @@ format_error({unknown_key_for_struct, Module, Key}) ->
   io_lib:format("unknown key ~ts for struct ~ts",
                 ['Elixir.Macro':to_string(Key), elixir_aliases:inspect(Module)]);
 format_error({invalid_key_for_struct, Key}) ->
-  io_lib:format("invalid key ~ts for struct, struct keys must be atoms, got: ",
+  io_lib:format("invalid key for struct, struct keys must be atoms, got: ~ts",
                 ['Elixir.Macro':to_string(Key)]);
 format_error(ignored_struct_key_in_struct) ->
   "key :__struct__ is ignored when using structs".

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -659,13 +659,16 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "invalid keys in structs" do
-      assert_compile_error(~r"invalid key :erlang\.\+\(1, 2\) for struct", fn ->
-        expand(
-          quote do
-            %User{(1 + 2) => :my_value}
-          end
-        )
-      end)
+      assert_compile_error(
+        "invalid key for struct, struct keys must be atoms, got: :erlang.+(1, 2)",
+        fn ->
+          expand(
+            quote do
+              %User{(1 + 2) => :my_value}
+            end
+          )
+        end
+      )
     end
 
     test "unknown key in structs" do


### PR DESCRIPTION
## Current 
produces an inconsistent (poorly formatted) error messages when passing non-atom keys to a struct:

```
iex> %URI{"port" => 80}
error: invalid key "port" for struct, struct keys must be atoms, got:
```

## Expected 
message like:
```
error: invalid key for struct, struct keys must be atoms, got: "port"
```

## Changes
 - fix error format
 - tighten test