### PR TITLE
Reuse the top non-empty list descriptor

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -2192,7 +2192,7 @@ defmodule Module.Types.Descr do
     list_part =
       case last_type do
         :term ->
-          list_new(:term, :term)
+          @non_empty_list_top
 
         {_, _, _} ->
           list_new(list_type, last_type)


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT-5.6 Sol

Avoid rebuilding and hashing the canonical non-empty list top leaf when the tail is term().

