### PR TITLE
Optimize Date.compare/2

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -556,14 +556,18 @@ defmodule Date do
   """
   @doc since: "1.4.0"
   @spec compare(Calendar.date(), Calendar.date()) :: :lt | :eq | :gt
-  def compare(%{calendar: calendar} = date1, %{calendar: calendar} = date2) do
-    %{year: year1, month: month1, day: day1} = date1
-    %{year: year2, month: month2, day: day2} = date2
-
-    case {{year1, month1, day1}, {year2, month2, day2}} do
-      {first, second} when first > second -> :gt
-      {first, second} when first < second -> :lt
-      _ -> :eq
+  def compare(
+        %{year: year1, month: month1, day: day1, calendar: calendar},
+        %{year: year2, month: month2, day: day2, calendar: calendar}
+      ) do
+    cond do
+      year1 > year2 -> :gt
+      year1 < year2 -> :lt
+      month1 > month2 -> :gt
+      month1 < month2 -> :lt
+      day1 > day2 -> :gt
+      day1 < day2 -> :lt
+      true -> :eq
     end
   end
 


### PR DESCRIPTION
Assisted-by: Antigravity CLI: Gemini 3.7 Flash

Achieves ~1.75x speedup, uses less memory, no regressions.

Bench:
```elixir
Mix.install([:benchee])

defmodule BenchDate do
  def compare_before(%{calendar: calendar} = date1, %{calendar: calendar} = date2) do
    %{year: year1, month: month1, day: day1} = date1
    %{year: year2, month: month2, day: day2} = date2

    case {{year1, month1, day1}, {year2, month2, day2}} do
      {first, second} when first > second -> :gt
      {first, second} when first < second -> :lt
      _ -> :eq
    end
  end

  def compare_after(
        %{year: year1, month: month1, day: day1, calendar: calendar},
        %{year: year2, month: month2, day: day2, calendar: calendar}
      ) do
    cond do
      year1 > year2 -> :gt
      year1 < year2 -> :lt
      month1 > month2 -> :gt
      month1 < month2 -> :lt
      day1 > day2 -> :gt
      day1 < day2 -> :lt
      true -> :eq
    end
  end
end

inputs = %{
  "diff year" => {~D[2023-05-12], ~D[2024-05-12]},
  "diff month" => {~D[2023-05-12], ~D[2023-08-12]},
  "diff day" => {~D[2023-05-12], ~D[2023-05-20]},
  "equal" => {~D[2023-05-12], ~D[2023-05-12]}
}

Benchee.run(
  %{
    "before" => fn {d1, d2} -> BenchDate.compare_before(d1, d2) end,
    "after" => fn {d1, d2} -> BenchDate.compare_after(d1, d2) end
  },
  inputs: inputs,
  memory_time: 1,
  time: 2,
  warmup: 1
)
```

Result:
```txt
##### With input diff year #####
    Name             ips        average  deviation         median         99th %
    after        34.36 M       29.10 ns   ±668.98%          30 ns          40 ns
    before       19.62 M       50.96 ns  ±6871.55%          40 ns          70 ns

    Comparison:
    after        34.36 M
    before       19.62 M - 1.75x slower +21.85 ns

    Memory usage statistics:
    Name      Memory usage
    after              0 B
    before            64 B - ∞ x memory usage +64 B

    ##### With input diff month #####
    Name             ips        average  deviation         median         99th %
    after        35.57 M       28.11 ns   ±463.24%          30 ns          41 ns
    before       20.30 M       49.26 ns  ±6684.24%          40 ns          70 ns

    Comparison:
    after        35.57 M
    before       20.30 M - 1.75x slower +21.15 ns

    Memory usage statistics:
    Name      Memory usage
    after              0 B
    before            64 B - ∞ x memory usage +64 B

    ##### With input diff day #####
    Name             ips        average  deviation         median         99th %
    after        33.92 M       29.48 ns   ±878.22%          30 ns          40 ns
    before       19.81 M       50.47 ns  ±6103.80%          40 ns          65 ns

    Comparison:
    after        33.92 M
    before       19.81 M - 1.71x slower +20.99 ns

    Memory usage statistics:
    Name      Memory usage
    after              0 B
    before            64 B - ∞ x memory usage +64 B

    ##### With input equal #####
    Name             ips        average  deviation         median         99th %
    after        34.25 M       29.20 ns   ±418.29%          30 ns          40 ns
    before       20.02 M       49.96 ns  ±6776.79%          40 ns          70 ns

    Comparison:
    after        34.25 M
    before       20.02 M - 1.71x slower +20.76 ns

    Memory usage statistics:
    Name      Memory usage
    after              0 B
    before            64 B - ∞ x memory usage +64 B
  ```
