### PR TITLE
Optimize Enum.slide/3 list assembly

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2927,8 +2927,12 @@ defmodule Enum do
     slide_list_last(t, last - 1, [h | acc], start_to_middle)
   end
 
-  defp slide_list_last(rest, _, acc, start_to_middle) do
+  defp slide_list_last(rest, 0, acc, start_to_middle) do
     :lists.reverse(acc, :lists.reverse(start_to_middle, rest))
+  end
+
+  defp slide_list_last([], _, acc, start_to_middle) do
+    :lists.reverse(acc, :lists.reverse(start_to_middle))
   end
 
   @doc """

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2915,8 +2915,7 @@ defmodule Enum do
   end
 
   defp slide_list_middle(list, 0, last, start_to_middle) do
-    {slid_range, tail} = slide_list_last(list, last + 1, [])
-    slid_range ++ :lists.reverse(start_to_middle, tail)
+    slide_list_last(list, last + 1, [], start_to_middle)
   end
 
   # You asked for a middle index off the end of the list... you get what we've got
@@ -2924,16 +2923,12 @@ defmodule Enum do
     :lists.reverse(acc)
   end
 
-  defp slide_list_last([h | t], last, acc) when last > 0 do
-    slide_list_last(t, last - 1, [h | acc])
+  defp slide_list_last([h | t], last, acc, start_to_middle) when last > 0 do
+    slide_list_last(t, last - 1, [h | acc], start_to_middle)
   end
 
-  defp slide_list_last(rest, 0, acc) do
-    {:lists.reverse(acc), rest}
-  end
-
-  defp slide_list_last([], _, acc) do
-    {:lists.reverse(acc), []}
+  defp slide_list_last(rest, _, acc, start_to_middle) do
+    :lists.reverse(acc, :lists.reverse(start_to_middle, rest))
   end
 
   @doc """


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT-5.6 Sol

Keep the slid range reverse-accumulated until final assembly, avoiding the extra copy performed by ++.

I have a problem with this one. It should be either same speed or faster but somehow benchmark is really noisy. 
I would like others to run the benchmark. I post my results below as usual. Please close if not conclusive.

Bench:
```elixir
Mix.install([:benchee])

defmodule SlideOld do
  def slide(enumerable, range_or_single_index, insertion_index)

  def slide(enumerable, single_index, insertion_index) when is_integer(single_index) do
    slide(enumerable, single_index..single_index, insertion_index)
  end

  def slide(_, _.._//step = index_range, _insertion_index) when step != 1 do
    raise ArgumentError,
          "Enum.slide/3 does not accept ranges with custom steps, got: #{inspect(index_range)}"
  end

  def slide(enumerable, first..last//_, insertion_index)
      when first < 0 or last < 0 or insertion_index < 0 do
    count = Enum.count(enumerable)
    normalized_first = if first >= 0, do: first, else: Kernel.max(first + count, 0)
    normalized_last = if last >= 0, do: last, else: last + count

    normalized_insertion_index =
      if insertion_index >= 0, do: insertion_index, else: insertion_index + count

    if normalized_first < count and normalized_first != normalized_insertion_index do
      normalized_range = normalized_first..normalized_last//1
      slide(enumerable, normalized_range, normalized_insertion_index)
    else
      Enum.to_list(enumerable)
    end
  end

  def slide(enumerable, insertion_index.._//_, insertion_index) do
    Enum.to_list(enumerable)
  end

  def slide(_, first..last//_, insertion_index)
      when insertion_index > first and insertion_index <= last do
    raise ArgumentError,
          "insertion index for slide must be outside the range being moved " <>
            "(tried to insert #{first}..#{last} at #{insertion_index})"
  end

  def slide(enumerable, first..last//_, _insertion_index) when first > last do
    Enum.to_list(enumerable)
  end

  def slide(enumerable, first..last//_, insertion_index) do
    impl = if is_list(enumerable), do: &slide_list_start/4, else: &slide_any/4

    cond do
      insertion_index <= first -> impl.(enumerable, insertion_index, first, last)
      insertion_index > last -> impl.(enumerable, first, last + 1, insertion_index)
    end
  end

  defp slide_any(enumerable, start, middle, last) do
    {_size, pre, post} =
      Enum.reduce(enumerable, {0, [], []}, fn item, {index, pre, post} ->
        {pre, post} =
          cond do
            index < start -> {[item | pre], post}
            index >= start and index < middle -> {pre, [item | post]}
            index >= middle and index <= last -> {[item | pre], post}
            true -> {pre, [item | post]}
          end

        {index + 1, pre, post}
      end)

    :lists.reverse(pre, :lists.reverse(post))
  end

  defp slide_list_start([head | tail], start, middle, last)
       when start > 0 and start <= middle and middle <= last do
    [head | slide_list_start(tail, start - 1, middle - 1, last - 1)]
  end

  defp slide_list_start(list, 0, middle, last), do: slide_list_middle(list, middle, last, [])
  defp slide_list_start([], _start, _middle, _last), do: []

  defp slide_list_middle([head | tail], middle, last, acc) when middle > 0 do
    slide_list_middle(tail, middle - 1, last - 1, [head | acc])
  end

  defp slide_list_middle(list, 0, last, start_to_middle) do
    {slid_range, tail} = slide_list_last(list, last + 1, [])
    slid_range ++ :lists.reverse(start_to_middle, tail)
  end

  defp slide_list_middle([], _middle, _last, acc), do: :lists.reverse(acc)

  defp slide_list_last([head | tail], last, acc) when last > 0 do
    slide_list_last(tail, last - 1, [head | acc])
  end

  defp slide_list_last(rest, 0, acc), do: {:lists.reverse(acc), rest}
  defp slide_list_last([], _last, acc), do: {:lists.reverse(acc), []}
end

defmodule SlideNew do
  def slide(enumerable, range_or_single_index, insertion_index)

  def slide(enumerable, single_index, insertion_index) when is_integer(single_index) do
    slide(enumerable, single_index..single_index, insertion_index)
  end

  def slide(_, _.._//step = index_range, _insertion_index) when step != 1 do
    raise ArgumentError,
          "Enum.slide/3 does not accept ranges with custom steps, got: #{inspect(index_range)}"
  end

  def slide(enumerable, first..last//_, insertion_index)
      when first < 0 or last < 0 or insertion_index < 0 do
    count = Enum.count(enumerable)
    normalized_first = if first >= 0, do: first, else: Kernel.max(first + count, 0)
    normalized_last = if last >= 0, do: last, else: last + count

    normalized_insertion_index =
      if insertion_index >= 0, do: insertion_index, else: insertion_index + count

    if normalized_first < count and normalized_first != normalized_insertion_index do
      normalized_range = normalized_first..normalized_last//1
      slide(enumerable, normalized_range, normalized_insertion_index)
    else
      Enum.to_list(enumerable)
    end
  end

  def slide(enumerable, insertion_index.._//_, insertion_index) do
    Enum.to_list(enumerable)
  end

  def slide(_, first..last//_, insertion_index)
      when insertion_index > first and insertion_index <= last do
    raise ArgumentError,
          "insertion index for slide must be outside the range being moved " <>
            "(tried to insert #{first}..#{last} at #{insertion_index})"
  end

  def slide(enumerable, first..last//_, _insertion_index) when first > last do
    Enum.to_list(enumerable)
  end

  def slide(enumerable, first..last//_, insertion_index) do
    impl = if is_list(enumerable), do: &slide_list_start/4, else: &slide_any/4

    cond do
      insertion_index <= first -> impl.(enumerable, insertion_index, first, last)
      insertion_index > last -> impl.(enumerable, first, last + 1, insertion_index)
    end
  end

  defp slide_any(enumerable, start, middle, last) do
    {_size, pre, post} =
      Enum.reduce(enumerable, {0, [], []}, fn item, {index, pre, post} ->
        {pre, post} =
          cond do
            index < start -> {[item | pre], post}
            index >= start and index < middle -> {pre, [item | post]}
            index >= middle and index <= last -> {[item | pre], post}
            true -> {pre, [item | post]}
          end

        {index + 1, pre, post}
      end)

    :lists.reverse(pre, :lists.reverse(post))
  end

  defp slide_list_start([head | tail], start, middle, last)
       when start > 0 and start <= middle and middle <= last do
    [head | slide_list_start(tail, start - 1, middle - 1, last - 1)]
  end

  defp slide_list_start(list, 0, middle, last), do: slide_list_middle(list, middle, last, [])
  defp slide_list_start([], _start, _middle, _last), do: []

  defp slide_list_middle([head | tail], middle, last, acc) when middle > 0 do
    slide_list_middle(tail, middle - 1, last - 1, [head | acc])
  end

  defp slide_list_middle(list, 0, last, start_to_middle) do
    slide_list_last(list, last + 1, [], start_to_middle)
  end

  defp slide_list_middle([], _middle, _last, acc), do: :lists.reverse(acc)

  defp slide_list_last([head | tail], last, acc, start_to_middle) when last > 0 do
    slide_list_last(tail, last - 1, [head | acc], start_to_middle)
  end

  defp slide_list_last(rest, 0, acc, start_to_middle) do
    :lists.reverse(acc, :lists.reverse(start_to_middle, rest))
  end

  defp slide_list_last([], _last, acc, start_to_middle) do
    :lists.reverse(acc, :lists.reverse(start_to_middle))
  end
end

defmodule SlideBenchmark do
  def run do
    inputs = %{
      "1k items, 20 backward" => {Enum.to_list(1..1_000), 700..719, 200},
      "10k items, 500 backward" => {Enum.to_list(1..10_000), 8_000..8_499, 1_000},
      "10k items, 500 forward" => {Enum.to_list(1..10_000), 1_000..1_499, 8_000},
      "10k items, truncated range" => {Enum.to_list(1..10_000), 9_500..11_000, 1_000}
    }

    Benchee.run(
      %{
        "main" => fn {list, index_or_range, insertion_index} ->
          SlideOld.slide(list, index_or_range, insertion_index)
        end,
        "branch" => fn {list, index_or_range, insertion_index} ->
          SlideNew.slide(list, index_or_range, insertion_index)
        end
      },
      inputs: inputs,
      pre_check: :all_same,
      memory_time: 2,
      reduction_time: 2
    )
  end
end

SlideBenchmark.run()
```

Results:
```txt
Operating System: Linux
CPU Information: AMD Ryzen 7 8845HS w
Number of Available Cores: 16
Available memory: 54.72 GB
Elixir 1.21.0-dev
Erlang 29.0.5
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 2 s
reduction time: 2 s
parallel: 1
inputs: 10k items, 500 backward, 10k items, 500 forward, 10k items, truncated range, 1k items, 20 backward
Estimated total run time: 1 min 28 s
Excluding outliers: false

##### With input 10k items, 500 backward #####
Name             ips        average  deviation         median         99th %
branch       13.55 K       73.79 μs    ±38.62%       79.62 μs       95.74 μs
main         13.52 K       73.98 μs    ±27.54%       78.98 μs       94.21 μs

Comparison: 
branch       13.55 K
main         13.52 K - 1.00x slower +0.185 μs

Memory usage statistics:

Name      Memory usage
branch       231.80 KB
main         231.80 KB - 1.00x memory usage +0.00781 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name   Reduction count
branch         11.43 K
main           11.44 K - 1.00x reduction count +0.0120 K

**All measurements for reduction count were the same**

##### With input 10k items, 500 forward #####
Name             ips        average  deviation         median         99th %
branch       17.75 K       56.33 μs    ±41.87%       64.17 μs       74.91 μs
main         12.67 K       78.95 μs    ±31.37%       69.20 μs      150.13 μs

Comparison: 
branch       17.75 K
main         12.67 K - 1.40x slower +22.62 μs

Memory usage statistics:

Name      Memory usage
branch       223.98 KB
main         333.37 KB - 1.49x memory usage +109.38 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name   Reduction count
branch         10.92 K
main           12.88 K - 1.18x reduction count +1.96 K

**All measurements for reduction count were the same**

##### With input 10k items, truncated range #####
Name             ips        average  deviation         median         99th %
branch       11.24 K       88.93 μs    ±37.76%       96.34 μs      109.57 μs
main         11.12 K       89.92 μs    ±19.23%       92.67 μs      117.99 μs

Comparison: 
branch       11.24 K
main         11.12 K - 1.01x slower +0.99 μs

Memory usage statistics:

Name      Memory usage
branch       231.80 KB
main         231.80 KB - 1.00x memory usage +0.00781 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name   Reduction count
branch         13.00 K
main           13.00 K - 1.00x reduction count +0 K

**All measurements for reduction count were the same**

##### With input 1k items, 20 backward #####
Name             ips        average  deviation         median         99th %
branch      192.63 K        5.19 μs   ±143.33%        4.97 μs        8.58 μs
main        186.08 K        5.37 μs   ±150.12%        5.12 μs        9.15 μs

Comparison: 
branch      192.63 K
main        186.08 K - 1.04x slower +0.183 μs

Memory usage statistics:

Name      Memory usage
branch        19.38 KB
main          19.71 KB - 1.02x memory usage +0.34 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name   Reduction count
branch          1.09 K
main            1.10 K - 1.00x reduction count +0.00400 K

**All measurements for reduction count were the same**
```