### PR TITLE
Allow color customization of all logger levels, notice blue by default

### DIFF
--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -158,9 +158,17 @@ defmodule Logger.Formatter do
 
     * `:info` - color for info and notice messages. Defaults to: `:normal`
 
+    * `:notice` - color for notice messages. Defaults to: `:blue`
+
     * `:warning` - color for warning messages. Defaults to: `:yellow`
 
-    * `:error` - color for error and higher messages. Defaults to: `:red`
+    * `:error` - color for error messages. Defaults to: `:red`
+
+    * `:critical` - color for critical messages. Defaults to: `:red`
+
+    * `:alert` - color for alert messages. Defaults to: `:red`
+
+    * `:emergency` - color for emergency messages. Defaults to: `:red`
 
   See the `IO.ANSI` module for a list of colors and attributes.
   The color of the message can also be configured per message via
@@ -186,16 +194,20 @@ defmodule Logger.Formatter do
 
   defp colors(colors) do
     %{
-      emergency: Keyword.get(colors, :error, :red),
-      alert: Keyword.get(colors, :error, :red),
-      critical: Keyword.get(colors, :error, :red),
+      emergency: color(colors, :emergency, :error, :red),
+      alert: color(colors, :alert, :error, :red),
+      critical: color(colors, :critical, :error, :red),
       error: Keyword.get(colors, :error, :red),
       warning: Keyword.get(colors, :warning, :yellow),
-      notice: Keyword.get(colors, :info, :normal),
+      notice: color(colors, :notice, :info, :blue),
       info: Keyword.get(colors, :info, :normal),
       debug: Keyword.get(colors, :debug, :cyan),
       enabled: Keyword.get(colors, :enabled, &IO.ANSI.enabled?/0)
     }
+  end
+
+  defp color(colors, level, fallback, default) do
+    Keyword.get_lazy(colors, level, fn -> Keyword.get(colors, fallback, default) end)
   end
 
   @doc false

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -759,16 +759,38 @@ defmodule LoggerTest do
       assert capture_log(fn -> Logger.info("hello") end) ==
                IO.ANSI.normal() <> "hello" <> IO.ANSI.reset()
 
+      assert capture_log(fn -> Logger.notice("hello") end) ==
+               IO.ANSI.blue() <> "hello" <> IO.ANSI.reset()
+
       assert capture_log(fn -> Logger.warning("hello") end) ==
                IO.ANSI.yellow() <> "hello" <> IO.ANSI.reset()
 
       assert capture_log(fn -> Logger.error("hello") end) ==
                IO.ANSI.red() <> "hello" <> IO.ANSI.reset()
+
+      assert capture_log(fn -> Logger.critical("hello") end) ==
+               IO.ANSI.red() <> "hello" <> IO.ANSI.reset()
+
+      assert capture_log(fn -> Logger.alert("hello") end) ==
+               IO.ANSI.red() <> "hello" <> IO.ANSI.reset()
+
+      assert capture_log(fn -> Logger.emergency("hello") end) ==
+               IO.ANSI.red() <> "hello" <> IO.ANSI.reset()
     end
 
     @tag formatter: [
            format: "$message",
-           colors: [enabled: true, debug: :magenta, info: :cyan, warning: :magenta, error: :cyan]
+           colors: [
+             enabled: true,
+             debug: :magenta,
+             info: :cyan,
+             notice: :red,
+             warning: :magenta,
+             error: :cyan,
+             critical: :green,
+             alert: :blue,
+             emergency: :black
+           ]
          ]
     test "custom" do
       assert capture_log(fn -> Logger.debug("hello") end) ==
@@ -777,12 +799,42 @@ defmodule LoggerTest do
       assert capture_log(fn -> Logger.info("hello") end) ==
                IO.ANSI.cyan() <> "hello" <> IO.ANSI.reset()
 
+      assert capture_log(fn -> Logger.notice("hello") end) ==
+               IO.ANSI.red() <> "hello" <> IO.ANSI.reset()
+
       assert capture_log(fn -> Logger.warning("hello") end) ==
                IO.ANSI.magenta() <> "hello" <> IO.ANSI.reset()
 
       assert capture_log(fn -> Logger.error("hello") end) ==
                IO.ANSI.cyan() <> "hello" <> IO.ANSI.reset()
+
+      assert capture_log(fn -> Logger.critical("hello") end) ==
+               IO.ANSI.green() <> "hello" <> IO.ANSI.reset()
+
+      assert capture_log(fn -> Logger.alert("hello") end) ==
+               IO.ANSI.blue() <> "hello" <> IO.ANSI.reset()
+
+      assert capture_log(fn -> Logger.emergency("hello") end) ==
+               IO.ANSI.black() <> "hello" <> IO.ANSI.reset()
     end
+  end
+
+  @tag formatter: [
+         format: "$message",
+         colors: [enabled: true, info: :magenta, error: :white]
+       ]
+  test "fallbacks" do
+    assert capture_log(fn -> Logger.notice("hello") end) ==
+             IO.ANSI.magenta() <> "hello" <> IO.ANSI.reset()
+
+    assert capture_log(fn -> Logger.critical("hello") end) ==
+             IO.ANSI.white() <> "hello" <> IO.ANSI.reset()
+
+    assert capture_log(fn -> Logger.alert("hello") end) ==
+             IO.ANSI.white() <> "hello" <> IO.ANSI.reset()
+
+    assert capture_log(fn -> Logger.emergency("hello") end) ==
+             IO.ANSI.white() <> "hello" <> IO.ANSI.reset()
   end
 
   describe "OTP integration" do


### PR DESCRIPTION
The new options `:notice`, `:critical`, `:alert` and `:emergency` when not configured fallback to the old configuration keys.

It allows better customization and feedback of the logged messages.

Let me know if the fallback is not needed or if it's worth to define new defaults. 

| Header | Preview |
|--------|--------|
| Previous default | ![](https://github.com/user-attachments/assets/38623ed1-8a0d-48ce-8fad-20041b98792d) |
| New Default | ![](https://github.com/user-attachments/assets/757b8cfa-ca86-4eb8-9c65-ca0adf3a298f) |
| Many possibilities | ![](https://github.com/user-attachments/assets/abfbfef3-9aac-4a98-90c2-283029d59b03) | 
| Important messages can standout | ![](https://github.com/user-attachments/assets/e4428ca8-a81d-43a5-9b2d-70d2b4519cc1) | 
| Why not? | ![](https://github.com/user-attachments/assets/c39f9030-afa6-4b93-8408-b73716ec3fdb) | 
