### PR TITLE
Remove intermediate list in elixir_interpolation hex_to_int

### DIFF
--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -211,7 +211,7 @@ unescape_chars(<<>>, _Map, Acc) -> Acc.
 % Unescape Helpers
 
 unescape_hex(<<A, B, Rest/binary>>, Map, Acc) when ?is_hex(A), ?is_hex(B) ->
-  Bytes = list_to_integer([A, B], 16),
+  Bytes = (hex_to_int(A) bsl 4) bor hex_to_int(B),
   unescape_chars(Rest, Map, <<Acc/binary, Bytes>>);
 
 unescape_hex(<<_/binary>>, _Map, _Acc) ->
@@ -251,6 +251,10 @@ append_codepoint(Rest, Map, List, Acc, Base) ->
     error:badarg ->
       throw({error, "invalid or reserved Unicode code point \\u{" ++ List ++ "}", "\\u"})
   end.
+
+hex_to_int(H) when ?is_digit(H) -> H - $0;
+hex_to_int(H) when H >= $A, H =< $F -> H - $A + 10;
+hex_to_int(H) when H >= $a, H =< $f -> H - $a + 10.
 
 unescape_map(newline) -> true;
 unescape_map(unicode) -> true;

--- a/lib/elixir/test/erlang/string_test.erl
+++ b/lib/elixir/test/erlang/string_test.erl
@@ -117,6 +117,23 @@ string_with_lower_case_hex_interpolation_test() ->
 string_with_upper_case_hex_interpolation_test() ->
   {<<"jklmno">>, _} = eval("\"\\x6A\\x6B\\x6C\\x6D\\x6E\\x6F\"").
 
+string_with_mixed_case_hex_interpolation_test() ->
+  {<<171>>, _} = eval("\"\\xaB\""),
+  {<<171>>, _} = eval("\"\\xAb\"").
+
+string_with_hex_boundaries_test() ->
+  {<<0>>, _} = eval("\"\\x00\""),
+  {<<255>>, _} = eval("\"\\xff\""),
+  {<<255>>, _} = eval("\"\\xFF\"").
+
+string_with_hex_stops_after_two_digits_test() ->
+  {<<195, $a>>, _} = eval("\"\\xc3a\"").
+
+string_with_incomplete_hex_test() ->
+  ?assertError(#{'__struct__' := 'Elixir.SyntaxError'}, eval("\"\\x\"")),
+  ?assertError(#{'__struct__' := 'Elixir.SyntaxError'}, eval("\"\\x0\"")),
+  ?assertError(#{'__struct__' := 'Elixir.SyntaxError'}, eval("\"\\xc\"")).
+
 string_without_interpolation_and_escaped_test() ->
   {<<"f#o">>, _} = eval("\"f\\#o\"").
 


### PR DESCRIPTION
While looking at the elixir_interpolation file I spotted one more place where list_to_integer can be removed.
