### PR TITLE
Optimize Date.Range.member?/2 by branching on step sign

### DIFF
--- a/lib/elixir/lib/calendar/date_range.ex
+++ b/lib/elixir/lib/calendar/date_range.ex
@@ -37,21 +37,19 @@ defmodule Date.Range do
             first_in_iso_days: first_days,
             last_in_iso_days: last_days,
             step: step
-          } = range,
+          },
           %Date{calendar: calendar} = date
         ) do
       {days, _} = Date.to_iso_days(date)
 
-      cond do
-        empty?(range) ->
-          {:ok, false}
+      in_range? =
+        if step > 0 do
+          first_days <= days and days <= last_days and rem(days - first_days, step) == 0
+        else
+          last_days <= days and days <= first_days and rem(days - first_days, step) == 0
+        end
 
-        first_days <= last_days ->
-          {:ok, first_days <= days and days <= last_days and rem(days - first_days, step) == 0}
-
-        true ->
-          {:ok, last_days <= days and days <= first_days and rem(days - first_days, step) == 0}
-      end
+      {:ok, in_range?}
     end
 
     def member?(%Date.Range{step: _}, _) do
@@ -194,33 +192,6 @@ defmodule Date.Range do
          ) do
       step = if first_days <= last_days, do: 1, else: -1
       size(Map.put(date_range, :step, step))
-    end
-
-    defp empty?(%Date.Range{
-           first_in_iso_days: first_days,
-           last_in_iso_days: last_days,
-           step: step
-         })
-         when step > 0 and first_days > last_days,
-         do: true
-
-    defp empty?(%Date.Range{
-           first_in_iso_days: first_days,
-           last_in_iso_days: last_days,
-           step: step
-         })
-         when step < 0 and first_days < last_days,
-         do: true
-
-    defp empty?(%Date.Range{step: _}), do: false
-
-    # TODO: Remove me on v2.0
-    defp empty?(
-           %{__struct__: Date.Range, first_in_iso_days: first_days, last_in_iso_days: last_days} =
-             date_range
-         ) do
-      step = if first_days <= last_days, do: 1, else: -1
-      empty?(Map.put(date_range, :step, step))
     end
   end
 

--- a/lib/elixir/test/elixir/calendar/date_range_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_range_test.exs
@@ -39,6 +39,12 @@ defmodule Date.RangeTest do
 
     test "empty range" do
       refute Enum.member?(@empty_range, @empty_range.first)
+      refute Enum.member?(@empty_range, @empty_range.last)
+
+      empty_desc = Date.range(~D[2000-01-01], ~D[2001-01-01], -1)
+      refute Enum.member?(empty_desc, empty_desc.first)
+      refute Enum.member?(empty_desc, empty_desc.last)
+      refute Enum.member?(empty_desc, ~D[2000-06-01])
     end
   end
 


### PR DESCRIPTION
Assisted-by: Antigravity CLI:Gemini-3.8-Flash

Less code and faster.

> Branching on the step sign rather than `first_days <= last_days` eliminates
the need for `empty?/1` because the interval bounding checks inherently
guarantee non-emptiness. This aligns `Enumerable.Date.Range` with
`Enumerable.Range`, eliminates a private function call per membership
check, and removes 27 lines of redundant code.

```elixir
Mix.install([:benchee])

defmodule OldMember do
  def member?(
        %Date.Range{
          first: %{calendar: calendar},
          first_in_iso_days: first_days,
          last_in_iso_days: last_days,
          step: step
        } = range,
        %Date{calendar: calendar} = date
      ) do
    {days, _} = Date.to_iso_days(date)

    cond do
      empty?(range) ->
        {:ok, false}

      first_days <= last_days ->
        {:ok, first_days <= days and days <= last_days and rem(days - first_days, step) == 0}

      true ->
        {:ok, last_days <= days and days <= first_days and rem(days - first_days, step) == 0}
    end
  end

  def member?(%Date.Range{step: _}, _), do: {:ok, false}

  defp empty?(%Date.Range{first_in_iso_days: first, last_in_iso_days: last, step: step})
       when step > 0 and first > last,
       do: true

  defp empty?(%Date.Range{first_in_iso_days: first, last_in_iso_days: last, step: step})
       when step < 0 and first < last,
       do: true

  defp empty?(%Date.Range{step: _}), do: false
end

defmodule NewMember do
  def member?(
        %Date.Range{
          first: %{calendar: calendar},
          first_in_iso_days: first_days,
          last_in_iso_days: last_days,
          step: step
        },
        %Date{calendar: calendar} = date
      ) do
    {days, _} = Date.to_iso_days(date)

    in_range? =
      if step > 0 do
        first_days <= days and days <= last_days and rem(days - first_days, step) == 0
      else
        last_days <= days and days <= first_days and rem(days - first_days, step) == 0
      end

    {:ok, in_range?}
  end

  def member?(%Date.Range{step: _}, _), do: {:ok, false}
end

first = ~D[2000-01-01]
last = Date.add(first, 20_000)
middle = Date.add(first, 10_000)
asc = Date.range(first, last, 2)
desc = Date.range(last, first, -2)

inputs = %{
  "ascending hit" => {asc, middle},
  "ascending step miss" => {asc, Date.add(middle, 1)},
  "ascending bounds miss" => {asc, Date.add(first, -1)},
  "descending hit" => {desc, middle},
  "descending step miss" => {desc, Date.add(middle, 1)},
  "descending bounds miss" => {desc, Date.add(last, 1)},
  "empty positive" => {Date.range(last, first, 2), middle},
  "empty negative" => {Date.range(first, last, -2), middle}
}

Benchee.run(
  %{
    "old" => fn {range, date} -> OldMember.member?(range, date) end,
    "new" => fn {range, date} -> NewMember.member?(range, date) end
  },
  inputs: inputs,
  memory_time: 2,
  pre_check: :all_same,
  reduction_time: 2,
  time: 2,
  warmup: 1
)
```

Results:
```txtOperating System: Linux
CPU Information: AMD Ryzen 7 8845HS w
Number of Available Cores: 16
Available memory: 54.72 GB
Elixir 1.20.4
Erlang 29.0.5
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 1 s
time: 2 s
memory time: 2 s
reduction time: 2 s
parallel: 1
inputs: ascending bounds miss, ascending hit, ascending step miss, descending bounds miss, descending hit, descending step miss, empty negative, empty positive
Estimated total run time: 1 min 52 s
Excluding outliers: false

##### With input ascending bounds miss #####
Name           ips        average  deviation         median         99th %
new        12.00 M       83.33 ns  ±9309.33%          60 ns          90 ns
old        10.37 M       96.44 ns  ±8132.65%          70 ns         100 ns

Comparison: 
new        12.00 M
old        10.37 M - 1.16x slower +13.11 ns

Memory usage statistics:

Name    Memory usage
new             24 B
old             24 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               12
old               14 - 1.17x reduction count +2

**All measurements for reduction count were the same**

##### With input ascending hit #####
Name           ips        average  deviation         median         99th %
new        14.06 M       71.14 ns  ±3905.58%          60 ns         100 ns
old        11.64 M       85.94 ns  ±6975.96%          70 ns         100 ns

Comparison: 
new        14.06 M
old        11.64 M - 1.21x slower +14.80 ns

Memory usage statistics:

Name    Memory usage
new             48 B
old             48 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               12
old               14 - 1.17x reduction count +2

**All measurements for reduction count were the same**

##### With input ascending step miss #####
Name           ips        average  deviation         median         99th %
new        13.56 M       73.73 ns  ±3816.64%          61 ns          90 ns
old        11.67 M       85.69 ns  ±7294.25%          70 ns          91 ns

Comparison: 
new        13.56 M
old        11.67 M - 1.16x slower +11.96 ns

Memory usage statistics:

Name    Memory usage
new             48 B
old             48 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               12
old               14 - 1.17x reduction count +2

**All measurements for reduction count were the same**

##### With input descending bounds miss #####
Name           ips        average  deviation         median         99th %
new        11.82 M       84.60 ns  ±8842.20%          60 ns          91 ns
old        10.95 M       91.35 ns  ±7744.64%          61 ns         100 ns

Comparison: 
new        11.82 M
old        10.95 M - 1.08x slower +6.75 ns

Memory usage statistics:

Name    Memory usage
new             24 B
old             24 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               12
old               14 - 1.17x reduction count +2

**All measurements for reduction count were the same**

##### With input descending hit #####
Name           ips        average  deviation         median         99th %
new        13.21 M       75.70 ns  ±3852.33%          70 ns         100 ns
old        11.72 M       85.35 ns  ±7514.65%          70 ns         100 ns

Comparison: 
new        13.21 M
old        11.72 M - 1.13x slower +9.66 ns

Memory usage statistics:

Name    Memory usage
new             48 B
old             48 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               12
old               14 - 1.17x reduction count +2

**All measurements for reduction count were the same**

##### With input descending step miss #####
Name           ips        average  deviation         median         99th %
new        14.04 M       71.24 ns  ±3512.01%          60 ns          91 ns
old        11.76 M       85.01 ns  ±7361.05%          70 ns          91 ns

Comparison: 
new        14.04 M
old        11.76 M - 1.19x slower +13.78 ns

Memory usage statistics:

Name    Memory usage
new             48 B
old             48 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               12
old               14 - 1.17x reduction count +2

**All measurements for reduction count were the same**

##### With input empty negative #####
Name           ips        average  deviation         median         99th %
new        11.63 M       86.01 ns  ±8459.54%          60 ns          80 ns
old        10.90 M       91.72 ns  ±8049.77%          61 ns         100 ns

Comparison: 
new        11.63 M
old        10.90 M - 1.07x slower +5.70 ns

Memory usage statistics:

Name    Memory usage
new             24 B
old             24 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               12
old               14 - 1.17x reduction count +2

**All measurements for reduction count were the same**

##### With input empty positive #####
Name           ips        average  deviation         median         99th %
new        11.79 M       84.79 ns  ±8771.12%          60 ns          90 ns
old        11.13 M       89.82 ns  ±8256.21%          60 ns         100 ns

Comparison: 
new        11.79 M
old        11.13 M - 1.06x slower +5.03 ns

Memory usage statistics:

Name    Memory usage
new             24 B
old             24 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               12
old               14 - 1.17x reduction count +2

**All measurements for reduction count were the same**
```

