### PR TITLE
Optimize comparison of parsed versions

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -362,11 +362,22 @@ defmodule Version do
 
   """
   @spec compare(version, version) :: :gt | :eq | :lt
+  def compare(
+        %Version{major: major1, minor: minor1, patch: patch1, pre: pre1},
+        %Version{major: major2, minor: minor2, patch: patch2, pre: pre2}
+      ) do
+    do_compare(major1, minor1, patch1, pre1, major2, minor2, patch2, pre2)
+  end
+
   def compare(version1, version2) do
     do_compare(to_matchable(version1, true), to_matchable(version2, true))
   end
 
   defp do_compare({major1, minor1, patch1, pre1, _}, {major2, minor2, patch2, pre2, _}) do
+    do_compare(major1, minor1, patch1, pre1, major2, minor2, patch2, pre2)
+  end
+
+  defp do_compare(major1, minor1, patch1, pre1, major2, minor2, patch2, pre2) do
     cond do
       major1 > major2 -> :gt
       major1 < major2 -> :lt

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -370,10 +370,9 @@ defmodule Version do
   end
 
   def compare(version1, version2) do
-    do_compare(to_matchable(version1, true), to_matchable(version2, true))
-  end
+    {major1, minor1, patch1, pre1, _} = to_matchable(version1, true)
+    {major2, minor2, patch2, pre2, _} = to_matchable(version2, true)
 
-  defp do_compare({major1, minor1, patch1, pre1, _}, {major2, minor2, patch2, pre2, _}) do
     do_compare(major1, minor1, patch1, pre1, major2, minor2, patch2, pre2)
   end
 

--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -38,6 +38,26 @@ defmodule VersionTest do
     assert Version.compare("1.5.0-rc.0", "1.5.0-rc0") == :lt
   end
 
+  test "compare/2 with Version structs" do
+    large_major = Bitwise.bsl(1, 256)
+    large_pre = Bitwise.bsl(1, 128)
+    left = %Version{major: large_major, minor: 2, patch: 3, pre: ["alpha", large_pre]}
+    right = %Version{major: large_major, minor: 2, patch: 3, pre: ["alpha", large_pre + 1]}
+
+    assert Version.compare(left, right) == :lt
+    assert Version.compare(right, left) == :gt
+    assert Version.compare(left, %{left | major: large_major + 1}) == :lt
+    assert Version.compare(%{left | minor: 1}, %{left | minor: 2}) == :lt
+    assert Version.compare(%{left | patch: 2}, %{left | patch: 3}) == :lt
+    assert Version.compare(%{left | pre: [1]}, %{left | pre: ["alpha"]}) == :lt
+    assert Version.compare(%{left | pre: ["alpha"]}, %{left | pre: ["alpha", 1]}) == :lt
+    assert Version.compare(%{left | pre: ["alpha"]}, %{left | pre: []}) == :lt
+    assert Version.compare(%{left | pre: []}, %{left | pre: ["alpha"]}) == :gt
+    assert Version.compare(%{left | build: "left"}, %{left | build: "right"}) == :eq
+    assert Version.compare(%{left | major: 1}, "2.0.0") == :lt
+    assert Version.compare("2.0.0", %{left | major: 1}) == :gt
+  end
+
   test "compare/2 with invalid versions" do
     assert_raise Version.InvalidVersionError, fn ->
       Version.compare("1.0", "1.0.0")


### PR DESCRIPTION
`Version.compare/2` converted parsed `%Version{}` values into two five-element tuples before comparing them. This adds a struct-to-struct clause that passes the precedence fields directly to the comparator, avoiding both tuple allocations. String and mixed operands retain parsing and validation through `to_matchable/2`, then call the same field comparator. Build metadata remains ignored.

Benchmarks used Elixir 1.21.0-dev, Erlang/OTP 29, macOS arm64, and one scheduler (`+S 1:1`). The benchmark baseline was `bc7844c`. Five runs produced 500 batch-average samples for individual comparisons and 150 complete-operation samples across six shuffled, one ascending, and one descending input order.

| Timed boundary | Baseline median / p99 | Updated median / p99 | Median speedup |
| --- | ---: | ---: | ---: |
| Early-core comparison | 34.06 / 47.14 ns | 19.40 / 24.44 ns | 1.76x |
| Numeric-prerelease comparison | 49.77 / 60.15 ns | 32.65 / 40.10 ns | 1.52x |
| Long-alphanumeric comparison | 45.92 / 55.23 ns | 29.61 / 35.01 ns | 1.55x |
| Build-only difference | 55.18 / 76.30 ns | 39.38 / 46.36 ns | 1.40x |
| 1,000-digit core comparison | 54.26 / 63.74 ns | 37.85 / 44.28 ns | 1.43x |
| Sort 895 parsed versions | 369.50 / 589.58 us | 258.25 / 404.08 us | 1.43x |
| Sort 2,964 parsed versions | 1.373 / 2.463 ms | 1.019 / 1.217 ms | 1.35x |
| Select maximum from 895 parsed versions | 34.88 / 77.42 us | 27.79 / 80.00 us | 1.26x |
| Select maximum from 2,964 parsed versions | 102.29 / 189.00 us | 77.67 / 137.88 us | 1.32x |

Parsed sorting and maximum selection exclude parsing. Parsing strings once and then sorting improved by 1.09x at 895 versions and 1.06x at 2,964 versions, although the per-run median ranges overlapped. Sorting strings through the public comparator remained within run variation.

OTP `tprof` allocation profiling measured 12 heap words, or 96 bytes on this VM, per baseline parsed comparison and zero words after the change. The semantic oracle compared 38,416 ordered pairs, including arbitrary-size core and prerelease integers, mixed and prefix prerelease lists, stable releases, build ties, and long identifiers, with no mismatches.

`make format` and `make test_stdlib TEST_FILES=version_test.exs` pass with 43 tests.
