### PR TITLE
Fix inferred type of :erlang.split_binary/2 result when arg is bitstring

### DIFF
--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -220,7 +220,11 @@ defmodule Module.Types.Apply do
         {:erlang, :spawn_link, [{mfargs, pid()}]},
         {:erlang, :spawn_monitor, [{[fun(0)], tuple([pid(), reference()])}]},
         {:erlang, :spawn_monitor, [{mfargs, tuple([pid(), reference()])}]},
-        {:erlang, :split_binary, [{[binary(), integer()], tuple([binary(), binary()])}]},
+        {:erlang, :split_binary,
+         [
+           {[binary(), integer()], tuple([binary(), binary()])},
+           {[bitstring_no_binary(), integer()], tuple([binary(), bitstring_no_binary()])}
+         ]},
         {:erlang, :tuple_size, [{[open_tuple([])], integer()}]},
         {:erlang, :trunc, [{[opt_union(integer(), float())], integer()}]},
         {:erlang, :++,


### PR DESCRIPTION
This PR addresses false positive warnings:
```
defmodule SplitRet do
              def take(b) when is_bitstring(b) do
                {h, t} = :erlang.split_binary(b, 1)
                case t do
                  x when is_binary(x) -> {:bin, h, x}
                  _ -> {:bits, h, t}
                end
              end
            end
warning: the following clause cannot match because the previous clauses already matched all possible values:

    _ ->

it attempts to match on the result of:

    t

which has the already matched type:

    binary()

└─ iex:6: SplitRet.take/1

defmodule Split4 do
              def split(b) when is_bitstring(b) do
                case b do
                  x when is_binary(x) -> {:bin, :erlang.split_binary(x, 0)}
                  _ -> {:bits, :erlang.split_binary(b, 0)}
                end
              end
            end
warning: incompatible types given to :erlang.split_binary/2:

    :erlang.split_binary(b, 0)

given types:

    bitstring() and not binary(), integer()

but expected one of:

    binary(), integer()

where "b" was given the types:

    # type: bitstring()
    # from: iex:3
    is_bitstring(b)

    # type: dynamic(bitstring())
    # from: iex:3
    b

    # type: bitstring() and not binary()
    # from: iex:4
    b

└─ iex:6: Split4.split/1
```

The code is fine and works in runtime. `split_binary` splits at byte position and tail may not by byte alligned.
```
SplitRet.take("foo" <> <<0>>)
{:bin, "f", <<111, 111, 0>>}
Split4.split("foo" <> <<0>>)
{:bin, {"", <<102, 111, 111, 0>>}}
```

Note https://www.erlang.org/doc/apps/erts/erlang.html#split_binary/2 does not document that it accepts a bitstring argument but the underlying NIF implementation is bitstring aware https://github.com/erlang/otp/blob/4542a0b14fa904c235fa5d03787ad3a7b2ebd368/erts/emulator/beam/binary.c#L476-L517. A PR to OTP may be needed to update the spec
