### PR TITLE
Fix DateTime convert/2 and truncate/2 ignoring custom calendar from map

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -2058,6 +2058,7 @@ defmodule DateTime do
 
   defp from_map(%{} = datetime_map) do
     %DateTime{
+      calendar: datetime_map.calendar,
       year: datetime_map.year,
       month: datetime_map.month,
       day: datetime_map.day,

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -618,6 +618,10 @@ defmodule DateTimeTest do
     # Test passing non-struct map when converting to same calendar returns DateTime struct
     assert DateTime.convert(Map.from_struct(datetime_iso), Calendar.ISO) ==
              {:ok, datetime_iso}
+
+    # Test passing non-struct map when converting to same calendar keeps its calendar
+    assert DateTime.convert(Map.from_struct(datetime_hol), Calendar.Holocene) ==
+             {:ok, datetime_hol}
   end
 
   test "from_iso8601/1 with tz offsets" do
@@ -776,6 +780,13 @@ defmodule DateTimeTest do
 
     assert DateTime.truncate(%{datetime | microsecond: {123_456, 6}}, :second) ==
              %{datetime | microsecond: {0, 0}}
+
+    # A custom calendar of the given map must be kept
+    datetime_hol = %{datetime | calendar: Calendar.Holocene, year: 12017}
+    datetime_hol_map = Map.from_struct(datetime_hol)
+
+    assert DateTime.truncate(%{datetime_hol_map | microsecond: {123_456, 6}}, :second) ==
+             %{datetime_hol | microsecond: {0, 0}}
   end
 
   describe "diff" do


### PR DESCRIPTION
DateTime's internal from_map/1 skips calendar field while building DateTime struct  which leads to the struct's default Calendar.ISO