### PR TITLE
Refine map key checks for literal keys

### DIFF
--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -1016,6 +1016,11 @@ defmodule Module.Types.Apply do
     {info, filter_domain(info, expected, 2), context}
   end
 
+  def remote_domain(:maps, :is_key, [key, map], expected, meta, stack, context)
+      when is_atom(key) do
+    remote_domain(:erlang, :is_map_key, [key, map], expected, meta, stack, context)
+  end
+
   def remote_domain(Kernel, :is_map_key, [_map, key], expected, _meta, _stack, context)
       when is_atom(key) do
     info =
@@ -1026,6 +1031,11 @@ defmodule Module.Types.Apply do
        ]}
 
     {info, filter_domain(info, expected, 2), context}
+  end
+
+  def remote_domain(Map, :has_key?, [map, key], expected, meta, stack, context)
+      when is_atom(key) do
+    remote_domain(Kernel, :is_map_key, [map, key], expected, meta, stack, context)
   end
 
   def remote_domain(:erlang, :map_get, [key, _], expected, _meta, _stack, context)

--- a/lib/elixir/test/elixir/module/types/map_test.exs
+++ b/lib/elixir/test/elixir/module/types/map_test.exs
@@ -254,8 +254,13 @@ defmodule Module.Types.MapTest do
 
   describe "Map.has_key?/2" do
     test "checking" do
-      assert typecheck!(Map.has_key?(%{key: 123}, :key)) == boolean()
-      assert typecheck!(:maps.is_key(:key, %{key: 123})) == boolean()
+      assert typecheck!(Map.has_key?(%{key: 123}, :key)) == atom([true])
+      assert typecheck!(Map.has_key?(%{}, :key)) == atom([false])
+      assert typecheck!([key], Map.has_key?(%{key: 123}, key)) == boolean()
+
+      assert typecheck!(:maps.is_key(:key, %{key: 123})) == atom([true])
+      assert typecheck!(:maps.is_key(:key, %{})) == atom([false])
+      assert typecheck!([key], :maps.is_key(key, %{key: 123})) == boolean()
     end
 
     test "errors" do


### PR DESCRIPTION
This PR adds always true/false literal refinement to `Map.has_key?/2` and `:maps.is_key/2` similar to already implemented `Kernel.is_map_key/2`

Assisted-by: Codex:GPT-5