### PR TITLE
Precompute ANSI escape sequences at compile time

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -111,13 +111,15 @@ defmodule IO.ANSI do
   end
 
   defsequence = fn name, code, terminator ->
+    sequence = "\e[#{code}#{terminator}"
+
     @spec unquote(name)() :: String.t()
     def unquote(name)() do
-      "\e[#{unquote(code)}#{unquote(terminator)}"
+      unquote(sequence)
     end
 
     defp format_sequence(unquote(name)) do
-      unquote(name)()
+      unquote(sequence)
     end
   end
 


### PR DESCRIPTION
Assisted-by: Antigravity:Gemini-3.7-Flash

Build named ANSI sequences once while defining their functions instead of interpolating their static components at runtime. Reuse the resulting literal in format_sequence/1 as well.