### PR TITLE
Fix final sigma handling in :greek

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1018,6 +1018,10 @@ defmodule String do
     downcase_ascii(string, string, 0)
   end
 
+  def downcase(string, :greek) when is_binary(string) do
+    String.Unicode.downcase_greek(string, [])
+  end
+
   def downcase(string, mode) when is_binary(string) and mode in @conditional_mappings do
     String.Unicode.downcase(string, [], mode)
   end
@@ -1078,17 +1082,37 @@ defmodule String do
   @letter_I_dot_above <<0x0130::utf8>>
 
   def capitalize(<<@letter_i, right::binary>>, mode) do
-    if(mode == :turkic, do: @letter_I_dot_above, else: @letter_I) <> downcase(right, mode)
+    capitalized = if mode == :turkic, do: @letter_I_dot_above, else: @letter_I
+    capitalized <> downcase_after_capitalize(right, mode, ?i)
   end
 
   def capitalize(string, mode) when is_binary(string) do
     case :unicode_util.gc(string) do
-      [gc] -> grapheme_to_binary(:string.titlecase([gc]))
-      [gc, rest] -> grapheme_to_binary(:string.titlecase([gc])) <> downcase(rest, mode)
-      [gc | rest] -> grapheme_to_binary(:string.titlecase([gc])) <> downcase(rest, mode)
-      [] -> ""
-      {:error, <<byte, rest::bits>>} -> <<byte>> <> downcase(rest, mode)
+      [gc] ->
+        grapheme_to_binary(:string.titlecase([gc]))
+
+      [gc, rest] ->
+        grapheme_to_binary(:string.titlecase([gc])) <>
+          downcase_after_capitalize(rest, mode, gc)
+
+      [gc | rest] ->
+        grapheme_to_binary(:string.titlecase([gc])) <>
+          downcase_after_capitalize(rest, mode, gc)
+
+      [] ->
+        ""
+
+      {:error, <<byte, rest::bits>>} ->
+        <<byte>> <> downcase(rest, mode)
     end
+  end
+
+  defp downcase_after_capitalize(rest, :greek, gc) do
+    String.Unicode.downcase_greek(rest, [], grapheme_to_binary(gc))
+  end
+
+  defp downcase_after_capitalize(rest, mode, _gc) do
+    downcase(rest, mode)
   end
 
   @doc false

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -232,6 +232,11 @@ defmodule StringTest do
     assert String.downcase("Σ ΣΑΣ Σ", :greek) == "σ σας σ"
     assert String.downcase("ΜΕΣ'ΑΠΟ", :greek) == "μεσ'απο"
     assert String.downcase("ΑΣ'ΤΟΥΣ", :greek) == "ασ'τους"
+    assert String.downcase("AΣ", :greek) == "aς"
+    assert String.downcase("AΣA", :greek) == "aσa"
+    assert String.downcase("A'Σ", :greek) == "a'ς"
+    assert String.downcase("İΣ", :greek) == "i̇ς"
+    assert String.downcase("ⅠΣ", :greek) == "ⅰς"
   end
 
   test "downcase/1 with ascii" do
@@ -273,6 +278,10 @@ defmodule StringTest do
     assert String.capitalize("ııı", :turkic) == "Iıı"
     assert String.capitalize("İii", :turkic) == "İii"
     assert String.capitalize("Iıı", :turkic) == "Iıı"
+
+    assert String.capitalize("AΣ", :greek) == "Aς"
+    assert String.capitalize("iΣ", :greek) == "Iς"
+    assert String.capitalize("1Σ", :greek) == "1σ"
 
     assert String.capitalize(<<138, ?B, ?C>>) == <<138, ?b, ?c>>
 

--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -46,6 +46,35 @@ rangify = fn [head | tail] ->
   [{first, last} | acc]
 end
 
+expand_range = fn range ->
+  [range | _] = :binary.split(range, " ")
+
+  case :binary.split(range, "..") do
+    [first] ->
+      [String.to_integer(first, 16)]
+
+    [first, last] ->
+      Enum.to_list(String.to_integer(first, 16)..String.to_integer(last, 16))
+  end
+end
+
+other_cased_letters =
+  Path.join(__DIR__, "PropList.txt")
+  |> File.read!()
+  |> String.split(["\r\n", "\n"])
+  |> Enum.reduce([], fn line, acc ->
+    case :binary.split(line, ";") do
+      [range, <<" Other_Lowercase", _::binary>>] ->
+        expand_range.(range) ++ acc
+
+      [range, <<" Other_Uppercase", _::binary>>] ->
+        expand_range.(range) ++ acc
+
+      _ ->
+        acc
+    end
+  end)
+
 # A character is case ignorable if:
 #
 #    Word_Break(C) = MidLetter or MidNumLet or Single_Quote, or
@@ -149,6 +178,17 @@ case_ignorable_categories = :binary.compile_pattern(["Mn", "Me", "Cf", "Lm", "Sk
     {cacc, lacc, iacc, wacc, dacc, kacc}
   end)
 
+cased_letters = Enum.sort(Enum.uniq(cased_letters ++ other_cased_letters), :desc)
+
+case_ignorable = Enum.sort(Enum.uniq(case_ignorable), :desc)
+
+case_ignorable_map =
+  Enum.reduce(case_ignorable, %{}, fn codepoint, acc ->
+    :maps.put(codepoint, true, acc)
+  end)
+
+cased_non_ignorable = Enum.reject(cased_letters, &:maps.is_key(&1, case_ignorable_map))
+
 defmodule String.Unicode do
   @moduledoc false
   def version, do: {17, 0, 0}
@@ -233,6 +273,19 @@ defmodule String.Unicode do
 
   # Downcase
 
+  def downcase_greek(string, acc) do
+    string
+    |> greek_final_sigma([], false)
+    |> downcase(acc, :default)
+  end
+
+  # Used by capitalize/2 to preserve the context supplied by the first grapheme.
+  def downcase_greek(string, acc, before) when is_binary(before) do
+    string
+    |> greek_final_sigma([], cased_letter_context(before, false))
+    |> downcase(acc, :default)
+  end
+
   # Turkic İ -> i
   def downcase(<<unquote(@letter_I_dot_above), rest::bits>>, acc, mode) do
     char = if mode == :turkic, do: @letter_i, else: <<@letter_i, @combining_dot_above>>
@@ -252,14 +305,7 @@ defmodule String.Unicode do
 
   # Greek sigma
   def downcase(<<@letter_sigma, rest::bits>>, acc, mode) do
-    downcased =
-      if mode == :greek and cased_letter_list?(acc) and not cased_letter_binary?(rest) do
-        @letter_small_sigma_final
-      else
-        @letter_small_sigma
-      end
-
-    downcase(rest, [downcased | acc], mode)
+    downcase(rest, [@letter_small_sigma | acc], mode)
   end
 
   conditional_downcase = [@letter_I, @letter_I_dot_above, @letter_sigma]
@@ -297,49 +343,80 @@ defmodule String.Unicode do
 
   # Sigma handling
 
+  defp greek_final_sigma(string, acc, cased_before) do
+    case :binary.match(string, @letter_sigma) do
+      {index, _length} ->
+        <<before::binary-size(^index), @letter_sigma, rest::bits>> = string
+        cased_before = cased_letter_context(before, cased_before)
+
+        downcased =
+          if cased_before and not cased_letter_binary?(rest) do
+            @letter_small_sigma_final
+          else
+            @letter_small_sigma
+          end
+
+        greek_final_sigma(rest, [downcased, before | acc], true)
+
+      :nomatch ->
+        if acc == [] do
+          string
+        else
+          IO.iodata_to_binary(:lists.reverse([string | acc]))
+        end
+    end
+  end
+
   defp cased_letter_binary?(<<codepoint::utf8, rest::bits>>) do
-    if case_ignorable?(codepoint) do
-      cased_letter_binary?(rest)
-    else
-      cased_letter?(codepoint)
+    case case_context(codepoint) do
+      :ignorable -> cased_letter_binary?(rest)
+      :cased -> true
+      :other -> false
     end
   end
 
   defp cased_letter_binary?(_), do: false
 
-  defp cased_letter_list?([<<codepoint::utf8>> | rest]) do
-    if case_ignorable?(codepoint) do
-      cased_letter_list?(rest)
-    else
-      cased_letter?(codepoint)
-    end
-  end
-
-  defp cased_letter_list?(_), do: false
-
-  for {first, last} <- rangify.(cased_letters) do
-    if first == last do
-      defp cased_letter?(unquote(first)), do: true
-    else
-      defp cased_letter?(codepoint)
-           when codepoint >= unquote(first) and codepoint <= unquote(last),
-           do: true
-    end
-  end
-
-  defp cased_letter?(_), do: false
-
   for {first, last} <- rangify.(case_ignorable) do
     if first == last do
-      defp case_ignorable?(unquote(first)), do: true
+      defp case_context(unquote(first)), do: :ignorable
     else
-      defp case_ignorable?(codepoint)
+      defp case_context(codepoint)
            when codepoint >= unquote(first) and codepoint <= unquote(last),
-           do: true
+           do: :ignorable
     end
   end
 
-  defp case_ignorable?(_), do: false
+  for {first, last} <- rangify.(cased_non_ignorable) do
+    if first == last do
+      defp case_context(unquote(first)), do: :cased
+    else
+      defp case_context(codepoint)
+           when codepoint >= unquote(first) and codepoint <= unquote(last),
+           do: :cased
+    end
+  end
+
+  defp case_context(_codepoint), do: :other
+
+  defp cased_letter_context(<<codepoint::utf8, rest::bits>>, cased_before) do
+    cased_before = update_cased_context(codepoint, cased_before)
+    cased_letter_context(rest, cased_before)
+  end
+
+  defp cased_letter_context(<<_byte, rest::bits>>, _cased_before) do
+    cased_letter_context(rest, false)
+  end
+
+  defp cased_letter_context("", cased_before), do: cased_before
+
+  defp update_cased_context(codepoint, cased_before) when is_integer(codepoint) do
+    case case_context(codepoint) do
+      :ignorable -> cased_before
+      :cased -> true
+      :other -> false
+    end
+  end
 
   # Upcase
 


### PR DESCRIPTION
Final sigma casing is incorrect in several common cases

Current implementation checks already lowercased output acc instead of the original input context

```elixir
iex> String.downcase("AΣ", :greek)
"aσ" # expected "aς"

ex> String.capitalize("ΑΣ", :greek)
"Ασ" # expected "Ας"
```

Final sigma applied when:
- has preceding cased character, ignoring case-ignorable characters
- does not have a following cased character, again ignoring case-ignorable characters

Cases covered:
- cased characters from Latin and Greek scripts
- case-ignorable punctuation and combining characters
- `Other_Lowercase` / `Other_Uppercase` Unicode props
- expanded lowercase mappings such as İ
- capitalization after cased / uncased prefixes ("AΣ" → "Aς", "1Σ" → "1σ")

(Reviewed) Assisted-by: GPT-5.6 Sol