### PR TITLE
Fix formatting of unary operators with do-end block operands

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -694,13 +694,26 @@ defmodule Code.Formatter do
   end
 
   defp unary_op_to_algebra(op, _meta, arg, context, state) do
-    {doc, state} = quoted_to_algebra(arg, force_many_args_or_operand(context, :operand), state)
+    arg_context = force_many_args_or_operand(context, :operand)
+    {doc, state} = quoted_to_algebra(arg, arg_context, state)
 
-    # not and ! are nestable, all others are not.
     doc =
-      case arg do
-        {^op, _, [_]} when op in [:!, :not] -> doc
-        _ -> wrap_in_parens_if_operator(doc, arg)
+      cond do
+        # not and ! are nestable, all others are not.
+        op in [:!, :not] and match?({^op, _, [_]}, arg) ->
+          doc
+
+        # A call with a do-end block captures everything on its right when
+        # parsed back, so the operand requires parens, otherwise
+        # "!(if x do y end) || z" would be read as "!(if x do y end || z)".
+        # Argument contexts already add those parens themselves and @ is
+        # skipped because the block is the attribute value, as in
+        # "@foo bar do baz end".
+        op != :@ and arg_context != :no_parens_arg and do_end_block_call?(arg, state) ->
+          wrap_in_parens(doc)
+
+        true ->
+          wrap_in_parens_if_operator(doc, arg)
       end
 
     # not requires a space unless the doc was wrapped in parens.
@@ -1358,6 +1371,12 @@ defmodule Code.Formatter do
   end
 
   defp do_end_blocks(_, _, _), do: nil
+
+  defp do_end_block_call?({_fun, meta, args}, state) when is_list(args) do
+    do_end_blocks(meta, List.last(args), state) != nil
+  end
+
+  defp do_end_block_call?(_, _), do: false
 
   defp can_force_do_end_blocks?(rest, state) do
     state.force_do_end_blocks and

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -211,13 +211,13 @@ defprotocol Inspect do
 
         quote do
           unquote(filtered_guard) and
-            not case unquote(Macro.escape(optional_map)) do
-              %{^var!(field) => var!(default)} ->
-                var!(default) == Map.get(var!(struct), var!(field))
+            not (case unquote(Macro.escape(optional_map)) do
+                   %{^var!(field) => var!(default)} ->
+                     var!(default) == Map.get(var!(struct), var!(field))
 
-              %{} ->
-                false
-            end
+                   %{} ->
+                     false
+                 end)
         end
       end
 

--- a/lib/elixir/test/elixir/code_formatter/operators_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/operators_test.exs
@@ -132,6 +132,41 @@ defmodule Code.Formatter.OperatorsTest do
       end
       """
     end
+
+    test "wraps operand with do-end block in parens" do
+      assert_same """
+      !(if x do
+          y
+        end)
+      """
+
+      assert_same """
+      !(if x do
+          y
+        end) || z
+      """
+
+      assert_same """
+      not (case x do
+             _ -> y
+           end) || z
+      """
+
+      assert_same """
+      !!(if x do
+           y
+         end)
+      |> z()
+      """
+    end
+
+    test "does not wrap module attribute value with do-end block in parens" do
+      assert_same """
+      @foo quote do
+        :ok
+      end
+      """
+    end
   end
 
   describe "binary without space" do


### PR DESCRIPTION
Assisted-by: Opus-5

Fixes: #15849 

`mix format` (and `Macro.to_string/1`, which shares `Code.quoted_to_algebra`) drops parentheses that are load-bearing when a unary operator is applied to a no-parens call carrying a do-end block. The re-parsed code has a different AST and different runtime behavior.

## Repro

```elixir
defmodule Demo do
  def check(a, c) do
    !(if a do
        :b
      end) || c
  end
end
```

After `mix format`:

```elixir
defmodule Demo do
  def check(a, c) do
    !if a do
      :b
    end || c
  end
end
```

## Fix
`unary_op_to_algebra/5` now also wraps the operand when it renders as a do-end block call

## Impact on existing code
Running `mix format` over the whole Elixir codebase after this change touches exactly one expression, `lib/elixir/lib/inspect.ex:214`, where a `not case ... end` sits in a trailing/safe position and now gains parens.

## Known remaining edge case
`@(if a do b end) || c` still round-trips incorrectly. It is structurally indistinguishable from the `@attr call do ... end` attribute-write form, and fixing it properly means teaching `module_attribute_to_algebra/4` to handle multi-argument attribute writes. Behavior there is unchanged by this PR, so it is not a regression.

