### PR TITLE
Add missing 'end'

### DIFF
--- a/lib/elixir/pages/meta-programming/macros.md
+++ b/lib/elixir/pages/meta-programming/macros.md
@@ -98,6 +98,7 @@ defmacro if(clause, do: expression) do
     case unquote(clause) do
       x when x in [false, nil] -> nil
       _ -> unquote(expression)
+    end
   end
 end
 ```


### PR DESCRIPTION
I was reading through the docs and found a missing `end`?