### PR TITLE
Optimize Time.compare/2

### DIFF
--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -720,14 +720,32 @@ defmodule Time do
   """
   @doc since: "1.4.0"
   @spec compare(Calendar.time(), Calendar.time()) :: :lt | :eq | :gt
-  def compare(%{calendar: calendar} = time1, %{calendar: calendar} = time2) do
-    %{hour: hour1, minute: minute1, second: second1, microsecond: {microsecond1, _}} = time1
-    %{hour: hour2, minute: minute2, second: second2, microsecond: {microsecond2, _}} = time2
-
-    case {{hour1, minute1, second1, microsecond1}, {hour2, minute2, second2, microsecond2}} do
-      {first, second} when first > second -> :gt
-      {first, second} when first < second -> :lt
-      _ -> :eq
+  def compare(
+        %{
+          hour: hour1,
+          minute: minute1,
+          second: second1,
+          microsecond: {microsecond1, _},
+          calendar: calendar
+        },
+        %{
+          hour: hour2,
+          minute: minute2,
+          second: second2,
+          microsecond: {microsecond2, _},
+          calendar: calendar
+        }
+      ) do
+    cond do
+      hour1 > hour2 -> :gt
+      hour1 < hour2 -> :lt
+      minute1 > minute2 -> :gt
+      minute1 < minute2 -> :lt
+      second1 > second2 -> :gt
+      second1 < second2 -> :lt
+      microsecond1 > microsecond2 -> :gt
+      microsecond1 < microsecond2 -> :lt
+      true -> :eq
     end
   end
 


### PR DESCRIPTION
Assisted-by: Antigravity CLI: Gemini 3.7 Flash

Achieves ~1.75x speedup, uses less memory, no regressions.

Same type of change as in https://github.com/elixir-lang/elixir/pull/15762

Bench:
```elixir
Mix.install([:benchee])

defmodule BenchTime do
  def compare_before(%{calendar: calendar} = time1, %{calendar: calendar} = time2) do
    %{hour: hour1, minute: minute1, second: second1, microsecond: {microsecond1, _}} = time1
    %{hour: hour2, minute: minute2, second: second2, microsecond: {microsecond2, _}} = time2

    case {{hour1, minute1, second1, microsecond1}, {hour2, minute2, second2, microsecond2}} do
      {first, second} when first > second -> :gt
      {first, second} when first < second -> :lt
      _ -> :eq
    end
  end

  def compare_after(
        %{
          hour: hour1,
          minute: minute1,
          second: second1,
          microsecond: {microsecond1, _},
          calendar: calendar
        },
        %{
          hour: hour2,
          minute: minute2,
          second: second2,
          microsecond: {microsecond2, _},
          calendar: calendar
        }
      ) do
    cond do
      hour1 > hour2 -> :gt
      hour1 < hour2 -> :lt
      minute1 > minute2 -> :gt
      minute1 < minute2 -> :lt
      second1 > second2 -> :gt
      second1 < second2 -> :lt
      microsecond1 > microsecond2 -> :gt
      microsecond1 < microsecond2 -> :lt
      true -> :eq
    end
  end
end

inputs = %{
  "diff hour" => {~T[10:15:20.123456], ~T[14:15:20.123456]},
  "diff minute" => {~T[10:15:20.123456], ~T[10:45:20.123456]},
  "diff second" => {~T[10:15:20.123456], ~T[10:15:50.123456]},
  "diff microsecond" => {~T[10:15:20.123456], ~T[10:15:20.654321]},
  "equal" => {~T[10:15:20.123456], ~T[10:15:20.123456]}
}

Benchee.run(
  %{
    "before" => fn {t1, t2} -> BenchTime.compare_before(t1, t2) end,
    "after" => fn {t1, t2} -> BenchTime.compare_after(t1, t2) end
  },
  inputs: inputs,
  memory_time: 1,
  time: 2,
  warmup: 1
)
```

Result:
```
##### With input diff hour #####
Name             ips        average  deviation         median         99th %
after        27.79 M       35.99 ns   ±122.78%          30 ns          50 ns
before       10.86 M       92.07 ns  ±2098.05%          70 ns         471 ns

Comparison:
after        27.79 M
before       10.86 M - 2.56x slower +56.09 ns

Memory usage statistics:

Name      Memory usage
after              0 B
before            80 B - ∞ x memory usage +80 B

##### With input diff microsecond #####
Name             ips        average  deviation         median         99th %
after        26.87 M       37.22 ns    ±59.15%          40 ns          50 ns
before       10.92 M       91.58 ns  ±2097.83%          70 ns         440 ns

Comparison:
after        26.87 M
before       10.92 M - 2.46x slower +54.36 ns

Memory usage statistics:

Name      Memory usage
after              0 B
before            80 B - ∞ x memory usage +80 B

##### With input diff minute #####
Name             ips        average  deviation         median         99th %
after        20.56 M       48.63 ns   ±203.71%          50 ns          80 ns
before       11.64 M       85.88 ns  ±2890.32%          70 ns         361 ns

Comparison:
after        20.56 M
before       11.64 M - 1.77x slower +37.25 ns

Memory usage statistics:

Name      Memory usage
after              0 B
before            80 B - ∞ x memory usage +80 B

##### With input diff second #####
Name             ips        average  deviation         median         99th %
after        19.94 M       50.15 ns   ±296.55%          50 ns          81 ns
before       12.27 M       81.53 ns  ±1501.75%          70 ns         290 ns

Comparison:
after        19.94 M
before       12.27 M - 1.63x slower +31.38 ns

Memory usage statistics:

Name      Memory usage
after              0 B
before            80 B - ∞ x memory usage +80 B

##### With input equal #####
Name             ips        average  deviation         median         99th %
after        19.51 M       51.25 ns   ±144.61%          50 ns          81 ns
before       10.15 M       98.52 ns  ±1240.21%          70 ns         551 ns

Comparison:
after        19.51 M
before       10.15 M - 1.92x slower +47.27 ns

Memory usage statistics:

Name      Memory usage
after              0 B
before            80 B - ∞ x memory usage +80 B
 ```