### PR TITLE
Clarify Keyword.drop/2 duplicate key behavior

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1321,7 +1321,7 @@ defmodule Keyword do
   end
 
   @doc """
-  Drops all entries corresponding to the given `keys` from the keyword list.
+  Drops the given `keys` from the keyword list.
 
   If a key occurs multiple times, all of its entries are removed when that key
   is included in `keys`.

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1321,9 +1321,10 @@ defmodule Keyword do
   end
 
   @doc """
-  Drops the given `keys` from the keyword list.
+  Drops all entries corresponding to the given `keys` from the keyword list.
 
-  Removes duplicate keys from the new keyword list.
+  If a key occurs multiple times, all of its entries are removed when that key
+  is included in `keys`. Duplicate entries for other keys remain.
 
   ## Examples
 

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1324,7 +1324,7 @@ defmodule Keyword do
   Drops all entries corresponding to the given `keys` from the keyword list.
 
   If a key occurs multiple times, all of its entries are removed when that key
-  is included in `keys`. Duplicate entries for other keys remain.
+  is included in `keys`.
 
   ## Examples
 


### PR DESCRIPTION
Assisted-by: Antigravity CLI:Gemini 3.8 Flash
Assisted-by: Code CLI:GPT 5.6 Sol

"**Removes duplicate keys from the new keyword list.**" was misleading since duplicated entries not included in `keys` remain.

