### PR TITLE
Fix Date.to_iso8601/2 loses :format with custom calendar

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -422,7 +422,7 @@ defmodule Date do
   def to_iso8601(%{calendar: _} = date, format) when format in [:basic, :extended] do
     date
     |> convert!(Calendar.ISO)
-    |> to_iso8601()
+    |> to_iso8601(format)
   end
 
   @doc """

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -38,6 +38,16 @@ defmodule DateTest do
     end
   end
 
+  test "to_iso8601/2" do
+    date = ~D[2000-01-01]
+    assert Date.to_iso8601(date) == "2000-01-01"
+    assert Date.to_iso8601(date, :basic) == "20000101"
+
+    holo_date = Calendar.Holocene.date(12001, 1, 1)
+    assert Date.to_iso8601(holo_date) == "2001-01-01"
+    assert Date.to_iso8601(holo_date, :basic) == "20010101"
+  end
+
   test "to_string/1" do
     date = ~D[2000-01-01]
     assert to_string(date) == "2000-01-01"


### PR DESCRIPTION
`Date.to_iso8601/2` loses :format for date with non-ISO calendar

## Current

```elixir
iex> date = Calendar.Holocene.date(12001, 1, 1)
~D[12001-01-01 Calendar.Holocene]

iex> Date.to_iso8601(date, :extended)
"2001-01-01"
iex> Date.to_iso8601(date, :basic)
"2001-01-01"
```

## Expected

```elixir
iex> Date.to_iso8601(date, :basic)
"20010101"
```

## Changes
- preserve format fix
- tests added