### PR TITLE
Optimize JSON map key encoding

### DIFF
--- a/lib/elixir/lib/json.ex
+++ b/lib/elixir/lib/json.ex
@@ -175,6 +175,7 @@ defimpl JSON.Encoder, for: Map do
 
   # Erlang supports only numbers, binaries, and atoms as keys,
   # we support anything that implements the String.Chars protocol.
+  @compile inline: [key: 2]
   defp key(key, encoder) when is_atom(key), do: encoder.(Atom.to_string(key), encoder)
   defp key(key, encoder) when is_binary(key), do: encoder.(key, encoder)
   defp key(key, encoder), do: encoder.(String.Chars.to_string(key), encoder)


### PR DESCRIPTION
Assisted-by: Codex CLI:GPT-5.6 Sol

Inline the per-key dispatch to avoid a private function call for every encoded map entry.

Bench:
```elixir
Mix.install([{:benchee, "~> 1.5"}])

inputs =
  for key_type <- [:binary, :atom, :integer], size <- [10, 100, 1000], into: %{} do
    entries =
      Enum.map(1..size, fn index ->
        key =
          case key_type do
            :binary -> "key#{index}"
            :atom -> String.to_atom("key#{index}")
            :integer -> index
          end

        {key, index}
      end)

    {"#{key_type} keys (#{size})", Map.new(entries)}
  end

Benchee.run(
  %{"JSON.encode_to_iodata!/1" => &JSON.encode_to_iodata!/1},
  inputs: inputs,
  warmup: 2,
  time: 5,
  reduction_time: 2
)
```

Results:
```txt
  - Base: 7bd7665a9
  - Current: 36e700b08
  - OTP 29, JIT enabled, one scheduler
  - Each cell is the mean of Benchee’s reported average across three runs

   Input                      Base      Current    Faster
  ━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━
   Atom keys ×10         546.80 ns    491.81 ns    10.06%
  ────────────────────  ───────────  ───────────  ────────
   Atom keys ×100         6.057 µs     5.363 µs    11.45%
  ────────────────────  ───────────  ───────────  ────────
   Atom keys ×1000       72.263 µs    62.560 µs    13.43%
  ────────────────────  ───────────  ───────────  ────────
   Binary keys ×10       488.05 ns    442.15 ns     9.40%
  ────────────────────  ───────────  ───────────  ────────
   Binary keys ×100       5.340 µs     4.560 µs    14.61%
  ────────────────────  ───────────  ───────────  ────────
   Binary keys ×1000     61.090 µs    52.720 µs    13.70%
  ────────────────────  ───────────  ───────────  ────────
   Integer keys ×10      696.37 ns    655.10 ns     5.93%
  ────────────────────  ───────────  ───────────  ────────
   Integer keys ×100      7.363 µs     6.603 µs    10.32%
  ────────────────────  ───────────  ───────────  ────────
   Integer keys ×1000    81.840 µs    73.710 µs     9.93%

  Geometric-mean improvement across all nine inputs: 11.02%
  ```

