### PR TITLE
Type `apply/2` with literal arguments precisely

### DIFF
--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -565,6 +565,20 @@ defmodule Module.Types.Apply do
     end
   end
 
+  defp do_remote(:erlang, :apply, [fun, args] = all_args, expected, expr, stack, context, of_fun)
+       when is_list(args) do
+    if Enum.any?(args, &match?({:|, _, [_, _]}, &1)) do
+      remote_domain(:erlang, :apply, all_args, expected, elem(expr, 1), stack, context)
+    else
+      {fun_type, context} = of_fun.(fun, dynamic(fun(length(args))), expr, stack, context)
+
+      {args_types, context} =
+        Enum.map_reduce(args, context, &of_fun.(&1, term(), expr, stack, &2))
+
+      fun(fun_type, args_types, expr, stack, context)
+    end
+  end
+
   defp do_remote(Kernel, :elem, [tuple, index], expected, expr, stack, context, of_fun)
        when is_integer(index) do
     tuple_type = open_tuple(List.duplicate(term(), max(index, 0)) ++ [expected])

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -233,6 +233,47 @@ defmodule Module.Types.ExprTest do
              ) == dynamic(atom([:ok, :error]))
     end
 
+    test "apply/2 with literal arguments" do
+      assert typecheck!([], apply(&String.to_integer/1, ["123"])) == integer()
+
+      assert typecheck!(
+               [x],
+               (
+                 apply(x, [1, 2])
+                 x
+               )
+             ) == dynamic(fun(2))
+
+      # Improper lists and dynamic arguments fall back to the generic signature
+      assert typecheck!([x, tail], apply(x, [1 | tail])) == dynamic()
+      assert typecheck!([f, args], apply(f, args)) == dynamic()
+
+      assert typeerror!([a1, a2], apply(&String.to_integer/1, [a1, a2])) == ~l"""
+             expected a 2-arity function on function call:
+
+                 apply(&String.to_integer/1, [a1, a2])
+
+             but got function with arity 1:
+
+                 (binary() -> integer())
+             """
+
+      assert typeerror!([], apply(&String.to_integer/1, [:foo]))
+             |> strip_ansi() == ~l"""
+             incompatible types given on function call:
+
+                 apply(&String.to_integer/1, [:foo])
+
+             given types:
+
+                 :foo
+
+             but function has type:
+
+                 (binary() -> integer())
+             """
+    end
+
     test "warns on redundant clauses" do
       assert typewarn!(fn
                x when is_binary(x) -> x


### PR DESCRIPTION
This PR adds precise typing for `apply/2` with literal arguments. It will allow for more warnings to be emitted. Limitations:
- `apply(f, List.wrap(x))` or `args = [a, b]; apply(f, args)` will not benefit from this PR as the typesystem does not track list element types through variables.
- Diagnostics say "function call", not "apply"
- The expected type is dropped as in the existing `fun.()` path so the TODO "perform inference based on the strong domain" applies here as well
- Double warning for invalid arg - emits "invalid function call" and badfun error

Alternatives considered:
- Rewrite `apply(f, [a, b])` into `f.(a, b)` - too big change with stacktrace effect etc
- Handle it in expr.ex - apply.ex aligns better with resto of the code
- Also handle `apply(mod, fun, args)` with literal module/function/args - low value? `apply(String, :to_integer, [x])` should just be written `String.to_integer(x)`
- Stricter improper-list handling - added cost of linear scan

AssistedBy: Claud Fable 5, GPT 5.6 Sol