### PR TITLE
Avoid rebuilding map domains during lookup

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -4098,8 +4098,7 @@ defmodule Module.Types.Descr do
         if init_map_line_empty?(tag_or_domains, fields, negs) do
           acc
         else
-          {_found, value, _bdd} = map_pop_domain_bdd(tag_or_domains, fields, domain_key)
-          opt_union(value, acc)
+          map_domain_tag_to_type(tag_or_domains, domain_key) |> opt_union(acc)
         end
     end)
   end
@@ -4463,18 +4462,6 @@ defmodule Module.Types.Descr do
       subtype_seen?(type, fields_get(neg_domains, domain_key, none()), seen)
     end)
   end
-
-  # Pop a domain's present-value type.
-  defp map_pop_domain_bdd(domains, fields, domain_key) when is_list(domains) do
-    case fields_take(domain_key, domains) do
-      {value, domains} -> {true, value, map_new(domains, fields)}
-      :error -> {false, none(), map_new(domains, fields)}
-    end
-  end
-
-  # Open/close key
-  defp map_pop_domain_bdd(tag, fields, _domain_key),
-    do: {false, map_domain_tag_to_type(tag), map_new(tag, fields)}
 
   defp map_to_quoted(bdd, opts) do
     bdd


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT-5.6 Sol

map_get_domain/3 only consumes the selected domain value, but map_pop_domain_bdd/3 also rebuilt and returned the remaining map BDD. Use the existing domain lookup helper directly so negated map lookups do not construct state that is immediately discarded.

