### PR TITLE
Fix Kernel.SpecialForms ::/2 doc example

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -768,8 +768,8 @@ defmodule Kernel.SpecialForms do
   It is used in typespecs to specify the type of a variable,
   function or of a type itself:
 
-      @type number :: integer | float
-      @spec add(number, number) :: number
+      @type num :: integer | float
+      @spec add(num, num) :: num
 
   It may also be used in bit strings to specify the type
   of a given bit segment:


### PR DESCRIPTION
Example `@type number :: integer | float` does not compile because number is built-in type