### PR TITLE
Preserve async module order across repeat-until-failure runs

### DIFF
--- a/lib/ex_unit/lib/ex_unit/server.ex
+++ b/lib/ex_unit/lib/ex_unit/server.ex
@@ -91,7 +91,7 @@ defmodule ExUnit.Server do
           {[module | async_modules], async_groups, groups}
 
         {group, group_modules}, {async_modules, async_groups, groups} ->
-          {async_modules, [group | async_groups], [{group, group_modules} | groups]}
+          {async_modules, [group | async_groups], [{group, Enum.reverse(group_modules)} | groups]}
       end)
 
     {:reply, :ok,
@@ -99,8 +99,8 @@ defmodule ExUnit.Server do
        state
        | loaded: :done,
          groups: Map.new(groups),
-         async_groups: async_groups,
-         async_modules: :queue.from_list(async_modules),
+         async_groups: Enum.reverse(async_groups),
+         async_modules: async_modules |> Enum.reverse() |> :queue.from_list(),
          sync_modules: sync_modules
      }}
   end

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -1018,21 +1018,36 @@ defmodule ExUnitTest do
     end
 
     test "repeats tests up to the configured number of times" do
-      defmodule TestRepeatUntilFailureReached do
-        use ExUnit.Case
+      {:ok, agent} =
+        Agent.start_link(fn -> [] end, name: :ex_unit_repeat_until_failure_async_order)
+
+      defmodule TestRepeatUntilFailureReachedOne do
+        use ExUnit.Case, async: true
 
         @tag :skip
         test "skipped #{__ENV__.line}", do: assert(false)
 
-        test __ENV__.line, do: assert(true)
-        test __ENV__.line, do: assert(true)
-        test __ENV__.line, do: assert(true)
+        test __ENV__.line do
+          Agent.update(:ex_unit_repeat_until_failure_async_order, &[__MODULE__ | &1])
+        end
+
+        test __ENV__.line do
+          Agent.update(:ex_unit_repeat_until_failure_async_order, &[__MODULE__ | &1])
+        end
 
         @tag :exclude
         test "excluded #{__ENV__.line}", do: assert(false)
       end
 
-      configure_and_reload_on_exit(repeat_until_failure: 5)
+      defmodule TestRepeatUntilFailureReachedTwo do
+        use ExUnit.Case, async: true
+
+        test __ENV__.line do
+          Agent.update(:ex_unit_repeat_until_failure_async_order, &[__MODULE__ | &1])
+        end
+      end
+
+      configure_and_reload_on_exit(repeat_until_failure: 5, max_cases: 1)
 
       output =
         capture_io(fn ->
@@ -1044,19 +1059,44 @@ defmodule ExUnitTest do
       assert length(runs) == 6
       assert output =~ "remaining_runs: 5"
       assert output =~ "remaining_runs: 0"
+
+      assert Agent.get(agent, &Enum.reverse/1) ==
+               List.duplicate(
+                 [
+                   TestRepeatUntilFailureReachedOne,
+                   TestRepeatUntilFailureReachedOne,
+                   TestRepeatUntilFailureReachedTwo
+                 ],
+                 6
+               )
+               |> List.flatten()
     end
 
     test "repeats tests up to the configured number of times with groups" do
-      defmodule TestGroupedRepeatUntilFailureReached do
+      {:ok, agent} =
+        Agent.start_link(fn -> [] end, name: :ex_unit_repeat_until_failure_group_order)
+
+      defmodule TestGroupedRepeatUntilFailureReachedOne do
         use ExUnit.Case, async: true, group: :example
-        test __ENV__.line, do: assert(true)
+
+        test __ENV__.line do
+          Agent.update(:ex_unit_repeat_until_failure_group_order, &[__MODULE__ | &1])
+        end
       end
 
-      configure_and_reload_on_exit(repeat_until_failure: 5)
+      defmodule TestGroupedRepeatUntilFailureReachedTwo do
+        use ExUnit.Case, async: true, group: :example
+
+        test __ENV__.line do
+          Agent.update(:ex_unit_repeat_until_failure_group_order, &[__MODULE__ | &1])
+        end
+      end
+
+      configure_and_reload_on_exit(repeat_until_failure: 5, max_cases: 1)
 
       output =
         capture_io(fn ->
-          assert ExUnit.run() == %{total: 1, failures: 0, skipped: 0, excluded: 0}
+          assert ExUnit.run() == %{total: 2, failures: 0, skipped: 0, excluded: 0}
         end)
 
       runs = String.split(output, "Running ExUnit", trim: true)
@@ -1064,6 +1104,21 @@ defmodule ExUnitTest do
       assert length(runs) == 6
       assert output =~ "remaining_runs: 5"
       assert output =~ "remaining_runs: 0"
+
+      assert Agent.get(agent, &Enum.reverse/1) == [
+               TestGroupedRepeatUntilFailureReachedOne,
+               TestGroupedRepeatUntilFailureReachedTwo,
+               TestGroupedRepeatUntilFailureReachedOne,
+               TestGroupedRepeatUntilFailureReachedTwo,
+               TestGroupedRepeatUntilFailureReachedOne,
+               TestGroupedRepeatUntilFailureReachedTwo,
+               TestGroupedRepeatUntilFailureReachedOne,
+               TestGroupedRepeatUntilFailureReachedTwo,
+               TestGroupedRepeatUntilFailureReachedOne,
+               TestGroupedRepeatUntilFailureReachedTwo,
+               TestGroupedRepeatUntilFailureReachedOne,
+               TestGroupedRepeatUntilFailureReachedTwo
+             ]
     end
 
     test "stops on failure" do


### PR DESCRIPTION
* Describe here the reasons behind the pull request.
* Make sure you have read the CONTRIBUTING.md file.
* Make sure any relevant documentation and tests have been added/updated.
* Do not submit Draft pull requests unless previously asked/agreed.


`--repeat-until-failure` restores async modules after each successful run.

The runner stores modules in execution order, but `ExUnit.Server.restore_modules/2` reconstructed the internal queue and group state using the opposite ordering.

As a result, subsequent runs could reverse:

* the order of ungrouped async modules;
* the order of async groups;
* the order of modules within each async group.

This change converts the runner representation back to the server's internal representation before restoring it, preserving FIFO order across repeated runs.



* `make test_ex_unit`
