### PR TITLE
Widen stacktrace extra info types

### DIFF
--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -118,7 +118,15 @@ defmodule Module.Types.Apply do
 
   args_or_arity = opt_union(list(term()), integer())
   args_or_none = opt_union(list(term()), atom([:none]))
-  extra_info = kw.(file: list(integer()), line: integer(), error_info: open_map())
+  custom_info_key = opt_difference(atom(), atom([:file, :line, :error_info]))
+
+  extra_info =
+    list(
+      tuple([atom([:file]), opt_union(list(integer()), binary())])
+      |> opt_union(tuple([atom([:line]), integer()]))
+      |> opt_union(tuple([atom([:error_info]), open_map()]))
+      |> opt_union(tuple([custom_info_key, term()]))
+    )
 
   raise_stacktrace =
     list(

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -40,11 +40,14 @@ defmodule Module.Types.Expr do
 
   args_or_arity = opt_union(list(term()), integer())
 
+  custom_info_key = opt_difference(atom(), atom([:file, :line, :error_info]))
+
   extra_info =
     list(
-      tuple([atom([:file]), list(integer())])
+      tuple([atom([:file]), opt_union(list(integer()), binary())])
       |> opt_union(tuple([atom([:line]), integer()]))
       |> opt_union(tuple([atom([:error_info]), open_map()]))
+      |> opt_union(tuple([custom_info_key, term()]))
     )
 
   @stacktrace list(

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -451,6 +451,21 @@ defmodule Module.Types.ExprTest do
                "incompatible types given to Kernel.send/2"
     end
 
+    test "raises with arbitrary stacktrace extra info" do
+      assert typecheck!(
+               :erlang.raise(:error, :oops, [
+                 {__MODULE__, :example, 1,
+                  [line: 1, column: 2, file: "example.ex", custom: {:any, :term}]}
+               ])
+             ) == none()
+
+      assert typeerror!(
+               :erlang.raise(:error, :oops, [
+                 {__MODULE__, :example, 1, [line: :unknown]}
+               ])
+             ) =~ "incompatible types given to :erlang.raise/3"
+    end
+
     test "undefined function warnings" do
       assert typewarn!(URI.unknown("foo")) ==
                {dynamic(), "URI.unknown/1 is undefined or private"}
@@ -2967,6 +2982,54 @@ defmodule Module.Types.ExprTest do
     end
 
     test "rescue: matches on stacktrace" do
+      assert typecheck!(
+               try do
+                 raise "oops"
+               rescue
+                 _ ->
+                   case __STACKTRACE__ do
+                     [{_, _, _, [{:line, line} | _]} | _] -> line + 1
+                     _ -> 0
+                   end
+               end
+             ) == integer()
+
+      assert typecheck!(
+               try do
+                 raise "oops"
+               rescue
+                 _ ->
+                   case __STACKTRACE__ do
+                     [{_, _, _, [{:file, file} | _]} | _] -> file
+                     _ -> "unknown"
+                   end
+               end
+             ) == opt_union(list(integer()), binary())
+
+      assert typecheck!(
+               try do
+                 raise "oops"
+               rescue
+                 _ ->
+                   case __STACKTRACE__ do
+                     [{_, _, _, [{:error_info, error_info} | _]} | _] -> map_size(error_info)
+                     _ -> 0
+                   end
+               end
+             ) == integer()
+
+      assert typecheck!(
+               try do
+                 raise "oops"
+               rescue
+                 _ ->
+                   case __STACKTRACE__ do
+                     [{_, _, _, [{:column, column} | _]} | _] -> column
+                     _ -> 0
+                   end
+               end
+             ) == term()
+
       assert typeerror!(
                try do
                  :ok


### PR DESCRIPTION
Match OTP's stacktrace contract in `__STACKTRACE__` inference and the `:erlang.raise/3` signature, allowing arbitrary keyword metadata.

Assisted-by: Codex:GPT-5.6
Fixes #15797
