### PR TITLE
Fix map operation verdicts to be representation-agnostic (#15688)

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -3531,42 +3531,46 @@ defmodule Module.Types.Descr do
   def map_update_unchecked(:term, _key_descr, _type_fun, _return_type?, _force?), do: :badmap
 
   def map_update_unchecked(descr, key_descr, type_fun, return_type?, force?) do
-    split_keys = map_split_keys_and_domains(key_descr)
+    if empty?(descr) do
+      :badmap
+    else
+      split_keys = map_split_keys_and_domains(key_descr)
 
-    case :maps.take(:dynamic, descr) do
-      :error ->
-        if descr_key?(descr, :map) and map_only?(descr) do
-          {type, descr, errors, found?} =
-            map_update_static(descr, split_keys, type_fun, return_type?, force?, true)
+      case :maps.take(:dynamic, descr) do
+        :error ->
+          if descr_key?(descr, :map) and map_only?(descr) do
+            {type, descr, errors, found?} =
+              map_update_static(descr, split_keys, type_fun, return_type?, force?, true)
 
-          if found? do
-            {type, descr, errors}
+            if found? do
+              {type, descr, errors}
+            else
+              {:error, errors}
+            end
           else
-            {:error, errors}
+            :badmap
           end
-        else
-          :badmap
-        end
 
-      {dynamic, static} ->
-        if descr_key?(dynamic, :map) and map_only?(static) do
-          {static_value, static_descr, static_errors, _static_found?} =
-            map_update_static(static, split_keys, type_fun, return_type?, force?, true)
+        {dynamic, static} ->
+          if descr_key?(dynamic, :map) and map_only?(static) do
+            {static_value, static_descr, static_errors, _static_found?} =
+              map_update_static(static, split_keys, type_fun, return_type?, force?, true)
 
-          {dynamic_value, dynamic_descr, dynamic_errors, dynamic_found?} =
-            map_update_static(dynamic, split_keys, type_fun, return_type?, force?, false)
+            {dynamic_value, dynamic_descr, dynamic_errors, dynamic_found?} =
+              map_update_static(dynamic, split_keys, type_fun, return_type?, force?, false)
 
-          # We can exceptionally check for none() here because
-          # we already check for empty downstream
-          if dynamic_found? do
-            {opt_union(static_value, dynamic(dynamic_value)),
-             opt_union(static_descr, dynamic(dynamic_descr)), static_errors ++ dynamic_errors}
+            # We can exceptionally check for none() here because
+            # we already check for empty downstream
+            if dynamic_found? do
+              {opt_union(static_value, dynamic(dynamic_value)),
+               opt_union(static_descr, dynamic(dynamic_descr)), static_errors ++ dynamic_errors}
+            else
+              {:error, static_errors ++ dynamic_errors}
+            end
           else
-            {:error, static_errors ++ dynamic_errors}
+            :badmap
           end
-        else
-          :badmap
-        end
+      end
     end
   end
 
@@ -3730,38 +3734,47 @@ defmodule Module.Types.Descr do
         # Optimization: if there are no negatives, we can directly remove the key.
         {tag, fields, []}, {field, bdd} ->
           {fst, snd} = map_pop_key_bdd(tag, fields, key)
-          {maybe_field_opt_union(field, fn -> fst end), opt_map_union(bdd, snd, %{})}
+
+          if map_empty?(snd, %{}) do
+            {field, bdd}
+          else
+            {maybe_field_opt_union(field, fn -> fst end), opt_map_union(bdd, snd, %{})}
+          end
 
         {tag, fields, negs}, {field, bdd} ->
           {fst, snd} = map_pop_key_bdd(tag, fields, key)
 
-          case map_split_negative_pairs_key(negs, key) do
-            :empty ->
-              {field, bdd}
+          if map_empty?(snd, %{}) do
+            {field, bdd}
+          else
+            case map_split_negative_pairs_key(negs, key) do
+              :empty ->
+                {field, bdd}
 
-            negative ->
-              keep_fst? =
-                field == nil or map_pair_projection_keeps_full_fst?(negative, snd)
+              negative ->
+                keep_fst? =
+                  field == nil or map_pair_projection_keeps_full_fst?(negative, snd)
 
-              keep_snd? = map_pair_projection_keeps_full_snd?(negative, fst)
+                keep_snd? = map_pair_projection_keeps_full_snd?(negative, fst)
 
-              pairs =
-                if keep_fst? and keep_snd?,
-                  do: [],
-                  else: map_remove_negative(negative, fst, snd)
+                pairs =
+                  if keep_fst? and keep_snd?,
+                    do: [],
+                    else: map_remove_negative(negative, fst, snd)
 
-              {maybe_field_opt_union(field, fn ->
-                 if keep_fst? do
-                   fst
+                {maybe_field_opt_union(field, fn ->
+                   if keep_fst? do
+                     fst
+                   else
+                     Enum.reduce(pairs, {none(), false}, &field_opt_union(elem(&1, 0), &2, %{}))
+                   end
+                 end),
+                 if keep_snd? do
+                   opt_map_union(bdd, snd, %{})
                  else
-                   Enum.reduce(pairs, {none(), false}, &field_opt_union(elem(&1, 0), &2, %{}))
-                 end
-               end),
-               if keep_snd? do
-                 opt_map_union(bdd, snd, %{})
-               else
-                 Enum.reduce(pairs, bdd, &opt_map_union(elem(&1, 1), &2, %{}))
-               end}
+                   Enum.reduce(pairs, bdd, &opt_map_union(elem(&1, 1), &2, %{}))
+                 end}
+            end
           end
       end)
 
@@ -3953,22 +3966,26 @@ defmodule Module.Types.Descr do
   end
 
   defp map_put_static_value(descr, split_keys, type) do
-    case :maps.take(:dynamic, descr) do
-      :error ->
-        if non_empty_map_only?(descr) do
-          {:ok, map_put_static(descr, split_keys, type)}
-        else
-          :badmap
-        end
+    if empty?(descr) do
+      :badmap
+    else
+      case :maps.take(:dynamic, descr) do
+        :error ->
+          if non_empty_map_only?(descr) do
+            {:ok, map_put_static(descr, split_keys, type)}
+          else
+            :badmap
+          end
 
-      {dynamic, static} ->
-        if descr_key?(dynamic, :map) and map_only?(static) do
-          static_descr = map_put_static(static, split_keys, type)
-          dynamic_descr = map_put_static(dynamic, split_keys, type)
-          {:ok, opt_union(static_descr, dynamic(dynamic_descr))}
-        else
-          :badmap
-        end
+        {dynamic, static} ->
+          if descr_key?(dynamic, :map) and map_only?(static) do
+            static_descr = map_put_static(static, split_keys, type)
+            dynamic_descr = map_put_static(dynamic, split_keys, type)
+            {:ok, opt_union(static_descr, dynamic(dynamic_descr))}
+          else
+            :badmap
+          end
+      end
     end
   end
 
@@ -4030,35 +4047,39 @@ defmodule Module.Types.Descr do
   def map_get(:term, _key_descr), do: :badmap
 
   def map_get(%{} = descr, key_descr) do
-    split_keys = map_split_keys_and_domains(key_descr)
+    if empty?(descr) do
+      :badmap
+    else
+      split_keys = map_split_keys_and_domains(key_descr)
 
-    case :maps.take(:dynamic, descr) do
-      :error ->
-        if descr_key?(descr, :map) and map_only?(descr) do
-          type_selected = map_get_static(descr, split_keys)
+      case :maps.take(:dynamic, descr) do
+        :error ->
+          if descr_key?(descr, :map) and map_only?(descr) do
+            type_selected = map_get_static(descr, split_keys)
 
-          if empty?(type_selected) do
-            :error
+            if empty?(type_selected) do
+              :error
+            else
+              {:ok, type_selected}
+            end
           else
-            {:ok, type_selected}
+            :badmap
           end
-        else
-          :badmap
-        end
 
-      {dynamic, static} ->
-        if descr_key?(dynamic, :map) and map_only?(static) do
-          static_type = map_get_static(static, split_keys)
-          dynamic_type = map_get_static(dynamic, split_keys)
+        {dynamic, static} ->
+          if descr_key?(dynamic, :map) and map_only?(static) do
+            static_type = map_get_static(static, split_keys)
+            dynamic_type = map_get_static(dynamic, split_keys)
 
-          if empty?(dynamic_type) do
-            :error
+            if empty?(dynamic_type) do
+              :error
+            else
+              {:ok, opt_union(dynamic(dynamic_type), static_type)}
+            end
           else
-            {:ok, opt_union(dynamic(dynamic_type), static_type)}
+            :badmap
           end
-        else
-          :badmap
-        end
+      end
     end
   end
 
@@ -4091,8 +4112,12 @@ defmodule Module.Types.Descr do
   defp map_get_domain(dnf, domain_key, acc) when is_atom(domain_key) do
     Enum.reduce(dnf, acc, fn
       # Optimization: if there are no negatives, get the domain tag directly
-      {tag, _fields, []}, acc ->
-        map_domain_tag_to_type(tag, domain_key) |> opt_union(acc)
+      {tag, fields, []}, acc ->
+        if init_map_line_empty?(tag, fields, []) do
+          acc
+        else
+          map_domain_tag_to_type(tag, domain_key) |> opt_union(acc)
+        end
 
       {tag_or_domains, fields, negs}, acc ->
         if init_map_line_empty?(tag_or_domains, fields, negs) do

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -870,6 +870,9 @@ defmodule Module.Types.Expr do
 
         {true, false} ->
           {type, :bitstring, context}
+
+        {false, false} ->
+          {type, :none, context}
       end
     else
       {_type, context} =

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -3728,6 +3728,49 @@ defmodule Module.Types.DescrTest do
       assert map_put(none(), atom([:a]), integer()) == :badmap
       assert map_put(a2, atom([:a]), integer()) == :badmap
     end
+
+    test "is representation-agnostic for branches containing none() (issue #15688)" do
+      # Repro 1: closed map with required key unioned with empty
+      a = opt_union(closed_map(b: {term(), false}), closed_map(a: {none(), false}))
+      a1 = closed_map(b: {term(), false})
+      assert equal?(a, a1)
+
+      assert map_update(a1, atom([:b]), atom([:x]), false) |> elem(1) |> to_quoted_string() ==
+               "%{b: :x}"
+
+      assert map_update(a, atom([:b]), atom([:x]), false) |> elem(1) |> to_quoted_string() ==
+               "%{b: :x}"
+
+      # Repro 2: empty open line fakes domain
+      b = opt_union(closed_map([]), open_map(a: {none(), false}))
+      assert equal?(b, closed_map([]))
+      assert map_update(b, integer(), atom([:x]), false) == {:error, [baddomain: integer()]}
+
+      assert map_update(empty_map(), integer(), atom([:x]), false) ==
+               {:error, [baddomain: integer()]}
+
+      # Repro 3: inconsistent errors for none() vs closed_map with none field
+      e = closed_map(a: {none(), false})
+      assert empty?(e)
+      assert equal?(e, none())
+      assert map_put(e, atom([:a]), atom([:x])) == :badmap
+      assert map_put(none(), atom([:a]), atom([:x])) == :badmap
+      assert map_get(e, atom([:a])) == :badmap
+      assert map_get(none(), atom([:a])) == :badmap
+      assert map_update(e, atom([:a]), atom([:x]), false) == :badmap
+      assert map_update(none(), atom([:a]), atom([:x]), false) == :badmap
+
+      # Repro 4: gradual path
+      e = open_map(a: {none(), false})
+      assert equal?(e, none())
+      assert map_put(e, atom(), integer()) == :badmap
+      assert map_put(none(), atom(), integer()) == :badmap
+      assert map_put(e, atom(), dynamic()) == :badmap
+      assert map_put(none(), atom(), dynamic()) == :badmap
+
+      # Valid gradual case must not be discarded
+      assert {:ok, _} = map_put(open_map(a: {integer(), false}), atom([:a]), integer())
+    end
   end
 
   describe "disjoint" do

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -3341,6 +3341,10 @@ defmodule Module.Types.ExprTest do
              """
     end
 
+    test ":into with non-returning collectable" do
+      assert typecheck!([list], for(x <- list, into: raise("oops"), do: x)) == none()
+    end
+
     test ":reduce checks" do
       assert typecheck!(
                [list],


### PR DESCRIPTION
Fixes #15688

**Problem**
`map_update` / `map_put` / `map_get` verdicts depended on syntactic BDD representation rather than semantic type. A required `none()` field kept as `closed([a: none])` or `open([a: none])` is `equal?(none())` and `empty?` but was not treated like `none()`:

- Repro 1: `closed([b: term]) ∪ closed([a: none])` equal to `closed([b: term])`, but `map_update(..., :b)` returned `{:error, badkey}` vs `"%{b: :x}"`.
- Repro 2: `closed([]) ∪ open([a: none])` equal to `closed([])`, but `map_update(..., integer())` returned `"%{..., a: none()}"` vs `{:error, baddomain}`.
- Repro 3: `closed([a: none])` equal to `none()` but `map_get` returned `:error` vs `:badmap`, `map_update` returned `{:error, badkey}` vs `:badmap`.
- Repro 4: `open([a: none])` (gradual `%{dynamic: leaf}`) returned `{:ok, ...}` for `dynamic()` put vs `:badmap` for `none()`.

Related to #15592, #15594. Commit `745ee1d` fixed `map_dnf_fetch_static` only.

**Fix**
`lib/elixir/lib/module/types/descr.ex` — make operations representation-agnostic:

- `map_dnf_pop_key_static:3727` — filter residual `snd` with `map_empty?(snd)` before `opt_map_union` (mirrors `745ee1d` fix for `fetch`), for both `negs==[]` and `negs` branches. Fixes Repro 1 empty-branch pollution.
- `map_get_domain:4091` fast-path `{tag, fields, []}` — add `init_map_line_empty?` guard (already in general branch). Fixes Repro 2 domain poisoning by `open([a: none])`.
- `map_get:4030`, `map_update_unchecked:3531`, `map_put_static_value:3955` — early `if empty?(descr) -> :badmap` so whole-empty descriptors (`closed([a:none])`, `open([a:none])` gradual) behave like `none()`. Preserves `dynamic(integer())` (non-empty) via `field_empty?` vs `bdd` distinction.

No change to `map_descr_pair` (keeps gradual upper bound) or `map_bdd_to_dnf_remove_empty` (already correct for whole-line).

**Tests**
- Added `test "is representation-agnostic for branches containing none() (issue #15688)"` in `lib/elixir/test/elixir/module/types/descr_test.exs:3722` covering all 4 repros plus valid `open([a: integer])` not discarded.
- `make compile` OK, `bin/elixir descr_test.exs` → `141 passed` (new test passes), `expr_test.exs` → `139 passed`, `mix format --check-formatted` → `0`.

**Branch:** `fix-15688-map-representation-agnostic` (includes `e27c5d7` for #15747 already merged as `345507a`)