### PR TITLE
fix: Range.disjoint?/2 for ranges beyond float precision

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -498,9 +498,9 @@ defmodule Range do
 
           if rem(first2 - first1, gcd) == 0 do
             c = first1 - first2 + step2 - step1
-            t1 = -c / step2 * u
-            t2 = -c / step1 * v
-            t = max(floor(t1) + 1, floor(t2) + 1)
+            t1 = Integer.floor_div(-c * u, step2)
+            t2 = Integer.floor_div(-c * v, step1)
+            t = max(t1 + 1, t2 + 1)
             x = div(c * u + t * step2, gcd) - 1
             y = div(c * v + t * step1, gcd) - 1
 

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -125,6 +125,25 @@ defmodule RangeTest do
     test "normalizes unaligned descending ranges to their actual bounds" do
       refute Range.disjoint?(27..11//-3, 26..0//-5)
     end
+
+    test "uses exact arithmetic for large ranges" do
+      # The intersection parameter was previously computed with float
+      # division, which loses precision past 2^53. d sits just below a
+      # representable float that rounds upward, so the float path overshot
+      # the first intersection (d itself, the last element of the first
+      # range) and wrongly reported the ranges as disjoint.
+      d = Integer.pow(2, 59) + 193
+      assert rem(d, 3) == 0
+      assert_overlap(0..d//3, (d - 2)..(d + 10))
+
+      # Beyond the float range (~1.8e308), the float division raised
+      # ArithmeticError for valid integer ranges before the fix.
+      # big - 2 is a multiple of 7, so both ranges are aligned (reversing
+      # preserves their elements) and they intersect at big - 2.
+      big = Integer.pow(10, 320)
+      assert rem(big - 2, 7) == 0
+      assert_overlap(0..(big - 2)//7, (big - 8)..big)
+    end
   end
 
   describe "split" do


### PR DESCRIPTION
The first-intersection parameter of the two arithmetic progressions
was computed with float division. Floats lose integer precision past
2^53, and the surrounding arithmetic is exact, so the error was not
absorbed: it shifted which intersection point got range-checked.

Two user-visible bugs, both reproduced before the fix:

  * Wrong answers: `Range.disjoint?(0..d//3, (d - 2)..(d + 10))` with
    d = 2^59 + 193 returned true although the ranges provably
    intersect at d. The float conversion rounds d upward by 63,
    overshooting the intersection past the range boundary. The
    misbehavior requires the float error to cross an integer floor
    boundary and a range endpoint simultaneously, which is why
    randomized testing never surfaced it.

  * Crashes: for ranges whose starts differ by more than the float
    range (~1.8e308), the division raised `ArithmeticError` on valid
    integer ranges.

Computing the floor of the exact rational with `Integer.floor_div/2`
fixes both; results for small ranges are unchanged (verified against
brute-force set intersection over thousands of randomized ranges).
The regression tests use aligned ranges (last element reachable from
first) so the suite's reversal helpers exercise all commuted
variants without changing the element sets.

Assisted by Claude Fable.

If you want the reproduction script I can provide it.