### PR TITLE
Mark type-check macro expansions as generated

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2624,7 +2624,7 @@ defmodule Kernel do
   defmacro is_struct(term) do
     case __CALLER__.context do
       nil ->
-        quote do
+        quote generated: true do
           case unquote(term) do
             %_{} -> true
             _ -> false
@@ -2712,7 +2712,7 @@ defmodule Kernel do
   defmacro is_non_struct_map(term) do
     case __CALLER__.context do
       nil ->
-        quote do
+        quote generated: true do
           case unquote(term) do
             %_{} -> false
             %{} -> true
@@ -2750,7 +2750,7 @@ defmodule Kernel do
   defmacro is_exception(term) do
     case __CALLER__.context do
       nil ->
-        quote do
+        quote generated: true do
           case unquote(term) do
             %_{__exception__: _} -> true
             _ -> false
@@ -2787,7 +2787,7 @@ defmodule Kernel do
   defmacro is_exception(term, name) do
     case __CALLER__.context do
       nil ->
-        quote do
+        quote generated: true do
           case unquote(name) do
             name when is_atom(name) ->
               case unquote(term) do

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -1625,6 +1625,34 @@ defmodule Module.Types.ExprTest do
                  p = %Point{..., x: 123}
              """
     end
+
+    test "type-check macros on known types do not warn" do
+      typecheck!([x = %Point{}], is_struct(x))
+      typecheck!([x = %ArgumentError{}], is_exception(x))
+      typecheck!([x = %Point{}], is_non_struct_map(x))
+      typecheck!([x = %{}], is_non_struct_map(x))
+
+      typecheck!(
+        (
+          x = %{}
+          is_struct(x)
+        )
+      )
+
+      typecheck!(
+        (
+          x = 123
+          is_struct(x)
+        )
+      )
+
+      typecheck!(
+        (
+          e = %ArgumentError{}
+          is_exception(e, ArgumentError)
+        )
+      )
+    end
   end
 
   describe "comparison" do
@@ -3073,6 +3101,24 @@ defmodule Module.Types.ExprTest do
                  __struct__: {atom(), false},
                  __exception__: {term(), false}
                )
+    end
+
+    test "rescue: type-check macros on the rescued variable do not warn" do
+      typecheck!(
+        try do
+          raise "oops"
+        rescue
+          e -> is_exception(e)
+        end
+      )
+
+      typecheck!(
+        try do
+          raise "oops"
+        rescue
+          e -> is_struct(e)
+        end
+      )
     end
 
     test "rescue: generates custom traces" do

--- a/lib/elixir/test/elixir/module/types/integration_test.exs
+++ b/lib/elixir/test/elixir/module/types/integration_test.exs
@@ -917,6 +917,25 @@ defmodule Module.Types.IntegrationTest do
         defmodule C do
           def example, do: to_string([?a, ?b | "!"])
         end
+        """,
+        # do not warn on clauses that belong to type-check macro expansions
+        "d.ex" => """
+        defmodule D do
+          def uri?(%URI{} = uri), do: is_struct(uri)
+
+          def blank_rescue(fun) do
+            try do
+              fun.()
+            rescue
+              x -> is_exception(x)
+            end
+          end
+
+          def assignment do
+            x = %{}
+            {is_struct(x), is_exception(%ArgumentError{}, ArgumentError)}
+          end
+        end
         """
       }
 


### PR DESCRIPTION
Since `%_{}` patterns became precise (#15635), the type-check macros leak warnings from their own expansion whenever the argument type is statically known. Calling `is_struct/1` on a struct:

```elixir
defmodule Foo do
  def uri?(%URI{} = uri), do: is_struct(uri)
end
```

```
$ elixirc foo.ex
warning: the following clause cannot match because the previous clauses already matched all possible values:

    _ ->

it attempts to match on the result of:

    uri

which has the already matched type:

    %URI{...}
```

The `_ -> false` clause belongs to the macro expansion, so the warning points at code the caller never wrote. The same happens with `is_exception/1` and `is_non_struct_map/1`, and in rescue clauses (`rescue x -> ... is_exception(x)`); compiling the test suite on main emits this warning for the doctest of `try/rescue x -> ...` in Kernel.SpecialForms. It also fires in the other direction: `x = %{}; is_struct(x)` warns that the `%_{}` clause will never match, and `e = %ArgumentError{}; is_exception(e, ArgumentError)` hits `is_exception/2` through the pinned name.

`is_struct/2` already wraps its whole expression expansion in `quote generated: true`, which is why it never triggers these warnings. This does the same for the remaining macros. Guards and match contexts are untouched.
