### PR TITLE
Remove unused task pid from async stream internal state

### DIFF
--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -335,8 +335,8 @@ defmodule Task.Supervised do
       # this response when the replying task dies (we'll see this in the :down
       # message).
       {{^monitor_ref, position}, reply} ->
-        %{^position => {pid, :running, _element}} = waiting
-        waiting = Map.put(waiting, position, {pid, {:ok, reply}})
+        %{^position => {:running, _element}} = waiting
+        waiting = Map.put(waiting, position, {:ok, reply})
         stream_reduce({:cont, acc}, max, spawned, delivered, waiting, next, config)
 
       # The task at position "position" died for some reason. We check if it
@@ -349,18 +349,18 @@ defmodule Task.Supervised do
           case waiting do
             # If the task replied, we don't care whether it went down for timeout
             # or for normal reasons.
-            %{^position => {_, {:ok, _} = ok}} ->
+            %{^position => {:ok, _} = ok} ->
               ok
 
             # If the task exited by itself before replying, we emit {:exit, reason}.
-            %{^position => {_, :running, element}}
+            %{^position => {:running, element}}
             when kind == :down ->
               if zip_input_on_exit?, do: {:exit, {element, reason}}, else: {:exit, reason}
 
             # If the task timed out before replying, we either exit (on_timeout: :exit)
             # or emit {:exit, :timeout} (on_timeout: :kill_task) (note the task is already
             # dead at this point).
-            %{^position => {_, :running, element}}
+            %{^position => {:running, element}}
             when kind == :timed_out ->
               if on_timeout == :exit do
                 stream_cleanup_inbox(monitor_pid, monitor_ref)
@@ -488,7 +488,7 @@ defmodule Task.Supervised do
     end
   end
 
-  # This function spawns a task for the given "value", and puts the pid of this
+  # This function spawns a task for the given "value", and stores it as running
   # new task in the map of "waiting" tasks, which is returned.
   defp stream_spawn(value, spawned, waiting, config) do
     %{
@@ -507,7 +507,7 @@ defmodule Task.Supervised do
         mfa_with_value = normalize_mfa_with_arg(mfa, value)
         send(pid, {self(), {monitor_ref, spawned}, self(), callers, mfa_with_value})
         stored_value = if zip_input_on_exit?, do: value, else: nil
-        Map.put(waiting, spawned, {pid, :running, stored_value})
+        Map.put(waiting, spawned, {:running, stored_value})
 
       {:max_children, ^monitor_ref} ->
         stream_close(config)


### PR DESCRIPTION
Remove unused task PID from async stream consumer `waiting` map.

Affected public functions:

- `Task.async_stream/3`
- `Task.async_stream/5`
- `Task.Supervisor.async_stream/4`
- `Task.Supervisor.async_stream/6`
- `Task.Supervisor.async_stream_nolink/4`
- `Task.Supervisor.async_stream_nolink/6`