### PR TITLE
Make formatter plugins which target .ex/.exs run alongside (not "instead of") standard formatting and other plugins which target sigils.

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -703,19 +703,25 @@ defmodule Mix.Tasks.Format do
   defp find_formatter_for_file(file, formatter_opts) do
     ext = Path.extname(file)
 
+    base_formatter =
+      cond do
+        ext in ~w(.ex .exs) ->
+          &elixir_format(&1, [file: file] ++ formatter_opts)
+
+        true ->
+          & &1
+      end
+
     cond do
       plugins = find_plugins_for_extension(formatter_opts, ext) ->
         fn input ->
-          Enum.reduce(plugins, input, fn plugin, input ->
+          Enum.reduce(plugins, base_formatter.(input), fn plugin, input ->
             plugin.format(input, [extension: ext, file: file] ++ formatter_opts)
           end)
         end
 
-      ext in ~w(.ex .exs) ->
-        &elixir_format(&1, [file: file] ++ formatter_opts)
-
       true ->
-        & &1
+        base_formatter
     end
   end
 

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -572,6 +572,125 @@ defmodule Mix.Tasks.FormatTest do
     end)
   end
 
+  defmodule Elixir.ExtensionExDoubleNewlinePlugin do
+    @behaviour Mix.Tasks.Format
+
+    def features(opts) do
+      assert opts[:from_formatter_exs] == :yes
+      [extensions: ~w(.ex .exs), sigils: []]
+    end
+
+    def format(contents, opts) do
+      assert opts[:from_formatter_exs] == :yes
+      assert opts[:extension] == ".ex"
+      assert opts[:file] =~ ~r/\/a\.ex$/
+      contents |> String.split("\n") |> Enum.join("\n\n")
+    end
+  end
+
+  defmodule Elixir.ExtensionExUpcasePlugin do
+    @behaviour Mix.Tasks.Format
+
+    def features(opts) do
+      assert opts[:from_formatter_exs] == :yes
+      [extensions: ~w(.ex .exs), sigils: []]
+    end
+
+    def format(contents, opts) do
+      assert opts[:from_formatter_exs] == :yes
+      assert opts[:extension] == ".ex"
+      assert opts[:file] =~ ~r/\/a\.ex$/
+      String.upcase(contents)
+    end
+  end
+
+  test "uses plugin from .formatter.exs which targets .ex files, after standard Elixir code formatting",
+       context do
+    in_tmp(context.test, fn ->
+      File.write!(".formatter.exs", """
+      [
+        inputs: ["a.ex"],
+        plugins: [ExtensionExUpcasePlugin],
+        from_formatter_exs: :yes
+      ]
+      """)
+
+      File.write!("a.ex", """
+      def   sigil_test( assigns  )  do
+        ~W"foo bar baz"abc
+      end
+      """)
+
+      Mix.Tasks.Format.run([])
+
+      assert File.read!("a.ex") == """
+             DEF SIGIL_TEST(ASSIGNS) DO
+               ~W"FOO BAR BAZ"ABC
+             END
+             """
+    end)
+  end
+
+  test "uses multiple plugins from .formatter.exs which target .ex files, after standard Elixir code formatting",
+       context do
+    in_tmp(context.test, fn ->
+      File.write!(".formatter.exs", """
+      [
+        inputs: ["a.ex"],
+        plugins: [ExtensionExDoubleNewlinePlugin, ExtensionExUpcasePlugin],
+        from_formatter_exs: :yes
+      ]
+      """)
+
+      File.write!("a.ex", """
+      def  sigil_test(assigns  )    do
+        ~W"foo bar baz"abc
+      end
+      """)
+
+      Mix.Tasks.Format.run([])
+
+      assert File.read!("a.ex") == """
+             DEF SIGIL_TEST(ASSIGNS) DO
+
+               ~W"FOO BAR BAZ"ABC
+
+             END
+
+             """
+    end)
+  end
+
+  test "uses multiple plugins from .formatter.exs which target both .ex files and sigils within them, after standard Elixir code formatting",
+       context do
+    in_tmp(context.test, fn ->
+      File.write!(".formatter.exs", """
+      [
+        inputs: ["a.ex"],
+        plugins: [ExtensionExDoubleNewlinePlugin, SigilWPlugin, NewlineToDotPlugin, ExtensionExUpcasePlugin],
+        from_formatter_exs: :yes
+      ]
+      """)
+
+      File.write!("a.ex", """
+      def sigil_test(   assigns)  do
+        ~W"foo bar baz"abc
+      end
+      """)
+
+      Mix.Tasks.Format.run([])
+
+      assert File.read!("a.ex") == """
+             DEF SIGIL_TEST(ASSIGNS) DO
+
+               ~W"FOO.BAR.BAZ"ABC
+
+             END
+
+             """
+    end)
+  end
+
   defmodule Elixir.SigilOuterPlugin do
     @behaviour Mix.Tasks.Format
 


### PR DESCRIPTION
**Expected behavior**
- When a mix format plugin is used which specifies `.ex`/`.exs` file extensions, plugin formatting is run *after* standard `mix format` formatting for those files.
- When mix format plugin A is used which specifies `.ex`/`.exs` file extensions, alongside plugin B which specifies sigils within those files, 
    - formatting from A is applied to the whole file
    - formatting from both A and B are applied to sigils specified by B (in order of `plugins` list in `.formatter.exs`)

**Observed behavior**
- When a mix format plugin is used which targets `.ex`/`.exs` file extensions, standard `mix format` formatting is not applied to those files.
- When mix format plugin A is used which targets `.ex`/`.exs` file extensions, alongside plugin B which targets sigils within those files, 
    - formatting from A is applied to the whole file
    - formatting from B is not applied at all (to sigils within `.ex`/`.exs` files)

---

Working with some mix format plugins, I noticed that a plugin targeting `.ex` files would cause a second plugin targeting `~H"""..."""` sigils to not format them at all. After looking into `format.ex`, it seems like this is because of the current implementation of [find_formatter_for_file](https://github.com/elixir-lang/elixir/blob/main/lib/mix/lib/mix/tasks/format.ex#L703) which has a cond with three branches:
```elixir
    cond do
      plugins = find_plugins_for_extension(formatter_opts, ext) ->
        fn input ->
          Enum.reduce(plugins, input, fn plugin, input ->
            plugin.format(input, [extension: ext, file: file] ++ formatter_opts)
          end)
        end

      ext in ~w(.ex .exs) ->
        &elixir_format(&1, [file: file] ++ formatter_opts)

      true ->
        & &1
    end
```
It looks like sigil formatting happens during `elixir_format`, which iiuc won't run at all if a plugin is found for an `.ex` or `.exs` file matching the first case of this `cond`. Because of this, it seems that sigil-targeting plugins won't run at all for files where another plugin was found targeting `.ex` or `.exs`. I think it also means standard elixir formatting won't run on `.ex`/`.exs` files if a plugin targets them. These interpretations seem to be verified by the three tests cases in [12a14ef](https://github.com/elixir-lang/elixir/pull/15742/commits/12a14ef6952004564c7a8a5e4e725c5059f523c3) which fail prior to the fix.

Perhaps this is all intentional behavior? I found it a bit surprising, and didn't see mention of it at https://mix.hexdocs.pm/main/Mix.Tasks.Format.html#plugins, but happy to simply be informed here as well!

Using this command to run the three test cases:
```sh
bin/elixirc lib/mix/lib/mix/tasks/format.ex -o lib/elixir/ebin && LINE=607 bin/elixir lib/mix/test/mix/tasks/format_test.exs; LINE=634 bin/elixir lib/mix/test/mix/tasks/format_test.exs; LINE=664 bin/elixir lib/mix/test/mix/tasks/format_test.exs
```
Now, I can't help but add something you've likely heard many times before: Elixir has been (and continues to be) a joy to work with, thank you for all your labors making it the wonderful set of tools it is today.



