### PR TITLE
Fix float round/2, floor/2, ceil/2 raises wrong exception for invalid precision

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -705,7 +705,7 @@ defmodule Float do
   end
 
   defp invalid_precision_message(precision) do
-    "precision #{precision} is out of valid range of #{inspect(@precision_range)}"
+    "precision #{inspect(precision)} is out of valid range of #{inspect(@precision_range)}"
   end
 
   defp expand_compact([{:compact, false} | t]), do: expand_compact(t)


### PR DESCRIPTION
Fixes `Float.round/2`, `Float.floor/2`, `Float.ceil/2` raises wrong exception for invalid precision

```elixir
iex> Float.round(1.1, %{})
** (Protocol.UndefinedError) protocol String.Chars not implemented for Map
```

expected:
```
** (ArgumentError) precision %{} is out of valid range of 0..15
```

I did not add tests because similar tests for other methods were recently removed during "warnings when running tests" cleanup.