### PR TITLE
Avoid duplicate arithmetic in Calendar.ISO.from_unix/2

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -2024,8 +2024,8 @@ defmodule Calendar.ISO do
     total = System.convert_time_unit(integer, unit, :microsecond)
 
     if total in @unix_range_microseconds do
-      microseconds = Integer.mod(total, @microseconds_per_second)
-      seconds = @unix_epoch + floor_div_positive_divisor(total, @microseconds_per_second)
+      {seconds, microseconds} = div_rem(total, @microseconds_per_second)
+      seconds = @unix_epoch + seconds
       precision = precision_for_unit(unit)
       {date, time} = iso_seconds_to_datetime(seconds)
       {:ok, date, time, {microseconds, precision}}


### PR DESCRIPTION
Assisted-by: Codex:GPT-6

> Compute seconds and microseconds together with div_rem/2,
preserving floor division for negative timestamps.



