### PR TITLE
Trim trailing whitespace without slicing per step

### DIFF
--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -424,44 +424,55 @@ defmodule String.Break do
 
   # trim_trailing
 
-  for cp <- whitespace do
-    # We need to increment @whitespace_max_size as well
-    # as the small table (_s) if we add a new entry here.
-    case byte_size(cp) do
-      3 ->
-        defp do_trim_trailing_l(unquote(cp)), do: -3
+  def trim_trailing(string) when is_binary(string) do
+    size = byte_size(string)
 
-      2 ->
-        defp do_trim_trailing_l(<<_, unquote(cp)>>), do: -2
-        defp do_trim_trailing_s(unquote(cp)), do: <<>>
-
-      1 ->
-        defp do_trim_trailing_l(<<unquote(cp), unquote(cp), unquote(cp)>>), do: -3
-        defp do_trim_trailing_l(<<_, unquote(cp), unquote(cp)>>), do: -2
-        defp do_trim_trailing_l(<<_, _, unquote(cp)>>), do: -1
-
-        defp do_trim_trailing_s(<<x, unquote(cp)>>), do: do_trim_trailing_s(<<x>>)
-        defp do_trim_trailing_s(unquote(cp)), do: <<>>
+    case do_trim_trailing_pos(string, size) do
+      ^size -> string
+      0 -> ""
+      pos -> binary_part(string, 0, pos)
     end
   end
 
-  defp do_trim_trailing_l(_), do: 0
-  defp do_trim_trailing_s(o), do: o
+  for cp <- whitespace do
+    # We need to increment @whitespace_max_size as well as
+    # do_trim_trailing_short/1 if we add a new entry here.
+    case byte_size(cp) do
+      3 ->
+        defp do_trim_trailing_lookahead(unquote(cp)), do: -3
 
-  def trim_trailing(string) when is_binary(string) do
-    trim_trailing(string, byte_size(string))
+      2 ->
+        defp do_trim_trailing_lookahead(<<_, unquote(cp)>>), do: -2
+        defp do_trim_trailing_short(unquote(cp)), do: <<>>
+
+      1 ->
+        <<byte>> = cp
+
+        defp do_trim_trailing_byte(unquote(byte), string, size),
+          do: do_trim_trailing_pos(string, size - 1)
+    end
   end
 
-  defp trim_trailing(string, size) when size < @whitespace_max_size do
-    do_trim_trailing_s(string)
-  end
+  defp do_trim_trailing_lookahead(_), do: 0
+  defp do_trim_trailing_short(o), do: o
 
-  defp trim_trailing(string, size) do
-    trail = binary_part(string, size, -@whitespace_max_size)
+  defp do_trim_trailing_pos(_string, 0), do: 0
 
-    case do_trim_trailing_l(trail) do
-      0 -> string
-      x -> trim_trailing(binary_part(string, 0, size + x), size + x)
+  defp do_trim_trailing_pos(string, size),
+    do: do_trim_trailing_byte(:binary.at(string, size - 1), string, size)
+
+  defp do_trim_trailing_byte(byte, string, size) when byte >= 0x80,
+    do: do_trim_trailing_multibyte(string, size)
+
+  defp do_trim_trailing_byte(_byte, _string, size), do: size
+
+  defp do_trim_trailing_multibyte(string, size) when size < @whitespace_max_size,
+    do: byte_size(do_trim_trailing_short(binary_part(string, 0, size)))
+
+  defp do_trim_trailing_multibyte(string, size) do
+    case do_trim_trailing_lookahead(binary_part(string, size, -@whitespace_max_size)) do
+      0 -> size
+      x -> do_trim_trailing_pos(string, size + x)
     end
   end
 


### PR DESCRIPTION
trim_trailing/1 walked the string with binary_part/3, which allocated the three byte lookahead plus a fresh prefix on every step even though every prefix but the last one is discarded, and paid one allocation even when there was nothing to trim.

Carry the position instead and slice once at the end. The one-byte whitespace codepoints, which are the common case, now need no lookahead at all, so the lookahead tables only hold the multi-byte ones.

It starts to be slower with around 1k trailing spaces than the previous implementation, but the memory usage does not change with ascii white spaces. I think it is a very uncommon case.

```
list = Enum.map(1..100, &to_string/1) |> Enum.join("") 
one = list |> Kernel.<>(" ")
l20 = list |> Kernel.<>("  \n     \r          \n  ")
onek = list |> Kernel.<> Enum.map_join(1..1000, "", fn _ -> " " end)

Benchee.run(
  %{
    "old_no_trailing" => fn -> String.Break.trim_trailing(list) end,
    "new_no_trailing" => fn -> String.BreakNew.trim_trailing(list) end,
    "old_one_trailing" => fn -> String.Break.trim_trailing(one) end,
    "new_one_trailing" => fn -> String.BreakNew.trim_trailing(one) end,
    "old_20_trailing" => fn -> String.Break.trim_trailing(l20) end,
    "new_20_trailing" => fn -> String.BreakNew.trim_trailing(l20) end,
    "old_1k_trailing" => fn -> String.Break.trim_trailing(onek) end,
    "new_1k_trailing" => fn -> String.BreakNew.trim_trailing(onek) end
  },
  time: 1,
  memory_time: 1
)
```
results
```
Name                       ips        average  deviation         median         99th %
new_no_trailing         3.59 M      278.81 ns  ±2436.56%         241 ns         571 ns
new_one_trailing        3.43 M      291.26 ns  ±2290.17%         260 ns         441 ns
old_no_trailing         3.20 M      312.65 ns  ±1931.60%         280 ns         461 ns
old_one_trailing        2.95 M      338.92 ns  ±1279.22%         311 ns         491 ns
new_20_trailing         1.69 M      592.09 ns  ±1222.26%         541 ns         802 ns
old_20_trailing         1.30 M      769.91 ns   ±542.88%         691 ns        1623 ns
old_1k_trailing       0.0827 M    12094.93 ns    ±32.20%       11061 ns       22492 ns
new_1k_trailing       0.0757 M    13202.34 ns    ±19.70%       12994 ns       17172 ns

Comparison: 
new_no_trailing         3.59 M
new_one_trailing        3.43 M - 1.04x slower +12.45 ns
old_no_trailing         3.20 M - 1.12x slower +33.84 ns
old_one_trailing        2.95 M - 1.22x slower +60.11 ns
new_20_trailing         1.69 M - 2.12x slower +313.28 ns
old_20_trailing         1.30 M - 2.76x slower +491.10 ns
old_1k_trailing       0.0827 M - 43.38x slower +11816.12 ns
new_1k_trailing       0.0757 M - 47.35x slower +12923.53 ns

Memory usage statistics:

Name                Memory usage
new_no_trailing            432 B
new_one_trailing           432 B - 1.00x memory usage +0 B
old_no_trailing            472 B - 1.09x memory usage +40 B
old_one_trailing           512 B - 1.19x memory usage +80 B
new_20_trailing            432 B - 1.00x memory usage +0 B
old_20_trailing            912 B - 2.11x memory usage +480 B
old_1k_trailing          13832 B - 32.02x memory usage +13400 B
new_1k_trailing            432 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

```

Btw - should the `do_trim_leading` above be private ?