### PR TITLE
Fix IEx incomplete codepoint autocomplete crash

### DIFF
--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -568,7 +568,7 @@ defmodule IEx.Autocomplete do
   defp format_expansion([first | _] = entries, hint) do
     binary = Enum.map(entries, & &1.name)
     length = byte_size(hint)
-    prefix = :binary.longest_common_prefix(binary)
+    prefix = byte_size(String.byte_slice(first.name, 0, :binary.longest_common_prefix(binary)))
 
     if prefix in [0, length] do
       case Enum.group_by(entries, &Map.get(&1, :group, "Exports")) do

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -271,6 +271,19 @@ defmodule IEx.AutocompleteTest do
     assert expand(~c"map.foo") == {:no, ~c"", []}
   end
 
+  test "map atom key completion does not split Unicode codepoints" do
+    eval(~s(map = %{école: "school", être: "to be"}))
+    assert expand(~c"map.") == {:yes, ~c"", [~c"école", ~c"être"]}
+  end
+
+  test "map atom key completion preserves complete Unicode prefixes" do
+    eval(~s(map = %{français_école: "school", français_être: "to be"}))
+    assert expand(~c"map.f") == {:yes, ~c"rançais_", []}
+
+    assert expand(~c"map.français_") ==
+             {:yes, ~c"", [~c"français_école", ~c"français_être"]}
+  end
+
   test "nested map atom key completion is supported" do
     eval("map = %{nested: %{deeply: %{foo: 1, bar_1: 23, bar_2: 14, mod: String, num: 1}}}")
     assert expand(~c"map.nested.deeply.f") == {:yes, ~c"oo", []}


### PR DESCRIPTION
Assisted-by: GPT-6 Astra

Fixes iex crash (UnicodeConversionError) when completion candidates shares 
an incomplete UTF-8 codepoint (map keys, vars, funs/macro names  and file paths).

```elixir
iex> map = %{école: 1, être: 2}
iex> map. # expand here
```

```
[error] :gen_statem #PID<0.70.0> terminating
** (UnicodeConversionError) incomplete encoding starting at <<195>>
    (elixir 1.21.0-dev) lib/string.ex:3005: String.to_charlist/1
    (iex 1.21.0-dev) lib/iex/autocomplete.ex:594: IEx.Autocomplete.format_expansion/2
    (kernel 11.0.3) group.erl:976: :group.get_line_edlin/3
    (kernel 11.0.3) group.erl:404: :group.xterm/3
    (stdlib 8.0.4) gen_statem.erl:3741: :gen_statem.loop_state_callback/11
,,,
*** ERROR: Shell process terminated! (^G to start new job) ***
```