### PR TITLE
Align ANSI.color() with ANSI.red() formatting

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -316,13 +316,22 @@ defmodule IO.ANSI do
     do_format(term, [rest | rem], acc, emit?, append_reset)
   end
 
-  defp do_format(term, rem, acc, true, append_reset) when is_atom(term) do
-    do_format([], rem, [acc | format_sequence(term)], true, !!append_reset)
+  defp do_format(term, rem, acc, emit?, append_reset) when is_atom(term) do
+    if emit? do
+      do_format([], rem, [acc | format_sequence(term)], true, !!append_reset)
+    else
+      format_sequence(term)
+      do_format([], rem, acc, false, append_reset)
+    end
   end
 
-  defp do_format(term, rem, acc, false, append_reset) when is_atom(term) do
-    format_sequence(term)
-    do_format([], rem, acc, false, append_reset)
+  defp do_format(<<"\e[", x, "8;5;", _::binary>> = term, rem, acc, emit?, append_reset)
+       when x in [?3, ?4] do
+    if emit? do
+      do_format([], rem, [acc | term], true, !!append_reset)
+    else
+      do_format([], rem, acc, false, append_reset)
+    end
   end
 
   defp do_format(term, rem, acc, emit?, append_reset) when not is_list(term) do

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -14,6 +14,14 @@ defmodule IO.ANSITest do
              "#{IO.ANSI.green()}#{IO.ANSI.reset()}"
 
     assert IO.chardata_to_string(IO.ANSI.format(:green, false)) == ""
+
+    assert IO.chardata_to_string(IO.ANSI.format(IO.ANSI.color(3), true)) ==
+             "#{IO.ANSI.color(3)}#{IO.ANSI.reset()}"
+
+    assert IO.chardata_to_string(IO.ANSI.format(IO.ANSI.color(3), false)) == ""
+
+    assert IO.chardata_to_string(IO.ANSI.format(IO.ANSI.color(0, 4, 2), true)) ==
+             "#{IO.ANSI.color(0, 4, 2)}#{IO.ANSI.reset()}"
   end
 
   test "format binary" do
@@ -32,7 +40,11 @@ defmodule IO.ANSITest do
     assert IO.chardata_to_string(IO.ANSI.format([:red, :bright], true)) ==
              "#{IO.ANSI.red()}#{IO.ANSI.bright()}#{IO.ANSI.reset()}"
 
+    assert IO.chardata_to_string(IO.ANSI.format([IO.ANSI.color(3), :bright], true)) ==
+             "#{IO.ANSI.color(3)}#{IO.ANSI.bright()}#{IO.ANSI.reset()}"
+
     assert IO.chardata_to_string(IO.ANSI.format([:red, :bright], false)) == ""
+    assert IO.chardata_to_string(IO.ANSI.format([IO.ANSI.color(3), :bright], false)) == ""
   end
 
   test "format binary list" do
@@ -52,6 +64,13 @@ defmodule IO.ANSITest do
              "Hello, #{IO.ANSI.red()}world!#{IO.ANSI.reset()}"
 
     assert IO.chardata_to_string(IO.ANSI.format(data, false)) == "Hello, world!"
+
+    data = ["Hello", ?,, 32, IO.ANSI.color(3), "world!"]
+
+    assert IO.chardata_to_string(IO.ANSI.format(data, true)) ==
+             "Hello, #{IO.ANSI.color(3)}world!#{IO.ANSI.reset()}"
+
+    assert IO.chardata_to_string(IO.ANSI.format(data, false)) == "Hello, world!"
   end
 
   test "format nested list" do
@@ -59,6 +78,13 @@ defmodule IO.ANSITest do
 
     assert IO.chardata_to_string(IO.ANSI.format(data, true)) ==
              "Hello, nested #{IO.ANSI.red()}world!#{IO.ANSI.reset()}"
+
+    assert IO.chardata_to_string(IO.ANSI.format(data, false)) == "Hello, nested world!"
+
+    data = ["Hello, ", ["nested", 32, IO.ANSI.color(3), "world!"]]
+
+    assert IO.chardata_to_string(IO.ANSI.format(data, true)) ==
+             "Hello, nested #{IO.ANSI.color(3)}world!#{IO.ANSI.reset()}"
 
     assert IO.chardata_to_string(IO.ANSI.format(data, false)) == "Hello, nested world!"
   end
@@ -70,6 +96,13 @@ defmodule IO.ANSITest do
              "Hello, #{IO.ANSI.red()}world!#{IO.ANSI.reset()}"
 
     assert IO.chardata_to_string(IO.ANSI.format(data, false)) == "Hello, world!"
+
+    data = ["Hello, ", IO.ANSI.color(3), "world" | "!"]
+
+    assert IO.chardata_to_string(IO.ANSI.format(data, true)) ==
+             "Hello, #{IO.ANSI.color(3)}world!#{IO.ANSI.reset()}"
+
+    assert IO.chardata_to_string(IO.ANSI.format(data, false)) == "Hello, world!"
   end
 
   test "format nested improper list" do
@@ -79,11 +112,23 @@ defmodule IO.ANSITest do
              "Hello, #{IO.ANSI.red()}world!#{IO.ANSI.green()}#{IO.ANSI.reset()}"
 
     assert IO.chardata_to_string(IO.ANSI.format(data, false)) == "Hello, world!"
+
+    data = [["Hello, " | IO.ANSI.color(3)], "world!" | IO.ANSI.color(4)]
+
+    assert IO.chardata_to_string(IO.ANSI.format(data, true)) ==
+             "Hello, #{IO.ANSI.color(3)}world!#{IO.ANSI.color(4)}#{IO.ANSI.reset()}"
+
+    assert IO.chardata_to_string(IO.ANSI.format(data, false)) == "Hello, world!"
   end
 
   test "format fragment" do
     assert IO.chardata_to_string(IO.ANSI.format_fragment([:red, "Hello!"], true)) ==
              "#{IO.ANSI.red()}Hello!"
+
+    assert IO.chardata_to_string(
+             IO.ANSI.format_fragment([IO.ANSI.color(0, 4, 2), "Hello!"], true)
+           ) ==
+             "#{IO.ANSI.color(0, 4, 2)}Hello!"
   end
 
   test "format invalid sequence" do


### PR DESCRIPTION

Align ANSI.color() with ANSI.red() ansi formatting for `disabling` and `append_reset`

* Disabling ansi color strings:
```elixir
IO.ANSI.format(IO.ANSI.color(0), false) |> to_string == ""
```

* Add append_reset for color strings:
```elixir
[IO.ANSI.format([IO.ANSI.color(3), " color(3) "]), " (no color)"] |> to_string ==
"#{IO.ANSI.color(3)} color(3) #{IO.ANSI.reset()} (no color)"
```

This change shows a 15% slowness for this bench:

```elixir
Mix.install([{:benchee, "~> 1.5"}])

data = [:red, "message "]

Benchee.run(
  %{"IO.ANSI.format/1" => &IO.ANSI.format/1},
  inputs:   %{
    "100 ansi code messages" => List.duplicate(data, 100)
    },
  warmup: 2,
  time: 5,
  memory_time: 2
)
```