### PR TITLE
Add `Macro.quoted_literal?` clause for `__block__` wrapped literals

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2183,6 +2183,9 @@ defmodule Macro do
   def quoted_literal?({:__aliases__, _, args}),
     do: quoted_literal?(args)
 
+  def quoted_literal?({:__block__, _, [wrapped]}),
+    do: quoted_literal?(wrapped)
+
   def quoted_literal?({:%, _, [left, right]}),
     do: quoted_literal?(left) and quoted_literal?(right)
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -1891,11 +1891,14 @@ defmodule MacroTest do
     assert Macro.quoted_literal?(quote(do: <<1000::size(8)-unit(4)>>))
     assert Macro.quoted_literal?(quote(do: <<1000::8*4>>))
     assert Macro.quoted_literal?(quote(do: <<102::unsigned-big-integer-size(8)>>))
+    assert Macro.quoted_literal?({:__block__, [], [1]})
     refute Macro.quoted_literal?(quote(do: {"foo", var}))
     refute Macro.quoted_literal?(quote(do: <<"foo"::size(name_size)>>))
     refute Macro.quoted_literal?(quote(do: <<"foo"::binary-size(name_size)>>))
     refute Macro.quoted_literal?(quote(do: <<"foo"::custom_modifier()>>))
     refute Macro.quoted_literal?(quote(do: <<102, rest::binary>>))
+    refute Macro.quoted_literal?({:__block__, [], [quote(do: var)]})
+    refute Macro.quoted_literal?({:__block__, [], [1, 2]})
   end
 
   test "underscore/1" do


### PR DESCRIPTION
Closes #15830.