### PR TITLE
Update ORT & switch to faster license Scanner

### DIFF
--- a/.github/workflows/ort/action.yml
+++ b/.github/workflows/ort/action.yml
@@ -89,9 +89,9 @@ runs:
 
     - name: Run OSS Review Toolkit
       id: ort
-      uses: oss-review-toolkit/ort-ci-github-action@1805edcf1f4f55f35ae6e4d2d9795ccfb29b6021 # v1.1.0
+      uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
       with:
-        image: ghcr.io/oss-review-toolkit/ort-minimal:65.0.0
+        image: ghcr.io/oss-review-toolkit/ort-minimal:92.2.0
         run: >-
           labels,
           cache-dependencies,

--- a/.github/workflows/ort/action.yml
+++ b/.github/workflows/ort/action.yml
@@ -91,7 +91,7 @@ runs:
       id: ort
       uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
       with:
-        image: ghcr.io/oss-review-toolkit/ort-minimal:92.2.0
+        image: ghcr.io/oss-review-toolkit/ort:92.2.0
         run: >-
           labels,
           cache-dependencies,
@@ -107,4 +107,6 @@ runs:
         ort-cli-report-args: >-
           -O CycloneDX=output.file.formats=json,xml
           -O SpdxDocument=outputFileFormats=JSON,YAML
+        ort-cli-scan-args: >-
+          --scanners Provenant
         sw-version: "${{ inputs.version }}"


### PR DESCRIPTION
* Update to OSS Review Toolkit v92.2.0
* Switch from ScanCode to Provenant Scanner.

Provenant is a newer Scanner, mostly compatible to ScanCode which was used before. But it's also a lot more performant.