### PR TITLE
Fix __CALLER__.macro_aliases type

### DIFF
--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -11,6 +11,7 @@ defmodule Module.Types.Expr do
   14 = length(Macro.Env.__info__(:struct))
 
   aliases = list(tuple([atom(), atom()]))
+  macro_aliases = list(tuple([atom(), tuple([term(), atom()])]))
   functions_and_macros = list(tuple([atom(), list(tuple([atom(), integer()]))]))
   list_of_modules = list(atom())
 
@@ -26,7 +27,7 @@ defmodule Module.Types.Expr do
             functions: {functions_and_macros, false},
             lexical_tracker: {opt_union(pid(), atom([nil])), false},
             line: {integer(), false},
-            macro_aliases: {aliases, false},
+            macro_aliases: {macro_aliases, false},
             macros: {functions_and_macros, false},
             module: {atom(), false},
             requires: {list_of_modules, false},


### PR DESCRIPTION
Make the type match spec from https://github.com/elixir-lang/elixir/blob/2e9ce85e91c8beef41dc0826c6666a44e6fa6913/lib/elixir/lib/macro/env.ex#L67

I assumed we want to keep the counter type opaque

Assisted-by: Codex:GPT-5
