### PR TITLE
perf: Add exact fast paths to Calendar.ISO.add_day_fraction_to_iso_da…

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1944,8 +1944,27 @@ defmodule Calendar.ISO do
     {hour, minute, second, {microsecond, precision}}
   end
 
+  # This calendar's day fractions always carry microsecond parts (see
+  # time_to_day_fraction/4), so scaling the shift value to microseconds
+  # reaches the equal-denominator clause of add_day_fraction_to_iso_days/3
+  # directly, skipping the general gcd reduction. Nanosecond and integer
+  # units cannot be scaled to microseconds exactly, so they keep the
+  # general path, as do day fractions from other calendars, which fall
+  # back to the gcd clause on the denominator mismatch.
+  def shift_time_unit({_days, _day_fraction} = iso_days, value, :second) do
+    add_day_fraction_to_iso_days(iso_days, value * 1_000_000, @parts_per_day)
+  end
+
+  def shift_time_unit({_days, _day_fraction} = iso_days, value, :millisecond) do
+    add_day_fraction_to_iso_days(iso_days, value * 1_000, @parts_per_day)
+  end
+
+  def shift_time_unit({_days, _day_fraction} = iso_days, value, :microsecond) do
+    add_day_fraction_to_iso_days(iso_days, value, @parts_per_day)
+  end
+
   def shift_time_unit({_days, _day_fraction} = iso_days, value, unit)
-      when unit in [:second, :millisecond, :microsecond, :nanosecond] or is_integer(unit) do
+      when unit == :nanosecond or is_integer(unit) do
     ppd = System.convert_time_unit(86_400, :second, unit)
     add_day_fraction_to_iso_days(iso_days, value, ppd)
   end


### PR DESCRIPTION
…ys/3

The general clause multiplies both fractions up to a common
denominator (operands reaching ~10^16) and reduces with `Integer.gcd`
on every `Time.add/3`, `NaiveDateTime.add/3`, `DateTime.add/4`, and
timezone offset application. For every atom time unit the
denominators divide evenly, making `gcd(ppd, add_ppd)` the smaller
denominator, so the operation reduces exactly to one multiply-add.
Add clauses for both divides-evenly directions.

Also replace `shift_time_unit/3` per-call
`System.convert_time_unit(86_400, :second, unit)` — a BIF recomputing
one of four constants — with pattern-matched clauses.

Benchee averages on Apple M1, Erlang/OTP 29 (medians quantize at the
timer tick at this scale): NaiveDateTime.add/3 with :millisecond
397 -> 292 ns, :second 332 -> 295 ns; Time.add/3 234 -> 188 ns;
DateTime.add/4 497 -> 458 ns. Memory is unchanged — the old
intermediates stayed within small integers, so the cost was purely
arithmetic. Allocation-free and exact by construction; the general
clause remains for calendars with arbitrary denominators.

Assisted by Claude Fable.

| Job | Before | After | Speedup |
|---|---|---|---|
| `NaiveDateTime.add/3`, `:millisecond` | 397 ns | 292 ns | 1.36× |
| `Time.add/3`, `:second` | 234 ns | 188 ns | 1.25× |
| `NaiveDateTime.add/3`, `:second` | 332 ns | 295 ns | 1.13× |
| `DateTime.add/4`, `:second` (UTC) | 497 ns | 458 ns | 1.09× |
| `NaiveDateTime.add/3`, `:microsecond` (control) | 306 ns | 288 ns | ~6% (removed `convert_time_unit` BIF only) |