### PR TITLE
Update Windows argument splitting warnings in Port and System

### DIFF
--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -88,10 +88,10 @@ defmodule Port do
   > On Unix systems, arguments are passed to a new operating system
   > process as an array of strings but on Windows it is up to the child
   > process to parse them and some Windows programs may apply their own
-  > rules, which are inconsistent with the standard C runtime `argv` parsing
+  > rules, which are inconsistent with the standard C runtime `argv` parsing.
   >
-  > This is particularly troublesome when invoking `.bat` or `.com` files
-  > as these run implicitly through `cmd.exe`, whose argument parsing is
+  > This is particularly troublesome when invoking `.bat`, `.cmd`, or `.com`
+  > files as these run implicitly through `cmd.exe`, whose argument parsing is
   > vulnerable to malicious input and can be used to run arbitrary shell
   > commands.
   >
@@ -99,7 +99,7 @@ defmodule Port do
   > files or `.com` applications, you must not pass untrusted input as
   > arguments to the program. You may avoid accidentally executing them
   > by explicitly passing the extension of the program you want to run,
-  > such as `.exe`, and double check the program is indeed not a batch
+  > such as `.exe`, and double-checking the program is indeed not a batch
   > file or `.com` application.
   >
   > This affects both `spawn` and `spawn_executable`.

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -1026,10 +1026,10 @@ defmodule System do
   > On Unix systems, arguments are passed to a new operating system
   > process as an array of strings but on Windows it is up to the child
   > process to parse them and some Windows programs may apply their own
-  > rules, which are inconsistent with the standard C runtime `argv` parsing
+  > rules, which are inconsistent with the standard C runtime `argv` parsing.
   >
-  > This is particularly troublesome when invoking `.bat` or `.com` files
-  > as these run implicitly through `cmd.exe`, whose argument parsing is
+  > This is particularly troublesome when invoking `.bat`, `.cmd`, or `.com`
+  > files as these run implicitly through `cmd.exe`, whose argument parsing is
   > vulnerable to malicious input and can be used to run arbitrary shell
   > commands.
   >
@@ -1037,7 +1037,7 @@ defmodule System do
   > files or `.com` applications, you must not pass untrusted input as
   > arguments to the program. You may avoid accidentally executing them
   > by explicitly passing the extension of the program you want to run,
-  > such as `.exe`, and double check the program is indeed not a batch
+  > such as `.exe`, and double-checking the program is indeed not a batch
   > file or `.com` application.
 
   ## Options


### PR DESCRIPTION
Align the Windows argument splitting warning with Erlang/OTP's open_port/2 documentation by including .cmd in the list of affected extensions alongside .bat and .com, and fixing a missing final period.

Also polish the mitigation advice grammar to maintain parallelism (double-checking).

Assisted-by: Antigravity:Gemini-3.7-Flash

---

- Erlang docs: https://www.erlang.org/doc/apps/erts/erlang.html#open_port/2
- Elixir docs: https://elixir.hexdocs.pm/Port.html#module-open-mechanisms