### PR TITLE
Avoid list allocation in OptionParser when checking underscores

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -463,7 +463,7 @@ defmodule OptionParser do
   defp next_with_config(["--" <> option | rest], config) do
     {option, value} = split_option(option)
 
-    if String.contains?(option, ["_"]) do
+    if String.contains?(option, "_") do
       {:undefined, "--" <> option, value, rest}
     else
       tagged = tag_option(option, config)


### PR DESCRIPTION
Assisted-by: Antigravity:Gemini-3.8-Flash