### PR TITLE
Fix OptionParser wrong errors for list switch types

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -886,7 +886,7 @@ defmodule OptionParser do
         msg = "#{option} : Unknown option"
         msg <> ". Did you mean #{String.replace(option, "_", "-")}?"
       else
-        "#{option} : Missing argument of type #{type}"
+        "#{option} : Missing argument of type #{format_type(type)}"
       end
     else
       msg = "#{option} : Unknown option"
@@ -908,7 +908,7 @@ defmodule OptionParser do
          {:error, {reason, position}} <- Regex.compile(value, "u") do
       "#{option} : Invalid regular expression #{inspect(value)}: #{reason} at position #{position}"
     else
-      _ -> "#{option} : Expected type #{type}, got #{inspect(value)}"
+      _ -> "#{option} : Expected type #{format_type(type)}, got #{inspect(value)}"
     end
   end
 
@@ -922,6 +922,14 @@ defmodule OptionParser do
       types[key]
     end
   end
+
+  defp format_type(type) when is_list(type) do
+    type |> List.delete(:keep) |> List.first(:string) |> format_type()
+  end
+
+  defp format_type(:keep), do: format_type(:string)
+
+  defp format_type(type) when is_atom(type), do: Atom.to_string(type)
 
   defp did_you_mean(option, types) do
     key = option |> String.trim_leading("-") |> String.replace("-", "_")

--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -162,6 +162,14 @@ defmodule OptionParserTest do
                  end
   end
 
+  test "parse!/2 raises for a missing argument with :keep" do
+    assert_raise OptionParser.ParseError,
+                 ~r/--port : Missing argument of type integer/,
+                 fn ->
+                   OptionParser.parse!(["--port"], switches: [port: [:integer, :keep]])
+                 end
+  end
+
   test "parse!/2 lists all supported options and aliases" do
     expected_suggestion =
       """
@@ -206,6 +214,16 @@ defmodule OptionParserTest do
       argv = ["--number", "lib", "test/enum_test.exs"]
       OptionParser.parse_head!(argv, strict: [number: :integer])
     end
+  end
+
+  test "parse_head!/2 raises for an invalid argument with :keep" do
+    assert_raise OptionParser.ParseError,
+                 ~r/--port : Expected type integer, got "oops"/,
+                 fn ->
+                   OptionParser.parse_head!(["--port", "oops"],
+                     switches: [port: [:integer, :keep]]
+                   )
+                 end
   end
 
   describe "arguments" do


### PR DESCRIPTION
`OptionParser.parse_head!/2` and `OptionParser.parse!/2` raises wrong errors when reporting
invalid/missing arguments with valid list type opts.

---

```elixir
iex> opts = [strict: [port: [:integer, :keep]]]
iex> OptionParser.parse!(["--port", "4000", "--port"], opts)
** (ArgumentError) cannot convert the given list to a string.
...
```

expected:
```
** (OptionParser.ParseError) 1 error found!
--port : Missing argument of type integer
```

---

```elixir
iex> opts = [switches: [value: [:integer, :keep]]]
iex> OptionParser.parse_head!(["--value"], opts)
** (ArgumentError) cannot convert the given list to a string.
```
expected:
```

** (OptionParser.ParseError) 1 error found!
--value : Missing argument of type integer
```