### PR TITLE
perf: Avoid copying the list in List.pop_at/3 for out-of-bounds indexes

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -960,9 +960,12 @@ defmodule List do
   @spec pop_at(list, integer, any) :: {any, list}
   def pop_at(list, index, default \\ nil) when is_integer(index) do
     if index < 0 do
-      do_pop_at(list, length(list) + index, default, [])
+      case length(list) + index do
+        index when index < 0 -> {default, list}
+        index -> do_pop_at(list, index, default, [], list)
+      end
     else
-      do_pop_at(list, index, default, [])
+      do_pop_at(list, index, default, [], list)
     end
   end
 
@@ -1522,15 +1525,16 @@ defmodule List do
 
   # pop_at
 
-  defp do_pop_at([], _index, default, acc) do
-    {default, :lists.reverse(acc)}
+  # The original list is returned when the index is out of bounds
+  defp do_pop_at([], _index, default, _acc, original) do
+    {default, original}
   end
 
-  defp do_pop_at([head | tail], 0, _default, acc) do
+  defp do_pop_at([head | tail], 0, _default, acc, _original) do
     {head, :lists.reverse(acc, tail)}
   end
 
-  defp do_pop_at([head | tail], index, default, acc) do
-    do_pop_at(tail, index - 1, default, [head | acc])
+  defp do_pop_at([head | tail], index, default, acc, original) do
+    do_pop_at(tail, index - 1, default, [head | acc], original)
   end
 end


### PR DESCRIPTION
#### Two improvements

  * `do_pop_at` reaching the end of the list (out-of-bounds index)
    built an n-cell reversed accumulator and reversed it again 2n
    allocations to return a copy equal to the input. The original
    list is now threaded through and returned as is.

  * `pop_at/3` with a negative index normalizing below zero walked the
    whole list the same way. It now returns `{default, list}` directly
    after the length check, matching the pattern `update_at/3` already
    uses.

`List.delete_at/2` inherits both improvements through its delegation
to `pop_at/3`.

Benchee medians on Apple M1, Erlang/OTP 29, 1000-element list:
pop_at with index -1500 goes from 6.79 us / 20.07 KB allocated to
1.63 us / 24 B; index 1500 from 5.21 us / 20.07 KB to 3.17 us /
15.65 KB; delete_at at index 1500 from 5.25 us to 3.17 us. All
in-bounds calls are unchanged.

Assisted by Claude Fable.

| Job (1000-element list) | Before (time / alloc) | After (time / alloc) | Speedup |
|---|---|---|---|
| `pop_at` -1500 (negative OOB) | 6.79 μs / 20.07 KB | 1.63 μs / 24 B | 4.2× |
| `pop_at` 1500 (out of bounds) | 5.21 μs / 20.07 KB | 3.17 μs / 15.65 KB | 1.6× |
| `delete_at` 1500 (out of bounds) | 5.25 μs / 20.07 KB | 3.17 μs / 15.65 KB | 1.7× |
| `delete_at` 999 (last) | 5.25 μs / 20.07 KB | 5.25 μs / 20.07 KB | flat |
| `delete_at` 500 (in bounds) | 2.83 μs / 15.65 KB | 2.83 μs / 15.65 KB | flat |
| `pop_at` 500 (in bounds, control) | 2.83 μs / 15.65 KB | 2.88 μs / 15.65 KB | flat |
