### PR TITLE
Detect disjoint maps with any required unmatched field

### DIFF
--- a/lib/elixir/lib/module/types/descr.ex
+++ b/lib/elixir/lib/module/types/descr.ex
@@ -6879,10 +6879,10 @@ defmodule Module.Types.Descr do
             :none
         end
 
-      tag1 == :closed and l2 != [] and Enum.all?(l2, fn {_, {_, optional?}} -> not optional? end) ->
+      tag1 == :closed and l2 != [] and Enum.any?(l2, fn {_, {_, optional?}} -> not optional? end) ->
         :disjoint
 
-      tag2 == :closed and l1 != [] and Enum.all?(l1, fn {_, {_, optional?}} -> not optional? end) ->
+      tag2 == :closed and l1 != [] and Enum.any?(l1, fn {_, {_, optional?}} -> not optional? end) ->
         :disjoint
 
       true ->

--- a/lib/elixir/test/elixir/module/types/descr_test.exs
+++ b/lib/elixir/test/elixir/module/types/descr_test.exs
@@ -469,6 +469,23 @@ defmodule Module.Types.DescrTest do
       refute disjoint?(empty_map(), closed_map(a: {integer(), true}))
     end
 
+    test "maps with optional and required unmatched keys" do
+      for prefix <- [[], [a: {integer(), false}]],
+          fields <- [
+            [b: {integer(), true}, c: {integer(), false}],
+            [b: {integer(), false}, c: {integer(), true}]
+          ],
+          constructor <- [&closed_map/1, &open_map/1] do
+        left = closed_map(prefix)
+        right = constructor.(prefix ++ fields)
+
+        assert opt_intersection(left, right) == none()
+        assert opt_intersection(right, left) == none()
+        assert opt_difference(left, right) == left
+        assert opt_difference(right, left) == right
+      end
+    end
+
     test "map with domain keys" do
       # %{..., int => t1, atom => t2} and %{int => t3}
       # intersection is %{int => t1 and t3, atom => none}


### PR DESCRIPTION
Assisted-by: Codex:GPT-6

> A required unmatched key cannot occur in the other closed map, even when
> the remaining unmatched keys include optional fields. Recognize this
> case early to avoid retaining unnecessary BDD nodes during subtraction.
> 
> Cover both operand orders, open and closed maps, and shared field prefixes.
