### PR TITLE
Fix version matching in mix local.hex --if-missing

### DIFF
--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -28,12 +28,13 @@ defmodule Mix.Tasks.Local.Hex do
     * `--force` - forces installation without a shell prompt; primarily
       intended for automation in build systems like `make`
 
-    * `--if-missing` - performs installation only if Hex is not installed yet;
-      intended to avoid repeatedly reinstalling Hex in automation when a script
-      may be run multiple times
+    * `--if-missing` - skips installation if Hex is already installed. If a
+      `version` is specified, skips installation only if that version is already
+      installed. Intended to avoid repeatedly reinstalling Hex in automation
+      when a script may be run multiple times
 
-  If both options are set, the shell prompt is skipped and Hex is not
-  re-installed if it was already installed.
+  If both options are set, the shell prompt is skipped and Hex is installed only
+  if it's missing or a different version is specified.
 
   ## Mirrors
 
@@ -51,7 +52,7 @@ defmodule Mix.Tasks.Local.Hex do
     should_install? =
       if Keyword.get(opts, :if_missing, false) do
         if version do
-          not Code.ensure_loaded?(Hex) or Version.compare(Hex.version(), version) == :gt
+          not Code.ensure_loaded?(Hex) or Version.compare(Hex.version(), version) != :eq
         else
           not Code.ensure_loaded?(Hex)
         end

--- a/lib/mix/test/mix/tasks/local.hex_test.exs
+++ b/lib/mix/test/mix/tasks/local.hex_test.exs
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2021 The Elixir Team
+
+Code.require_file("../../test_helper.exs", __DIR__)
+
+defmodule Mix.Tasks.Local.HexTest do
+  use MixTest.Case
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: tmp_dir} do
+    url = System.get_env("HEX_BUILDS_URL")
+    purge([Hex])
+
+    on_exit(fn ->
+      purge([Hex])
+      if url, do: System.put_env("HEX_BUILDS_URL", url), else: System.delete_env("HEX_BUILDS_URL")
+    end)
+
+    defmodule Elixir.Hex do
+      def version, do: "0.2.0"
+    end
+
+    System.put_env("HEX_BUILDS_URL", tmp_dir)
+    File.mkdir_p!(Path.join(tmp_dir, "installs"))
+    File.write!(Path.join(tmp_dir, "installs/hex.csv"), "")
+    :ok
+  end
+
+  test "--if-missing attempts to upgrade to the requested version" do
+    assert_raise Mix.Error, "Could not find a version of Hex matching: 0.3.0", fn ->
+      Mix.Tasks.Local.Hex.run(["0.3.0", "--if-missing", "--force"])
+    end
+  end
+
+  test "--if-missing attempts to downgrade to the requested version" do
+    assert_raise Mix.Error, "Could not find a version of Hex matching: 0.1.0", fn ->
+      Mix.Tasks.Local.Hex.run(["0.1.0", "--if-missing", "--force"])
+    end
+  end
+
+  test "--if-missing skips the installed version" do
+    refute Mix.Tasks.Local.Hex.run(["0.2.0", "--if-missing", "--force"])
+  end
+end


### PR DESCRIPTION
Fix `mix local.hex VERSION --if-missing` skipping upgrades by installing whenever the requested and installed versions differ. Document this behavior and add tests for the version comparison.

Verified with `make format` and `make test` on macOS with OTP 29.

Fixes https://github.com/elixir-lang/elixir/issues/15847
