### PR TITLE
Report unused aliases due to shadowing

### DIFF
--- a/lib/elixir/lib/kernel/lexical_tracker.ex
+++ b/lib/elixir/lib/kernel/lexical_tracker.ex
@@ -35,7 +35,7 @@ defmodule Kernel.LexicalTracker do
   that must be warned if unused.
   """
   def warn_alias(pid, meta, alias, module) do
-    :gen_server.cast(pid, {:warn_alias, alias, meta})
+    :gen_server.cast(pid, {:warn_alias, alias, module, meta})
     module
   end
 
@@ -87,8 +87,8 @@ defmodule Kernel.LexicalTracker do
   end
 
   @doc false
-  def alias_dispatch(pid, module) when is_atom(module) do
-    :gen_server.cast(pid, {:alias_dispatch, module})
+  def alias_dispatch(pid, alias, module) when is_atom(alias) and is_atom(module) do
+    :gen_server.cast(pid, {:alias_dispatch, alias, module})
   end
 
   @doc false
@@ -157,7 +157,7 @@ defmodule Kernel.LexicalTracker do
 
   @doc false
   def handle_call(:unused_aliases, _from, state) do
-    aliases = for {alias, meta} when is_list(meta) <- state.aliases, do: {alias, meta}
+    aliases = for {{alias, _}, meta} when is_list(meta) <- state.aliases, do: {alias, meta}
     {:reply, Enum.sort(aliases), state}
   end
 
@@ -176,7 +176,7 @@ defmodule Kernel.LexicalTracker do
     unused_requires =
       for {module, {meta, alias}} <- state.requires,
           Map.get(references, module) != :compile do
-        {module, meta, alias, Map.get(aliases, alias) == :used}
+        {module, meta, alias, Map.get(aliases, {alias, module}) == :used}
       end
 
     {:reply, Enum.sort(unused_requires), state}
@@ -223,8 +223,8 @@ defmodule Kernel.LexicalTracker do
     {:noreply, %{state | imports: imports, references: references}}
   end
 
-  def handle_cast({:alias_dispatch, module}, state) do
-    {:noreply, put_in(state.aliases[module], :used)}
+  def handle_cast({:alias_dispatch, alias, module}, state) do
+    {:noreply, put_in(state.aliases[{alias, module}], :used)}
   end
 
   def handle_cast({:import_quoted, module, function, arities}, state) do
@@ -266,10 +266,12 @@ defmodule Kernel.LexicalTracker do
     {:noreply, put_in(state.imports[module], Map.from_keys(keys, meta))}
   end
 
-  def handle_cast({:warn_alias, alias, meta}, %{aliases: aliases} = state) do
+  def handle_cast({:warn_alias, alias, module, meta}, %{aliases: aliases} = state) do
+    key = {alias, module}
+
     case aliases do
-      %{^alias => :used} -> {:noreply, state}
-      %{} -> {:noreply, %{state | aliases: Map.put(aliases, alias, meta)}}
+      %{^key => :used} -> {:noreply, state}
+      %{} -> {:noreply, %{state | aliases: Map.put(aliases, key, meta)}}
     end
   end
 

--- a/lib/elixir/src/elixir_lexical.erl
+++ b/lib/elixir/src/elixir_lexical.erl
@@ -32,8 +32,8 @@ run(#{tracers := Tracers} = E, ExecutionCallback, AfterExecutionCallback) ->
       ExecutionCallback(E),
       AfterExecutionCallback(E)
   end.
-trace({alias_expansion, _Meta, Lookup, _Result}, #{lexical_tracker := Pid}) ->
-  ?tracker:alias_dispatch(Pid, Lookup),
+trace({alias_expansion, _Meta, Lookup, Result}, #{lexical_tracker := Pid}) ->
+  ?tracker:alias_dispatch(Pid, Lookup, Result),
   ok;
 trace({require, Meta, Module, _Opts}, #{lexical_tracker := Pid}) ->
   case lists:keyfind(from_macro, 1, Meta) of

--- a/lib/elixir/test/elixir/kernel/alias_test.exs
+++ b/lib/elixir/test/elixir/kernel/alias_test.exs
@@ -38,6 +38,12 @@ defmodule Kernel.AliasTest do
     assert Billing == :"Elixir.MyApp.Billing"
   end
 
+  test "overriding parent alias with child alias" do
+    alias MyApp.Billing
+    alias Billing.Billing
+    assert Billing == :"Elixir.MyApp.Billing.Billing"
+  end
+
   test "lexical" do
     if Process.get(:unused, true) do
       alias OMG, as: List, warn: false

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -57,7 +57,7 @@ defmodule Kernel.LexicalTrackerTest do
   end
 
   test "can add aliases", config do
-    D.alias_dispatch(config[:pid], String)
+    D.alias_dispatch(config[:pid], String, String)
     assert D.references(config[:pid]) == {[], [], [], []}
   end
 
@@ -113,7 +113,7 @@ defmodule Kernel.LexicalTrackerTest do
     D.warn_require(config[:pid], [], String, S)
     D.remote_dispatch(config[:pid], String, :runtime)
     assert D.collect_unused_requires(config[:pid]) == [{String, [], S, false}]
-    D.alias_dispatch(config[:pid], S)
+    D.alias_dispatch(config[:pid], S, String)
     assert D.collect_unused_requires(config[:pid]) == [{String, [], S, true}]
   end
 
@@ -124,12 +124,12 @@ defmodule Kernel.LexicalTrackerTest do
 
   test "used aliases are not unused", config do
     D.warn_alias(config[:pid], [], String, String)
-    D.alias_dispatch(config[:pid], String)
+    D.alias_dispatch(config[:pid], String, String)
     assert D.collect_unused_aliases(config[:pid]) == []
   end
 
   test "used aliases are not unused in reverse order", config do
-    D.alias_dispatch(config[:pid], String)
+    D.alias_dispatch(config[:pid], String, String)
     D.warn_alias(config[:pid], [], String, String)
     assert D.collect_unused_aliases(config[:pid]) == []
   end

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -134,6 +134,13 @@ defmodule Kernel.LexicalTrackerTest do
     assert D.collect_unused_aliases(config[:pid]) == []
   end
 
+  test "unused aliases when target module differs", config do
+    D.warn_alias(config[:pid], [], S, String)
+    D.warn_alias(config[:pid], [], S, Stream)
+    D.alias_dispatch(config[:pid], S, Stream)
+    assert D.collect_unused_aliases(config[:pid]) == [{S, []}]
+  end
+
   describe "references" do
     test "typespecs do not tag aliases nor types" do
       Code.eval_string("""

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -118,19 +118,19 @@ defmodule Kernel.LexicalTrackerTest do
   end
 
   test "unused aliases", config do
-    D.warn_alias(config[:pid], [], String, String)
-    assert D.collect_unused_aliases(config[:pid]) == [{String, []}]
+    D.warn_alias(config[:pid], [], S, String)
+    assert D.collect_unused_aliases(config[:pid]) == [{S, []}]
   end
 
   test "used aliases are not unused", config do
-    D.warn_alias(config[:pid], [], String, String)
-    D.alias_dispatch(config[:pid], String, String)
+    D.warn_alias(config[:pid], [], S, String)
+    D.alias_dispatch(config[:pid], S, String)
     assert D.collect_unused_aliases(config[:pid]) == []
   end
 
   test "used aliases are not unused in reverse order", config do
-    D.alias_dispatch(config[:pid], String, String)
-    D.warn_alias(config[:pid], [], String, String)
+    D.alias_dispatch(config[:pid], S, String)
+    D.warn_alias(config[:pid], [], S, String)
     assert D.collect_unused_aliases(config[:pid]) == []
   end
 

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -941,6 +941,53 @@ defmodule Kernel.WarningTest do
     purge(Sample)
   end
 
+  test "unused alias due to shadowing" do
+    assert_warn_compile(
+      ["nofile:2:3", "unused alias Baz"],
+      """
+      defmodule Sample do
+        alias Foo.Baz
+        alias Bar.Baz
+
+        def baz, do: Baz
+      end
+      """
+    )
+  after
+    purge(Sample)
+  end
+
+  test "does not warn when shadowing alias in nested block" do
+    assert capture_compile("""
+           defmodule Sample do
+             alias Foo.Baz
+
+             def foo do
+               alias Bar.Baz
+               Baz
+             end
+
+             def baz, do: Baz
+           end
+           """) == ""
+  after
+    purge(Sample)
+  end
+
+  test "does not warn when shadowing alias after using it" do
+    assert capture_compile("""
+           defmodule Sample do
+             alias Foo.Baz
+             def foo_baz, do: Baz
+
+             alias Bar.Baz
+             def bar_baz, do: Baz
+           end
+           """) == ""
+  after
+    purge(Sample)
+  end
+
   test "duplicate map keys" do
     assert_warn_eval(
       [


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/13549

@josevalim I think I got it figured out.
If we actually track the alias usage by `alias/module` instead or just `alias` (and we have all the info available at hand to do so in `warn_alias` and `{:alias_expansion, ...}`), we should be addressing the original issue without any false positives (previously reported or that I can think of).

Possible follow-up: By tweaking the structure of `state.aliases` a bit more, we might even be able to catch duplicated aliases: https://github.com/elixir-lang/elixir/pull/15889.