### PR TITLE
Optimize String prefix and suffix list matching

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2768,9 +2768,8 @@ defmodule String do
     starts_with_string?(string, byte_size(string), prefix)
   end
 
-  def starts_with?(string, prefix) when is_binary(string) and is_list(prefix) do
-    string_size = byte_size(string)
-    Enum.any?(prefix, &starts_with_string?(string, string_size, &1))
+  def starts_with?(string, prefixes) when is_binary(string) and is_list(prefixes) do
+    starts_with_any?(prefixes, string, byte_size(string))
   end
 
   def starts_with?(string, prefix) when is_binary(string) do
@@ -2788,6 +2787,13 @@ defmodule String do
       false
     end
   end
+
+  defp starts_with_any?([prefix | prefixes], string, string_size) do
+    starts_with_string?(string, string_size, prefix) or
+      starts_with_any?(prefixes, string, string_size)
+  end
+
+  defp starts_with_any?([], _string, _string_size), do: false
 
   @doc """
   Returns `true` if `string` ends with any of the suffixes given.
@@ -2816,9 +2822,8 @@ defmodule String do
     ends_with_string?(string, byte_size(string), suffix)
   end
 
-  def ends_with?(string, suffix) when is_binary(string) and is_list(suffix) do
-    string_size = byte_size(string)
-    Enum.any?(suffix, &ends_with_string?(string, string_size, &1))
+  def ends_with?(string, suffixes) when is_binary(string) and is_list(suffixes) do
+    ends_with_any?(suffixes, string, byte_size(string))
   end
 
   @compile {:inline, ends_with_string?: 3}
@@ -2831,6 +2836,13 @@ defmodule String do
       false
     end
   end
+
+  defp ends_with_any?([suffix | suffixes], string, string_size) do
+    ends_with_string?(string, string_size, suffix) or
+      ends_with_any?(suffixes, string, string_size)
+  end
+
+  defp ends_with_any?([], _string, _string_size), do: false
 
   @doc """
   Checks if `string` matches the given regular expression.


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT-5.6 Sol

Avoid allocating captured functions and dispatching through Enum.any?/2 when matching lists of prefixes or suffixes. Use specialized tail-recursive helpers so the binary comparison remains inlined.

Bench:
```elixir
Mix.install([{:benchee, "~> 1.3"}])

defmodule Old do
  @compile {:inline, starts_with_string?: 3}

  def starts_with?(string, prefix) when is_binary(string) and is_binary(prefix) do
    starts_with_string?(string, byte_size(string), prefix)
  end

  def starts_with?(string, prefixes) when is_binary(string) and is_list(prefixes) do
    string_size = byte_size(string)
    Enum.any?(prefixes, &starts_with_string?(string, string_size, &1))
  end

  defp starts_with_string?(string, string_size, prefix) when is_binary(prefix) do
    prefix_size = byte_size(prefix)

    if prefix_size <= string_size do
      prefix == binary_part(string, 0, prefix_size)
    else
      false
    end
  end

  @compile {:inline, ends_with_string?: 3}

  def ends_with?(string, suffix) when is_binary(string) and is_binary(suffix) do
    ends_with_string?(string, byte_size(string), suffix)
  end

  def ends_with?(string, suffixes) when is_binary(string) and is_list(suffixes) do
    string_size = byte_size(string)
    Enum.any?(suffixes, &ends_with_string?(string, string_size, &1))
  end

  defp ends_with_string?(string, string_size, suffix) when is_binary(suffix) do
    suffix_size = byte_size(suffix)

    if suffix_size <= string_size do
      suffix == binary_part(string, string_size - suffix_size, suffix_size)
    else
      false
    end
  end
end

defmodule New do
  @compile {:inline, starts_with_string?: 3}

  def starts_with?(string, prefix) when is_binary(string) and is_binary(prefix) do
    starts_with_string?(string, byte_size(string), prefix)
  end

  def starts_with?(string, prefixes) when is_binary(string) and is_list(prefixes) do
    starts_with_any?(prefixes, string, byte_size(string))
  end

  defp starts_with_string?(string, string_size, prefix) when is_binary(prefix) do
    prefix_size = byte_size(prefix)

    if prefix_size <= string_size do
      prefix == binary_part(string, 0, prefix_size)
    else
      false
    end
  end

  defp starts_with_any?([prefix | prefixes], string, string_size) do
    starts_with_string?(string, string_size, prefix) or
      starts_with_any?(prefixes, string, string_size)
  end

  defp starts_with_any?([], _string, _string_size), do: false

  @compile {:inline, ends_with_string?: 3}

  def ends_with?(string, suffix) when is_binary(string) and is_binary(suffix) do
    ends_with_string?(string, byte_size(string), suffix)
  end

  def ends_with?(string, suffixes) when is_binary(string) and is_list(suffixes) do
    ends_with_any?(suffixes, string, byte_size(string))
  end

  defp ends_with_string?(string, string_size, suffix) when is_binary(suffix) do
    suffix_size = byte_size(suffix)

    if suffix_size <= string_size do
      suffix == binary_part(string, string_size - suffix_size, suffix_size)
    else
      false
    end
  end

  defp ends_with_any?([suffix | suffixes], string, string_size) do
    ends_with_string?(string, string_size, suffix) or
      ends_with_any?(suffixes, string, string_size)
  end

  defp ends_with_any?([], _string, _string_size), do: false
end

defmodule Inputs do
  @string String.duplicate("abcdefgh", 128)
  @candidate_counts [1, 10, 100, 1_000]
  @match_positions [:first, :middle, :last, :none]

  def starts_with do
    build(binary_part(@string, 0, 32))
  end

  def ends_with do
    build(binary_part(@string, byte_size(@string) - 32, 32))
  end

  defp build(match) do
    inputs =
      for count <- @candidate_counts,
          position <- @match_positions,
          not (count == 1 and position in [:middle, :last]),
          into: %{} do
        candidates =
          for index <- 1..count do
            "x" <> String.pad_leading(Integer.to_string(index), 31, "0")
          end

        candidates = put_match(candidates, match, position)
        {"#{count} candidates, #{position}", {@string, candidates}}
      end

    Map.put(inputs, "0 candidates, none", {@string, []})
  end

  defp put_match(candidates, match, :first), do: List.replace_at(candidates, 0, match)

  defp put_match(candidates, match, :middle),
    do: List.replace_at(candidates, div(length(candidates), 2), match)

  defp put_match(candidates, match, :last), do: List.replace_at(candidates, -1, match)
  defp put_match(candidates, _match, :none), do: candidates
end

options = [time: 1, warmup: 1, memory_time: 0, reduction_time: 0]
starts_with_inputs = Inputs.starts_with()
ends_with_inputs = Inputs.ends_with()

Enum.each(starts_with_inputs, fn {_name, {string, prefixes}} ->
  true = Old.starts_with?(string, prefixes) == New.starts_with?(string, prefixes)
end)

Enum.each(ends_with_inputs, fn {_name, {string, suffixes}} ->
  true = Old.ends_with?(string, suffixes) == New.ends_with?(string, suffixes)
end)

IO.puts("\nString.starts_with?/2 with a list of prefixes\n")

Benchee.run(
  %{
    "old (Enum.any?/2)" => fn {string, prefixes} -> Old.starts_with?(string, prefixes) end,
    "new (recursive helper)" => fn {string, prefixes} -> New.starts_with?(string, prefixes) end
  },
  Keyword.put(options, :inputs, starts_with_inputs)
)

IO.puts("\nString.ends_with?/2 with a list of suffixes\n")

Benchee.run(
  %{
    "old (Enum.any?/2)" => fn {string, suffixes} -> Old.ends_with?(string, suffixes) end,
    "new (recursive helper)" => fn {string, suffixes} -> New.ends_with?(string, suffixes) end
  },
  Keyword.put(options, :inputs, ends_with_inputs)
)
```

Results:
<!--
  SPDX-License-Identifier: Apache-2.0
  SPDX-FileCopyrightText: 2021 The Elixir Team
-->


## Results

Times are the arithmetic mean reported by Benchee. Speedup is the old mean
divided by the new mean, so higher values favor the recursive helper.

| Candidates | Match | `starts_with?` old | `starts_with?` new | Speedup | `ends_with?` old | `ends_with?` new | Speedup |
|---:|:---|---:|---:|---:|---:|---:|---:|
| 0 | none | 46.06 ns | 29.66 ns | **1.55x** | 45.30 ns | 31.81 ns | **1.42x** |
| 1 | first | 87.83 ns | 49.06 ns | **1.79x** | 64.61 ns | 50.31 ns | **1.28x** |
| 1 | none | 93.61 ns | 50.13 ns | **1.87x** | 72.02 ns | 50.54 ns | **1.43x** |
| 10 | first | 87.85 ns | 53.75 ns | **1.63x** | 65.23 ns | 54.52 ns | **1.20x** |
| 10 | middle | 197.79 ns | 139.92 ns | **1.41x** | 198.11 ns | 141.98 ns | **1.40x** |
| 10 | last | 288.82 ns | 208.76 ns | **1.38x** | 289.40 ns | 210.41 ns | **1.38x** |
| 10 | none | 277.42 ns | 245.49 ns | **1.13x** | 258.05 ns | 248.70 ns | **1.04x** |
| 100 | first | 87.83 ns | 61.10 ns | **1.44x** | 65.08 ns | 59.80 ns | **1.09x** |
| 100 | middle | 1.18 us | 1.05 us | **1.13x** | 1.22 us | 1.03 us | **1.19x** |
| 100 | last | 2.20 us | 1.99 us | **1.11x** | 2.28 us | 2.00 us | **1.14x** |
| 100 | none | 2.24 us | 1.95 us | **1.15x** | 2.28 us | 1.94 us | **1.18x** |
| 1,000 | first | 84.79 ns | 51.84 ns | **1.64x** | 62.98 ns | 51.75 ns | **1.22x** |
| 1,000 | middle | 10.63 us | 9.09 us | **1.17x** | 10.90 us | 9.50 us | **1.15x** |
| 1,000 | last | 21.15 us | 18.62 us | **1.14x** | 21.86 us | 18.67 us | **1.17x** |
| 1,000 | none | 21.06 us | 18.40 us | **1.14x** | 21.78 us | 18.39 us | **1.18x** |


