### PR TITLE
Remove duplicate pattern compilation in Unicode data processing

### DIFF
--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -107,9 +107,6 @@ case_ignorable_categories = :binary.compile_pattern(["Mn", "Me", "Cf", "Lm", "Sk
         cacc
       end
 
-    cased_letter_categories = :binary.compile_pattern(["Ll", "Lt", "Lu"])
-    case_ignorable_categories = :binary.compile_pattern(["Mn", "Me", "Cf", "Lm", "Sk"])
-
     {lacc, iacc} =
       cond do
         match?({0, _}, :binary.match(category, cased_letter_categories)) ->


### PR DESCRIPTION
Assisted-by: Claude Code:claude-fable-5

The following code is currently being declared in two places, outside the reduce function and inside of the reduce function. 
We can remove the inner version since it is just shadowing the outer variables exactly and re-evaluating on every loop. See lines:77-78 for confirmation.

```elixir
cased_letter_categories = :binary.compile_pattern(["Ll", "Lt", "Lu"])
case_ignorable_categories = :binary.compile_pattern(["Mn", "Me", "Cf", "Lm", "Sk"])
```
