### PR TITLE
Keep dead branch domains when refining case subjects on inference

### DIFF
--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -451,9 +451,9 @@ defmodule Module.Types.Expr do
       end
 
     cache_arrows(meta, stack, fn ->
-      acc = {false, none(), []}
+      acc = {false, none(), [], []}
 
-      {{none?, body_acc, clauses_acc}, context} =
+      {{none?, body_acc, clauses_acc, dead_acc}, context} =
         of_clauses_fun(clauses, [case_type], info, stack, context, acc, fn
           trees, precise?, {:->, _, [_, body]} = clause, context, acc ->
             # Compute the arg type based on the clause itself
@@ -473,20 +473,36 @@ defmodule Module.Types.Expr do
               of_expr(body, expected, body, stack, reset_warnings(refined_context, context))
 
             # Now we compute the return type and the clauses for reverse arrow
-            {none?, body_acc, clauses_acc} = acc
+            {none?, body_acc, clauses_acc, dead_acc} = acc
 
             if precise? and empty?(body_type) do
-              {{true, body_acc, clauses_acc}, context}
+              {{true, body_acc, clauses_acc, [arg_type | dead_acc]}, context}
             else
               [arg_type] = Pattern.of_domain(trees, stack, context)
               clauses_acc = [{arg_type, body_type, clause} | clauses_acc]
-              {{none?, opt_union(body_type, body_acc), clauses_acc}, context}
+              {{none?, opt_union(body_type, body_acc), clauses_acc, dead_acc}, context}
             end
         end)
 
       context =
         if none? or stack.mode != :static do
-          head_type = Enum.reduce(clauses_acc, none(), &opt_union(elem(&1, 0), &2))
+          # Branches that can never return are excluded from the refinement
+          # during static checking, so code after the case sees the subject
+          # negated by their patterns. However, during inference (and dynamic
+          # mode), excluding them would narrow the inferred signature of the
+          # enclosing function depending on how it is written (a case clause
+          # raising versus a function clause raising), so we keep their types.
+          dead_acc =
+            if stack.mode == :static do
+              []
+            else
+              dead_acc
+            end
+
+          head_type =
+            clauses_acc
+            |> Enum.reduce(none(), &opt_union(elem(&1, 0), &2))
+            |> opt_union(Enum.reduce(dead_acc, none(), &opt_union/2))
 
           {_, refined_context} =
             of_expr(

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -2230,6 +2230,45 @@ defmodule Module.Types.ExprTest do
              ) == dynamic(opt_union(open_map(), tuple([])))
     end
 
+    test "refine types when there are dead branches on inference" do
+      # Dead branches are excluded from the refinement during static checking
+      # but not during dynamic checking and inference, otherwise they would
+      # narrow the signature of the enclosing function based on how the code
+      # is written (a case clause raising versus a function clause raising).
+      #
+      # Note we compare with equal?/2 because the resulting descr may be kept
+      # in a non-canonical BDD form depending on how the expression expands.
+      result =
+        typedyn!(
+          [x],
+          (
+            case x do
+              {:ok, value} -> value
+              _value -> raise "oops"
+            end
+
+            x
+          )
+        )
+
+      assert equal?(result, dynamic())
+
+      result =
+        typecheck!(
+          [x],
+          (
+            case x do
+              {:ok, value} -> value
+              _value -> raise "oops"
+            end
+
+            x
+          )
+        )
+
+      assert equal?(result, dynamic(tuple([atom([:ok]), term()])))
+    end
+
     test "warns on redundant clauses" do
       assert typewarn!(
                [x],

--- a/lib/elixir/test/elixir/module/types/infer_test.exs
+++ b/lib/elixir/test/elixir/module/types/infer_test.exs
@@ -376,6 +376,50 @@ defmodule Module.Types.InferTest do
     end
   end
 
+  test "from expressions (case with dead branches)", config do
+    types =
+      infer config do
+        def case_ok_or_raise!(result) do
+          case result do
+            {:ok, value} -> value
+            value -> raise "Failed to unwrap value #{inspect(value)}"
+          end
+        end
+
+        def clause_ok_or_raise!({:ok, v}), do: v
+        def clause_ok_or_raise!(value), do: raise("Failed to unwrap value #{inspect(value)}")
+      end
+
+    # A dead branch (one that never returns, such as a raise) must not narrow
+    # the inferred domain of its function, matching the equivalent definition
+    # written with multiple clauses.
+    assert {:infer, _, [{[case_arg], _}]} = types[{:case_ok_or_raise!, 1}]
+    assert case_arg |> equal?(term())
+
+    # Note each clause keeps the difference of the previous clauses as its type,
+    # so we assert on the overall domain instead.
+    assert {:infer, [clause_domain], [{[ok_arg], _}, _]} = types[{:clause_ok_or_raise!, 1}]
+    assert ok_arg |> equal?(tuple([atom([:ok]), term()]))
+    assert clause_domain |> equal?(term())
+  end
+
+  test "from expressions (case without dead branches)", config do
+    types =
+      infer config do
+        def f(x) do
+          case x do
+            {:ok, v} -> v
+            {:error, r} -> r
+          end
+        end
+      end
+
+    # Without dead branches, the case subject is still refined on inference,
+    # so non-total cases keep narrowing the domain.
+    assert {:infer, _, [{[arg], _}]} = types[{:f, 1}]
+    assert arg |> equal?(tuple([atom([:error, :ok]), term()]))
+  end
+
   test "from defaults (regression with multiple clauses)", config do
     types =
       infer config do


### PR DESCRIPTION
## Summary

When a `case` has a precise clause whose body can never return (e.g. it raises), we refine the case subject with the negation of that clause's domain. Within function bodies this is desirable: code after the `case` can rely on the subject not matching the dead branches.

However, during type inference this refinement also leaked into the enclosing function's inferred signature through `Pattern.of_domain/3`, which computes argument types after the body has been checked. As a result, semantically equivalent code produced different signatures depending on how it was written:

```elixir
def case_ok_or_raise!(result) do
  case result do
    {:ok, value} -> value
    value -> raise "Failed to unwrap value #{inspect(value)}"
  end
end

def clause_ok_or_raise!({:ok, v}), do: v
def clause_ok_or_raise!(value), do: raise("Failed to unwrap value #{inspect(value)}")
```

Calling both with `nil` emitted a warning for `case_ok_or_raise!/1` but not for `clause_ok_or_raise!/1`.

## Solution

Dead branch domains are now included whenever refinement happens outside static checking (that is, during inference and dynamic mode), so inferred signatures stay consistent regardless of structure. Static checking keeps refining subjects to live branches only, preserving negation typing inside function bodies.

## Verification

- Regression tests in `infer_test.exs` fail before this change and pass after, including a guard asserting non-total cases *without* dead branches still narrow signatures (intended behavior)
- A unit test in `expr_test.exs` covers subject refinement in both dynamic and static modes
- Reproducer above compiles warning-free and matches its multi-clause equivalent
- Full suite green (`make test`) plus a clean bootstrap (`make clean_elixir compile`)

Fixes #15777