### PR TITLE
Minor improvements to invalid struct key error

### DIFF
--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -299,7 +299,7 @@ format_error({unknown_key_for_struct, Module, Key}) ->
   io_lib:format("unknown key ~ts for struct ~ts",
                 ['Elixir.Macro':to_string(Key), elixir_aliases:inspect(Module)]);
 format_error({invalid_key_for_struct, Key}) ->
-  io_lib:format("invalid key for struct, struct keys must be atoms, got: ~ts",
+  io_lib:format("invalid key for struct, struct keys must be static atoms, got: ~ts",
                 ['Elixir.Macro':to_string(Key)]);
 format_error(ignored_struct_key_in_struct) ->
   "key :__struct__ is ignored when using structs".

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -299,7 +299,7 @@ format_error({unknown_key_for_struct, Module, Key}) ->
   io_lib:format("unknown key ~ts for struct ~ts",
                 ['Elixir.Macro':to_string(Key), elixir_aliases:inspect(Module)]);
 format_error({invalid_key_for_struct, Key}) ->
-  io_lib:format("invalid key for struct, struct keys must be static atoms, got: ~ts",
+  io_lib:format("invalid key for struct, struct keys must be literal atoms, got: ~ts",
                 ['Elixir.Macro':to_string(Key)]);
 format_error(ignored_struct_key_in_struct) ->
   "key :__struct__ is ignored when using structs".

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -225,7 +225,7 @@ load_struct(Meta, Name, Assocs, E) ->
 
 assert_and_trace_struct_assocs(Meta, Name, Assocs, E) ->
   Keys = [begin
-    is_atom(K) orelse function_error(Meta, E, ?MODULE, {invalid_key_for_struct, K}),
+    is_atom(K) orelse file_error(Meta, E, ?MODULE, {invalid_key_for_struct, K}),
     K
   end || {K, _} <- Assocs],
   elixir_env:trace({struct_expansion, Meta, Name, Keys}, E),

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -660,7 +660,7 @@ defmodule Kernel.ExpansionTest do
 
     test "invalid keys in structs" do
       assert_compile_error(
-        "invalid key for struct, struct keys must be static atoms, got: :erlang.+(1, 2)",
+        "invalid key for struct, struct keys must be literal atoms, got: :erlang.+(1, 2)",
         fn ->
           expand(
             quote do

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -660,7 +660,7 @@ defmodule Kernel.ExpansionTest do
 
     test "invalid keys in structs" do
       assert_compile_error(
-        "invalid key for struct, struct keys must be atoms, got: :erlang.+(1, 2)",
+        "invalid key for struct, struct keys must be static atoms, got: :erlang.+(1, 2)",
         fn ->
           expand(
             quote do


### PR DESCRIPTION
Following on https://github.com/elixir-lang/elixir/issues/15834#issuecomment-551801367

- update the message to mention "static" (since in the issue a dynamic atom was provided)
- fail early to avoid propagating and causing a possibly confusing `KeyError` later

Before

<img width="525" height="87" alt="Screenshot 2026-09-05 at 14 37 22" src="https://github.com/user-attachments/assets/33b42654-6155-4416-8db0-cf62aa439896" />

After

<img width="628" height="81" alt="Screenshot 2026-09-05 at 14 36 48" src="https://github.com/user-attachments/assets/79f8e382-d51f-4846-a861-bd2b8fc8cec3" />