### PR TITLE
Improve diagnostics for typespecs stepped ranges

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -686,6 +686,13 @@ defmodule Kernel.Typespec do
     {{:type, location(meta), :range, [left, right]}, state}
   end
 
+  defp typespec({:..//, _meta, [_first, _last, _step]} = range, _vars, caller, _state) do
+    compile_error(
+      caller,
+      "ranges with steps are not supported in typespecs, got: #{Macro.to_string(range)}"
+    )
+  end
+
   # Handle special forms
   defp typespec({:__MODULE__, _, atom}, vars, caller, state) when is_atom(atom) do
     typespec(caller.module, vars, caller, state)

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -476,6 +476,14 @@ defmodule TypespecTest do
       end
     end
 
+    test "@type with a stepped range" do
+      assert_raise Kernel.TypespecError, ~r"ranges with steps are not supported", fn ->
+        test_module do
+          @type my_type :: 1..10//2
+        end
+      end
+    end
+
     test "@type with a keyword map" do
       bytecode =
         test_module do


### PR DESCRIPTION
Current error message is unclear:

```elixir
defmodule MT do
    @type my_type :: 1..10//2
end
```

`** (Kernel.TypespecError) iex:2: type ..///3 undefined (no such type in MT)`

After fix:

`** (Kernel.TypespecError) iex:2: ranges with steps are not supported in typespecs, got: 1..10//2`