### PR TITLE
Optimize URI.encode_www_form/1 and RFC 3986 query encoding

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -168,8 +168,8 @@ defmodule URI do
   end
 
   defp encode_kv_pair({key, value}, :rfc3986) do
-    encode(Kernel.to_string(key), &char_unreserved?/1) <>
-      "=" <> encode(Kernel.to_string(value), &char_unreserved?/1)
+    encode_unreserved(Kernel.to_string(key), :percent) <>
+      "=" <> encode_unreserved(Kernel.to_string(value), :percent)
   end
 
   defp encode_kv_pair({key, value}, :www_form) do
@@ -340,6 +340,10 @@ defmodule URI do
     character in @reserved_characters
   end
 
+  defguardp unreserved_char?(character)
+            when character in ?0..?9 or character in ?a..?z or character in ?A..?Z or
+                   character in ~c"~_-."
+
   @doc """
   Checks if `character` is an unreserved one in a URI.
 
@@ -357,7 +361,7 @@ defmodule URI do
   """
   @spec char_unreserved?(byte) :: boolean
   def char_unreserved?(character) do
-    character in ?0..?9 or character in ?a..?z or character in ?A..?Z or character in ~c"~_-."
+    unreserved_char?(character)
   end
 
   @doc """
@@ -432,14 +436,30 @@ defmodule URI do
 
   """
   @spec encode_www_form(binary) :: binary
+  def encode_www_form(<<>>), do: ""
+
   def encode_www_form(string) when is_binary(string) do
-    for <<byte <- string>>, into: "" do
-      case percent(byte, &char_unreserved?/1) do
-        "%20" -> "+"
-        percent -> percent
-      end
-    end
+    encode_unreserved(string, "", :www_form)
   end
+
+  # Matching upfront keeps the empty case from allocating the accumulator.
+  defp encode_unreserved(<<>>, _mode), do: ""
+
+  defp encode_unreserved(string, mode), do: encode_unreserved(string, "", mode)
+
+  defp encode_unreserved(<<?\s, rest::binary>>, acc, :www_form) do
+    encode_unreserved(rest, <<acc::binary, ?+>>, :www_form)
+  end
+
+  defp encode_unreserved(<<byte, rest::binary>>, acc, mode) when unreserved_char?(byte) do
+    encode_unreserved(rest, <<acc::binary, byte>>, mode)
+  end
+
+  defp encode_unreserved(<<byte, rest::binary>>, acc, mode) do
+    encode_unreserved(rest, <<acc::binary, ?%, hex(bsr(byte, 4)), hex(band(byte, 15))>>, mode)
+  end
+
+  defp encode_unreserved(<<>>, acc, _mode), do: acc
 
   defp percent(char, predicate) do
     if predicate.(char) do

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -17,9 +17,34 @@ defmodule URITest do
   end
 
   test "encode_www_form/1" do
+    assert URI.encode_www_form("") == ""
     assert URI.encode_www_form("4test ~1.x") == "4test+~1.x"
     assert URI.encode_www_form("poll:146%") == "poll%3A146%25"
     assert URI.encode_www_form("/\n+/ゆ") == "%2F%0A%2B%2F%E3%82%86"
+
+    for byte <- 0..255, input <- [<<byte>>, <<?a, byte, ?z>>] do
+      assert URI.encode_www_form(input) == www_form_reference(input)
+    end
+  end
+
+  defp www_form_reference(input) do
+    for <<byte <- input>>, into: "" do
+      cond do
+        byte == ?\s -> "+"
+        unreserved_reference?(byte) -> <<byte>>
+        true -> "%" <> Base.encode16(<<byte>>)
+      end
+    end
+  end
+
+  defp rfc3986_reference(input) do
+    for <<byte <- input>>, into: "" do
+      if unreserved_reference?(byte), do: <<byte>>, else: "%" <> Base.encode16(<<byte>>)
+    end
+  end
+
+  defp unreserved_reference?(byte) do
+    byte in ?0..?9 or byte in ?a..?z or byte in ?A..?Z or byte in ~c"~_-."
   end
 
   test "encode_query/1,2" do
@@ -38,6 +63,11 @@ defmodule URITest do
 
     assert URI.encode_query([{"foo[]", "+=/?&# Ñ"}], :www_form) ==
              "foo%5B%5D=%2B%3D%2F%3F%26%23+%C3%91"
+
+    for byte <- 0..255, input <- [<<byte>>, <<?a, byte, ?z>>] do
+      expected = rfc3986_reference(input)
+      assert URI.encode_query([{input, input}], :rfc3986) == expected <> "=" <> expected
+    end
 
     assert_raise ArgumentError, fn ->
       URI.encode_query([{"foo", ~c"bar"}])


### PR DESCRIPTION
Split out of #15733 — the loop rewrite only, without the SWAR fast path, details in the commit message.

Benchmark results, OTP 29 / MacBook M4:

| Input | `encode_www_form/1` | rfc3986 encoding |
|---|---|---|
| empty | 63.9 → 6.3 · 10.15× | 66.2 → 6.6 · 10.07× |
| safe, 6 B | 191.4 → 96.4 · 1.98× | 169.3 → 95.4 · 1.77× |
| safe, 70 B | 1422 → 376 · 3.78× | 1126 → 372 · 3.02× |
| mixed, 70 B | 1866 → 556 · 3.36× | 1594 → 622 · 2.56× |
| safe, 700 B | 16187 → 3268 · 4.95× | 11521 → 3275 · 3.52× |
| mixed, 700 B | 19337 → 4938 · 3.92× | 16170 → 5933 · 2.73× |

Allocation is now flat regardless of input size: 1.74 KB -> 104 B at 70 bytes, 16.51 KB -> 104 B at 700 bytes, and 104 B -> 0 B for empty. Reductions 3.51 K -> 0.70 K (safe 700 B).

Benchmark, Claude generated:
```exs
Mix.install([{:benchee, "~> 1.5"}])

defmodule Old do
  ...
end

defmodule New do
  ...
end

safe_70 = String.duplicate("abcdefg", 10)
mixed_70 = String.duplicate("abc /?~", 10)

inputs = %{
  "empty" => "",
  "safe, 6 bytes" => "abcdef",
  "safe, 7 bytes" => "abcdefg",
  "safe, 70 bytes" => safe_70,
  "mixed, 70 bytes" => mixed_70,
  "safe, 700 bytes" => String.duplicate(safe_70, 10),
  "mixed, 700 bytes" => String.duplicate(mixed_70, 10)
}

options = [
  inputs: inputs,
  time: 3,
  warmup: 1,
  memory_time: 1,
  reduction_time: 1,
  print: [fast_warning: false]
]

IO.puts("\n=== encode_www_form/1 ===\n")

Benchee.run(
  %{
    "old (comprehension)" => &Old.encode_www_form/1,
    "new (tail-recursive loop)" => &New.encode_www_form/1
  },
  options
)

IO.puts("\n=== rfc3986 unreserved encoding (per key/value in encode_query/2) ===\n")

Benchee.run(
  %{
    "old (comprehension)" => &Old.encode_rfc3986/1,
    "new (tail-recursive loop)" => &New.encode_rfc3986/1
  },
  options
)
```