### PR TITLE
Optimize URI.append_query field access

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -1059,11 +1059,11 @@ defmodule URI do
     %{uri | query: query}
   end
 
-  def append_query(%URI{} = uri, query) when is_binary(query) do
-    if String.ends_with?(uri.query, "&") do
-      %{uri | query: uri.query <> query}
+  def append_query(%URI{query: current} = uri, query) when is_binary(query) do
+    if String.ends_with?(current, "&") do
+      %{uri | query: current <> query}
     else
-      %{uri | query: uri.query <> "&" <> query}
+      %{uri | query: current <> "&" <> query}
     end
   end
 


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT-5.6 Sol

Bind the current query in the function head so generated code can reuse the field instead of emitting repeated dynamic access paths.


