### PR TITLE
Avoid system_info call on every regex operation

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -615,8 +615,8 @@ defmodule Regex do
   defp safe_run(%Regex{re_pattern: re_pattern} = regex, string, options) do
     # TODO: Remove me when Erlang/OTP 28+ is required
     # This allows regexes precompiled on Erlang/OTP 27- to work on Erlang/OTP 28+
-    with true <- :erlang.system_info(:otp_release) >= [?2, ?8],
-         {:re_pattern, _, _, _, <<_::bitstring>>} <- re_pattern do
+    with {:re_pattern, _, _, _, <<_::bitstring>>} <- re_pattern,
+         true <- :erlang.system_info(:otp_release) >= [?2, ?8] do
       %Regex{source: source, opts: compile_opts} = regex
       :re.run(string, source, compile_opts ++ options)
     else


### PR DESCRIPTION
Check the pattern match first as it fails fast for regexes compiled on Erlang/OTP 28+, skipping the system_info call on every run.
