### PR TITLE
Improve type inference for non-literal tuple element access

### DIFF
--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -1104,12 +1104,7 @@ defmodule Module.Types.Apply do
   end
 
   defp remote_apply(:erlang, :element, info, [_index, tuple] = args_types, stack) do
-    with {:ok, fallback} <- remote_apply(info, args_types, stack) do
-      case tuple_values(tuple) do
-        :badtuple -> {:ok, fallback}
-        values -> {:ok, return(values, args_types, stack)}
-      end
-    end
+    remote_apply_tuple_element(info, args_types, tuple, stack)
   end
 
   defp remote_apply(:erlang, :tuple_to_list, info, [tuple] = args_types, stack) do
@@ -1126,15 +1121,6 @@ defmodule Module.Types.Apply do
             end
 
           {:ok, return(list_type, args_types, stack)}
-      end
-    end
-  end
-
-  defp remote_apply(Kernel, :elem, info, [tuple, _index] = args_types, stack) do
-    with {:ok, fallback} <- remote_apply(info, args_types, stack) do
-      case tuple_values(tuple) do
-        :badtuple -> {:ok, fallback}
-        values -> {:ok, return(values, args_types, stack)}
       end
     end
   end
@@ -1186,6 +1172,10 @@ defmodule Module.Types.Apply do
       :badproperlist ->
         {:error, badremote(:erlang, :++, [left, right])}
     end
+  end
+
+  defp remote_apply(Kernel, :elem, info, [tuple, _index] = args_types, stack) do
+    remote_apply_tuple_element(info, args_types, tuple, stack)
   end
 
   @struct_key atom([:__struct__])
@@ -1546,6 +1536,22 @@ defmodule Module.Types.Apply do
 
   defp remote_apply(_mod, _fun, info, args_types, stack) do
     remote_apply(info, args_types, stack)
+  end
+
+  defp remote_apply_tuple_element(info, args_types, tuple, stack) do
+    with {:ok, fallback} <- remote_apply(info, args_types, stack) do
+      case tuple_values(tuple) do
+        :badtuple ->
+          {:ok, fallback}
+
+        values ->
+          if empty?(values) and not empty?(tuple) do
+            {:error, {:badindex, 1, tuple}}
+          else
+            {:ok, return(values, args_types, stack)}
+          end
+      end
+    end
   end
 
   defp remote_apply(:none, _args_types, _stack) do

--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -1103,6 +1103,42 @@ defmodule Module.Types.Apply do
     end
   end
 
+  defp remote_apply(:erlang, :element, info, [_index, tuple] = args_types, stack) do
+    with {:ok, fallback} <- remote_apply(info, args_types, stack) do
+      case tuple_values(tuple) do
+        :badtuple -> {:ok, fallback}
+        values -> {:ok, return(values, args_types, stack)}
+      end
+    end
+  end
+
+  defp remote_apply(:erlang, :tuple_to_list, info, [tuple] = args_types, stack) do
+    with {:ok, fallback} <- remote_apply(info, args_types, stack) do
+      case tuple_values(tuple) do
+        :badtuple ->
+          {:ok, fallback}
+
+        values ->
+          list_type =
+            case tuple_fetch(tuple, 0) do
+              {false, _value} -> non_empty_list(values)
+              _otherwise -> if empty?(values), do: empty_list(), else: list(values)
+            end
+
+          {:ok, return(list_type, args_types, stack)}
+      end
+    end
+  end
+
+  defp remote_apply(Kernel, :elem, info, [tuple, _index] = args_types, stack) do
+    with {:ok, fallback} <- remote_apply(info, args_types, stack) do
+      case tuple_values(tuple) do
+        :badtuple -> {:ok, fallback}
+        values -> {:ok, return(values, args_types, stack)}
+      end
+    end
+  end
+
   defp remote_apply(:erlang, :map_get, _info, [key, map] = args_types, stack) do
     case map_get(map, key) do
       {:ok, value} -> {:ok, return(value, args_types, stack)}

--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -1545,7 +1545,7 @@ defmodule Module.Types.Apply do
           {:ok, fallback}
 
         values ->
-          if empty?(values) and not empty?(tuple) do
+          if empty?(values) do
             {:error, {:badindex, 1, tuple}}
           else
             {:ok, return(values, args_types, stack)}

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -5355,6 +5355,8 @@ defmodule Module.Types.Descr do
 
   @doc """
   Returns all of the values that are part of a tuple.
+
+  Returns `:badtuple` if the projection is invalid or the tuple descriptor is uninhabited.
   """
   def tuple_values(:term), do: :badtuple
   def tuple_values(descr) when descr == %{}, do: :badtuple
@@ -5369,7 +5371,7 @@ defmodule Module.Types.Descr do
         end
 
       {dynamic, static} ->
-        if tuple_only?(static) and descr_key?(dynamic, :tuple) do
+        if not empty?(descr) and tuple_only?(static) and descr_key?(dynamic, :tuple) do
           dynamic_value =
             case dynamic do
               :term -> term()

--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -5173,10 +5173,9 @@ defmodule Module.Types.Descr do
           # The trouble with allowing the access is that it is a potential runtime
           # error not being caught by the type system.
           #
-          # Furthermore, our choice here, needs to be consistent with elem/put_elem
-          # when the index is the `integer()` type. If we choose to return `:badindex`,
-          # then all elem/put_elem with an `integer()` and the tuple is not dynamic
-          # should also be a static typing error. We chose to go with 1.
+          # This applies when checking a concrete index. Non-literal element/elem
+          # calls use tuple_values/1 instead, since no inaccessible index has been
+          # selected statically.
           if static_optional? or empty?(static_type) do
             :badindex
           else

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -2310,9 +2310,12 @@ defmodule Module.Types.DescrTest do
     test "tuple_values" do
       assert tuple_values(term()) == :badtuple
       assert tuple_values(dynamic()) == dynamic()
+      assert tuple_values(none()) == :badtuple
       assert tuple_values(integer()) == :badtuple
       assert tuple_values(tuple([none()])) == :badtuple
       assert tuple_values(tuple([])) == none()
+      assert tuple_values(dynamic(tuple([none()]))) == :badtuple
+      assert tuple_values(dynamic(tuple([]))) == dynamic(none())
       assert tuple_values(tuple()) == term()
       assert tuple_values(open_tuple([integer()])) == term()
       assert tuple_values(tuple([integer(), atom()])) == opt_union(integer(), atom())
@@ -2343,6 +2346,8 @@ defmodule Module.Types.DescrTest do
 
       assert tuple_values(opt_union(dynamic(tuple([integer()])), tuple([integer()])))
              |> equal?(integer())
+
+      assert tuple_values(opt_union(tuple([]), tuple([integer()]))) == integer()
     end
 
     test "map_to_list" do

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -828,8 +828,25 @@ defmodule Module.Types.ExprTest do
       assert typecheck!(elem({:ok, 123}, 1)) == integer()
       assert typecheck!(:erlang.element(1, {:ok, 123})) == atom([:ok])
       assert typecheck!(:erlang.element(2, {:ok, 123})) == integer()
+      assert typecheck!([index], elem({1, 2, 3}, index)) == integer()
+
+      assert typecheck!([index], :erlang.element(index, {:ok, 123})) ==
+               opt_union(atom([:ok]), integer())
+
+      assert typecheck!([index], elem({}, index)) == none()
       assert typecheck!([x], elem({:ok, x}, 0)) == dynamic(atom([:ok]))
       assert typecheck!([x], elem({:ok, x}, 1)) == dynamic(term())
+
+      assert typeerror!(
+               [index],
+               case elem({1, 2}, index) do
+                 :probe -> :error
+                 _otherwise -> :ok
+               end
+             ) =~ "which has type:\n\n    integer()"
+
+      assert typeerror!([<<index::float>>], elem({1, 2}, index)) |> strip_ansi() =~
+               "incompatible types given to Kernel.elem/2"
 
       assert typeerror!([<<x::float>>], elem(x, 0)) |> strip_ansi() ==
                ~l"""
@@ -873,6 +890,26 @@ defmodule Module.Types.ExprTest do
 
                    -1
                """
+    end
+
+    test "tuple_to_list/1" do
+      assert typecheck!(:erlang.tuple_to_list({:ok, 123})) ==
+               non_empty_list(opt_union(atom([:ok]), integer()))
+
+      assert typecheck!(Tuple.to_list({})) |> equal?(empty_list())
+      assert typecheck!(hd(Tuple.to_list({:ok, 123}))) == opt_union(atom([:ok]), integer())
+      assert typecheck!([x], hd(Tuple.to_list({x}))) == dynamic()
+
+      assert typecheck!([tuple], is_tuple(tuple), Tuple.to_list(tuple)) ==
+               list(dynamic())
+
+      assert typecheck!(
+               [condition, x = 1],
+               Tuple.to_list(if(condition, do: x, else: {:ok}))
+             ) == non_empty_list(opt_union(atom([:ok]), dynamic(atom([:ok]))))
+
+      assert typeerror!(:erlang.tuple_to_list(123)) |> strip_ansi() =~
+               "incompatible types given to Tuple.to_list/1"
     end
 
     test "Tuple.insert_at/3" do

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -833,7 +833,39 @@ defmodule Module.Types.ExprTest do
       assert typecheck!([index], :erlang.element(index, {:ok, 123})) ==
                opt_union(atom([:ok]), integer())
 
-      assert typecheck!([index], elem({}, index)) == none()
+      assert typeerror!([index], elem({}, index)) =~
+               ~l"""
+               expected a tuple with at least 1 element in Kernel.elem/2:
+
+                   elem({}, index)
+
+               the given type does not have the given index:
+
+                   {}
+               """
+
+      assert typeerror!([index], :erlang.element(index, {})) =~
+               ~l"""
+               expected a tuple with at least 1 element in :erlang.element/2:
+
+                   :erlang.element(index, {})
+
+               the given type does not have the given index:
+
+                   {}
+               """
+
+      assert typeerror!([tuple = {}, index], elem(tuple, index)) =~
+               ~l"""
+               expected a tuple with at least 1 element in Kernel.elem/2:
+
+                   elem(tuple, index)
+
+               the given type does not have the given index:
+
+                   dynamic({})
+               """
+
       assert typecheck!([x], elem({:ok, x}, 0)) == dynamic(atom([:ok]))
       assert typecheck!([x], elem({:ok, x}, 1)) == dynamic(term())
 


### PR DESCRIPTION
This PR uses `Descr.tuple_values/1` to improve inference for `elem/2`, `:erlang.element/2` and `tuple_to_list/1` calls with non literal args. Tuple element access now returns the union of all element types(or `:badindex` for empty tuples). `tuple_to_list` inference preserves empty/non-empty shape and gradual fallbacks.

It was a likely omission - `Descr.tuple_values/1` is public, documented and covered by tests

AssistedBy: GPT 5.6 Sol, Claude Fable 5
