### PR TITLE
Optimize Enum.min_max/1,2 for non-empty lists

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2240,8 +2240,6 @@ defmodule Enum do
           {min :: element, max :: element} | empty_result
         when empty_result: any
 
-  def min_max(list = [_ | _]), do: min_max_list(list)
-
   def min_max(enumerable, sorter_or_empty_fallback \\ fn -> raise Enum.EmptyError end)
 
   def min_max(list = [_ | _], empty_fallback) when is_function(empty_fallback, 0) do

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2240,7 +2240,13 @@ defmodule Enum do
           {min :: element, max :: element} | empty_result
         when empty_result: any
 
+  def min_max(list = [_ | _]), do: min_max_list(list)
+
   def min_max(enumerable, sorter_or_empty_fallback \\ fn -> raise Enum.EmptyError end)
+
+  def min_max(list = [_ | _], empty_fallback) when is_function(empty_fallback, 0) do
+    min_max_list(list)
+  end
 
   def min_max(first..last//step = range, empty_fallback)
       when is_function(empty_fallback, 0) do
@@ -2398,6 +2404,18 @@ defmodule Enum do
   end
 
   defp min_max_sort_fun(module) when is_atom(module), do: &(module.compare(&1, &2) == :lt)
+
+  defp min_max_list([h | t]), do: min_max_list(t, h, h)
+
+  defp min_max_list([h | t], min, max) do
+    cond do
+      h < min -> min_max_list(t, h, max)
+      max < h -> min_max_list(t, min, h)
+      true -> min_max_list(t, min, max)
+    end
+  end
+
+  defp min_max_list([], min, max), do: {min, max}
 
   @doc """
   Splits the `enumerable` in two lists according to the given function `fun`.

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -743,6 +743,10 @@ defmodule EnumTest do
   test "min_max/1" do
     assert Enum.min_max([1]) == {1, 1}
     assert Enum.min_max([2, 3, 1]) == {1, 3}
+    assert Enum.min_max([5, 4, 3, 2, 1]) == {1, 5}
+    assert Enum.min_max([-10, -20, 0, 10, 20]) == {-20, 20}
+    assert Enum.min_max([3, 1, 4, 1, 5, 9, 2, 6, 5]) == {1, 9}
+    assert Enum.min_max(Enum.to_list(1..1000)) == {1, 1000}
     assert Enum.min_max([[], :a, {}]) == {:a, []}
 
     assert Enum.min_max([1, 1.0]) === {1, 1}
@@ -756,6 +760,8 @@ defmodule EnumTest do
   test "min_max/2" do
     assert Enum.min_max([1], fn -> nil end) == {1, 1}
     assert Enum.min_max([2, 3, 1], fn -> nil end) == {1, 3}
+    assert Enum.min_max([5, 4, 3, 2, 1], fn -> nil end) == {1, 5}
+    assert Enum.min_max([-10, -20, 0, 10, 20], fn -> nil end) == {-20, 20}
     assert Enum.min_max([[], :a, {}], fn -> nil end) == {:a, []}
     assert Enum.min_max([], fn -> {:empty_min, :empty_max} end) == {:empty_min, :empty_max}
     assert Enum.min_max(%{}, fn -> {:empty_min, :empty_max} end) == {:empty_min, :empty_max}


### PR DESCRIPTION
Assisted-by: Antigravity:Gemini-3.8-Flash

If the added complexity doesn't worth it then this should be closed of course.

> Add fast paths for non-empty lists matching Enum.min/1,2 and Enum.max/1,2. Traversing directly avoids closure and cons-cell allocations while improving performance.

Bench:
```elixir
Mix.install([:benchee])

defmodule OldEnum do
  @moduledoc """
  Previous implementation of Enum.min_max/1,2 before non-empty list fast-path.
  """

  def min_max(enumerable, sorter_or_empty_fallback \\ fn -> raise Enum.EmptyError end)

  def min_max(first..last//step = range, empty_fallback)
      when is_function(empty_fallback, 0) do
    case Range.size(range) do
      0 ->
        empty_fallback.()

      _ ->
        last = last - rem(last - first, step)
        {Kernel.min(first, last), Kernel.max(first, last)}
    end
  end

  def min_max(enumerable, empty_fallback)
      when is_function(empty_fallback, 0) do
    min_max(enumerable, &</2, empty_fallback)
  end

  def min_max(enumerable, sorter) when is_atom(sorter) do
    min_max(enumerable, min_max_sort_fun(sorter))
  end

  def min_max(enumerable, sorter) when is_function(sorter, 2) do
    min_max(enumerable, sorter, fn -> raise Enum.EmptyError end)
  end

  def min_max(enumerable, sorter, empty_fallback)
      when is_atom(sorter) and is_function(empty_fallback, 0) do
    min_max(enumerable, min_max_sort_fun(sorter), empty_fallback)
  end

  def min_max(enumerable, sorter, empty_fallback)
      when is_function(sorter, 2) and is_function(empty_fallback, 0) do
    first_fun = &[&1 | &1]

    reduce_fun = fn entry, [min | max] = acc ->
      cond do
        sorter.(entry, min) ->
          [entry | max]

        sorter.(max, entry) ->
          [min | entry]

        true ->
          acc
      end
    end

    case reduce_by(enumerable, first_fun, reduce_fun) do
      :empty -> empty_fallback.()
      [min | max] -> {min, max}
    end
  end

  defp reduce_by([head | tail], first, fun) do
    :lists.foldl(fun, first.(head), tail)
  end

  defp reduce_by([], _first, _fun) do
    :empty
  end

  defp reduce_by(enumerable, first, fun) do
    case Enumerable.reduce(enumerable, {:cont, :empty}, fn
           entry, :empty -> {:cont, first.(entry)}
           entry, acc -> {:cont, fun.(entry, acc)}
         end) do
      {:done, acc} -> acc
      {:halted, acc} -> acc
    end
  end

  defp min_max_sort_fun(module) when is_atom(module), do: &(module.compare(&1, &2) == :lt)
end

defmodule NewEnum do
  @moduledoc """
  Optimized implementation of Enum.min_max/1,2 with non-empty list fast-path.
  """

  def min_max(list = [_ | _]), do: min_max_list(list)

  def min_max(enumerable, sorter_or_empty_fallback \\ fn -> raise Enum.EmptyError end)

  def min_max(list = [_ | _], empty_fallback) when is_function(empty_fallback, 0) do
    min_max_list(list)
  end

  def min_max(first..last//step = range, empty_fallback)
      when is_function(empty_fallback, 0) do
    case Range.size(range) do
      0 ->
        empty_fallback.()

      _ ->
        last = last - rem(last - first, step)
        {Kernel.min(first, last), Kernel.max(first, last)}
    end
  end

  def min_max(enumerable, empty_fallback)
      when is_function(empty_fallback, 0) do
    min_max(enumerable, &</2, empty_fallback)
  end

  def min_max(enumerable, sorter) when is_atom(sorter) do
    min_max(enumerable, min_max_sort_fun(sorter))
  end

  def min_max(enumerable, sorter) when is_function(sorter, 2) do
    min_max(enumerable, sorter, fn -> raise Enum.EmptyError end)
  end

  def min_max(enumerable, sorter, empty_fallback)
      when is_atom(sorter) and is_function(empty_fallback, 0) do
    min_max(enumerable, min_max_sort_fun(sorter), empty_fallback)
  end

  def min_max(enumerable, sorter, empty_fallback)
      when is_function(sorter, 2) and is_function(empty_fallback, 0) do
    first_fun = &[&1 | &1]

    reduce_fun = fn entry, [min | max] = acc ->
      cond do
        sorter.(entry, min) ->
          [entry | max]

        sorter.(max, entry) ->
          [min | entry]

        true ->
          acc
      end
    end

    case reduce_by(enumerable, first_fun, reduce_fun) do
      :empty -> empty_fallback.()
      [min | max] -> {min, max}
    end
  end

  defp reduce_by([head | tail], first, fun) do
    :lists.foldl(fun, first.(head), tail)
  end

  defp reduce_by([], _first, _fun) do
    :empty
  end

  defp reduce_by(enumerable, first, fun) do
    case Enumerable.reduce(enumerable, {:cont, :empty}, fn
           entry, :empty -> {:cont, first.(entry)}
           entry, acc -> {:cont, fun.(entry, acc)}
         end) do
      {:done, acc} -> acc
      {:halted, acc} -> acc
    end
  end

  defp min_max_sort_fun(module) when is_atom(module), do: &(module.compare(&1, &2) == :lt)

  defp min_max_list([h | t]), do: min_max_list(t, h, h)

  defp min_max_list([h | t], min, max) do
    cond do
      h < min -> min_max_list(t, h, max)
      max < h -> min_max_list(t, min, h)
      true -> min_max_list(t, min, max)
    end
  end

  defp min_max_list([], min, max), do: {min, max}
end

inputs = %{
  "1. Single element [42]" => [42],
  "2. Tiny list [2, 3, 1]" => [2, 3, 1],
  "3. Atoms list (8 elements)" => [:foo, :bar, :baz, :qux, :apple, :banana, :zebra, :aardvark],
  "4. Ascending integers (100 elements)" => Enum.to_list(1..100),
  "5. Descending integers (100 elements)" => Enum.to_list(100..1//-1),
  "6. Random integers (1,000 elements)" => Enum.take_random(1..100_000, 1_000),
  "7. Strings (1,000 elements)" => for(_ <- 1..1_000, do: Integer.to_string(:rand.uniform(1_000_000))),
  "8. Mixed integers & floats (2,000 elements)" => Enum.to_list(1..1_000) ++ Enum.map(1..1_000, &(&1 + 0.5)),
  "9. Negative to positive (10,000 elements)" => Enum.to_list(-5_000..5_000),
  "10. Ascending integers (10,000 elements)" => Enum.to_list(1..10_000),
  "11. Descending integers (10,000 elements)" => Enum.to_list(10_000..1//-1),
  "12. All identical duplicates (10,000 elements)" => List.duplicate(42, 10_000)
}

Benchee.run(
  %{
    "Old (reduce_by + [min | max] closures)" => &OldEnum.min_max/1,
    "New (min_max_list fast-path)" => &NewEnum.min_max/1
  },
  inputs: inputs,
  pre_check: :all_same,
  warmup: 0.5,
  time: 1.0,
  memory_time: 0.5,
  reduction_time: 0.5
)
```

Results:
```txtOperating System: Linux
CPU Information: AMD Ryzen 7 8845HS w
Number of Available Cores: 16
Available memory: 54.72 GB
Elixir 1.20.4
Erlang 29.0.5
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 500 ms
time: 1 s
memory time: 500 ms
reduction time: 500 ms
parallel: 1
inputs: 1. Single element [42], 10. Ascending integers (10,000 elements), 11. Descending integers (10,000 elements), 12. All identical duplicates (10,000 elements), 2. Tiny list [2, 3, 1], 3. Atoms list (8 elements), 4. Ascending integers (100 elements), 5. Descending integers (100 elements), 6. Random integers (1,000 elements), 7. Strings (1,000 elements), 8. Mixed integers & floats (2,000 elements), 9. Negative to positive (10,000 elements)
Estimated total run time: 1 min
Excluding outliers: false

##### With input 1. Single element [42] #####
Name                                             ips        average  deviation         median         99th %
New (min_max_list fast-path)                 29.94 M       33.40 ns  ±5890.15%          30 ns          40 ns
Old (reduce_by + [min | max] closures)       16.91 M       59.15 ns  ±7094.52%          40 ns          71 ns

Comparison: 
New (min_max_list fast-path)                 29.94 M
Old (reduce_by + [min | max] closures)       16.91 M - 1.77x slower +25.75 ns

Memory usage statistics:

Name                                      Memory usage
New (min_max_list fast-path)                      24 B
Old (reduce_by + [min | max] closures)            64 B - 2.67x memory usage +40 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name                                   Reduction count
New (min_max_list fast-path)                         3
Old (reduce_by + [min | max] closures)               8 - 2.67x reduction count +5

**All measurements for reduction count were the same**

##### With input 10. Ascending integers (10,000 elements) #####
Name                                             ips        average  deviation         median         99th %
New (min_max_list fast-path)                 50.85 K       19.66 μs    ±24.19%       18.66 μs       37.58 μs
Old (reduce_by + [min | max] closures)        5.62 K      177.86 μs    ±13.98%      171.72 μs      290.45 μs

Comparison: 
New (min_max_list fast-path)                 50.85 K
Old (reduce_by + [min | max] closures)        5.62 K - 9.04x slower +158.20 μs

Memory usage statistics:

Name                                      Memory usage
New (min_max_list fast-path)                 0.0234 KB
Old (reduce_by + [min | max] closures)       156.30 KB - 6668.67x memory usage +156.27 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                                   Reduction count
New (min_max_list fast-path)                   10.00 K
Old (reduce_by + [min | max] closures)         31.14 K - 3.11x reduction count +21.14 K

**All measurements for reduction count were the same**

##### With input 11. Descending integers (10,000 elements) #####
Name                                             ips        average  deviation         median         99th %
New (min_max_list fast-path)                 75.28 K       13.28 μs    ±26.78%       12.20 μs       26.18 μs
Old (reduce_by + [min | max] closures)        8.93 K      111.92 μs    ±15.24%      108.91 μs      180.71 μs

Comparison: 
New (min_max_list fast-path)                 75.28 K
Old (reduce_by + [min | max] closures)        8.93 K - 8.43x slower +98.64 μs

Memory usage statistics:

Name                                      Memory usage
New (min_max_list fast-path)                 0.0234 KB
Old (reduce_by + [min | max] closures)       156.30 KB - 6668.67x memory usage +156.27 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                                   Reduction count
New (min_max_list fast-path)                   10.00 K
Old (reduce_by + [min | max] closures)         31.14 K - 3.11x reduction count +21.14 K

**All measurements for reduction count were the same**

##### With input 12. All identical duplicates (10,000 elements) #####
Name                                             ips        average  deviation         median         99th %
New (min_max_list fast-path)                 52.81 K       18.93 μs    ±23.60%       18.16 μs       37.11 μs
Old (reduce_by + [min | max] closures)        6.69 K      149.43 μs    ±14.61%      145.32 μs      233.30 μs

Comparison: 
New (min_max_list fast-path)                 52.81 K
Old (reduce_by + [min | max] closures)        6.69 K - 7.89x slower +130.49 μs

Memory usage statistics:

Name                                      Memory usage
New (min_max_list fast-path)                      24 B
Old (reduce_by + [min | max] closures)            64 B - 2.67x memory usage +40 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name                                   Reduction count
New (min_max_list fast-path)                   10.00 K
Old (reduce_by + [min | max] closures)         30.00 K - 3.00x reduction count +20.00 K

**All measurements for reduction count were the same**

##### With input 2. Tiny list [2, 3, 1] #####
Name                                             ips        average  deviation         median         99th %
New (min_max_list fast-path)                 27.59 M       36.24 ns  ±5478.94%          30 ns          50 ns
Old (reduce_by + [min | max] closures)       13.19 M       75.83 ns  ±2254.64%          60 ns         110 ns

Comparison: 
New (min_max_list fast-path)                 27.59 M
Old (reduce_by + [min | max] closures)       13.19 M - 2.09x slower +39.58 ns

Memory usage statistics:

Name                                      Memory usage
New (min_max_list fast-path)                      24 B
Old (reduce_by + [min | max] closures)            96 B - 4.00x memory usage +72 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name                                   Reduction count
New (min_max_list fast-path)                         5
Old (reduce_by + [min | max] closures)              14 - 2.80x reduction count +9

**All measurements for reduction count were the same**

##### With input 3. Atoms list (8 elements) #####
Name                                             ips        average  deviation         median         99th %
New (min_max_list fast-path)                 14.50 M       68.95 ns  ±2674.25%          60 ns         110 ns
Old (reduce_by + [min | max] closures)        5.68 M      176.07 ns  ±3418.35%         150 ns         241 ns

Comparison: 
New (min_max_list fast-path)                 14.50 M
Old (reduce_by + [min | max] closures)        5.68 M - 2.55x slower +107.11 ns

Memory usage statistics:

Name                                      Memory usage
New (min_max_list fast-path)                      24 B
Old (reduce_by + [min | max] closures)           144 B - 6.00x memory usage +120 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name                                   Reduction count
New (min_max_list fast-path)                        10
Old (reduce_by + [min | max] closures)              29 - 2.90x reduction count +19

**All measurements for reduction count were the same**

##### With input 4. Ascending integers (100 elements) #####
Name                                             ips        average  deviation         median         99th %
New (min_max_list fast-path)                  4.72 M        0.21 μs   ±599.84%        0.20 μs        0.39 μs
Old (reduce_by + [min | max] closures)        0.56 M        1.80 μs   ±346.23%        1.69 μs        3.07 μs

Comparison: 
New (min_max_list fast-path)                  4.72 M
Old (reduce_by + [min | max] closures)        0.56 M - 8.48x slower +1.58 μs

Memory usage statistics:

Name                                      Memory usage
New (min_max_list fast-path)                 0.0234 KB
Old (reduce_by + [min | max] closures)         1.61 KB - 68.67x memory usage +1.59 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                                   Reduction count
New (min_max_list fast-path)                       102
Old (reduce_by + [min | max] closures)             343 - 3.36x reduction count +241

**All measurements for reduction count were the same**

##### With input 5. Descending integers (100 elements) #####
Name                                             ips        average  deviation         median         99th %
New (min_max_list fast-path)                  6.60 M       0.151 μs   ±831.78%       0.141 μs        0.26 μs
Old (reduce_by + [min | max] closures)        0.80 M        1.26 μs   ±563.31%        1.13 μs        2.24 μs

Comparison: 
New (min_max_list fast-path)                  6.60 M
Old (reduce_by + [min | max] closures)        0.80 M - 8.30x slower +1.11 μs

Memory usage statistics:

Name                                      Memory usage
New (min_max_list fast-path)                 0.0234 KB
Old (reduce_by + [min | max] closures)         1.61 KB - 68.67x memory usage +1.59 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                                   Reduction count
New (min_max_list fast-path)                       102
Old (reduce_by + [min | max] closures)             343 - 3.36x reduction count +241

**All measurements for reduction count were the same**

##### With input 6. Random integers (1,000 elements) #####
Name                                             ips        average  deviation         median         99th %
New (min_max_list fast-path)                445.37 K        2.25 μs    ±98.91%        2.12 μs        4.20 μs
Old (reduce_by + [min | max] closures)       55.95 K       17.87 μs    ±27.13%       17.01 μs       29.55 μs

Comparison: 
New (min_max_list fast-path)                445.37 K
Old (reduce_by + [min | max] closures)       55.95 K - 7.96x slower +15.63 μs

Memory usage statistics:

Name                                      Memory usage
New (min_max_list fast-path)                      24 B
Old (reduce_by + [min | max] closures)           256 B - 10.67x memory usage +232 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name                                   Reduction count
New (min_max_list fast-path)                    1.00 K
Old (reduce_by + [min | max] closures)          3.00 K - 3.00x reduction count +2.00 K

**All measurements for reduction count were the same**

##### With input 7. Strings (1,000 elements) #####
Name                                             ips        average  deviation         median         99th %
New (min_max_list fast-path)                 47.49 K       21.06 μs    ±25.62%       20.26 μs       35.52 μs
Old (reduce_by + [min | max] closures)       30.21 K       33.10 μs    ±19.55%       31.41 μs       61.98 μs

Comparison: 
New (min_max_list fast-path)                 47.49 K
Old (reduce_by + [min | max] closures)       30.21 K - 1.57x slower +12.05 μs

Memory usage statistics:

Name                                      Memory usage
New (min_max_list fast-path)                      24 B
Old (reduce_by + [min | max] closures)           240 B - 10.00x memory usage +216 B

**All measurements for memory usage were the same**

Reduction count statistics:

Name                                   Reduction count
New (min_max_list fast-path)                    1.00 K
Old (reduce_by + [min | max] closures)          3.00 K - 3.00x reduction count +2.00 K

**All measurements for reduction count were the same**

##### With input 8. Mixed integers & floats (2,000 elements) #####
Name                                             ips        average  deviation         median         99th %
New (min_max_list fast-path)                 48.70 K       20.53 μs    ±25.72%       19.71 μs       38.07 μs
Old (reduce_by + [min | max] closures)       20.43 K       48.95 μs    ±16.01%       46.95 μs       86.02 μs

Comparison: 
New (min_max_list fast-path)                 48.70 K
Old (reduce_by + [min | max] closures)       20.43 K - 2.38x slower +28.42 μs

Memory usage statistics:

Name                                      Memory usage
New (min_max_list fast-path)                 0.0234 KB
Old (reduce_by + [min | max] closures)        15.69 KB - 669.33x memory usage +15.66 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                                   Reduction count
New (min_max_list fast-path)                    2.00 K
Old (reduce_by + [min | max] closures)          6.53 K - 3.26x reduction count +4.53 K

**All measurements for reduction count were the same**

##### With input 9. Negative to positive (10,000 elements) #####
Name                                             ips        average  deviation         median         99th %
New (min_max_list fast-path)                 49.40 K       20.24 μs    ±21.98%       19.25 μs       38.39 μs
Old (reduce_by + [min | max] closures)        5.80 K      172.50 μs     ±5.66%      170.71 μs      197.07 μs

Comparison: 
New (min_max_list fast-path)                 49.40 K
Old (reduce_by + [min | max] closures)        5.80 K - 8.52x slower +152.26 μs

Memory usage statistics:

Name                                      Memory usage
New (min_max_list fast-path)                 0.0234 KB
Old (reduce_by + [min | max] closures)       156.31 KB - 6669.33x memory usage +156.29 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                                   Reduction count
New (min_max_list fast-path)                   10.00 K
Old (reduce_by + [min | max] closures)         31.14 K - 3.11x reduction count +21.14 K

**All measurements for reduction count were the same**
```
