### PR TITLE
perf: Speed up Enum.dedup_by/2 on lists via a hand-rolled, tail-recursive implementation

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -859,6 +859,10 @@ defmodule Enum do
 
   """
   @spec dedup_by(t, (element -> term)) :: list
+  def dedup_by([head | tail], fun) do
+    dedup_by_list(tail, fun, fun.(head), [head])
+  end
+
   def dedup_by(enumerable, fun) do
     {list, _} = reduce(enumerable, {[], []}, R.dedup(fun))
     :lists.reverse(list)
@@ -4526,6 +4530,17 @@ defmodule Enum do
   defp dedup_list([value | [value | _] = tail]), do: dedup_list(tail)
   defp dedup_list([value | tail]), do: [value | dedup_list(tail)]
   defp dedup_list([]), do: []
+
+  ## dedup_by
+
+  defp dedup_by_list([head | tail], fun, prev, acc) do
+    case fun.(head) do
+      ^prev -> dedup_by_list(tail, fun, prev, acc)
+      new_val -> dedup_by_list(tail, fun, new_val, [head | acc])
+    end
+  end
+
+  defp dedup_by_list([], _fun, _prev, acc), do: :lists.reverse(acc)
 
   ## drop
 


### PR DESCRIPTION
This improves the runtime of `Enum.dedup_by/2` on lists by replacing the generic `reduce/3` implementation with a hand-rolled version similar in spirit to the `dedup_list/1` optimization. In my benchmarking, the magnitude of the improvement depends heavily on the size and shape of the data, but it looks roughly like this:

| List length | Duplicates | Speedup |
|------------:|-----------:|--------:|
|          10 |          0 |   +140% |
|       1,000 |          0 |    +81% |
|   1,000,000 |          0 |     +7% |
|          10 |        20% |   +116% |
|       1,000 |        20% |    +64% |
|   1,000,000 |        20% |     +2% |
|          10 |        50% |    +45% |
|       1,000 |        50% |    +62% |
|   1,000,000 |        50% |    +12% |

<details><summary>Benchmarking script</summary>

```elixir
defmodule New do
  def dedup_by([head | tail], fun) do
    dedup_by_list(tail, fun, fun.(head), [head])
  end

  def dedup_by(enum, fun), do: Enum.dedup_by(enum, fun)

  defp dedup_by_list([head | tail], fun, prev, acc) do
    case fun.(head) do
      ^prev -> dedup_by_list(tail, fun, prev, acc)
      new_val -> dedup_by_list(tail, fun, new_val, [head | acc])
    end
  end

  defp dedup_by_list([], _fun, _prev, acc), do: :lists.reverse(acc)
end

large_0pct = Enum.to_list(1..1_000_000)
mid_0pct = Enum.to_list(1..1_000)
small_0pct = Enum.to_list(1..10)
large_20pct = Enum.map(1..1_000_000, &rem(&1, 5))
mid_20pct = Enum.map(1..1_000, &rem(&1, 5))
small_20pct = Enum.map(1..10, &rem(&1, 5))
large_50pct = Enum.map(1..1_000_000, &rem(&1, 2))
mid_50pct = Enum.map(1..1_000, &rem(&1, 2))
small_50pct = Enum.map(1..10, &rem(&1, 2))

inputs = [
  {"1M elements, no dupes", for(_ <- 1..50, do: Enum.shuffle(large_0pct))},
  {"1K elements, no dupes", for(_ <- 1..1_000, do: Enum.shuffle(mid_0pct))},
  {"10 elements, no dupes", for(_ <- 1..100_000, do: Enum.shuffle(small_0pct))},
  {"1M elements, 20% dupes", for(_ <- 1..50, do: Enum.shuffle(large_20pct))},
  {"1K elements, 20% dupes", for(_ <- 1..1_000, do: Enum.shuffle(mid_20pct))},
  {"10 elements, 20% dupes", for(_ <- 1..100_000, do: Enum.shuffle(small_20pct))},
  {"1M elements, 50% dupes", for(_ <- 1..50, do: Enum.shuffle(large_50pct))},
  {"1K elements, 50% dupes", for(_ <- 1..1_000, do: Enum.shuffle(mid_50pct))},
  {"10 elements, 50% dupes", for(_ <- 1..100_000, do: Enum.shuffle(small_50pct))},
]

Benchee.run(
  %{
    "Old" => fn input -> Enum.dedup_by(input, &Function.identity/1) end,
    "New" => fn input -> New.dedup_by(input, &Function.identity/1) end,
  },
  time: 10,
  warmup: 1,
  inputs: inputs
)
```

</details>

