### PR TITLE
Optimize EEx fn block detection

### DIFF
--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -209,11 +209,8 @@ defmodule EEx.Compiler do
       {[{:end, _} | _], [{:stab_op, _, _} | _]} ->
         {:middle_expr, expr, %{}}
 
-      {_, [{:stab_op, _, _} | reverse_tokens]} ->
-        fn_index = Enum.find_index(reverse_tokens, &match?({:fn, _}, &1)) || :infinity
-        end_index = Enum.find_index(reverse_tokens, &match?({:end, _}, &1)) || :infinity
-
-        if end_index > fn_index do
+      {_, [{:stab_op, _, _} | rev_tokens]} ->
+        if fn_before_end?(rev_tokens) do
           {:start_expr, expr, %{}}
         else
           {:middle_expr, expr, %{}}
@@ -226,6 +223,11 @@ defmodule EEx.Compiler do
         end
     end
   end
+
+  defp fn_before_end?([{:fn, _} | _]), do: true
+  defp fn_before_end?([{:end, _} | _]), do: false
+  defp fn_before_end?([_ | rev_tokens]), do: fn_before_end?(rev_tokens)
+  defp fn_before_end?([]), do: false
 
   defp drop_eol([{:eol, _} | rest]), do: drop_eol(rest)
   defp drop_eol(rest), do: rest


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT-5.6 Sol

Scan reversed tokens once to identify whether a stab expression starts an anonymous function block.

Bench:
```elixir
Mix.install([{:benchee, "~> 1.3"}])

defmodule FnBlockBench do
  def old(tokens) do
    fn_index = Enum.find_index(tokens, &match?({:fn, _}, &1)) || :infinity
    end_index = Enum.find_index(tokens, &match?({:end, _}, &1)) || :infinity
    end_index > fn_index
  end

  def new([{:fn, _} | _]), do: true
  def new([{:end, _} | _]), do: false
  def new([_ | tokens]), do: new(tokens)
  def new([]), do: false
end

token = {:identifier, {1, 1, nil}, :value}

inputs =
  Map.new([10, 100, 1_000], fn size ->
    {"#{size} preceding tokens", [token, {:fn, {1, 1, nil}} | List.duplicate(token, size)]}
  end)

Benchee.run(
  %{"old" => &FnBlockBench.old/1, "new" => &FnBlockBench.new/1},
  inputs: inputs,
  time: 2,
  warmup: 1
)
```

```txt
   Preceding tokens          New          Old    Difference
  ━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━━━━━
                 10     28.47 ns    135.09 ns         4.75×
  ──────────────────  ───────────  ───────────  ────────────
                100     27.01 ns    719.61 ns        26.64×
  ──────────────────  ───────────  ───────────  ────────────
              1,000    0.0308 μs      6.62 μs       215.23×
```