### PR TITLE
Optimize Myers list diff setup

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -542,16 +542,16 @@ defmodule ExUnit.Diff do
 
   defp myers_difference_list(left, right, env) do
     path = {0, left, right, {[], [], env}}
-    find_diff(0, length(left) + length(right), [path])
+    find_diff(0, [path])
   end
 
-  defp find_diff(envelope, max, paths) do
+  defp find_diff(envelope, paths) do
     case each_diagonal(-envelope, envelope, paths, []) do
       {:done, {edit1, edit2, env}} ->
         list_script_to_diff(Enum.reverse(edit1), Enum.reverse(edit2), true, [], [], env)
 
       {:next, paths} ->
-        find_diff(envelope + 1, max, paths)
+        find_diff(envelope + 1, paths)
     end
   end
 


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT 5.6 Sol
Assisted-by: Antigravity CLI:Gemini 3.7 Flash

Remove the unused maximum-distance parameter in ExUnit.Diff. This avoids traversing both input lists with length/1 before computing the diff.