### PR TITLE
perf: Copy file mode with chmod instead of stat and write_stat

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1362,9 +1362,8 @@ defmodule File do
   end
 
   defp copy_file_mode(src, dest) do
-    with {:ok, dest_fileinfo} <- stat(dest),
-         {:ok, src_fileinfo} <- stat(src) do
-      write_stat(dest, %{dest_fileinfo | mode: src_fileinfo.mode})
+    with {:ok, src_fileinfo} <- stat(src) do
+      chmod(dest, src_fileinfo.mode)
     end
   end
 


### PR DESCRIPTION
`copy_file_mode/2` read the destination's `file_info` purely to rebuild
a full record and write it back with only `:mode` changed. The
destination stat served no purpose: `:file.change_mode/2` is
implemented as `write_file_info` with a mode-only record, so applying
the source mode directly performs the same operation with one fewer
file-server round trip per file copied by `File.cp/3` and `File.cp_r/3`.

Writing the full record back also had two unintended effects that
this removes: it attempted to set the destination's owner, which
POSIX permits to fail with EPERM for non-owner copies even when the
value is unchanged, and it rewrote the destination's timestamps with
the second-precision values read by stat, truncating the sub-second
mtime of the freshly written file.

Assisted by: Claude Fable.