### PR TITLE
Fix Task.yield_many/2 waits too long or forever when :limit exceeds task count

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -1248,9 +1248,10 @@ defmodule Task do
         {ref, nil}
       end)
 
+    ref_count = map_size(refs)
     on_timeout = Keyword.get(opts, :on_timeout, :nothing)
     timeout = Keyword.get(opts, :timeout, 5_000)
-    limit = Keyword.get(opts, :limit, map_size(refs))
+    limit = min(Keyword.get(opts, :limit, ref_count), ref_count)
     timeout_ref = make_ref()
 
     timer_ref =

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -630,6 +630,21 @@ defmodule TaskTest do
                [{task2, nil}, {task3, {:exit, :normal}}]
     end
 
+    test "returns once all tasks have replied" do
+      parent = self()
+
+      pid =
+        spawn(fn ->
+          task = Task.async(fn -> :done end)
+          result = Task.yield_many([task], limit: 2, timeout: :infinity)
+          send(parent, {self(), result})
+        end)
+
+      on_exit(fn -> Process.exit(pid, :kill) end)
+
+      assert_receive {^pid, [{%Task{}, {:ok, :done}}]}, 500
+    end
+
     test "returns results from multiple tasks with limit and on timeout" do
       Process.flag(:trap_exit, true)
       task1 = Task.async(fn -> Process.sleep(:infinity) end)

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -630,7 +630,7 @@ defmodule TaskTest do
                [{task2, nil}, {task3, {:exit, :normal}}]
     end
 
-    test "returns once all tasks have replied" do
+    test "returns once all tasks have replied below limit" do
       parent = self()
 
       pid =


### PR DESCRIPTION
`Task.yield_many/2` waits until timeout/forever when `:limit` exceeds number of unique tasks.

Examples:

```elixir
task = Task.completed(:ok)

Task.yield_many(
  [task, task],
  limit: 2,
  timeout: :infinity
)
# waits forever, unique task count is lower than limit
```


```elixir
task = Task.async(fn -> :done end)

Task.yield_many(
  [task],
  limit: 2,
  timeout: 15_000
)
# waits 15 secs, instead of returning immediately
```


The fix is to clamp limit to the number of unique task refs so the function returns as soon as all tasks have been completed.