### PR TITLE
Use native remainder in Calendar.ISO division

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -945,7 +945,7 @@ defmodule Calendar.ISO do
 
   defp div_rem(int1, int2) do
     div = div(int1, int2)
-    rem = int1 - div * int2
+    rem = rem(int1, int2)
 
     if rem >= 0 do
       {div, rem}


### PR DESCRIPTION
Assisted-by: Codex:GPT-6

> Replace quotient-based remainder reconstruction with rem/2 while
preserving quotient evaluation and negative-remainder correction.



