### PR TITLE
DynamicSupervisor: handle :get_childspec like Supervisor does

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -686,6 +686,13 @@ defmodule DynamicSupervisor do
     {:reply, reply, state}
   end
 
+  def handle_call({:get_childspec, _id}, _from, state) do
+    # DynamicSupervisor doesn't track children by :id (see "Erlang's
+    # :supervisor module functions" above), so there's no id -> child
+    # lookup to perform here: no id can ever resolve to a tracked child.
+    {:reply, {:error, :not_found}, state}
+  end
+
   def handle_call(:count_children, _from, state) do
     %{children: children} = state
     specs = map_size(children)

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -757,6 +757,12 @@ defmodule DynamicSupervisorTest do
     end
   end
 
+  test "handles :get_childspec from :supervisor" do
+    {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
+    assert :supervisor.get_childspec(pid, :whatever) == {:error, :not_found}
+    assert Process.alive?(pid)
+  end
+
   defp sleepy_worker(opts \\ []) do
     mfa = {Task, :start_link, [Process, :sleep, [:infinity]]}
     Supervisor.child_spec(%{id: Task, start: mfa}, opts)


### PR DESCRIPTION
### Title

DynamicSupervisor: handle `:get_childspec` like `Supervisor` does

### Description

Erlang's `:supervisor` module has a public `get_childspec/2` function (since OTP 22). Call it against a plain `Supervisor` and it works as documented (verified in `iex`):

```
iex> Supervisor.start_link([%{id: Worker, start: {Worker, :start_link, [[]]}}], strategy: :one_for_one, name: :s)
iex> :supervisor.get_childspec(:s, Worker)
{:ok, %{id: Worker, start: {Worker, :start_link, [[]]}, restart: :permanent, ...}}
```

Call the exact same function against a `DynamicSupervisor` and it crashes the DynamicSupervisor instead, since `handle_call/3` has no clause for `{:get_childspec, id}` — and since `DynamicSupervisor.start_link/1` links the caller, calling this from a plain `iex` session takes the whole shell process down with it (real `iex` output, trimmed for length — full details in the stacktrace itself when you run it):

```
iex> {:ok, d} = DynamicSupervisor.start_link(strategy: :one_for_one, name: :d)
iex> :supervisor.get_childspec(d, :whatever)

02:xx:xx.xxx [error] GenServer :d terminating
** (FunctionClauseError) no function clause matching in DynamicSupervisor.handle_call/3
    (elixir 1.20.1) lib/dynamic_supervisor.ex:672: DynamicSupervisor.handle_call({:get_childspec, :whatever}, {...}, %DynamicSupervisor{...})
    (stdlib 8.0.3) gen_server.erl:2470: :gen_server.try_handle_call/4
    ...
** (EXIT from #PID<0.111.0>) shell process exited with reason: an exception was raised:
    ** (FunctionClauseError) no function clause matching in DynamicSupervisor.handle_call/3
        (elixir 1.20.1) lib/dynamic_supervisor.ex:672: DynamicSupervisor.handle_call({:get_childspec, :whatever}, ...)

Interactive Elixir (1.20.1) - press Ctrl+C to exit (type h() ENTER for help)
```

(iex's own supervision restarts the shell afterward — outside `iex`, whatever process made this call, and anything linked to the `DynamicSupervisor`, goes down with no such safety net.)

`which_children/1` and `count_children/1` — the other two functions in this same family — already work fine against a `DynamicSupervisor`. `get_childspec/2` being the one left crashing instead of erroring looks like a simple oversight, so this PR adds the missing clause:

```elixir
def handle_call({:get_childspec, _id}, _from, state) do
  {:reply, {:error, :not_found}, state}
end
```

`{:error, :not_found}` for every `id` is correct here, not a placeholder: `save_child/7` stores each child in `state.children` keyed by `pid`, as `{mfa, restart, shutdown, type, modules}` — `:id` is discarded entirely at `start_child/2` time and never stored anywhere (see [#11662](https://github.com/elixir-lang/elixir/issues/11662), which documents the same discarding for a different reason). There's no `:id` → child lookup this function could ever perform, so there's nothing more to implement — this one clause is the complete fix.

(There's a reasonable position that a `gen_server` should fail-fast on messages it doesn't recognize, and that crashing here is fine on those grounds. This patch doesn't take a stance on that question in general — it's narrower than that: it just brings `DynamicSupervisor` in line with what the static `Supervisor` implementation already does for this exact call, and what `DynamicSupervisor`'s own `which_children/1`/`count_children/1` already do for the same family of calls. The goal is consistency with existing, already-shipped behavior elsewhere in this same module, not a general argument about how unrecognized messages should be handled.)

With the patch applied (verified locally):

```
iex> :supervisor.get_childspec(d, :whatever)
{:error, :not_found}
iex> Process.alive?(Process.whereis(:d))
true
iex> DynamicSupervisor.which_children(d)   # unaffected
[]
```

**Tests:** Added a test case in `dynamic_supervisor_test.exs` verifying that `:supervisor.get_childspec/2` returns `{:error, :not_found}` and does not crash the supervisor. Neither `dynamic_supervisor_test.exs` nor `supervisor_test.exs` had any existing test for `get_childspec` to extend (it's presumably covered by Erlang/OTP's own test suite instead, for the static-`Supervisor` case), so this is a new, minimal one matching the file's existing style:

```elixir
test "handles :get_childspec from :supervisor" do
  {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
  assert :supervisor.get_childspec(pid, :whatever) == {:error, :not_found}
  assert Process.alive?(pid)
end
```
