### PR TITLE
Add IEx continuation for :range_op

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -131,21 +131,42 @@ defmodule IEx.Evaluator do
 
   # We use elem operations, instead of pattern matching,
   # because "not in" tokenizer tuples have four elements.
-  defp adjust_operator([token | _] = _tokens, line, column, _file, _opts, :match)
-       when elem(token, 0) in @op_tokens,
-       do:
-         {:error,
-          {[line: line, column: column],
-           "pipe shorthand is not allowed immediately after a match expression in IEx. To make it work, surround the whole pipeline with parentheses ",
-           "'#{elem(token, 2)}'"}}
+  defp adjust_operator([token | _] = tokens, line, column, file, opts, last_op)
+       when elem(token, 0) == :range_op do
+    # Preserve `..` when a leading value isn't required
+    case :elixir.tokens_to_quoted(tokens, file, opts) do
+      {:ok, _forms, _warnings} ->
+        {:ok, tokens, nil}
 
-  defp adjust_operator([token | _] = tokens, line, column, file, opts, _last_op)
+      {:error, _reason} ->
+        {:ok, prefix, _warnings} =
+          :elixir.string_to_tokens(~c"v(-1)", line, column, file, opts)
+
+        case :elixir.tokens_to_quoted(prefix ++ tokens, file, opts) do
+          {:ok, _forms, _warnings} -> prepend_operator(prefix, tokens, line, column, last_op)
+          {:error, _reason} -> {:ok, tokens, nil}
+        end
+    end
+  end
+
+  defp adjust_operator([token | _] = tokens, line, column, file, opts, last_op)
        when elem(token, 0) in @op_tokens do
     {:ok, prefix, _warnings} = :elixir.string_to_tokens(~c"v(-1)", line, column, file, opts)
-    {:ok, prefix ++ tokens, elem(token, 0)}
+    prepend_operator(prefix, tokens, line, column, last_op)
   end
 
   defp adjust_operator(tokens, _line, _column, _file, _opts, _last_op), do: {:ok, tokens, nil}
+
+  defp prepend_operator(_prefix, [token | _], line, column, :match) do
+    {:error,
+     {[line: line, column: column],
+      "pipe shorthand is not allowed immediately after a match expression in IEx. To make it work, surround the whole pipeline with parentheses ",
+      "'#{elem(token, 2)}'"}}
+  end
+
+  defp prepend_operator(prefix, [token | _] = tokens, _line, _column, _last_op) do
+    {:ok, prefix ++ tokens, elem(token, 0)}
+  end
 
   @doc """
   Raises an error if the last iex result was itself an error

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1347,6 +1347,8 @@ defmodule IEx.HelpersTest do
       assert capture_iex("[42]\n++ [24]\n|> IO.inspect(label: \"foo\")") =~ "foo: [42, 24]"
       assert capture_iex("|> IO.puts()") =~ "(RuntimeError) v(-1) is out of bounds"
       assert capture_iex("4\nnot in [1, 2]") == "4\ntrue"
+      assert capture_iex("1\n..3") == "1\n1..3"
+      assert capture_iex("1\n..3//2") == "1\n1..3//2"
     end
 
     test "raises if previous expression was a match" do
@@ -1361,6 +1363,16 @@ defmodule IEx.HelpersTest do
 
       assert capture_iex("x = 4\nnot in [1, 2]") =~
                "surround the whole pipeline with parentheses 'not in'"
+
+      assert capture_iex("x = 1\n..3") =~
+               "surround the whole pipeline with parentheses '..'"
+    end
+
+    test "preserves the nullary range operator" do
+      assert capture_iex("..") == "0..-1//1"
+      assert capture_iex(".. |> Enum.to_list()") == "[]"
+      assert capture_iex(".. == 0..-1//1") == "true"
+      assert capture_iex("x = 1\n..") == "1\n0..-1//1"
     end
   end
 


### PR DESCRIPTION
Adds support for `:range_op` continuation in IEx.

It was slightly trickier than just extending `@op_tokens`, cases covered:

- standalone `..` 
- basic/stepped range form
- beginning with ../0: `.. |> Enum.to_list()`