### PR TITLE
perf: Skip no-op microsecond step in Calendar.ISO shift functions

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1855,6 +1855,9 @@ defmodule Calendar.ISO do
     shift_options = shift_datetime_options(duration)
 
     Enum.reduce(shift_options, {year, month, day, hour, minute, second, microsecond}, fn
+      {:microsecond, {0, _}}, naive_datetime ->
+        naive_datetime
+
       {_, 0}, naive_datetime ->
         naive_datetime
 
@@ -1884,6 +1887,9 @@ defmodule Calendar.ISO do
     shift_options = shift_time_options(duration)
 
     Enum.reduce(shift_options, {hour, minute, second, microsecond}, fn
+      {:microsecond, {0, _}}, time ->
+        time
+
       {_, 0}, time ->
         time
 


### PR DESCRIPTION
shift_datetime_options/1 and shift_time_options/1 always emit
`microsecond: {0, 0}` as a tuple, so the `{_, 0}` skip clause in the
shift reducers never matched it. Every NaiveDateTime.shift/2,
DateTime.shift/2,3, and Time.shift/2 therefore paid a full
date<->iso-days round trip only to return its input unchanged.

Skipping `{:microsecond, {0, _}}` is behavior-preserving:
shift_time_unit_values/2 maps a `{0, _}` shift value to
`{0, original_precision}`, so the round trip was the identity on both
the microsecond value and the result precision. The only observable
difference is that shifting an invalid hand-crafted struct by an
all-zero duration no longer raises from the round trip's internal
validation, which shift/2 does not document as part of its contract.

Benchee on Apple M1 (Erlang/OTP 29): NaiveDateTime.shift with
month: 1 goes from 2.87M to 5.33M ips (+86%), day: 1 +45%, mixed
durations +56%, DateTime.shift +35%, Time.shift +34%, with memory
per call dropping 35-50%. Durations carrying a non-zero microsecond
component are unchanged in both time and memory.

Found and remediated with Claude Fable.