### PR TITLE
Document that DynamicSupervisor doesn't support most of Erlang's :sup…

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -137,6 +137,18 @@ defmodule DynamicSupervisor do
 
   A supervisor is bound to the same name registration rules as a `GenServer`.
   Read more about these rules in the documentation for `GenServer`.
+
+  ## Erlang's `:supervisor` module functions
+
+  `DynamicSupervisor` implements the message-based interface behind
+  `which_children/1` and `count_children/1`, so those (and the equivalent
+  functions in Erlang's `:supervisor` module) can be called against a
+  `DynamicSupervisor` safely. It does not implement the rest of Erlang's
+  `:supervisor` module's public API, though. In particular,
+  dynamically-started children aren't tracked by `:id` the way a static
+  `Supervisor`'s children are, so functions like `:supervisor.get_childspec/2`
+  that look children up by `:id` are not meaningfully supported against a
+  `DynamicSupervisor`.
   """
 
   @behaviour GenServer


### PR DESCRIPTION
### Title

Document that `DynamicSupervisor` doesn't support most of Erlang's `:supervisor` module functions

### Description

Adds a short moduledoc section to `DynamicSupervisor` (after "Name registration"): `which_children/1`/`count_children/1` (and their Erlang `:supervisor` equivalents) are safe to call, but the rest of Erlang's `:supervisor` module's public API isn't meaningfully supported, since `DynamicSupervisor` doesn't track children by `:id`. Worded around that underlying limitation rather than any specific function's current crashing behavior, so this stays accurate even if that behavior changes later (e.g. if `get_childspec/2` is made to return an error instead of crashing, which I plan to propose separately).

Documentation-only, no behavior change, no test needed.
