### PR TITLE
Fast path for unescape_char/2

### DIFF
--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -171,7 +171,15 @@ unescape_string(String, Map) ->
 % Unescape chars. For instance, "\" "n" (two chars) needs to be converted to "\n" (one char).
 
 unescape_chars(String, Map) ->
-  unescape_chars(String, Map, <<>>).
+  case binary:match(String, <<$\\>>) of
+    nomatch ->
+      String;
+
+    {Pos, _} ->
+      <<Part:Pos/binary, Rest/binary>> = String,
+      Acc = <<>>,
+      unescape_chars(Rest, Map, <<Acc/binary, Part/binary>>)
+  end.
 
 unescape_chars(<<$\\, $x, Rest/binary>>, Map, Acc) ->
   case Map(hex) of


### PR DESCRIPTION
As proposed on elixir-lang-core:
unescape_chars/2 always built its result byte by byte into an accumulator, so every string went through a full copy even when it had nothing to unescape (from my analysis, only 5% of the strings in the Elixir source code need unescaping).