### PR TITLE
Fix macro dbg/3 ignores ANSI color setting

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -3046,6 +3046,8 @@ defmodule Macro do
   @doc false
   def __dbg__(to_debug, header, options) do
     {print_location?, options} = Keyword.pop(options, :print_location, true)
+    syntax_colors = if IO.ANSI.enabled?(), do: IO.ANSI.syntax_colors(), else: []
+    options = Keyword.merge([width: 80, pretty: true, syntax_colors: syntax_colors], options)
     ansi_enabled? = options[:syntax_colors] != []
 
     if print_location? and is_binary(header) do
@@ -3053,8 +3055,6 @@ defmodule Macro do
       :ok = IO.write(IO.ANSI.format(formatted, ansi_enabled?))
     end
 
-    syntax_colors = if IO.ANSI.enabled?(), do: IO.ANSI.syntax_colors(), else: []
-    options = Keyword.merge([width: 80, pretty: true, syntax_colors: syntax_colors], options)
     {formatted, result} = dbg_format_ast_to_debug(to_debug, options)
     :ok = IO.write(IO.ANSI.format([formatted, ?\n], ansi_enabled?))
     result

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -1943,3 +1943,18 @@ defmodule MacroTest do
     assert Macro.camelize("") == ""
   end
 end
+
+defmodule Macro.DbgAnsiTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    previous = Application.get_env(:elixir, :ansi_enabled, false)
+    Application.put_env(:elixir, :ansi_enabled, false)
+    on_exit(fn -> Application.put_env(:elixir, :ansi_enabled, previous) end)
+  end
+
+  test "dbg/3 respects disabled ANSI" do
+    output = ExUnit.CaptureIO.capture_io(fn -> assert dbg(:ok) == :ok end)
+    refute output =~ "\e["
+  end
+end


### PR DESCRIPTION
Fixes macro `dbg/3` ignores ANSI color setting (`--no-color`, `:ansi_enabled`)

<img width="340" height="47" alt="" src="https://github.com/user-attachments/assets/5cb85592-9f48-4c65-8c83-206ff76348f6" />
