### PR TITLE
Mix test parameters into the per-test :rand seed

### DIFF
--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -550,7 +550,12 @@ defmodule ExUnit.Runner do
 
   ## Helpers
 
-  defp generate_test_seed(seed, %ExUnit.Test{module: module, name: name}, rand_algorithm) do
+  # Parameterized tests share module and name, so mix the parameters into the seed
+  # to give each parameter set its own random sequence. Tests without parameters keep
+  # the seed they had before, so existing `--seed` reproductions are unaffected.
+  defp generate_test_seed(seed, %ExUnit.Test{} = test, rand_algorithm) do
+    %ExUnit.Test{module: module, name: name, parameters: parameters} = test
+    name = if parameters == %{}, do: name, else: {name, parameters}
     :rand.seed(rand_algorithm, {:erlang.phash2(module), :erlang.phash2(name), seed})
   end
 

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -717,6 +717,27 @@ defmodule ExUnitTest do
     assert_receive {:tmp_dir, tmp_dir2} when tmp_dir1 != tmp_dir2
   end
 
+  test "parameterized tests get a different seed for each parameter set" do
+    Process.register(self(), :parameterized_seed_tests)
+
+    defmodule ParameterizedSeedTests do
+      use ExUnit.Case, async: true, parameterize: [%{value: 1}, %{value: 2}]
+
+      test "hello world" do
+        send(:parameterized_seed_tests, {:rand, :rand.uniform(1_000_000)})
+      end
+    end
+
+    configure_and_reload_on_exit(seed: 1)
+
+    capture_io(fn ->
+      assert ExUnit.run() == %{failures: 0, skipped: 0, total: 2, excluded: 0}
+    end)
+
+    assert_receive {:rand, rand1}
+    assert_receive {:rand, rand2} when rand1 != rand2
+  end
+
   test "empty parameterized tests" do
     defmodule EmptyParameterizedTests do
       use ExUnit.Case, async: true, parameterize: []


### PR DESCRIPTION
ExUnit seeds each test process with `{phash2(module), phash2(name), suite_seed}`. `parameterize` re-runs the module once per parameter set, changing only `test.parameters` and leaving `test.name` as is, so every parameterized run of a test starts from the same `:rand` state and draws the same random sequence.

```elixir
use ExUnit.Case, parameterize: for(n <- 1..3, do: %{n: n})

test "first :rand value", %{n: n} do
  IO.puts("parameter #{n}: #{:rand.uniform(1_000_000_000)}")
end
```

```
parameter 1: 297992752
parameter 2: 297992752
parameter 3: 297992752
```

In practice this bites any test helper that generates random unique values. With Ecto's SQL sandbox, every parameter set inserts the same random email, and the unique index turns that into lock waits between the concurrent transactions, so the parameterized tests end up running one after another.

This PR hashes the parameters together with the name when they are present, so each parameter set gets its own seed. Tests without parameters keep their previous seed, so existing `--seed` reproductions are unaffected and the constants in the existing "seed is predictable" test still pass. `short_hash/3` in the same file already takes this approach for `tmp_dir` paths.

The added test fails on the current runner and passes with the change.

Reproduction: https://github.com/jechol/repro-exunit-parameterize-seed

The code was written with the help of an AI coding agent and reviewed by me; see the `Assisted-by` tag in the commit.
