### PR TITLE
Fix functions with impossible clauses typecheck crash

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -217,7 +217,7 @@ defmodule Module.Types.Descr do
   @doc """
   Creates a function from overlapping function clauses.
   """
-  def fun_from_inferred_clauses(args_clauses) do
+  def fun_from_inferred_clauses([{args, _return} | _] = args_clauses) do
     domain_clauses =
       Enum.reduce(args_clauses, [], fn {args, return}, acc ->
         domain = args |> Enum.map(&upper_bound/1) |> args_to_domain()
@@ -230,7 +230,10 @@ defmodule Module.Types.Descr do
           args <- domain_to_args(domain),
           do: fun(args, dynamic(union))
 
-    Enum.reduce(funs, &bare_intersection/2)
+    case funs do
+      [] -> fun(length(args))
+      [_ | _] -> Enum.reduce(funs, &bare_intersection/2)
+    end
   end
 
   # If you have a function with multiple clauses, they may overlap,

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -1303,6 +1303,14 @@ defmodule Module.Types.DescrTest do
     end
 
     test "fun_from_inferred_clauses" do
+      # Empty domains
+      assert fun_from_inferred_clauses([{[none()], atom()}]) == fun(1)
+
+      assert fun_from_inferred_clauses([
+               {[none(), integer()], atom()},
+               {[binary(), none()], binary()}
+             ]) == fun(2)
+
       # No overlap
       assert fun_from_inferred_clauses([{[integer()], atom()}, {[float()], binary()}])
              |> equal?(

--- a/lib/elixir/test/elixir/module/types/integration_test.exs
+++ b/lib/elixir/test/elixir/module/types/integration_test.exs
@@ -296,6 +296,66 @@ defmodule Module.Types.IntegrationTest do
       assert_warnings(files, warnings)
     end
 
+    test "captures with impossible clauses" do
+      files = %{
+        "impossible_clauses.ex" => """
+        defmodule ImpossibleClauses do
+          def anonymous, do: fn x = 1 = :a -> x end
+          def local_capture, do: &local/1
+
+          defp local(x = 1 = :a), do: x
+          def remote(x = 1 = :a), do: x
+        end
+        """,
+        "remote_capture.ex" => """
+        defmodule ImpossibleRemoteCapture do
+          def capture, do: &ImpossibleClauses.remote/1
+        end
+        """
+      }
+
+      warnings = [
+        """
+            warning: the following pattern will never match:
+
+                x = 1 = :a
+
+            type warning found at:
+            │
+          2 │   def anonymous, do: fn x = 1 = :a -> x end
+            │                           ~
+            │
+            └─ impossible_clauses.ex:2:27: ImpossibleClauses.anonymous/0
+        """,
+        """
+            warning: the 1st pattern in clause will never match:
+
+                x = 1 = :a
+
+            type warning found at:
+            │
+          5 │   defp local(x = 1 = :a), do: x
+            │                ~
+            │
+            └─ impossible_clauses.ex:5:16: ImpossibleClauses.local/1
+        """,
+        """
+            warning: the 1st pattern in clause will never match:
+
+                x = 1 = :a
+
+            type warning found at:
+            │
+          6 │   def remote(x = 1 = :a), do: x
+            │                ~
+            │
+            └─ impossible_clauses.ex:6:16: ImpossibleClauses.remote/1
+        """
+      ]
+
+      assert_warnings(files, warnings)
+    end
+
     test "mismatched locals" do
       files = %{
         "a.ex" => """


### PR DESCRIPTION
Fixes #15793

This change returns an uncallable `fun(arity)` type for that case, preserving the existing behavior whenever at least one domain is reachable.

Cases covered:
- anonymous functions
- local function captures
- cross-module remote captures
- empty domains at multiple arities

Assisted-by: GPT-5.6 Sol