### PR TITLE
Inline Calendar.ISO parsing heads and eliminate guarded helpers

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -423,16 +423,13 @@ defmodule Calendar.ISO do
   @spec parse_date(String.t(), format) ::
           {:ok, {year, month, day}}
           | {:error, atom}
-  def parse_date(string, format) when is_binary(string) and is_format(format),
-    do: parse_date_guarded(string, format)
-
-  defp parse_date_guarded("-" <> string, format),
+  def parse_date("-" <> string, format) when is_format(format),
     do: do_parse_date(string, -1, format)
 
-  defp parse_date_guarded("+" <> string, format),
+  def parse_date("+" <> string, format) when is_format(format),
     do: do_parse_date(string, 1, format)
 
-  defp parse_date_guarded(string, format),
+  def parse_date(string, format) when is_binary(string) and is_format(format),
     do: do_parse_date(string, 1, format)
 
   defp do_parse_date(unquote(match_basic_date), multiplier, :basic) when unquote(guard_date) do
@@ -508,16 +505,13 @@ defmodule Calendar.ISO do
   @spec parse_naive_datetime(String.t(), format) ::
           {:ok, {year, month, day, hour, minute, second, microsecond}}
           | {:error, atom}
-  def parse_naive_datetime(string, format) when is_binary(string) and is_format(format),
-    do: parse_naive_datetime_guarded(string, format)
-
-  defp parse_naive_datetime_guarded("-" <> string, format),
+  def parse_naive_datetime("-" <> string, format) when is_format(format),
     do: do_parse_naive_datetime(string, -1, format)
 
-  defp parse_naive_datetime_guarded("+" <> string, format),
+  def parse_naive_datetime("+" <> string, format) when is_format(format),
     do: do_parse_naive_datetime(string, 1, format)
 
-  defp parse_naive_datetime_guarded(string, format),
+  def parse_naive_datetime(string, format) when is_binary(string) and is_format(format),
     do: do_parse_naive_datetime(string, 1, format)
 
   defp do_parse_naive_datetime(
@@ -612,16 +606,13 @@ defmodule Calendar.ISO do
   @spec parse_utc_datetime(String.t(), format) ::
           {:ok, {year, month, day, hour, minute, second, microsecond}, utc_offset}
           | {:error, atom}
-  def parse_utc_datetime(string, format) when is_binary(string) and is_format(format),
-    do: parse_utc_datetime_guarded(string, format)
-
-  defp parse_utc_datetime_guarded("-" <> string, format),
+  def parse_utc_datetime("-" <> string, format) when is_format(format),
     do: do_parse_utc_datetime(string, -1, format)
 
-  defp parse_utc_datetime_guarded("+" <> string, format),
+  def parse_utc_datetime("+" <> string, format) when is_format(format),
     do: do_parse_utc_datetime(string, 1, format)
 
-  defp parse_utc_datetime_guarded(string, format),
+  def parse_utc_datetime(string, format) when is_binary(string) and is_format(format),
     do: do_parse_utc_datetime(string, 1, format)
 
   defp do_parse_utc_datetime(


### PR DESCRIPTION
Assisted-by: Antigravity CLI:Gemini-3.8-Flash

Refactor for less code and eliminating a function call.

> Pattern matching on "-" and "+" binary prefixes directly across the
> public function heads of parse_date/2, parse_naive_datetime/2, and
> parse_utc_datetime/2 eliminates the need for parse_date_guarded/2,
> parse_naive_datetime_guarded/2, and parse_utc_datetime_guarded/2.
> 
> This removes an intermediate function dispatch on every date and
> datetime parsing call and removes 9 lines of code.

Bench: 
```elixir
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: 2021 The Elixir Team

Mix.install([:benchee])

path = "lib/elixir/lib/calendar/iso.ex"
{old, 0} = System.cmd("git", ["show", "HEAD^:#{path}"])

for {module, source} <- [
      {CalendarISOBench.Old, old},
      {CalendarISOBench.New, File.read!(path)}
    ] do
  source
  |> String.replace("defmodule Calendar.ISO do", "defmodule #{inspect(module)} do", global: false)
  |> Code.compile_string()
end

defmodule CalendarISOBench.Jobs do
  def old_date({string, format}), do: CalendarISOBench.Old.parse_date(string, format)
  def new_date({string, format}), do: CalendarISOBench.New.parse_date(string, format)

  def old_naive({string, format}),
    do: CalendarISOBench.Old.parse_naive_datetime(string, format)

  def new_naive({string, format}),
    do: CalendarISOBench.New.parse_naive_datetime(string, format)

  def old_utc({string, format}), do: CalendarISOBench.Old.parse_utc_datetime(string, format)
  def new_utc({string, format}), do: CalendarISOBench.New.parse_utc_datetime(string, format)
end

inputs = fn basic, extended ->
  for {format, string} <- [basic: basic, extended: extended],
      sign <- ["", "+", "-"],
      into: %{} do
    suffix = if sign == "", do: "", else: " #{sign}"
    {"#{format}#{suffix}", {sign <> string, format}}
  end
end

bench = fn name, jobs, inputs ->
  IO.puts("\n#{name}")

  Benchee.run(jobs,
    inputs: inputs,
    pre_check: :all_same,
    warmup: 1,
    time: 3,
    memory_time: 1,
    reduction_time: 1
  )
end

bench.(
  "parse_date/2",
  %{"old" => &CalendarISOBench.Jobs.old_date/1, "new" => &CalendarISOBench.Jobs.new_date/1},
  inputs.("20150123", "2015-01-23")
)

bench.(
  "parse_naive_datetime/2",
  %{"old" => &CalendarISOBench.Jobs.old_naive/1, "new" => &CalendarISOBench.Jobs.new_naive/1},
  inputs.("20150123T235007.123456", "2015-01-23T23:50:07.123456")
)

bench.(
  "parse_utc_datetime/2",
  %{"old" => &CalendarISOBench.Jobs.old_utc/1, "new" => &CalendarISOBench.Jobs.new_utc/1},
  inputs.("20150123T235007.123456Z", "2015-01-23T23:50:07.123456Z")
)
```

Results:
```txt

parse_date/2
Operating System: Linux
CPU Information: AMD Ryzen 7 8845HS w
Number of Available Cores: 16
Available memory: 54.72 GB
Elixir 1.20.4
Erlang 29.0.5
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 1 s
time: 3 s
memory time: 1 s
reduction time: 1 s
parallel: 1
inputs: basic, basic +, basic -, extended, extended +, extended -
Estimated total run time: 1 min 12 s
Excluding outliers: false

##### With input basic #####
Name           ips        average  deviation         median         99th %
new         9.19 M      108.86 ns  ±1513.54%         100 ns         170 ns
old         8.54 M      117.07 ns  ±3404.10%         101 ns         190 ns

Comparison: 
new         9.19 M
old         8.54 M - 1.08x slower +8.21 ns

Memory usage statistics:

Name    Memory usage
new            200 B
old            176 B - 0.88x memory usage -24 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               19
old               20 - 1.05x reduction count +1

**All measurements for reduction count were the same**

##### With input basic + #####
Name           ips        average  deviation         median         99th %
new         8.88 M      112.59 ns  ±4392.19%         100 ns         161 ns
old         8.52 M      117.40 ns  ±4174.81%         100 ns         171 ns

Comparison: 
new         8.88 M
old         8.52 M - 1.04x slower +4.81 ns

Memory usage statistics:

Name    Memory usage
new            176 B
old            176 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               19
old               20 - 1.05x reduction count +1

**All measurements for reduction count were the same**

##### With input basic - #####
Name           ips        average  deviation         median         99th %
new         8.77 M      114.00 ns  ±3782.71%         100 ns         191 ns
old         8.63 M      115.93 ns  ±3984.50%         100 ns         160 ns

Comparison: 
new         8.77 M
old         8.63 M - 1.02x slower +1.93 ns

Memory usage statistics:

Name    Memory usage
new            176 B
old            176 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               19
old               20 - 1.05x reduction count +1

**All measurements for reduction count were the same**

##### With input extended #####
Name           ips        average  deviation         median         99th %
new         7.85 M      127.33 ns  ±4233.33%         110 ns         210 ns
old         7.45 M      134.27 ns  ±2998.02%         120 ns         191 ns

Comparison: 
new         7.85 M
old         7.45 M - 1.05x slower +6.94 ns

Memory usage statistics:

Name    Memory usage
new            208 B
old            176 B - 0.85x memory usage -32 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               19
old               20 - 1.05x reduction count +1

**All measurements for reduction count were the same**

##### With input extended + #####
Name           ips        average  deviation         median         99th %
new         8.41 M      118.87 ns  ±3898.14%         101 ns         211 ns
old         7.30 M      137.02 ns  ±3423.59%         121 ns         240 ns

Comparison: 
new         8.41 M
old         7.30 M - 1.15x slower +18.15 ns

Memory usage statistics:

Name    Memory usage
new            176 B
old            176 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               19
old               20 - 1.05x reduction count +1

**All measurements for reduction count were the same**

##### With input extended - #####
Name           ips        average  deviation         median         99th %
new         8.36 M      119.58 ns  ±3837.40%         110 ns         200 ns
old         7.12 M      140.49 ns  ±3430.77%         130 ns         250 ns

Comparison: 
new         8.36 M
old         7.12 M - 1.17x slower +20.92 ns

Memory usage statistics:

Name    Memory usage
new            176 B
old            176 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               19
old               20 - 1.05x reduction count +1

**All measurements for reduction count were the same**

parse_naive_datetime/2
Operating System: Linux
CPU Information: AMD Ryzen 7 8845HS w
Number of Available Cores: 16
Available memory: 54.72 GB
Elixir 1.20.4
Erlang 29.0.5
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 1 s
time: 3 s
memory time: 1 s
reduction time: 1 s
parallel: 1
inputs: basic, basic +, basic -, extended, extended +, extended -
Estimated total run time: 1 min 12 s
Excluding outliers: false

##### With input basic #####
Name           ips        average  deviation         median         99th %
old         4.11 M      243.04 ns  ±2401.75%         220 ns         371 ns
new         3.99 M      250.54 ns  ±1942.71%         211 ns         441 ns

Comparison: 
old         4.11 M
new         3.99 M - 1.03x slower +7.50 ns

Memory usage statistics:

Name    Memory usage
old            440 B
new            480 B - 1.09x memory usage +40 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
old               39
new               38 - 0.97x reduction count -1

**All measurements for reduction count were the same**

##### With input basic + #####
Name           ips        average  deviation         median         99th %
old         4.17 M      239.60 ns  ±2653.93%         211 ns         371 ns
new         4.11 M      243.10 ns  ±2299.81%         210 ns         401 ns

Comparison: 
old         4.17 M
new         4.11 M - 1.01x slower +3.51 ns

Memory usage statistics:

Name    Memory usage
old            440 B
new            440 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
old               39
new               38 - 0.97x reduction count -1

**All measurements for reduction count were the same**

##### With input basic - #####
Name           ips        average  deviation         median         99th %
new         4.20 M      238.18 ns  ±2089.39%         210 ns         381 ns
old         4.19 M      238.55 ns  ±2477.47%         211 ns         371 ns

Comparison: 
new         4.20 M
old         4.19 M - 1.00x slower +0.38 ns

Memory usage statistics:

Name    Memory usage
new            440 B
old            440 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               38
old               39 - 1.03x reduction count +1

**All measurements for reduction count were the same**

##### With input extended #####
Name           ips        average  deviation         median         99th %
old         3.90 M      256.13 ns  ±1736.07%         230 ns         391 ns
new         3.81 M      262.60 ns  ±2391.21%         221 ns         410 ns

Comparison: 
old         3.90 M
new         3.81 M - 1.03x slower +6.46 ns

Memory usage statistics:

Name    Memory usage
old            472 B
new            520 B - 1.10x memory usage +48 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
old               39
new               38 - 0.97x reduction count -1

**All measurements for reduction count were the same**

##### With input extended + #####
Name           ips        average  deviation         median         99th %
new         4.26 M      235.01 ns  ±1922.66%         211 ns         361 ns
old         4.05 M      246.92 ns  ±1641.50%         230 ns         391 ns

Comparison: 
new         4.26 M
old         4.05 M - 1.05x slower +11.90 ns

Memory usage statistics:

Name    Memory usage
new            472 B
old            472 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               38
old               39 - 1.03x reduction count +1

**All measurements for reduction count were the same**

##### With input extended - #####
Name           ips        average  deviation         median         99th %
new         4.26 M      234.88 ns  ±2125.52%         211 ns         361 ns
old         4.04 M      247.58 ns  ±1595.09%         230 ns         390 ns

Comparison: 
new         4.26 M
old         4.04 M - 1.05x slower +12.70 ns

Memory usage statistics:

Name    Memory usage
new            472 B
old            472 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               38
old               39 - 1.03x reduction count +1

**All measurements for reduction count were the same**

parse_utc_datetime/2
Operating System: Linux
CPU Information: AMD Ryzen 7 8845HS w
Number of Available Cores: 16
Available memory: 54.72 GB
Elixir 1.20.4
Erlang 29.0.5
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 1 s
time: 3 s
memory time: 1 s
reduction time: 1 s
parallel: 1
inputs: basic, basic +, basic -, extended, extended +, extended -
Estimated total run time: 1 min 12 s
Excluding outliers: false

##### With input basic #####
Name           ips        average  deviation         median         99th %
new         4.69 M      213.33 ns   ±999.74%         191 ns         360 ns
old         4.22 M      237.01 ns  ±1113.90%         220 ns         371 ns

Comparison: 
new         4.69 M
old         4.22 M - 1.11x slower +23.67 ns

Memory usage statistics:

Name    Memory usage
new            496 B
old            456 B - 0.92x memory usage -40 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               38
old               39 - 1.03x reduction count +1

**All measurements for reduction count were the same**

##### With input basic + #####
Name           ips        average  deviation         median         99th %
new         4.78 M      209.08 ns  ±1121.09%         190 ns         351 ns
old         4.07 M      245.64 ns  ±2255.66%         220 ns         371 ns

Comparison: 
new         4.78 M
old         4.07 M - 1.17x slower +36.56 ns

Memory usage statistics:

Name    Memory usage
new            456 B
old            456 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               38
old               39 - 1.03x reduction count +1

**All measurements for reduction count were the same**

##### With input basic - #####
Name           ips        average  deviation         median         99th %
new         4.75 M      210.65 ns   ±897.56%         191 ns         351 ns
old         4.14 M      241.44 ns  ±2308.73%         220 ns         370 ns

Comparison: 
new         4.75 M
old         4.14 M - 1.15x slower +30.78 ns

Memory usage statistics:

Name    Memory usage
new            456 B
old            456 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               38
old               39 - 1.03x reduction count +1

**All measurements for reduction count were the same**

##### With input extended #####
Name           ips        average  deviation         median         99th %
new         4.29 M      233.02 ns  ±2781.85%         201 ns         360 ns
old         4.00 M      249.74 ns  ±2789.99%         221 ns         370 ns

Comparison: 
new         4.29 M
old         4.00 M - 1.07x slower +16.72 ns

Memory usage statistics:

Name    Memory usage
new            536 B
old            488 B - 0.91x memory usage -48 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               38
old               39 - 1.03x reduction count +1

**All measurements for reduction count were the same**

##### With input extended + #####
Name           ips        average  deviation         median         99th %
new         4.45 M      224.77 ns  ±2486.42%         201 ns         351 ns
old         4.02 M      248.83 ns  ±2797.78%         221 ns         371 ns

Comparison: 
new         4.45 M
old         4.02 M - 1.11x slower +24.07 ns

Memory usage statistics:

Name    Memory usage
new            488 B
old            488 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               38
old               39 - 1.03x reduction count +1

**All measurements for reduction count were the same**

##### With input extended - #####
Name           ips        average  deviation         median         99th %
new         4.50 M      222.10 ns  ±1980.97%         200 ns         351 ns
old         4.02 M      248.89 ns  ±2701.21%         221 ns         371 ns

Comparison: 
new         4.50 M
old         4.02 M - 1.12x slower +26.78 ns

Memory usage statistics:

Name    Memory usage
new            488 B
old            488 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name Reduction count
new               38
old               39 - 1.03x reduction count +1

**All measurements for reduction count were the same**
```
