### PR TITLE
Fix defdelegate self-recusion check

### DIFF
--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -30,11 +30,17 @@ defmodule Kernel.Utils do
   """
   def defdelegate_all(funs, opts, env) do
     to = Keyword.get(opts, :to) || raise ArgumentError, "expected to: to be given as argument"
-    as = Keyword.get(opts, :as)
 
-    if to == env.module and is_nil(as) do
-      raise ArgumentError,
-            "defdelegate function is calling itself, which will lead to an infinite loop. You should either change the value of the :to option or specify the :as option"
+    if to == env.module do
+      # TODO: Remove List.wrap when multiple funs are no longer supported
+      Enum.each(List.wrap(funs), fn fun ->
+        {name, _args, as, _as_args} = defdelegate_each(fun, opts)
+
+        if name == as do
+          raise ArgumentError,
+                "defdelegate function is calling itself, which will lead to an infinite loop. You should either change the value of the :to option or specify the :as option"
+        end
+      end)
     end
 
     if is_list(funs) do

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -874,14 +874,21 @@ defmodule KernelTest do
       end
     end
 
-    test "raises when :to targeting the delegating module is given without the :as option" do
-      assert_raise ArgumentError,
-                   ~r/defdelegate function is calling itself, which will lead to an infinite loop. You should either change the value of the :to option or specify the :as option/,
-                   fn ->
-                     defmodule ImplAttributes do
-                       defdelegate foo(), to: __MODULE__
-                     end
-                   end
+    test "raises when a delegate targets itself" do
+      message =
+        ~r/defdelegate function is calling itself, which will lead to an infinite loop. You should either change the value of the :to option or specify the :as option/
+
+      assert_raise ArgumentError, message, fn ->
+        defmodule ImplAttributes do
+          defdelegate foo(), to: __MODULE__
+        end
+      end
+
+      assert_raise ArgumentError, message, fn ->
+        defmodule ImplAttributesSameAs do
+          defdelegate foo(), to: __MODULE__, as: :foo
+        end
+      end
     end
 
     defdelegate my_reverse(list \\ []), to: :lists, as: :reverse


### PR DESCRIPTION
Current `defdelegate` self-recursion check doesn't detect case when `:as` is explicit and self-targeting:

```elixir
defdelegate foo(), to: __MODULE__, as: :foo
```

which causes an infinite loop at runtime.

## Changes
- add check of resolved `:as` name when targeting current module
- tests updated