### PR TITLE
perf: Remove unused length computation in List.myers_difference

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -1371,13 +1371,13 @@ defmodule List do
 
   defp myers_difference_with_diff_script(list1, list2, diff_script) do
     path = {0, list1, list2, []}
-    find_script(0, length(list1) + length(list2), [path], diff_script)
+    find_script(0, [path], diff_script)
   end
 
-  defp find_script(envelope, max, paths, diff_script) do
+  defp find_script(envelope, paths, diff_script) do
     case each_diagonal(-envelope, envelope, paths, [], diff_script) do
       {:done, edits} -> compact_reverse(edits, [])
-      {:next, paths} -> find_script(envelope + 1, max, paths, diff_script)
+      {:next, paths} -> find_script(envelope + 1, paths, diff_script)
     end
   end
 


### PR DESCRIPTION
`myers_difference_with_diff_script/3` computed
`length(list1) + length(list2)` and threaded it through `find_script/4`,
which never read it: the recursion is bounded by `each_diagonal/5`
finding the endpoint, which the Myers algorithm guarantees within
n + m iterations. Two full list traversals of dead work per call,
also paid by `String.myers_difference/2` and ExUnit's diff output.

Assisted by: Claude Fable.