### PR TITLE
Avoid rebuilding Cartesian map suffixes

### DIFF
--- a/lib/elixir/lib/module/types/of.ex
+++ b/lib/elixir/lib/module/types/of.ex
@@ -381,8 +381,10 @@ defmodule Module.Types.Of do
           closed_map(non_multiple)
 
         [{keys, type} | tail] ->
-          for key <- keys, t <- cartesian_map(tail) do
-            closed_map(non_multiple ++ [{key, {type, false}} | t])
+          products = cartesian_map(tail)
+
+          for key <- keys, product <- products do
+            closed_map(non_multiple ++ [{key, {type, false}} | product])
           end
           |> Enum.reduce(&opt_union/2)
       end
@@ -463,7 +465,8 @@ defmodule Module.Types.Of do
         [[]]
 
       [{keys, type} | tail] ->
-        for key <- keys, t <- cartesian_map(tail), do: [{key, {type, false}} | t]
+        products = cartesian_map(tail)
+        for key <- keys, product <- products, do: [{key, {type, false}} | product]
     end
   end
 


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT 5.6 Sol
Assisted-by: Antigravity CLI:Gemini 3.7 Flash

I just learned:

> In comprehensions with multiple generators, tail generators are re-evaluated for each element of earlier generators, causing `cartesian_map(tail)` to be recomputed for every key. Precomputing `cartesian_map(tail)` avoids redundant recursive calls and list allocations.
