### PR TITLE
Use a lookup table for two-digit zero padding in Calendar.ISO

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1740,6 +1740,15 @@ defmodule Calendar.ISO do
   defp sign(total) when total < 0, do: ?-
   defp sign(_), do: ?+
 
+  # Width-2 padding of 0..99 covers most pads when formatting dates and
+  # times (month, day, hour, minute, second, offset). The dense integer
+  # head compiles to a jump table returning a literal binary, avoiding
+  # the Integer.to_string and list allocations of the general clause.
+  for int <- 0..99 do
+    string = int |> Integer.to_string() |> String.pad_leading(2, "0")
+    defp zero_pad(unquote(int), 2), do: unquote(string)
+  end
+
   defp zero_pad(val, count) when val >= 0 and count <= 6 do
     num = Integer.to_string(val)
 


### PR DESCRIPTION
Assisted-by: Claude Code:claude-fable-5

Padding of a 0..99 value accounts for most `zero_pad/2` calls in
every date/time formatting path: month and day in `Date.to_iso8601/2`,
hour/minute/second in `Time.to_iso8601/2`, plus the two offset pads for
non UTC datetimes. Each of those pads currently calls `Integer.to_string/1`
(allocating a heap binary), then `byte_size` + `max` + a `case`, and for
values below 10 allocates a `["0" | num]` cons cell.

This adds comprehension-generated clauses for `zero_pad(0..99, 2)` that
return two-byte literal binaries. The dense integer head compiles to a
jump table, and the literals live in the module's literal pool, so the
common pads become allocation-free. The general clause is unchanged and
still handles width 4 and 6, as well as out-of-range values passed to the
public `date_to_iodata/4`; the negative-value clause is untouched.

## Benchmark

Apple M5, macOS, OTP 29, JIT enabled. Averages over 3 s per job
(sub-microsecond medians quantize at the timer tick). Memory is per call.

| Job | before | after | speedup | memory |
|---|---|---|---|---|
| `Time.to_iso8601/1` (single-digit fields) | 72.43 ns | 47.26 ns | 1.5x | 208 B → 88 B |
| `Time.to_iso8601/1` (double-digit fields) | 86.92 ns | 47.26 ns | 1.8x | 160 B → 88 B |
| `Time.to_iso8601/1` (with microseconds) | 78.68 ns | 55.50 ns | 1.4x | 224 B → 152 B |
| `Date.to_iso8601/1` | 72.70 ns | 64.74 ns | 1.1x | 184 B → 120 B |
| `NaiveDateTime.to_iso8601/1` | 167.99 ns | 92.56 ns | 1.8x | 440 B → 304 B |
| `DateTime.to_iso8601/1` (UTC) | 190.02 ns | 134.62 ns | 1.4x | 472 B → 336 B |
| `DateTime.to_string/1` (offset +02:00) | 251.94 ns | 181.07 ns | 1.4x | 672 B → 456 B |
| `inspect/1` of `~T` | 220.10 ns | 208.61 ns | 1.1x | 560 B → 488 B |
| `microseconds_to_iodata/2` precision 6 (control, general clause) | 17.63 ns | 17.66 ns | flat | 24 B → 24 B |

<details>
<summary>Benchmark script</summary>

```elixir
Mix.install([{:benchee, "~> 1.4"}])

date = ~D[2026-08-20]
time_low = ~T[09:05:03]
time_high = ~T[19:45:53]
time_us = ~T[19:45:53.123456]
ndt = ~N[2026-08-20 19:45:53.123456]
dt_utc = DateTime.from_naive!(ndt, "Etc/UTC")

# Non-UTC offset without needing a tz database: exercises the two
# offset pads (+02:00) on top of the datetime ones.
dt_berlin = %DateTime{
  calendar: Calendar.ISO,
  year: 2026,
  month: 8,
  day: 20,
  hour: 19,
  minute: 45,
  second: 53,
  microsecond: {123_456, 6},
  time_zone: "Europe/Berlin",
  zone_abbr: "CEST",
  utc_offset: 3600,
  std_offset: 3600
}

Benchee.run(
  %{
    "Date.to_iso8601" => fn -> Date.to_iso8601(date) end,
    "Time.to_iso8601 single-digit fields (worst case)" => fn -> Time.to_iso8601(time_low) end,
    "Time.to_iso8601 double-digit fields" => fn -> Time.to_iso8601(time_high) end,
    "Time.to_iso8601 with microseconds" => fn -> Time.to_iso8601(time_us) end,
    "NaiveDateTime.to_iso8601" => fn -> NaiveDateTime.to_iso8601(ndt) end,
    "DateTime.to_iso8601 (UTC)" => fn -> DateTime.to_iso8601(dt_utc) end,
    "DateTime.to_string (offset +02:00)" => fn -> DateTime.to_string(dt_berlin) end,
    "inspect ~T (sigil formatting)" => fn -> inspect(time_high) end,
    "microseconds_to_iodata precision 6 (general clause)" => fn ->
      Calendar.ISO.microseconds_to_iodata(123_456, 6)
    end
  },
  warmup: 1,
  time: 3,
  memory_time: 1
)
```
</details>