### PR TITLE
Fix unsound refinement of `min/2` and `max/2` arguments

### DIFF
--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -466,9 +466,13 @@ defmodule Module.Types.Apply do
     #     a and not number(), b and not number() -> a and b
     #
     # However, during inference, we type it as `a, b -> a and b` only.
-    {left_type, context} = of_fun.(left, expected, expr, stack, context)
-    {right_type, context} = of_fun.(right, expected, expr, stack, context)
+    # Either argument may be discarded based on term ordering, so the result's
+    # expected type cannot be used to refine either argument.
+    {left_type, context} = of_fun.(left, term(), expr, stack, context)
+    {right_type, context} = of_fun.(right, term(), expr, stack, context)
     result = opt_union(left_type, right_type)
+    refined_result = opt_intersection(result, expected)
+    result = if empty?(refined_result), do: result, else: refined_result
 
     if error = mismatched_ordered_comparison(left_type, right_type, stack) do
       remote_error(error, :erlang, name, 2, expr, stack, context)

--- a/lib/elixir/lib/module/types/apply.ex
+++ b/lib/elixir/lib/module/types/apply.ex
@@ -467,7 +467,8 @@ defmodule Module.Types.Apply do
     #
     # However, during inference, we type it as `a, b -> a and b` only.
     # Either argument may be discarded based on term ordering, so the result's
-    # expected type cannot be used to refine either argument.
+    # expected type cannot be used to refine either argument. The result itself
+    # flows directly to the consumer, so it can still be contextually refined.
     {left_type, context} = of_fun.(left, term(), expr, stack, context)
     {right_type, context} = of_fun.(right, term(), expr, stack, context)
     result = opt_union(left_type, right_type)

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -159,9 +159,9 @@ defmodule Module.Types.Expr do
 
             # The function may still return a too broad type,
             # so we refine once again to assign the most appropriate to the pattern.
-            # This contextual refinement is safe only if any continuation that observes
-            # bindings introduced by the match runs after `expected` is established or
-            # enforced. Callers must not propagate `expected` into discarded values.
+            # This contextual refinement is safe only if an `expected` type violation
+            # raises before bindings introduced by the match can be observed. Callers
+            # must not pass `expected` into a subexpression whose value may be discarded.
             {opt_intersection(result, expected), context}
           end
 

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -159,9 +159,6 @@ defmodule Module.Types.Expr do
 
             # The function may still return a too broad type,
             # so we refine once again to assign the most appropriate to the pattern.
-            # This contextual refinement is safe only if an `expected` type violation
-            # raises before bindings introduced by the match can be observed. Callers
-            # must not pass `expected` into a subexpression whose value may be discarded.
             {opt_intersection(result, expected), context}
           end
 

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -159,6 +159,9 @@ defmodule Module.Types.Expr do
 
             # The function may still return a too broad type,
             # so we refine once again to assign the most appropriate to the pattern.
+            # This contextual refinement is safe only if any continuation that observes
+            # bindings introduced by the match runs after `expected` is established or
+            # enforced. Callers must not propagate `expected` into discarded values.
             {opt_intersection(result, expected), context}
           end
 

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -1647,6 +1647,44 @@ defmodule Module.Types.ExprTest do
       assert typecheck!([x = 123, y = 456.0], min(x, y)) == dynamic(opt_union(integer(), float()))
     end
 
+    test "min/max does not refine discarded arguments from the expected type" do
+      assert typecheck!(
+               (
+                 min(v = 1, 2)
+                 v
+               )
+             ) == integer()
+
+      assert typecheck!(
+               [x],
+               (
+                 :erlang.binary_part(:erlang.max(x, ""), 0, 0)
+                 x
+               )
+             ) == dynamic()
+
+      assert typecheck!(
+               [x],
+               (
+                 :erlang.binary_part(
+                   :erlang.max(v = if(is_integer(x), do: x, else: "x"), ""),
+                   0,
+                   0
+                 )
+
+                 v
+               )
+             ) == opt_union(binary(), dynamic(opt_union(integer(), binary())))
+
+      assert typecheck!(
+               [x],
+               (
+                 div(:erlang.min(v = if(is_binary(x), do: x, else: 1), 0), 1)
+                 v
+               )
+             ) == opt_union(integer(), dynamic(opt_union(integer(), binary())))
+    end
+
     test "warns when comparison is constant" do
       assert typeerror!([x = :foo, y = 321], min(x, y)) ==
                ~l"""

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -1649,13 +1649,6 @@ defmodule Module.Types.ExprTest do
 
     test "min/max does not refine discarded arguments from the expected type" do
       assert typecheck!(
-               (
-                 min(v = 1, 2)
-                 v
-               )
-             ) == integer()
-
-      assert typecheck!(
                [x],
                (
                  :erlang.binary_part(:erlang.max(x, ""), 0, 0)

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -849,17 +849,20 @@ defmodule Module.Types.PatternTest do
 
     test "min/max" do
       assert typecheck!([x, y], is_integer(min(x, y)), min(x, y)) ==
-               dynamic(integer())
+               dynamic()
 
       assert typecheck!([x, y], is_number(min(x, y)), min(x, y)) ==
-               dynamic(opt_union(integer(), float()))
+               dynamic()
+
+      assert typecheck!([x, y], is_integer(min(x, y)), {x, y}) ==
+               dynamic(tuple([term(), term()]))
 
       assert typecheck!([m], elem(m.pair, max(m.x, m.y)) > 0, m) ==
                dynamic(
                  open_map(
                    pair: {opt_difference(open_tuple([]), tuple([])), false},
-                   x: {integer(), false},
-                   y: {integer(), false}
+                   x: {term(), false},
+                   y: {term(), false}
                  )
                )
 


### PR DESCRIPTION
This PR removes unsound refinement of arguments by expected result type. Instead it refines the args using `term` type similarly to sibling `>=`/`<` and uses expected type on argument union

Fixes #15833

AssistedBy: GPT 5.6 Sol, Claude Fable 5.1