### PR TITLE
Replace protocol dispatch with arithmetic in Access.slice/1

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -1035,12 +1035,12 @@ defmodule Access do
   end
 
   defp slice(:get_and_update, data, range, next) when is_list(data) do
-    range = normalize_range(range, data)
+    %Range{first: first, last: last, step: step} = normalize_range(range, data)
 
-    if range.first > range.last do
+    if first > last do
       {[], data}
     else
-      get_and_update_slice(data, range, next, [], [], 0)
+      get_and_update_slice(data, first, last, step, next, [], [], 0)
     end
   end
 
@@ -1145,21 +1145,23 @@ defmodule Access do
 
   defp normalize_range(range, _list), do: range
 
-  defp get_and_update_slice(rest, %Range{last: last}, _next, updates, gets, index)
+  defp get_and_update_slice(rest, _first, last, _step, _next, updates, gets, index)
        when index > last do
     {:lists.reverse(gets), :lists.reverse(updates, rest)}
   end
 
-  defp get_and_update_slice([head | rest], range, next, updates, gets, index) do
-    if index in range do
+  defp get_and_update_slice([head | rest], first, last, step, next, updates, gets, index) do
+    if index >= first and rem(index - first, step) == 0 do
       case next.(head) do
         :pop ->
-          get_and_update_slice(rest, range, next, updates, [head | gets], index + 1)
+          get_and_update_slice(rest, first, last, step, next, updates, [head | gets], index + 1)
 
         {get, update} ->
           get_and_update_slice(
             rest,
-            range,
+            first,
+            last,
+            step,
             next,
             [update | updates],
             [get | gets],
@@ -1167,11 +1169,11 @@ defmodule Access do
           )
       end
     else
-      get_and_update_slice(rest, range, next, [head | updates], gets, index + 1)
+      get_and_update_slice(rest, first, last, step, next, [head | updates], gets, index + 1)
     end
   end
 
-  defp get_and_update_slice([], _range, _next, updates, gets, _index) do
+  defp get_and_update_slice([], _first, _last, _step, _next, updates, gets, _index) do
     {:lists.reverse(gets), :lists.reverse(updates)}
   end
 

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -217,6 +217,26 @@ defmodule AccessTest do
     test "returns empty when the start of the range is greater than the end" do
       assert [] == get_in(@test_list, [Access.slice(2..1//1)])
     end
+
+    test "pops empty when the start of the range is greater than the end" do
+      assert {[], @test_list} == pop_in(@test_list, [Access.slice(2..1//1)])
+    end
+
+    test "pops empty when the range is out of bounds" do
+      assert {[], @test_list} == pop_in(@test_list, [Access.slice(10..20)])
+    end
+
+    test "gets and updates a range with mixed pop and update returns" do
+      assert {[100, 2, 300, 4, 500], [10, 30, 50, 6, 7]} ==
+               get_and_update_in(@test_list, [Access.slice(0..4)], fn value ->
+                 if rem(value, 2) == 0, do: :pop, else: {value * 100, value * 10}
+               end)
+    end
+
+    test "updates a stepped range that starts past the beginning of the list" do
+      assert [1, 2, -3, 4, -5, 6, -7] ==
+               update_in(@test_list, [Access.slice(2..6//2)], &(&1 * -1))
+    end
   end
 
   describe "key/2 and key!/1" do


### PR DESCRIPTION
Assisted-by: Claude Code:claude-fable-5

The `get_and_update` path of `Access.slice/1` evaluates `index in range`
once per list element. Because the range is a runtime value, `in/2`
expands to `Enum.__in__/2`: a protocol dispatch plus an `{:ok, boolean}`
tuple allocation and unwrap for every element scanned.

This destructures the range's `first/last/step` once and tests
membership with integer comparisons. The upper bound is already enforced
by the recursion's early-termination clause (`index > last`), and
`slice/1` rejects non-positive steps, so membership reduces to
`index >= first and rem(index - first, step) == 0` (short-circuited so
`rem` never sees a negative offset during the lead-in). The `:get` path
is untouched, it goes through `Enum.slice/2` and is included in the
benchmark as a control.

Benchmark (benchee), Apple M1, OTP 29:

```elixir
Mix.install([{:benchee, "~> 1.4"}])

inputs =
  for n <- [3, 10, 100, 1000], into: %{} do
    list = Enum.to_list(1..n)
    middle = div(n, 4)..max(div(3 * n, 4) - 1, div(n, 4))
    step2 = 0..(n - 1)//2
    {"#{n} elems", {list, middle, step2}}
  end

update = fn v -> {v, v + 1} end

Benchee.run(
  %{
    "update middle half" => fn {list, middle, _step2} ->
      get_and_update_in(list, [Access.slice(middle)], update)
    end,
    "update every other (step 2)" => fn {list, _middle, step2} ->
      get_and_update_in(list, [Access.slice(step2)], update)
    end,
    "pop middle half" => fn {list, middle, _step2} ->
      pop_in(list, [Access.slice(middle)])
    end,
    "get middle half (control)" => fn {list, middle, _step2} ->
      get_in(list, [Access.slice(middle)])
    end
  },
  inputs: inputs,
  warmup: 0.5,
  time: 2,
  memory_time: 0.5
)
```

Results (averages; before → after). The update function is a minimal
`fn v -> {v, v + 1} end`, so relative gains are upper bounds; the
absolute per-element saving is what carries to real update functions.

| job | 3 elems | 10 elems | 100 elems | 1000 elems |
|---|---|---|---|---|
| update middle half | 235 → 140 ns (1.7x) | 612 → 202 ns (3.0x) | 4.60 → 1.02 μs (4.5x) | 37.9 → 9.6 μs (3.9x) |
| update every other (step 2) | 297 → 158 ns (1.9x) | 688 → 254 ns (2.7x) | 5.67 → 1.36 μs (4.2x) | 52.7 → 14.0 μs (3.8x) |
| pop middle half | 204 → 108 ns (1.9x) | 589 → 188 ns (3.1x) | 4.48 → 0.86 μs (5.2x) | 36.3 → 7.7 μs (4.7x) |
| get control | 127 → 114 ns (noise) | 154 → 158 ns (flat) | 1.50 → 1.49 μs (flat) | 15.0 → 14.9 μs (flat) |

| memory | 3 elems | 10 elems | 100 elems | 1000 elems |
|---|---|---|---|---|
| update middle half | 288 → 240 B | 688 → 568 B | 6.19 → 4.61 KB | 60.1 → 44.8 KB |
| update every other (step 2) | 344 → 272 B | 904 → 664 B | 7.16 → 4.47 KB | 77.7 → 44.3 KB |
| pop middle half | 176 → 128 B | 408 → 288 B | 3.53 → 2.41 KB | 33.8 → 20.1 KB |
| get control | identical | identical | identical | identical |

The memory delta tracks the removed allocation: roughly one 2-tuple per
scanned element.

While auditing coverage for this change, a few branches of the
`get_and_update` path turned out to be exercised only by doctests or not
at all, so this PR also adds four tests: an inverted range through
`pop_in` (the `{[], data}` early return had no coverage), a fully
out of bounds range through `pop_in`, a traversal mixing `:pop` and
`{get, update}` returns (asserting both accumulators and the
early termination splice), and a stepped range starting past index 0
(pinning the membership check's short-circuit order — at index 0,
`rem(0 - 2, 2) == 0`, so only the `index >= first` guard keeps it
excluded). All four pass on the current implementation as well.

Full `make test` green (9,622 tests); `make format` produces no changes.

One unrelated observation from working in this module: the moduledoc's
accessor overview (access.ex:125-126) points readers at `key/1`,
`key!/1`, `elem/1`, and `all/0` "for some of the available accessors",
omitting the six added since — `at/1`, `at!/1`, `filter/1`, `find/1`,
`slice/1`, and `values/0`. Happy to add them to that list here or in a
separate docs PR, whichever you prefer.
